### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-72-codex-belt-worker.yml
+++ b/.github/workflows/agents-72-codex-belt-worker.yml
@@ -497,6 +497,7 @@ jobs:
         if: ${{ steps.parallel.outputs.allowed == 'true' && (inputs.keepalive != true || steps.keepalive_gate.outputs.action != 'skip') }}
         uses: actions/checkout@v6
         with:
+          repository: stranske/Workflows
           ref: ${{ github.ref }}
           token: ${{ env.GH_BELT_TOKEN }}
           fetch-depth: 1


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-72-codex-belt-worker.yml: Codex belt worker - executes Codex agent on issues with full prompt and context

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** [stranske/Workflows](https://github.com/stranske/Workflows)
**Manifest:** [`.github/sync-manifest.yml`](https://github.com/stranske/Workflows/blob/main/.github/sync-manifest.yml)