### PR TITLE
docs: add trip-planner product architecture brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,44 @@
 # trip-planner
-<br>markdown<br>## Static HTML Bundle<br>The self‑contained demo bundle lives in `/bundle/`.<br><br>**Local test:**<br>
-<br>markdown<br>## Will be editing
-<br>file:///home/oai/share/bundle/index.html<br><br><br>**Deploy:** 
 
-## Quick Start
+`trip-planner` is transitioning from a static itinerary-scoring demo into a broader travel-planning application with two product modes:
 
-1. **Install deps**
+- recreational trip planning for individuals and families
+- business trip planning that optimizes against company travel constraints and exports policy-ready trip plans
+
+## Current Direction
+
+The target product should handle:
+
+- trip design from traveler preferences
+- lodging, airfare, rail, rental-car, and local transport option planning
+- day-by-day activity planning with maps and route context
+- budget and tradeoff analysis
+- interactive LLM-assisted trip refinement
+- business-travel planning that can hand structured output to `Travel-Plan-Permission`
+
+## Key Docs
+
+- [Product and architecture brief](docs/product-architecture-brief.md)
+- [Source channel strategy](docs/source-channel-strategy.md)
+- [Legacy itinerary methodology](docs/methodology.md)
+- [CI system guide](docs/CI_SYSTEM_GUIDE.md)
+
+## Current Repo State
+
+The implementation in this repository is still mostly a script-based generator for static itinerary bundles:
+
+- `scripts/validate_request.py`
+- `scripts/generate_itins.py`
+- `scripts/build_html.py`
+
+That legacy flow remains useful as seed logic for the future preference-scoring and itinerary-ranking engine, but it is no longer the full product definition.
+
+## Legacy Quick Start
 
 ```bash
 pip install -r requirements.txt
 
-python scripts/validate_request.py   # schema check
-python scripts/generate_itins.py     # writes data/itineraries_*.json
-python scripts/build_html.py         # renders bundle/ HTML
-
-
+python scripts/validate_request.py
+python scripts/generate_itins.py
+python scripts/build_html.py
+```

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -1,5 +1,9 @@
 # Trip Planner Methodology
 
+This document captures the **legacy itinerary scoring model** already present in the repo.
+
+It should now be treated as one subsystem inside the broader product direction described in [product-architecture-brief.md](product-architecture-brief.md), not as the full application design.
+
 ## 1. Scoring Factors
 - **Natural** (0‑5)
 - **Cultural** (0‑5)

--- a/docs/product-architecture-brief.md
+++ b/docs/product-architecture-brief.md
@@ -1,0 +1,228 @@
+# Product And Architecture Brief
+
+## Product Purpose
+
+`trip-planner` should become a dynamic travel-planning system with two first-class modes:
+
+1. **Recreational travel**
+   - Primary users: you and family members
+   - Scope: worldwide
+   - Goal: design coherent trips that fit traveler preferences, time, cost, travel complexity, and desired experiences
+2. **Business travel**
+   - Primary users: business travelers
+   - Scope: start with the United States
+   - Goal: build policy-aware, approval-ready plans with realistic inventory and pricing inputs
+
+## Design Recommendation: Keep `Travel-Plan-Permission` Separate
+
+Business-trip planning should stay in `trip-planner`, while `Travel-Plan-Permission` should remain the policy and approval system.
+
+That boundary is cleaner for three reasons:
+
+- `trip-planner` needs to optimize across traveler intent, inventory, maps, budgets, and itinerary coherence, which is planning logic rather than policy logic.
+- `Travel-Plan-Permission` already positions itself as the approval and reimbursement layer and exposes a canonical trip-plan contract plus policy APIs.
+- Keeping planning and policy enforcement separate reduces coupling to organization-specific rules and makes the leisure/business planning core reusable.
+
+The integration model should be:
+
+- `trip-planner` produces a versioned `TripPlanProposal`
+- `Travel-Plan-Permission` evaluates policy fit, approved vendors, exceptions, and approval requirements
+- `trip-planner` can then re-optimize against returned constraints
+
+Relevant local references:
+
+- `Travel-Plan-Permission` README
+- `Travel-Plan-Permission/docs/policy-api.md`
+- `Travel-Plan-Permission/schemas/trip_plan.min.schema.json`
+
+## Product Capabilities
+
+### 1. Preference Engine
+
+The old repo used fixed scoring across natural, cultural, significance, and experience-bundle factors. That should become part of a broader preference model that captures:
+
+- destination style
+- activity intensity
+- nature vs. culture balance
+- budget sensitivity
+- tolerance for transfers and travel complexity
+- lodging style
+- route density per day
+- business constraints, when applicable
+
+### 2. Inventory And Coherence Engine
+
+The planner should ingest and normalize:
+
+- flights
+- hotels and other lodging
+- rail
+- rental cars
+- public transit and local ground transport
+- points of interest and activities
+
+The system should enforce:
+
+- time-feasible arrival/departure chains
+- realistic transfer and check-in windows
+- daily activity density limits
+- cost ceilings and soft budget preferences
+- route continuity and map-aware travel distances
+
+### 3. Budget And Tradeoff System
+
+Budgeting should not just total prices. It should support:
+
+- planned vs. actual cost tracking
+- tradeoff analysis
+- opportunity cost of higher-comfort or lower-complexity options
+- optional cost hiding for experience-first trip design
+- business-policy-aware cost reasoning
+
+### 4. Interactive Planning Layer
+
+Use LangChain-based orchestration for:
+
+- guided preference capture
+- interactive trip revision
+- explanation of tradeoffs
+- policy-prep flows for business trips
+
+LangChain should not be the whole architecture. It should sit on top of explicit tools and domain services for:
+
+- search and source retrieval
+- itinerary scoring
+- budget calculation
+- map/routing queries
+- policy requirement assembly
+
+### 5. Business-Travel Output
+
+Business mode should:
+
+- identify all data needed by a policy system
+- optimize toward policy fit before export
+- record vendor choices, comparables, and justification
+- produce structured payloads that plug into `Travel-Plan-Permission`
+
+## Recommended Architecture
+
+### Frontend
+
+Build toward a stateful web app with:
+
+- user accounts
+- saved trips
+- trip comparison views
+- itinerary timeline
+- interactive maps
+- LLM chat side panel
+- business-policy readiness summary
+
+### Core Backend Services
+
+Organize the application into five bounded modules:
+
+1. `preferences`
+   - traveler profiles
+   - trip goals
+   - preference elicitation and weighting
+2. `options`
+   - source adapters
+   - canonical flight/lodging/activity/transport records
+   - vendor metadata and approval flags
+3. `itinerary`
+   - route assembly
+   - coherence rules
+   - scoring and ranking
+4. `budget`
+   - estimated and actual costs
+   - tradeoffs
+   - scenario comparison
+5. `business_policy_export`
+   - policy-ready proposal schema
+   - compatibility with `Travel-Plan-Permission`
+   - constraint feedback loop
+
+### Supporting Services
+
+- identity and account storage
+- trip persistence
+- cache for external source data
+- map/geocoding/routing service
+- audit trail for business plan changes
+- LLM orchestration and tool execution layer
+
+## Domain Model
+
+The next design iteration should define explicit schemas for:
+
+- `User`
+- `TravelerProfile`
+- `Trip`
+- `TripMode`
+- `PreferenceProfile`
+- `Destination`
+- `PointOfInterest`
+- `TravelSegment`
+- `LodgingOption`
+- `TransportOption`
+- `ActivityOption`
+- `ItineraryDay`
+- `BudgetPlan`
+- `ActualSpendEvent`
+- `PolicyConstraintSet`
+- `TripPlanProposal`
+- `PolicyEvaluationResult`
+
+The most important near-term design decision is to define these contracts before building a larger LLM workflow. Without stable types, conversational updates will become fragile quickly.
+
+## How The Legacy Methodology Fits
+
+The current scoring model in [methodology.md](methodology.md) should be retained, but narrowed to a reusable subsystem:
+
+- legacy natural/cultural/significance scoring becomes one part of leisure preference ranking
+- complexity scoring becomes one part of itinerary feasibility and traveler-friction scoring
+- route segments remain useful as first-class itinerary objects
+- compact vs. extended itinerary generation can evolve into multi-scenario planning
+
+## Delivery Phases
+
+### Phase 1: Foundation
+
+- define canonical schemas
+- add user/trip persistence model
+- preserve and refactor the existing scoring code into reusable modules
+- stand up source-adapter interfaces
+
+### Phase 2: Leisure MVP
+
+- worldwide destination and activity planning
+- preference capture
+- itinerary ranking
+- schematic map support
+- budget scenarios
+
+### Phase 3: Business MVP
+
+- US-first
+- policy-aware business mode
+- approved-source filtering
+- structured export to `Travel-Plan-Permission`
+- approval-readiness summary
+
+### Phase 4: Advanced Planning
+
+- fuller interactive maps
+- route menus inspired by guide-based travel design
+- richer local transportation modeling
+- actual-spend tracking and post-trip analysis
+
+## Open Design Questions
+
+These remain worth resolving in a later pass:
+
+- whether business mode should support direct booking connections in the first production release or start with priced recommendations plus links
+- how much live pricing should be cached vs. refreshed on demand
+- which map/provider stack should back routing, transit, and nearby-option discovery
+- whether leisure and business should share one UI shell with modes, or one platform with separate entry journeys

--- a/docs/source-channel-strategy.md
+++ b/docs/source-channel-strategy.md
@@ -1,0 +1,110 @@
+# Source Channel Strategy
+
+This document proposes an initial set of travel-planning source channels for the new `trip-planner` design.
+
+Two lists are included:
+
+- a **consumer-usage shortlist** for recreational planning
+- a **business-approved shortlist** for managed-travel planning
+
+These are not universal truths. They are an initial operating set based on current market position, consumer traffic signals, and managed-travel adoption. Corporate approval varies by employer and policy.
+
+## Consumer-Usage Top 10
+
+Ordered by a blend of current consumer reach and usefulness for trip planning:
+
+1. **Airbnb**
+2. **Expedia**
+3. **Booking.com**
+4. **Vrbo**
+5. **Marriott**
+6. **Tripadvisor**
+7. **Google Flights**
+8. **Kayak**
+9. **Priceline**
+10. **Skyscanner**
+
+### Why this list
+
+- Similarweb’s latest U.S. accommodation ranking puts `airbnb.com`, `expedia.com`, `booking.com`, `vrbo.com`, and `marriott.com` in the top five accommodation/hotel destinations.
+- Similarweb’s North American travel report says airlines still dominate actual flight conversions, and notes Google Flights’ growing referral influence to airline websites.
+- Tripadvisor, Kayak, Priceline, and Skyscanner remain strategically important because they cover discovery, comparison, and price-shopping workflows that a leisure-planning app needs even when the final booking path lands elsewhere.
+
+### Product Recommendation
+
+Use this list in two tiers:
+
+- **Discovery tier**: Tripadvisor, Google Flights, Kayak, Priceline, Skyscanner
+- **Bookable inventory tier**: Airbnb, Expedia, Booking.com, Vrbo, Marriott plus direct supplier sites
+
+For leisure mode, direct supplier sites should still be preferred when pricing parity, cancellation terms, or itinerary reliability matter.
+
+## Business-Approved Top 10
+
+Ordered by a blend of enterprise prevalence and suitability for policy-controlled travel programs:
+
+1. **SAP Concur Travel**
+2. **Amex GBT / Egencia**
+3. **BCD Travel**
+4. **Navan**
+5. **CWT**
+6. **FCM Travel**
+7. **Corporate Travel Management (CTM)**
+8. **Direct Travel**
+9. **TravelPerk**
+10. **Corporate Traveler**
+
+### Why this list
+
+- Travel Weekly’s 2025 Power List places Amex GBT, BCD Travel, Navan, and CTM among the major travel-management players.
+- Business Travel News still describes the market through the influence of the historical “three megas” and highlights growing competition from newer platforms.
+- Skift’s 2025 market coverage similarly points to Amex GBT and BCD as leaders and notes the rise of CTM and Navan.
+- Official product materials show the kinds of policy and control capabilities this app should expect from managed-travel integrations:
+  - Navan emphasizes dynamic policy controls and broad supplier inventory.
+  - TravelPerk documents managed travel policies, including rental-car policy controls.
+  - Amex GBT positions Egencia inside a global managed-travel platform.
+
+### Product Recommendation
+
+For business mode, split the source strategy into:
+
+- **Managed-travel channels**: Concur, Amex GBT/Egencia, BCD, Navan, CWT, FCM, CTM, Direct Travel, TravelPerk, Corporate Traveler
+- **Underlying supplier allowlists**: approved airlines, hotel programs, rail providers, rental-car suppliers, and ground transport services defined per policy pack
+
+That way `trip-planner` can:
+
+- optimize inside approved channels first
+- fall back to structured alternatives only when policies allow exceptions
+- preserve comparables and justification for approval review
+
+## Integration With `Travel-Plan-Permission`
+
+Business mode should not hardcode a single universal vendor policy.
+
+Instead:
+
+- `trip-planner` should maintain a default source shortlist and canonical vendor taxonomy
+- `Travel-Plan-Permission` should provide organization-specific allowed vendors, preferred suppliers, caps, and exception logic
+- the planner should annotate every candidate option with:
+  - `source_channel`
+  - `supplier`
+  - `approval_status`
+  - `policy_reason`
+  - `comparable_reference`
+
+## Notes On Confidence
+
+- The top of the consumer list is higher confidence than the lower half because current Similarweb category rankings directly support it.
+- The top of the business list is higher confidence than the bottom half because enterprise adoption is easier to observe for the biggest TMCs and platforms than for the long tail.
+- The business list should be treated as the default seed list, then narrowed or reordered per organization.
+
+## Reference Links
+
+- [Similarweb: U.S. accommodation and hotels ranking](https://www.similarweb.com/top-websites/united-states/travel-and-tourism/accommodation-and-hotels/)
+- [Similarweb: North American travel industry digital trends](https://www.similarweb.com/corp/reports/the-evolving-digital-state-of-the-north-american-travel-industry/)
+- [Travel Weekly Power List 2025](https://www.travelweekly.com/Power-List-2025)
+- [BTN CT100 2025 market overview](https://www.businesstravelnews.com/corporate-travel-100/2025/will-the-wait-and-see-approach-finally-end)
+- [Skift on 2025 corporate travel market structure](https://skift.com/2025/02/20/bcd-and-amex-gbt-lead-the-corporate-travel-market-by-far-uk-regulator-reveals/)
+- [Navan for Travel Managers](https://navan.com/travel-managers)
+- [TravelPerk travel policy help center](https://support.travelperk.com/hc/en-us/sections/14451265665820-Managing-travel-policies)
+- [Amex GBT on Egencia acquisition and platform strategy](https://www.amexglobalbusinesstravel.com/press-releases/american-express-global-business-travel-agrees-to-acquire-egencia-from-expedia-group/?highlight=Amex%2BTravel%2BCenter)


### PR DESCRIPTION
## Summary
- replace the broken README with a clean overview of the repo's new direction
- add a product and architecture brief covering leisure and business travel modes
- add a source-channel strategy document, including initial consumer and business travel source shortlists
- reposition the existing methodology doc as legacy scoring logic within the broader design

## Testing
- docs-only change
- reviewed updated markdown locally for structure and link targets