### PR TITLE
fix: lint errors, mypy issues, and workflow references

### DIFF
--- a/.github/codex/prompts/keepalive_next_task.md
+++ b/.github/codex/prompts/keepalive_next_task.md
@@ -1,4 +1,4 @@
-## Keepalive Next Task
+# Keepalive Next Task
 
 Your objective is to satisfy the **Acceptance Criteria** by completing each **Task** within the defined **Scope**.
 

--- a/.github/scripts/decode_raw_input.py
+++ b/.github/scripts/decode_raw_input.py
@@ -10,7 +10,7 @@ import argparse
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 RAW_FILE = Path("raw_input.json")
 OUT_FILE = Path("input.txt")
@@ -52,7 +52,7 @@ def main() -> None:
                 text = json.loads(raw)
             else:
                 text = ""
-        except Exception:
+        except json.JSONDecodeError:
             text = raw
     original = text or ""
     # Normalize CR-only to LF and remove BOM if present
@@ -89,13 +89,13 @@ def main() -> None:
 
     # Heuristic: if the input lost original line breaks (appears mostly as one very long line)
     # reconstruct newlines before common enumeration patterns so the parser can split topics.
-    applied: List[str] = []
+    applied: list[str] = []
 
     def apply_enumerator_newlines(s: str) -> str:
         pattern = re.compile(
             r"(?<!\n)(?:(?<=\s)|^)(?P<enum>([0-9]{1,3}|[A-Za-z][0-9]*))[\)\.:\-]\s+"
         )
-        parts: List[str] = []
+        parts: list[str] = []
         last = 0
         for m in pattern.finditer(s):
             start = m.start()
@@ -140,10 +140,10 @@ def main() -> None:
             applied.append("forced_split")
             text = forced
 
-    def extract_enumerators(s: str) -> Tuple[List[str], List[str]]:
+    def extract_enumerators(s: str) -> tuple[list[str], list[str]]:
         # Enumerators followed by punctuation ) . : - then space
         enum_pattern = re.compile(r"(^|\s)(([0-9]{1,3}|[A-Za-z][0-9]*))[\)\.:\-](?=\s)")
-        tokens: List[str] = []
+        tokens: list[str] = []
         for m in enum_pattern.finditer(s):
             token = m.group(2)
             tokens.append(token)
@@ -156,7 +156,7 @@ def main() -> None:
     raw_tokens, raw_distinct = extract_enumerators(original)
     reb_tokens, reb_distinct = extract_enumerators(text)
 
-    diagnostics: Dict[str, Any] = {
+    diagnostics: dict[str, Any] = {
         "raw_len": len(original),
         "raw_newlines": original.count("\n"),
         "rebuilt_len": len(text),

--- a/.github/scripts/parse_chatgpt_topics.py
+++ b/.github/scripts/parse_chatgpt_topics.py
@@ -213,7 +213,7 @@ def parse_text(
         else:
             raw_lines = []
         labels, sections, extras = _parse_sections(raw_lines)
-        data = {
+        data: dict[str, object] = {
             "title": str(item.get("title", "")).strip(),
             "labels": labels,
             "sections": {key: _join_section(value) for key, value in sections.items()},
@@ -221,7 +221,7 @@ def parse_text(
             "enumerator": item.get("enumerator"),
             "continuity_break": bool(item.get("continuity_break", False)),
         }
-        normalized_title = re.sub(r"\s+", " ", data["title"].strip().lower())
+        normalized_title = re.sub(r"\s+", " ", str(data["title"]).strip().lower())
         data["guid"] = str(uuid.uuid5(uuid.NAMESPACE_DNS, normalized_title))
         parsed.append(data)
     return parsed

--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -1168,7 +1168,7 @@ jobs:
           github.run_id
         }}
       cancel-in-progress: true
-    uses: ./.github/workflows/reusable-agents-issue-bridge.yml
+    uses: stranske/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main
     with:
       agent: ${{ needs.normalize_inputs.outputs.bridge_agent || needs.bridge_preflight.outputs.agent_key }}
       issue_number: ${{ needs.normalize_inputs.outputs.issue_number || needs.bridge_preflight.outputs.issue_number || '' }}
@@ -1176,5 +1176,5 @@ jobs:
       post_agent_comment: ${{ needs.normalize_inputs.outputs.post_codex_comment }}
       agent_pr_draft: ${{ needs.normalize_inputs.outputs.bridge_draft_pr }}
     secrets:
-      service_bot_pat: ${{ secrets.service_bot_pat }}
-      owner_pr_pat: ${{ secrets.owner_pr_pat }}
+      service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
+      owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}


### PR DESCRIPTION
## Summary
Fixes the same issues found in other consumer repos (Manager-Database, Template):

### Python lint fixes
- **decode_raw_input.py**: Use modern type annotations (`list`, `dict`, `tuple`) instead of deprecated `typing` imports
- **decode_raw_input.py**: Use `json.JSONDecodeError` instead of broad `Exception`
- **parse_chatgpt_topics.py**: Add explicit `dict[str, object]` type annotation for mypy
- **parse_chatgpt_topics.py**: Cast `data["title"]` to `str` before calling `.strip()` for mypy

### Workflow fixes
- **agents-63-issue-intake.yml**: Reference `stranske/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main` instead of non-existent local path
- **agents-63-issue-intake.yml**: Use uppercase secret names (`SERVICE_BOT_PAT`, `OWNER_PR_PAT`) matching repo secrets

### Documentation fixes
- **keepalive_next_task.md**: Use H1 heading for standalone document

These changes ensure CI passes and workflows reference the correct reusable workflow locations.