### PR TITLE
fix: Use remote reference for reusable-agents-issue-bridge.yml

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -1168,7 +1168,7 @@ jobs:
           github.run_id
         }}
       cancel-in-progress: true
-    uses: ./.github/workflows/reusable-agents-issue-bridge.yml
+    uses: stranske/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main
     with:
       agent: ${{ needs.normalize_inputs.outputs.bridge_agent || needs.bridge_preflight.outputs.agent_key }}
       issue_number: ${{ needs.normalize_inputs.outputs.issue_number || needs.bridge_preflight.outputs.issue_number || '' }}


### PR DESCRIPTION
## Problem

The `agents-63-issue-intake.yml` workflow was incorrectly referencing a local reusable workflow:
```yaml
uses: ./.github/workflows/reusable-agents-issue-bridge.yml
```

Consumer repos do not have this file locally - it only exists in the Workflows repo.

## Solution

Changed to reference the workflow from the Workflows repo:
```yaml
uses: stranske/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main
```