### PR TITLE
chore: sync workflow templates

### DIFF
--- a/autofix_report_enriched.json
+++ b/autofix_report_enriched.json
@@ -1,1 +1,1 @@
-{"changed": true, "classification": {"total": 0, "new": 0, "allowed": 0}, "timestamp": "2026-01-31T17:12:06Z", "files": ["scripts/sync_test_dependencies.py"]}
+{"changed": true, "classification": {"total": 0, "new": 0, "allowed": 0}, "timestamp": "2026-02-01T02:36:27Z", "files": ["scripts/sync_test_dependencies.py"]}

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -12,9 +12,10 @@ import argparse
 import ast
 import re
 import sys
-import tomllib
 from pathlib import Path
 from typing import Any, cast
+
+import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = REPO_ROOT / "src"


### PR DESCRIPTION
## Sync Summary

### Files Updated
- sync_test_dependencies.py: Syncs test dependency pins - required by reusable CI workflow

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** [stranske/Workflows](https://github.com/stranske/Workflows)
**Manifest:** [`.github/sync-manifest.yml`](https://github.com/stranske/Workflows/blob/main/.github/sync-manifest.yml)