### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=25.12.0
-RUFF_VERSION=0.14.11
+RUFF_VERSION=0.14.12
 ISORT_VERSION=7.0.0
 DOCFORMATTER_VERSION=1.7.7
 MYPY_VERSION=1.19.1
@@ -13,4 +13,3 @@ PYTEST_VERSION=9.0.2
 PYTEST_COV_VERSION=7.0.0
 PYTEST_XDIST_VERSION=3.8.0
 COVERAGE_VERSION=7.13.1
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [project.optional-dependencies]
 dev = [
-    "ruff>=0.14.11",
+    "ruff>=0.14.12",
     "mypy>=1.19.1",
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -28,7 +28,7 @@ pytest==9.0.2
     #   pytest-cov
 pytest-cov==7.0.0
     # via trip-planner (pyproject.toml)
-ruff==0.14.11
+ruff==0.14.12
     # via trip-planner (pyproject.toml)
 typing-extensions==4.15.0
     # via mypy


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 2 version updates:
  - ruff: >=0.14.11 -> >=0.14.12
  - requirements.lock:ruff: 0.14.11 -> ==0.14.12

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** [`.github/workflows/autofix-versions.env`](https://github.com/stranske/Workflows/blob/main/.github/workflows/autofix-versions.env)