### PR TITLE
Fix agents-63-issue-intake.yml: use thin caller template

### DIFF
--- a/.github/workflows/agents-63-issue-intake.yml
+++ b/.github/workflows/agents-63-issue-intake.yml
@@ -5,7 +5,7 @@
 # - Issue opened/reopened/labeled with agent:codex, agent:copilot, etc.
 # - Manual dispatch for testing
 #
-# Copy this file to: .github/workflows/agents-issue-intake.yml
+# This file: .github/workflows/agents-63-issue-intake.yml
 #
 # Required secrets:
 # - SERVICE_BOT_PAT: PAT for service bot account (comments, labels)
@@ -51,10 +51,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Gate: only proceed if issue has agent:* or agents:* label
+  # Gate: only proceed if issue has agent:* or agents:* label (or workflow_dispatch)
   check_labels:
-    if: >
-      github.event_name != 'issues' ||
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
       contains(toJson(github.event.issue.labels.*.name), 'agent:') ||
       contains(toJson(github.event.issue.labels.*.name), 'agents:')
     runs-on: ubuntu-latest
@@ -105,8 +105,8 @@ jobs:
       agent: ${{ needs.check_labels.outputs.agent }}
       issue_number: ${{ needs.check_labels.outputs.issue_number }}
       mode: "invite"
-      post_agent_comment: ${{ inputs.post_codex_comment && 'true' || 'false' }}
-      agent_pr_draft: ${{ inputs.bridge_draft_pr && 'true' || 'false' }}
+      post_agent_comment: ${{ inputs.post_codex_comment == true && 'true' || 'false' }}
+      agent_pr_draft: ${{ inputs.bridge_draft_pr == true && 'true' || 'false' }}
     secrets:
       service_bot_pat: ${{ secrets.SERVICE_BOT_PAT }}
       owner_pr_pat: ${{ secrets.OWNER_PR_PAT }}


### PR DESCRIPTION
## Problem

The workflow was incorrectly using the Workflows repo's own intake workflow (1180 lines) instead of the thin caller template (112 lines).

## Solution

Replace with the correct thin caller template that references the Workflows repo directly.