### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,7 +5,7 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.1.0
-RUFF_VERSION=0.14.14
+RUFF_VERSION=0.15.0
 ISORT_VERSION=7.0.0
 DOCFORMATTER_VERSION=1.7.7
 MYPY_VERSION=1.19.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [project.optional-dependencies]
 dev = [
-    "ruff==0.14.14",
+    "ruff>=0.15.0",
     "mypy>=1.19.1",
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",

--- a/requirements.lock
+++ b/requirements.lock
@@ -2,7 +2,7 @@
 #    uv pip compile pyproject.toml --extra dev --universal --output-file requirements.lock
 colorama==0.4.6 ; sys_platform == 'win32'
     # via pytest
-coverage==7.13.2
+coverage==7.13.3
     # via pytest-cov
 iniconfig==2.3.0
     # via pytest
@@ -28,7 +28,7 @@ pytest==9.0.2
     #   pytest-cov
 pytest-cov==7.0.0
     # via trip-planner (pyproject.toml)
-ruff==0.14.14
+ruff==0.15.0
     # via trip-planner (pyproject.toml)
 typing-extensions==4.15.0
     # via mypy


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 3 version updates:
  - ruff: ==0.14.14 -> >=0.15.0
  - requirements.lock:coverage: 7.13.2 -> ==7.13.3
  - requirements.lock:ruff: 0.14.14 -> ==0.15.0

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** [`.github/workflows/autofix-versions.env`](https://github.com/stranske/Workflows/blob/main/.github/workflows/autofix-versions.env)