### PR TITLE
Issue #509: create traveler archetype fixture corpus

### DIFF
--- a/docs/leisure-preference-contract.md
+++ b/docs/leisure-preference-contract.md
@@ -16,6 +16,10 @@ This package is the source of truth for the first implementation pass of the lei
   - allowed evidence pathways and strength levels for tradeoffs, hybrid factors, and anchors
 - `trip_planner/preferences/legacy_request_adapter.py`
   - narrow compatibility adapter from the repo's older `request.json` shape into the canonical contract
+- `tests/fixtures/preferences/leisure_traveler_corpus.json`
+  - regression corpus of leisure archetypes and tension cases used to validate future resolver work
+- `tests/preferences/fixture_corpus.py`
+  - reusable loader that instantiates fixture profiles and evidence records from the corpus
 
 ## What This Replaces
 

--- a/docs/preferences-fixture-corpus.md
+++ b/docs/preferences-fixture-corpus.md
@@ -1,0 +1,65 @@
+# Preference Fixture Corpus
+
+The leisure preference fixture corpus lives at:
+
+- `tests/fixtures/preferences/leisure_traveler_corpus.json`
+- `tests/preferences/fixture_corpus.py`
+
+This corpus is intended to be the reusable regression backbone for preference work. It should be used by:
+
+- schema and contract tests
+- evidence-model tests
+- resolver and contradiction-handling tests
+- itinerary-objective derivation tests
+
+## Format
+
+Each fixture contains:
+
+- `id`
+  - stable identifier used by tests
+- `fixture_kind`
+  - `archetype` or `tension_case`
+- `summary`
+  - terse engineering description of the traveler pattern
+- `tags`
+  - short clustering labels for discovery and coverage review
+- `raw_inputs`
+  - compact traveler statements and planning-style notes
+- `profile_overrides`
+  - canonical leisure-profile overrides layered onto a shared default profile
+- `evidence`
+  - `PreferenceEvidence` payloads that can be instantiated directly
+- `intended_interpretation`
+  - qualitative expectations that later tests can assert without freezing final numeric outputs
+
+## Design Rules
+
+- Keep fixtures implementation-focused rather than user-facing.
+- Prefer a smaller number of serious fixtures over many shallow personas.
+- Model real tensions explicitly instead of averaging them away.
+- Use `profile_overrides` only for meaningful deviations from the default baseline.
+- When adding option-choice evidence, include realistic comparison context through `option_evidence`.
+
+## Extension Guidance
+
+Add a new fixture when at least one of these is true:
+
+- a first-tier dimension is underrepresented
+- a hybrid factor changes route or budget logic in a new way
+- a new contradiction pattern needs explicit regression coverage
+- a resolver change would otherwise be tested only against one narrow travel style
+
+When extending the corpus:
+
+- keep `id` values stable once published
+- update the intended interpretation before adding numeric assertions elsewhere
+- add evidence that explains why the profile should resolve the way it does
+- prefer new fixtures over mutating old ones when the traveler pattern is materially different
+
+## What Not To Do
+
+- Do not turn the corpus into marketing personas.
+- Do not add live booking or destination inventory here.
+- Do not use old `request.json` fields as the primary fixture format.
+- Do not treat the corpus as a final ranking benchmark; it is for preference-engine regression first.

--- a/tests/fixtures/preferences/leisure_traveler_corpus.json
+++ b/tests/fixtures/preferences/leisure_traveler_corpus.json
@@ -1,0 +1,1225 @@
+{
+  "schema_version": "0.1.0",
+  "fixtures": [
+    {
+      "id": "scenic-rail-nomad",
+      "fixture_kind": "archetype",
+      "summary": "High-mobility traveler who wants overland movement and scenic rail to be a core part of the trip rather than dead time.",
+      "tags": ["mobility", "rail", "nature", "discovery"],
+      "raw_inputs": {
+        "trip_brief": "I can handle frequent moves if the route itself is part of the experience. I would rather cross a region by rail than fly over it.",
+        "stated_constraints": ["trip length around 30 days", "prefers shoulder season weather"],
+        "planning_style_notes": ["comfortable booking independent rail segments", "wants a route with narrative flow"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 30,
+          "traveler_party": "solo",
+          "season_window": ["September", "October"],
+          "trip_stage": "first_visit",
+          "regions_in_scope": ["Japan", "South Korea"],
+          "special_themes": ["rail travel", "landscape transitions"]
+        },
+        "budget_model": {
+          "total_budget_sensitivity": 0.45,
+          "spending_priorities": {
+            "transport_experience": 0.85,
+            "lodging_location": 0.65
+          },
+          "splurge_allowed": true,
+          "splurge_style": "pay for scenic rail or ferry legs that materially improve the route"
+        },
+        "anchors": {
+          "mode_anchors": [
+            {
+              "type": "mode",
+              "label": "Long-form rail segments",
+              "strength": 0.92,
+              "flexibility": 0.18,
+              "notes": "Route should privilege trains over flights when feasible."
+            }
+          ],
+          "regional_adjacency_preferences": [
+            {
+              "type": "region",
+              "label": "Contiguous overland progression",
+              "strength": 0.78,
+              "flexibility": 0.34,
+              "notes": "Avoid backtracking unless a major payoff exists."
+            }
+          ]
+        },
+        "tradeoff_dimensions": {
+          "movement_vs_friction": {
+            "value": -0.82,
+            "confidence": 0.88,
+            "salience": 0.9,
+            "stability": 0.82
+          },
+          "nature_vs_culture": {
+            "value": -0.42,
+            "confidence": 0.72,
+            "salience": 0.58,
+            "stability": 0.68
+          },
+          "structure_vs_elasticity": {
+            "value": 0.18,
+            "confidence": 0.62,
+            "salience": 0.46,
+            "stability": 0.44
+          },
+          "self_reliance_vs_convenience": {
+            "value": -0.72,
+            "confidence": 0.78,
+            "salience": 0.74,
+            "stability": 0.76
+          },
+          "scenic_transit_vs_destination_time": {
+            "value": -0.9,
+            "confidence": 0.94,
+            "salience": 0.96,
+            "stability": 0.88
+          },
+          "route_coherence_vs_eclectic_contrast": {
+            "value": -0.68,
+            "confidence": 0.8,
+            "salience": 0.8,
+            "stability": 0.78
+          },
+          "iconic_vs_discovery": {
+            "value": 0.36,
+            "confidence": 0.64,
+            "salience": 0.56,
+            "stability": 0.48
+          }
+        },
+        "hybrid_factors": {
+          "route_modes": {
+            "mode": "both",
+            "salience": 0.9,
+            "anchor_strength": 0.86,
+            "tradeoff_role": "route_design",
+            "notes": "Rail and ferry are part of the identity of the trip.",
+            "preferences": {
+              "rail": 0.96,
+              "ferry": 0.62,
+              "car_rental": 0.18
+            }
+          },
+          "rest": {
+            "mode": "tradeoff",
+            "salience": 0.42,
+            "tradeoff_role": "rhythm",
+            "preferences": {
+              "buffer_days": 0.35
+            }
+          }
+        },
+        "interaction_rules": [
+          {
+            "id": "rail_nomad_movement_x_scenic",
+            "dimensions": ["movement_vs_friction", "scenic_transit_vs_destination_time"],
+            "activation": {
+              "all_of": [
+                {"dimension": "movement_vs_friction", "max_value": -0.6},
+                {"dimension": "scenic_transit_vs_destination_time", "max_value": -0.7}
+              ]
+            },
+            "effect": {
+              "prioritize": ["rail corridors", "overnight trains", "ferry links"],
+              "deprioritize": ["short-haul flights"]
+            },
+            "strength": 0.88,
+            "priority": 0.82
+          }
+        ],
+        "evidence_summary": {
+          "sources": {
+            "direct_statements": ["Traveler says transit is part of the trip."],
+            "revealed_preferences": ["Traveler picks overland bundles over direct flights."]
+          },
+          "confidence_notes": ["High signal because both stated and option-choice evidence align."]
+        }
+      },
+      "evidence": [
+        {
+          "id": "scenic-rail-nomad-ev-1",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": ["movement_vs_friction", "scenic_transit_vs_destination_time"],
+          "affected_hybrid_factors": ["route_modes"],
+          "sequence": 1,
+          "confidence_hint": 0.84,
+          "salience_hint": 0.9,
+          "note": "Traveler wants the route itself to be a major part of the trip."
+        },
+        {
+          "id": "scenic-rail-nomad-ev-2",
+          "evidence_type": "option_selection",
+          "source_type": "option_menu",
+          "affected_dimensions": ["route_coherence_vs_eclectic_contrast"],
+          "affected_hybrid_factors": ["route_modes"],
+          "sequence": 2,
+          "confidence_hint": 0.88,
+          "salience_hint": 0.82,
+          "note": "Selected a coherent rail chain instead of a cheaper disconnected flight package.",
+          "option_evidence": {
+            "option_set_id": "rail-route-options",
+            "option_id": "rail-corridor",
+            "option_kind": "mixed_bundle",
+            "presented_option_ids": ["rail-corridor", "flight-hopper", "car-loop"],
+            "comparison_label": "regional route bundle"
+          }
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "This traveler is not merely tolerant of movement; they actively want scenic transit and coherent overland flow.",
+        "dominant_dimensions": [
+          "movement_vs_friction",
+          "scenic_transit_vs_destination_time",
+          "route_coherence_vs_eclectic_contrast"
+        ],
+        "expected_tensions": [
+          "May accept more moves than average, but still benefits from route logic that avoids wasteful backtracking."
+        ],
+        "planning_implications": [
+          "Offer route bundles where the transit segments are a feature rather than a penalty.",
+          "Use flights only when they protect a materially better overland structure."
+        ]
+      }
+    },
+    {
+      "id": "urban-historian",
+      "fixture_kind": "archetype",
+      "summary": "Depth-oriented city traveler who values historic layers, museums, and urban walking more than broad destination coverage.",
+      "tags": ["history", "cities", "depth", "culture"],
+      "raw_inputs": {
+        "trip_brief": "I would rather spend five dense days in one great city than race through four capitals. I care about museums, neighborhoods, and historic texture.",
+        "stated_constraints": ["trip length around 21 days"],
+        "planning_style_notes": ["comfortable with transit-rich cities", "prefers a researched daily structure"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 21,
+          "traveler_party": "pair",
+          "season_window": ["April", "May"],
+          "trip_stage": "first_visit",
+          "regions_in_scope": ["Italy", "Austria", "Czech Republic"],
+          "special_themes": ["urban history", "museums", "historic neighborhoods"]
+        },
+        "anchors": {
+          "place_anchors": [
+            {
+              "type": "place",
+              "label": "Rome",
+              "strength": 0.95,
+              "flexibility": 0.1,
+              "notes": "Major anchor city."
+            }
+          ],
+          "experience_anchors": [
+            {
+              "type": "experience",
+              "label": "Museum and old-city days",
+              "strength": 0.82,
+              "flexibility": 0.3,
+              "notes": "Historic urban immersion matters more than countryside exposure."
+            }
+          ]
+        },
+        "tradeoff_dimensions": {
+          "movement_vs_friction": {
+            "value": 0.46,
+            "confidence": 0.7,
+            "salience": 0.68,
+            "stability": 0.72
+          },
+          "nature_vs_culture": {
+            "value": 0.86,
+            "confidence": 0.9,
+            "salience": 0.92,
+            "stability": 0.86
+          },
+          "structure_vs_elasticity": {
+            "value": -0.58,
+            "confidence": 0.72,
+            "salience": 0.74,
+            "stability": 0.78
+          },
+          "breadth_vs_depth": {
+            "value": 0.84,
+            "confidence": 0.9,
+            "salience": 0.94,
+            "stability": 0.88
+          },
+          "historic_vs_contemporary": {
+            "value": -0.88,
+            "confidence": 0.94,
+            "salience": 0.9,
+            "stability": 0.86
+          },
+          "iconic_vs_discovery": {
+            "value": -0.38,
+            "confidence": 0.68,
+            "salience": 0.58,
+            "stability": 0.64
+          }
+        },
+        "hybrid_factors": {
+          "food": {
+            "mode": "tradeoff",
+            "salience": 0.52,
+            "tradeoff_role": "cost",
+            "preferences": {
+              "destination_meals": 0.64
+            }
+          }
+        },
+        "interaction_rules": [
+          {
+            "id": "urban_historian_depth_x_history",
+            "dimensions": ["breadth_vs_depth", "historic_vs_contemporary"],
+            "activation": {
+              "all_of": [
+                {"dimension": "breadth_vs_depth", "min_value": 0.65},
+                {"dimension": "historic_vs_contemporary", "max_value": -0.6}
+              ]
+            },
+            "effect": {
+              "prioritize": ["longer stays in heritage-rich cities", "walkable districts", "museum clusters"]
+            },
+            "strength": 0.86,
+            "priority": 0.84
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "id": "urban-historian-ev-1",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": ["breadth_vs_depth", "nature_vs_culture", "historic_vs_contemporary"],
+          "sequence": 1,
+          "confidence_hint": 0.9,
+          "salience_hint": 0.94,
+          "note": "Traveler explicitly rejects fast multi-city hopping in favor of depth."
+        },
+        {
+          "id": "urban-historian-ev-2",
+          "evidence_type": "scenario_reaction",
+          "source_type": "scenario_prompt",
+          "affected_dimensions": ["structure_vs_elasticity"],
+          "sequence": 2,
+          "confidence_hint": 0.74,
+          "salience_hint": 0.7,
+          "note": "Traveler reacts positively to a museum district day with preselected targets."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "Depth and cultural-historic attention dominate this profile, so route sprawl should be penalized early.",
+        "dominant_dimensions": [
+          "breadth_vs_depth",
+          "nature_vs_culture",
+          "historic_vs_contemporary"
+        ],
+        "expected_tensions": [
+          "Iconic sites matter, but they are acceptable mainly when they fit a deeper urban immersion plan."
+        ],
+        "planning_implications": [
+          "Use fewer bases with denser local cultural menus.",
+          "Prefer neighborhood and museum clustering over broader regional coverage."
+        ]
+      }
+    },
+    {
+      "id": "food-splurger",
+      "fixture_kind": "archetype",
+      "summary": "Traveler with moderate overall budget discipline who will pay for standout meals and market experiences if the value is obvious.",
+      "tags": ["food", "budget", "value", "urban"],
+      "raw_inputs": {
+        "trip_brief": "I do not need luxury hotels, but I do want the option to spend real money on meals that feel special or locally important.",
+        "stated_constraints": ["trip length around 18 days"],
+        "planning_style_notes": ["wants side-by-side options to judge value", "likes mixing splurges with simpler days"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 18,
+          "traveler_party": "pair",
+          "season_window": ["March", "April"],
+          "trip_stage": "mixed",
+          "regions_in_scope": ["Mexico City", "Oaxaca", "Puebla"],
+          "special_themes": ["food", "markets", "restaurants"]
+        },
+        "budget_model": {
+          "total_budget_sensitivity": 0.58,
+          "spending_priorities": {
+            "food": 0.94,
+            "lodging_location": 0.62,
+            "transport_simplicity": 0.56
+          },
+          "quality_floors": {
+            "lodging": "clean, central, and quiet"
+          },
+          "splurge_allowed": true,
+          "splurge_style": "selectively splurge on destination-defining meals and cooking experiences"
+        },
+        "tradeoff_dimensions": {
+          "nature_vs_culture": {
+            "value": 0.62,
+            "confidence": 0.7,
+            "salience": 0.62,
+            "stability": 0.68
+          },
+          "structure_vs_elasticity": {
+            "value": -0.14,
+            "confidence": 0.56,
+            "salience": 0.5,
+            "stability": 0.44
+          },
+          "scenic_transit_vs_destination_time": {
+            "value": 0.42,
+            "confidence": 0.66,
+            "salience": 0.58,
+            "stability": 0.6
+          },
+          "iconic_vs_discovery": {
+            "value": 0.24,
+            "confidence": 0.58,
+            "salience": 0.5,
+            "stability": 0.42
+          }
+        },
+        "hybrid_factors": {
+          "food": {
+            "mode": "both",
+            "salience": 0.96,
+            "anchor_strength": 0.72,
+            "tradeoff_role": "cost",
+            "notes": "Food is a planning driver rather than just a supporting factor.",
+            "preferences": {
+              "fine_dining": 0.82,
+              "markets": 0.88,
+              "casual_local": 0.76
+            }
+          },
+          "rest": {
+            "mode": "tradeoff",
+            "salience": 0.4,
+            "tradeoff_role": "rhythm",
+            "preferences": {
+              "late_start_days": 0.52
+            }
+          }
+        },
+        "anchors": {
+          "experience_anchors": [
+            {
+              "type": "experience",
+              "label": "Destination-defining meals",
+              "strength": 0.78,
+              "flexibility": 0.42,
+              "notes": "Not every dinner, but some meals should be major events."
+            }
+          ]
+        }
+      },
+      "evidence": [
+        {
+          "id": "food-splurger-ev-1",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_hybrid_factors": ["food"],
+          "sequence": 1,
+          "confidence_hint": 0.88,
+          "salience_hint": 0.94,
+          "note": "Traveler frames food as a major reason for choosing destinations."
+        },
+        {
+          "id": "food-splurger-ev-2",
+          "evidence_type": "scenario_reaction",
+          "source_type": "scenario_prompt",
+          "affected_hybrid_factors": ["food"],
+          "affected_dimensions": ["scenic_transit_vs_destination_time"],
+          "sequence": 2,
+          "confidence_hint": 0.78,
+          "salience_hint": 0.76,
+          "note": "Traveler chooses shorter transit and higher meal budget over a scenic detour."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "Food is one of the few elements that can override otherwise moderate budget discipline.",
+        "dominant_dimensions": [
+          "scenic_transit_vs_destination_time"
+        ],
+        "expected_tensions": [
+          "The planner should protect food-value opportunities without silently upgrading lodging or transit across the board."
+        ],
+        "planning_implications": [
+          "Present 2-3 concrete restaurant and food-experience options to calibrate revealed value preference.",
+          "Protect splurge budget for meals while keeping other categories disciplined."
+        ]
+      }
+    },
+    {
+      "id": "discovery-wanderer",
+      "fixture_kind": "archetype",
+      "summary": "Traveler who values exploratory wandering, contemporary life, and locally textured discovery over heavily curated landmark lists.",
+      "tags": ["discovery", "wandering", "contemporary", "elastic"],
+      "raw_inputs": {
+        "trip_brief": "I like neighborhoods where I can walk with only a loose direction and keep stumbling into places that look interesting.",
+        "stated_constraints": ["trip length around 24 days"],
+        "planning_style_notes": ["does not want every day tightly scripted", "still benefits from strong wandering zones"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 24,
+          "traveler_party": "solo",
+          "season_window": ["October"],
+          "trip_stage": "mixed",
+          "regions_in_scope": ["Taiwan", "Japan"],
+          "special_themes": ["street life", "wandering", "contemporary neighborhoods"]
+        },
+        "tradeoff_dimensions": {
+          "structure_vs_elasticity": {
+            "value": 0.86,
+            "confidence": 0.88,
+            "salience": 0.92,
+            "stability": 0.82
+          },
+          "breadth_vs_depth": {
+            "value": 0.26,
+            "confidence": 0.56,
+            "salience": 0.5,
+            "stability": 0.42
+          },
+          "historic_vs_contemporary": {
+            "value": 0.68,
+            "confidence": 0.76,
+            "salience": 0.72,
+            "stability": 0.7
+          },
+          "social_energy_vs_solitude": {
+            "value": 0.42,
+            "confidence": 0.68,
+            "salience": 0.58,
+            "stability": 0.6
+          },
+          "iconic_vs_discovery": {
+            "value": 0.88,
+            "confidence": 0.92,
+            "salience": 0.94,
+            "stability": 0.86
+          },
+          "route_coherence_vs_eclectic_contrast": {
+            "value": 0.34,
+            "confidence": 0.56,
+            "salience": 0.48,
+            "stability": 0.44
+          }
+        },
+        "hybrid_factors": {
+          "music": {
+            "mode": "tradeoff",
+            "salience": 0.38,
+            "tradeoff_role": "atmosphere",
+            "preferences": {
+              "small_venues": 0.58
+            }
+          },
+          "rest": {
+            "mode": "tradeoff",
+            "salience": 0.52,
+            "tradeoff_role": "rhythm",
+            "preferences": {
+              "open_afternoons": 0.68
+            }
+          }
+        },
+        "anchors": {
+          "experience_anchors": [
+            {
+              "type": "experience",
+              "label": "Strong wandering districts",
+              "strength": 0.72,
+              "flexibility": 0.46,
+              "notes": "The planner should suggest places to wander toward rather than only fixed bookings."
+            }
+          ]
+        }
+      },
+      "evidence": [
+        {
+          "id": "discovery-wanderer-ev-1",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": ["structure_vs_elasticity", "iconic_vs_discovery", "historic_vs_contemporary"],
+          "sequence": 1,
+          "confidence_hint": 0.9,
+          "salience_hint": 0.92,
+          "note": "Traveler asks for neighborhoods and streets, not a checklist of sights."
+        },
+        {
+          "id": "discovery-wanderer-ev-2",
+          "evidence_type": "scenario_reaction",
+          "source_type": "scenario_prompt",
+          "affected_dimensions": ["social_energy_vs_solitude"],
+          "sequence": 2,
+          "confidence_hint": 0.62,
+          "salience_hint": 0.52,
+          "note": "Traveler likes lively streets but still wants solo movement freedom."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "This profile needs strong discovery scaffolding without heavy over-structuring.",
+        "dominant_dimensions": [
+          "structure_vs_elasticity",
+          "historic_vs_contemporary",
+          "iconic_vs_discovery"
+        ],
+        "expected_tensions": [
+          "The traveler still needs some directional guidance so wandering does not become aimless or low-value."
+        ],
+        "planning_implications": [
+          "Surface wandering zones, neighborhoods, and loose thematic routes.",
+          "Avoid turning every day into a reservation-driven plan."
+        ]
+      }
+    },
+    {
+      "id": "social-recovery-balancer",
+      "fixture_kind": "archetype",
+      "summary": "Traveler who enjoys lively atmospheres and social contact but burns out if every day is packed or every night is late.",
+      "tags": ["social", "recovery", "rhythm", "cities"],
+      "raw_inputs": {
+        "trip_brief": "I like cafes, bars, street life, and a sense that things are happening, but I hit a wall if the trip is intense every day.",
+        "stated_constraints": ["trip length around 16 days"],
+        "planning_style_notes": ["wants recovery blocks built into the trip", "likes a social environment more than a nonstop schedule"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 16,
+          "traveler_party": "friends",
+          "season_window": ["May"],
+          "trip_stage": "mixed",
+          "regions_in_scope": ["Spain", "Portugal"],
+          "special_themes": ["street life", "food", "night atmosphere"]
+        },
+        "tradeoff_dimensions": {
+          "recovery_vs_intensity": {
+            "value": -0.82,
+            "confidence": 0.9,
+            "salience": 0.94,
+            "stability": 0.86
+          },
+          "structure_vs_elasticity": {
+            "value": 0.22,
+            "confidence": 0.58,
+            "salience": 0.54,
+            "stability": 0.44
+          },
+          "social_energy_vs_solitude": {
+            "value": -0.74,
+            "confidence": 0.86,
+            "salience": 0.92,
+            "stability": 0.84
+          }
+        },
+        "hybrid_factors": {
+          "rest": {
+            "mode": "both",
+            "salience": 0.88,
+            "anchor_strength": 0.54,
+            "tradeoff_role": "rhythm",
+            "preferences": {
+              "slow_mornings_after_late_nights": 0.84,
+              "low_commitment_days": 0.72
+            }
+          },
+          "food": {
+            "mode": "tradeoff",
+            "salience": 0.48,
+            "tradeoff_role": "cost",
+            "preferences": {
+              "social_dining": 0.58
+            }
+          }
+        },
+        "interaction_rules": [
+          {
+            "id": "social_x_recovery_guardrail",
+            "dimensions": ["social_energy_vs_solitude", "recovery_vs_intensity"],
+            "activation": {
+              "all_of": [
+                {"dimension": "social_energy_vs_solitude", "max_value": -0.55},
+                {"dimension": "recovery_vs_intensity", "max_value": -0.55}
+              ]
+            },
+            "effect": {
+              "prioritize": ["late/early rhythm balancing", "restorative base days"],
+              "avoid": ["stacking demanding nights back to back"]
+            },
+            "strength": 0.92,
+            "priority": 0.9
+          }
+        ],
+        "tension_flags": [
+          {
+            "id": "social-energy-recovery-conflict",
+            "severity": 0.78,
+            "description": "Traveler wants lively environments but needs rhythm-protective recovery blocks."
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "id": "social-recovery-balancer-ev-1",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": ["social_energy_vs_solitude", "recovery_vs_intensity"],
+          "affected_hybrid_factors": ["rest"],
+          "sequence": 1,
+          "confidence_hint": 0.9,
+          "salience_hint": 0.94,
+          "note": "Traveler wants street energy but explicitly describes burnout risk."
+        },
+        {
+          "id": "social-recovery-balancer-ev-2",
+          "evidence_type": "trip_revision",
+          "source_type": "trip_revision",
+          "affected_hybrid_factors": ["rest"],
+          "sequence": 2,
+          "confidence_hint": 0.76,
+          "salience_hint": 0.82,
+          "note": "Traveler asks to remove one packed evening after seeing the draft."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "The planner should not misread social appetite as intensity tolerance.",
+        "dominant_dimensions": [
+          "recovery_vs_intensity",
+          "social_energy_vs_solitude"
+        ],
+        "expected_tensions": [
+          "High-social-energy days need explicit recovery design, not just optimistic pacing."
+        ],
+        "planning_implications": [
+          "Protect easy mornings, flexible afternoons, or lighter transfer days after big social blocks.",
+          "Prefer places with ambient social life over plans that require constant high-energy participation."
+        ]
+      }
+    },
+    {
+      "id": "comfort-floor-traveler",
+      "fixture_kind": "archetype",
+      "summary": "Traveler with a meaningful comfort floor who still wants real exploration, but not at the cost of sleep, safety, or booking simplicity.",
+      "tags": ["comfort", "lodging", "convenience", "quality"],
+      "raw_inputs": {
+        "trip_brief": "I do not need luxury for its own sake, but I do need a quiet, clean room, easy arrivals, and logistics that do not feel chaotic.",
+        "stated_constraints": ["trip length around 14 days"],
+        "planning_style_notes": ["willing to pay for smoother logistics", "does not want heroic transfers"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 14,
+          "traveler_party": "pair",
+          "season_window": ["June"],
+          "trip_stage": "repeat_visit",
+          "regions_in_scope": ["United Kingdom"],
+          "special_themes": ["comfortable city breaks", "walkable bases"]
+        },
+        "budget_model": {
+          "total_budget_sensitivity": 0.52,
+          "spending_priorities": {
+            "lodging_quality": 0.82,
+            "transport_simplicity": 0.74
+          },
+          "quality_floors": {
+            "lodging": "quiet private room in a central area",
+            "transfer_reliability": "avoid risky late-night arrivals"
+          },
+          "splurge_allowed": true,
+          "splurge_style": "spend to avoid disruption and poor sleep"
+        },
+        "anchors": {
+          "quality_floor_anchors": [
+            {
+              "type": "quality_floor",
+              "label": "Quiet central lodging",
+              "strength": 0.88,
+              "flexibility": 0.2,
+              "notes": "A poor room can drag down the whole trip."
+            }
+          ]
+        },
+        "tradeoff_dimensions": {
+          "movement_vs_friction": {
+            "value": 0.62,
+            "confidence": 0.76,
+            "salience": 0.72,
+            "stability": 0.8
+          },
+          "recovery_vs_intensity": {
+            "value": -0.42,
+            "confidence": 0.68,
+            "salience": 0.66,
+            "stability": 0.74
+          },
+          "self_reliance_vs_convenience": {
+            "value": 0.86,
+            "confidence": 0.92,
+            "salience": 0.94,
+            "stability": 0.88
+          },
+          "route_coherence_vs_eclectic_contrast": {
+            "value": -0.36,
+            "confidence": 0.58,
+            "salience": 0.54,
+            "stability": 0.66
+          }
+        },
+        "interaction_rules": [
+          {
+            "id": "comfort_floor_budget_guardrail",
+            "dimensions": ["self_reliance_vs_convenience"],
+            "activation": {
+              "all_of": [
+                {"dimension": "self_reliance_vs_convenience", "min_value": 0.7}
+              ]
+            },
+            "effect": {
+              "enforce_quality_floors": ["lodging", "transfer_reliability"]
+            },
+            "strength": 0.84,
+            "priority": 0.86
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "id": "comfort-floor-traveler-ev-1",
+          "evidence_type": "hard_constraint_declaration",
+          "source_type": "structured_input",
+          "anchor_groups": ["quality_floor_anchors"],
+          "sequence": 1,
+          "confidence_hint": 0.92,
+          "salience_hint": 0.92,
+          "note": "Traveler sets a hard lodging quality floor."
+        },
+        {
+          "id": "comfort-floor-traveler-ev-2",
+          "evidence_type": "option_selection",
+          "source_type": "option_menu",
+          "affected_dimensions": ["self_reliance_vs_convenience"],
+          "sequence": 2,
+          "confidence_hint": 0.82,
+          "salience_hint": 0.86,
+          "note": "Traveler chooses a smoother but slightly more expensive transfer package.",
+          "option_evidence": {
+            "option_set_id": "arrival-options",
+            "option_id": "direct-transfer",
+            "option_kind": "transport",
+            "presented_option_ids": ["direct-transfer", "late-connection", "budget-bus"],
+            "comparison_label": "arrival transfer options"
+          }
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "This traveler needs the planner to respect comfort floors as real constraints rather than optional upgrades.",
+        "dominant_dimensions": [
+          "self_reliance_vs_convenience",
+          "movement_vs_friction"
+        ],
+        "expected_tensions": [
+          "Budget discipline still matters, but not enough to justify noisy or fragile logistics."
+        ],
+        "planning_implications": [
+          "Carry quality-floor checks into option filtering before ranking.",
+          "Offer a narrower but cleaner option set rather than a long list of false economy choices."
+        ]
+      }
+    },
+    {
+      "id": "route-coherence-first",
+      "fixture_kind": "archetype",
+      "summary": "Traveler who strongly prefers route logic and geographic coherence over eclectic contrast, even when multiple regions look attractive on paper.",
+      "tags": ["route", "coherence", "planning", "transport"],
+      "raw_inputs": {
+        "trip_brief": "I dislike trips that bounce around just because individual cities are interesting. I want the route to make sense on a map.",
+        "stated_constraints": ["trip length around 20 days"],
+        "planning_style_notes": ["cares about map logic", "happy to skip good places that break the route"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 20,
+          "traveler_party": "solo",
+          "season_window": ["September"],
+          "trip_stage": "first_visit",
+          "regions_in_scope": ["Argentina", "Uruguay"],
+          "special_themes": ["route logic", "regional progression"]
+        },
+        "anchors": {
+          "regional_adjacency_preferences": [
+            {
+              "type": "adjacency",
+              "label": "Contiguous regional progression",
+              "strength": 0.86,
+              "flexibility": 0.24,
+              "notes": "Avoids scattershot route shapes."
+            }
+          ]
+        },
+        "tradeoff_dimensions": {
+          "movement_vs_friction": {
+            "value": -0.26,
+            "confidence": 0.56,
+            "salience": 0.5,
+            "stability": 0.58
+          },
+          "route_coherence_vs_eclectic_contrast": {
+            "value": -0.92,
+            "confidence": 0.94,
+            "salience": 0.96,
+            "stability": 0.9
+          },
+          "scenic_transit_vs_destination_time": {
+            "value": -0.22,
+            "confidence": 0.52,
+            "salience": 0.46,
+            "stability": 0.52
+          }
+        }
+      },
+      "evidence": [
+        {
+          "id": "route-coherence-first-ev-1",
+          "evidence_type": "anchor_declaration",
+          "source_type": "structured_input",
+          "anchor_groups": ["regional_adjacency_preferences"],
+          "sequence": 1,
+          "confidence_hint": 0.92,
+          "salience_hint": 0.94,
+          "note": "Traveler names geographic coherence as a trip-defining rule."
+        },
+        {
+          "id": "route-coherence-first-ev-2",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": ["route_coherence_vs_eclectic_contrast"],
+          "sequence": 2,
+          "confidence_hint": 0.92,
+          "salience_hint": 0.94,
+          "note": "Traveler explicitly cares about geographic logic."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "This profile should bias toward elegant routes with fewer discontinuities, even if the candidate list becomes narrower.",
+        "dominant_dimensions": [
+          "route_coherence_vs_eclectic_contrast"
+        ],
+        "expected_tensions": [
+          "May give up individually attractive destinations to preserve route quality."
+        ],
+        "planning_implications": [
+          "Score route shape early instead of only ranking destinations independently.",
+          "Use adjacency and backtracking penalties aggressively."
+        ]
+      }
+    },
+    {
+      "id": "breadth-under-recovery-pressure",
+      "fixture_kind": "tension_case",
+      "summary": "Traveler wants to see a lot over a limited window but also knows they fatigue quickly when transfers and busy days pile up.",
+      "tags": ["tension", "breadth", "recovery", "pace"],
+      "raw_inputs": {
+        "trip_brief": "I want to cover a lot because I may not be back soon, but I also do badly when every few days are packed and I need time to reset.",
+        "stated_constraints": ["trip length around 19 days"],
+        "planning_style_notes": ["anxious about missing out", "wants pacing help"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 19,
+          "traveler_party": "solo",
+          "season_window": ["November"],
+          "trip_stage": "first_visit",
+          "regions_in_scope": ["Vietnam"],
+          "special_themes": ["first long independent trip", "fear of missing out"]
+        },
+        "tradeoff_dimensions": {
+          "recovery_vs_intensity": {
+            "value": -0.76,
+            "confidence": 0.84,
+            "salience": 0.92,
+            "stability": 0.74
+          },
+          "breadth_vs_depth": {
+            "value": -0.82,
+            "confidence": 0.86,
+            "salience": 0.94,
+            "stability": 0.64
+          },
+          "movement_vs_friction": {
+            "value": -0.18,
+            "confidence": 0.54,
+            "salience": 0.66,
+            "stability": 0.42
+          }
+        },
+        "interaction_rules": [
+          {
+            "id": "breadth_x_recovery_tradeoff",
+            "dimensions": ["breadth_vs_depth", "recovery_vs_intensity"],
+            "activation": {
+              "all_of": [
+                {"dimension": "breadth_vs_depth", "max_value": -0.6},
+                {"dimension": "recovery_vs_intensity", "max_value": -0.6}
+              ]
+            },
+            "effect": {
+              "prioritize": ["clustered breadth", "fewer lodging changes", "intentional buffer days"]
+            },
+            "strength": 0.94,
+            "priority": 0.94
+          }
+        ],
+        "tension_flags": [
+          {
+            "id": "breadth-recovery-conflict",
+            "severity": 0.9,
+            "description": "Traveler wants coverage that exceeds their sustainable pace without route discipline."
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "id": "breadth-under-recovery-pressure-ev-1",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": ["breadth_vs_depth", "recovery_vs_intensity"],
+          "sequence": 1,
+          "confidence_hint": 0.9,
+          "salience_hint": 0.94,
+          "note": "Traveler describes strong FOMO alongside a need for reset time."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "The engine should not average these values into a mushy middle; it should surface a genuine pacing tension.",
+        "dominant_dimensions": [
+          "breadth_vs_depth",
+          "recovery_vs_intensity"
+        ],
+        "expected_tensions": [
+          "Breadth desires are real, but route clustering and recovery blocks are mandatory."
+        ],
+        "planning_implications": [
+          "Offer clustered variants that trade breadth against move density transparently.",
+          "Make the opportunity cost of extra stops explicit."
+        ]
+      }
+    },
+    {
+      "id": "elastic-discovery-with-fixed-anchors",
+      "fixture_kind": "tension_case",
+      "summary": "Traveler wants open-ended discovery but has enough fixed places and calendar anchors that the trip cannot simply drift.",
+      "tags": ["tension", "anchors", "elasticity", "discovery"],
+      "raw_inputs": {
+        "trip_brief": "I want the trip to feel open and exploratory, but I also know there are a few places and events I really do not want to miss.",
+        "stated_constraints": ["trip length around 22 days"],
+        "planning_style_notes": ["likes flexibility", "still committed to several specific stops"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 22,
+          "traveler_party": "pair",
+          "season_window": ["October"],
+          "trip_stage": "mixed",
+          "regions_in_scope": ["Turkey"],
+          "special_themes": ["wandering", "anchor cities", "festival dates"]
+        },
+        "hard_constraints": {
+          "must_include_places": ["Istanbul", "Cappadocia"],
+          "must_protect_experiences": ["concert in Istanbul"]
+        },
+        "anchors": {
+          "place_anchors": [
+            {
+              "type": "place",
+              "label": "Istanbul",
+              "strength": 0.96,
+              "flexibility": 0.08,
+              "notes": "Non-negotiable anchor."
+            },
+            {
+              "type": "place",
+              "label": "Cappadocia",
+              "strength": 0.84,
+              "flexibility": 0.18,
+              "notes": "Important anchor but timing is somewhat flexible."
+            }
+          ],
+          "calendar_anchors": [
+            {
+              "type": "calendar",
+              "label": "Istanbul concert date",
+              "strength": 0.98,
+              "flexibility": 0.02,
+              "notes": "Fixed calendar event."
+            }
+          ]
+        },
+        "tradeoff_dimensions": {
+          "structure_vs_elasticity": {
+            "value": 0.72,
+            "confidence": 0.82,
+            "salience": 0.88,
+            "stability": 0.62
+          },
+          "iconic_vs_discovery": {
+            "value": 0.74,
+            "confidence": 0.78,
+            "salience": 0.82,
+            "stability": 0.6
+          }
+        },
+        "tension_flags": [
+          {
+            "id": "elasticity-anchor-conflict",
+            "severity": 0.82,
+            "description": "Traveler wants flexible discovery inside a trip that has several immovable anchor commitments."
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "id": "elastic-discovery-with-fixed-anchors-ev-1",
+          "evidence_type": "anchor_declaration",
+          "source_type": "structured_input",
+          "anchor_groups": ["place_anchors", "calendar_anchors"],
+          "sequence": 1,
+          "confidence_hint": 0.96,
+          "salience_hint": 0.96,
+          "note": "Traveler names specific cities and a fixed event date."
+        },
+        {
+          "id": "elastic-discovery-with-fixed-anchors-ev-2",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": ["structure_vs_elasticity", "iconic_vs_discovery"],
+          "sequence": 2,
+          "confidence_hint": 0.82,
+          "salience_hint": 0.84,
+          "note": "Traveler still wants much of the trip to feel unstructured and exploratory."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "The planner should preserve elasticity in the spaces between anchors, not pretend the trip can stay fully open-ended.",
+        "dominant_dimensions": [
+          "structure_vs_elasticity",
+          "iconic_vs_discovery"
+        ],
+        "expected_tensions": [
+          "Discovery remains important, but anchor commitments should shape the route skeleton first."
+        ],
+        "planning_implications": [
+          "Build around fixed anchors, then allocate elastic days and wandering zones around them.",
+          "Do not oversell full spontaneity where calendar commitments make it impossible."
+        ]
+      }
+    },
+    {
+      "id": "quality-floors-under-budget-pressure",
+      "fixture_kind": "tension_case",
+      "summary": "Traveler has strict lodging and comfort minimums but also a real budget ceiling that makes those standards costly to maintain everywhere.",
+      "tags": ["tension", "budget", "quality", "lodging"],
+      "raw_inputs": {
+        "trip_brief": "I cannot do bad rooms, chaotic late arrivals, or very poor locations, but I also do not have the budget to do that perfectly in every stop.",
+        "stated_constraints": ["trip length around 17 days", "budget ceiling matters"],
+        "planning_style_notes": ["wants realistic tradeoffs surfaced early", "prefers fewer better bases over many weak ones"]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 17,
+          "traveler_party": "pair",
+          "season_window": ["July"],
+          "trip_stage": "mixed",
+          "regions_in_scope": ["France"],
+          "special_themes": ["city and countryside mix", "lodging tradeoffs"]
+        },
+        "hard_constraints": {
+          "budget_ceiling": 5200.0
+        },
+        "budget_model": {
+          "total_budget_sensitivity": 0.78,
+          "spending_priorities": {
+            "lodging_quality": 0.9,
+            "lodging_location": 0.8
+          },
+          "quality_floors": {
+            "lodging": "quiet private room within practical distance of core sights"
+          },
+          "splurge_allowed": false
+        },
+        "anchors": {
+          "quality_floor_anchors": [
+            {
+              "type": "quality_floor",
+              "label": "Quiet and well-located lodging",
+              "strength": 0.94,
+              "flexibility": 0.12,
+              "notes": "Comfort floor is strong, but budget is not loose."
+            }
+          ]
+        },
+        "tradeoff_dimensions": {
+          "self_reliance_vs_convenience": {
+            "value": 0.54,
+            "confidence": 0.68,
+            "salience": 0.66,
+            "stability": 0.72
+          }
+        },
+        "tension_flags": [
+          {
+            "id": "quality-floor-budget-conflict",
+            "severity": 0.9,
+            "description": "Quality floors and budget ceiling pull against each other, especially in expensive hubs."
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "id": "quality-floors-under-budget-pressure-ev-1",
+          "evidence_type": "hard_constraint_declaration",
+          "source_type": "structured_input",
+          "anchor_groups": ["quality_floor_anchors"],
+          "sequence": 1,
+          "confidence_hint": 0.94,
+          "salience_hint": 0.94,
+          "note": "Traveler sets firm lodging minimums."
+        },
+        {
+          "id": "quality-floors-under-budget-pressure-ev-2",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": ["self_reliance_vs_convenience"],
+          "sequence": 2,
+          "confidence_hint": 0.62,
+          "salience_hint": 0.58,
+          "note": "Traveler can accept some convenience tradeoffs, but not full comfort collapse."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "The planner should convert this into route and lodging strategy decisions, not pretend everything can stay high-quality everywhere.",
+        "dominant_dimensions": [
+          "self_reliance_vs_convenience"
+        ],
+        "expected_tensions": [
+          "Quality floors are real, but route breadth or top-season timing may need to contract to preserve them."
+        ],
+        "planning_implications": [
+          "Offer fewer-base and shoulder-value scenarios rather than simply cheaper downgraded rooms.",
+          "Show quality tradeoffs explicitly when the budget ceiling binds."
+        ]
+      }
+    }
+  ]
+}

--- a/tests/preferences/fixture_corpus.py
+++ b/tests/preferences/fixture_corpus.py
@@ -28,6 +28,7 @@ from trip_planner.preferences.models import (
 from trip_planner.preferences.schema import (
     ANCHOR_GROUPS,
     HYBRID_FACTOR_KEYS,
+    SCHEMA_VERSION,
     TRADEOFF_DIMENSION_KEYS,
 )
 
@@ -61,12 +62,20 @@ def fixture_corpus_path() -> Path:
     )
 
 
-def load_fixture_corpus() -> list[TravelerFixture]:
-    payload = json.loads(fixture_corpus_path().read_text())
+def load_fixture_corpus(path: Path | None = None) -> list[TravelerFixture]:
+    payload = json.loads((path or fixture_corpus_path()).read_text(encoding="utf-8"))
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(
+            "fixture corpus schema_version must match trip_planner.preferences.schema.SCHEMA_VERSION"
+        )
     fixtures = payload.get("fixtures", [])
     if not isinstance(fixtures, list):
         raise ValueError("fixtures must be a list")
-    return [_build_fixture(entry) for entry in fixtures]
+    fixture_objects = [_build_fixture(entry) for entry in fixtures]
+    fixture_ids = [fixture.id for fixture in fixture_objects]
+    if len(set(fixture_ids)) != len(fixture_ids):
+        raise ValueError("fixture corpus ids must be unique")
+    return fixture_objects
 
 
 def load_fixture_map() -> dict[str, TravelerFixture]:
@@ -77,6 +86,11 @@ def _build_fixture(payload: dict[str, Any]) -> TravelerFixture:
     intended = payload.get("intended_interpretation", {})
     profile = build_profile_from_overrides(payload.get("profile_overrides", {}))
     evidence = [build_evidence_record(item) for item in payload.get("evidence", [])]
+    if not intended.get("qualitative_summary"):
+        raise ValueError(
+            f"fixture {payload.get('id', '<unknown>')!r} must define intended_interpretation."
+            "qualitative_summary"
+        )
     return TravelerFixture(
         id=payload["id"],
         fixture_kind=payload["fixture_kind"],

--- a/tests/preferences/fixture_corpus.py
+++ b/tests/preferences/fixture_corpus.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from trip_planner.preferences.evidence import (
+    ContradictionMarker,
+    OptionEvidence,
+    PreferenceEvidence,
+)
+from trip_planner.preferences.models import (
+    Anchor,
+    BudgetModel,
+    DateWindow,
+    DurationBounds,
+    EvidenceSummary,
+    HardConstraints,
+    HybridFactor,
+    InteractionRule,
+    LeisurePreferenceProfile,
+    TensionFlag,
+    TradeoffDimension,
+    TripFrame,
+)
+from trip_planner.preferences.schema import (
+    ANCHOR_GROUPS,
+    HYBRID_FACTOR_KEYS,
+    TRADEOFF_DIMENSION_KEYS,
+)
+
+
+@dataclass(slots=True)
+class IntendedInterpretation:
+    qualitative_summary: str
+    dominant_dimensions: list[str]
+    expected_tensions: list[str]
+    planning_implications: list[str]
+
+
+@dataclass(slots=True)
+class TravelerFixture:
+    id: str
+    fixture_kind: str
+    summary: str
+    tags: list[str]
+    raw_inputs: dict[str, Any]
+    intended_interpretation: IntendedInterpretation
+    profile: LeisurePreferenceProfile
+    evidence: list[PreferenceEvidence]
+
+
+def fixture_corpus_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "preferences"
+        / "leisure_traveler_corpus.json"
+    )
+
+
+def load_fixture_corpus() -> list[TravelerFixture]:
+    payload = json.loads(fixture_corpus_path().read_text())
+    fixtures = payload.get("fixtures", [])
+    if not isinstance(fixtures, list):
+        raise ValueError("fixtures must be a list")
+    return [_build_fixture(entry) for entry in fixtures]
+
+
+def load_fixture_map() -> dict[str, TravelerFixture]:
+    return {fixture.id: fixture for fixture in load_fixture_corpus()}
+
+
+def _build_fixture(payload: dict[str, Any]) -> TravelerFixture:
+    intended = payload.get("intended_interpretation", {})
+    profile = build_profile_from_overrides(payload.get("profile_overrides", {}))
+    evidence = [build_evidence_record(item) for item in payload.get("evidence", [])]
+    return TravelerFixture(
+        id=payload["id"],
+        fixture_kind=payload["fixture_kind"],
+        summary=payload["summary"],
+        tags=list(payload.get("tags", [])),
+        raw_inputs=dict(payload.get("raw_inputs", {})),
+        intended_interpretation=IntendedInterpretation(
+            qualitative_summary=intended["qualitative_summary"],
+            dominant_dimensions=list(intended.get("dominant_dimensions", [])),
+            expected_tensions=list(intended.get("expected_tensions", [])),
+            planning_implications=list(intended.get("planning_implications", [])),
+        ),
+        profile=profile,
+        evidence=evidence,
+    )
+
+
+def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreferenceProfile:
+    profile_payload = _default_profile_payload()
+
+    trip_frame_overrides = overrides.get("trip_frame", {})
+    profile_payload["trip_frame"] = {**profile_payload["trip_frame"], **trip_frame_overrides}
+
+    hard_constraint_overrides = overrides.get("hard_constraints", {})
+    date_window = {
+        **profile_payload["hard_constraints"]["date_window"],
+        **hard_constraint_overrides.get("date_window", {}),
+    }
+    duration_bounds = {
+        **profile_payload["hard_constraints"]["duration_bounds"],
+        **hard_constraint_overrides.get("duration_bounds", {}),
+    }
+    merged_constraints = {
+        **profile_payload["hard_constraints"],
+        **hard_constraint_overrides,
+        "date_window": date_window,
+        "duration_bounds": duration_bounds,
+    }
+    profile_payload["hard_constraints"] = merged_constraints
+
+    budget_overrides = overrides.get("budget_model", {})
+    profile_payload["budget_model"] = {**profile_payload["budget_model"], **budget_overrides}
+
+    for key, values in overrides.get("tradeoff_dimensions", {}).items():
+        if key not in profile_payload["tradeoff_dimensions"]:
+            raise ValueError(f"unsupported tradeoff dimension override: {key}")
+        profile_payload["tradeoff_dimensions"][key] = {
+            **profile_payload["tradeoff_dimensions"][key],
+            **values,
+        }
+
+    for key, values in overrides.get("hybrid_factors", {}).items():
+        if key not in profile_payload["hybrid_factors"]:
+            raise ValueError(f"unsupported hybrid factor override: {key}")
+        profile_payload["hybrid_factors"][key] = {
+            **profile_payload["hybrid_factors"][key],
+            **values,
+        }
+
+    anchor_overrides = overrides.get("anchors", {})
+    for group, values in anchor_overrides.items():
+        if group not in profile_payload["anchors"]:
+            raise ValueError(f"unsupported anchor group override: {group}")
+        profile_payload["anchors"][group] = list(values)
+
+    for key in ("interaction_rules", "tension_flags", "conditional_overrides"):
+        if key in overrides:
+            profile_payload[key] = deepcopy(overrides[key])
+    if "evidence_summary" in overrides:
+        profile_payload["evidence_summary"] = {
+            **profile_payload["evidence_summary"],
+            **overrides["evidence_summary"],
+        }
+
+    return LeisurePreferenceProfile(
+        trip_frame=TripFrame(**profile_payload["trip_frame"]),
+        hard_constraints=HardConstraints(
+            date_window=DateWindow(**profile_payload["hard_constraints"]["date_window"]),
+            duration_bounds=DurationBounds(
+                **profile_payload["hard_constraints"]["duration_bounds"]
+            ),
+            budget_ceiling=profile_payload["hard_constraints"].get("budget_ceiling"),
+            must_include_places=list(
+                profile_payload["hard_constraints"].get("must_include_places", [])
+            ),
+            must_protect_experiences=list(
+                profile_payload["hard_constraints"].get("must_protect_experiences", [])
+            ),
+            mobility_constraints=list(
+                profile_payload["hard_constraints"].get("mobility_constraints", [])
+            ),
+            lodging_constraints=list(
+                profile_payload["hard_constraints"].get("lodging_constraints", [])
+            ),
+            visa_border_constraints=list(
+                profile_payload["hard_constraints"].get("visa_border_constraints", [])
+            ),
+        ),
+        anchors={
+            group: [Anchor(**anchor) for anchor in anchors]
+            for group, anchors in profile_payload["anchors"].items()
+        },
+        budget_model=BudgetModel(**profile_payload["budget_model"]),
+        tradeoff_dimensions={
+            key: TradeoffDimension(**values)
+            for key, values in profile_payload["tradeoff_dimensions"].items()
+        },
+        hybrid_factors={
+            key: HybridFactor(**values) for key, values in profile_payload["hybrid_factors"].items()
+        },
+        conditional_overrides=list(profile_payload["conditional_overrides"]),
+        interaction_rules=[
+            InteractionRule(**rule) for rule in profile_payload["interaction_rules"]
+        ],
+        tension_flags=[TensionFlag(**flag) for flag in profile_payload["tension_flags"]],
+        evidence_summary=EvidenceSummary(**profile_payload["evidence_summary"]),
+    )
+
+
+def build_evidence_record(payload: dict[str, Any]) -> PreferenceEvidence:
+    option_evidence = payload.get("option_evidence")
+    contradictions = payload.get("contradictions", [])
+    return PreferenceEvidence(
+        id=payload["id"],
+        evidence_type=payload["evidence_type"],
+        source_type=payload["source_type"],
+        affected_dimensions=list(payload.get("affected_dimensions", [])),
+        affected_hybrid_factors=list(payload.get("affected_hybrid_factors", [])),
+        anchor_groups=list(payload.get("anchor_groups", [])),
+        signal_direction=payload.get("signal_direction", "positive"),
+        confidence_hint=payload.get("confidence_hint", 0.5),
+        salience_hint=payload.get("salience_hint", 0.5),
+        observed_at=payload.get("observed_at"),
+        sequence=payload.get("sequence"),
+        note=payload.get("note", ""),
+        option_evidence=OptionEvidence(**option_evidence) if option_evidence else None,
+        contradictions=[ContradictionMarker(**item) for item in contradictions],
+    )
+
+
+def _default_profile_payload() -> dict[str, Any]:
+    return {
+        "trip_frame": {
+            "duration_days": 28,
+            "traveler_party": "solo",
+            "season_window": [],
+            "trip_stage": "mixed",
+            "regions_in_scope": [],
+            "special_themes": [],
+        },
+        "hard_constraints": {
+            "date_window": {"start": None, "end": None},
+            "duration_bounds": {"min_days": 14, "max_days": 42},
+            "budget_ceiling": None,
+            "must_include_places": [],
+            "must_protect_experiences": [],
+            "mobility_constraints": [],
+            "lodging_constraints": [],
+            "visa_border_constraints": [],
+        },
+        "budget_model": {
+            "total_budget_sensitivity": 0.5,
+            "spending_priorities": {},
+            "quality_floors": {},
+            "splurge_allowed": False,
+            "splurge_style": None,
+        },
+        "anchors": {group: [] for group in ANCHOR_GROUPS},
+        "tradeoff_dimensions": {
+            key: {
+                "value": 0.0,
+                "confidence": 0.4,
+                "salience": 0.4,
+                "stability": 0.4,
+                "trip_stage_sensitivity": {
+                    "initial_design": 0.3,
+                    "inventory_selection": 0.3,
+                    "daily_activity_design": 0.3,
+                    "in_trip_adjustment": 0.3,
+                },
+                "scope": "global",
+                "notes": "",
+            }
+            for key in TRADEOFF_DIMENSION_KEYS
+        },
+        "hybrid_factors": {
+            key: {
+                "mode": "tradeoff",
+                "salience": 0.2,
+                "anchor_strength": 0.0,
+                "tradeoff_role": "none",
+                "notes": "",
+                "preferences": {},
+            }
+            for key in HYBRID_FACTOR_KEYS
+        },
+        "conditional_overrides": [],
+        "interaction_rules": [],
+        "tension_flags": [],
+        "evidence_summary": {"sources": {}, "confidence_notes": []},
+    }

--- a/tests/preferences/fixture_corpus.py
+++ b/tests/preferences/fixture_corpus.py
@@ -71,7 +71,7 @@ def load_fixture_corpus(path: Path | None = None) -> list[TravelerFixture]:
     fixtures = payload.get("fixtures", [])
     if not isinstance(fixtures, list):
         raise ValueError("fixtures must be a list")
-    fixture_objects = [_build_fixture(entry) for entry in fixtures]
+    fixture_objects = [_build_fixture(index, entry) for index, entry in enumerate(fixtures)]
     fixture_ids = [fixture.id for fixture in fixture_objects]
     if len(set(fixture_ids)) != len(fixture_ids):
         raise ValueError("fixture corpus ids must be unique")
@@ -82,21 +82,31 @@ def load_fixture_map() -> dict[str, TravelerFixture]:
     return {fixture.id: fixture for fixture in load_fixture_corpus()}
 
 
-def _build_fixture(payload: dict[str, Any]) -> TravelerFixture:
+def _build_fixture(index: int, payload: Any) -> TravelerFixture:
+    if not isinstance(payload, dict):
+        raise ValueError(f"fixture at index {index} must be an object")
+    fixture_id = payload.get("id", f"<fixture {index}>")
+    for required_field in ("id", "fixture_kind", "summary"):
+        if not payload.get(required_field):
+            raise ValueError(f"fixture {fixture_id!r} must define {required_field}")
     intended = payload.get("intended_interpretation", {})
+    if not isinstance(intended, dict):
+        raise ValueError(f"fixture {fixture_id!r} intended_interpretation must be an object")
+    raw_inputs = payload.get("raw_inputs", {})
+    if not isinstance(raw_inputs, dict):
+        raise ValueError(f"fixture {fixture_id!r} raw_inputs must be an object")
     profile = build_profile_from_overrides(payload.get("profile_overrides", {}))
     evidence = [build_evidence_record(item) for item in payload.get("evidence", [])]
     if not intended.get("qualitative_summary"):
         raise ValueError(
-            f"fixture {payload.get('id', '<unknown>')!r} must define intended_interpretation."
-            "qualitative_summary"
+            f"fixture {fixture_id!r} must define intended_interpretation.qualitative_summary"
         )
     return TravelerFixture(
         id=payload["id"],
         fixture_kind=payload["fixture_kind"],
         summary=payload["summary"],
         tags=list(payload.get("tags", [])),
-        raw_inputs=dict(payload.get("raw_inputs", {})),
+        raw_inputs=dict(raw_inputs),
         intended_interpretation=IntendedInterpretation(
             qualitative_summary=intended["qualitative_summary"],
             dominant_dimensions=list(intended.get("dominant_dimensions", [])),
@@ -115,14 +125,39 @@ def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreference
     profile_payload["trip_frame"] = {**profile_payload["trip_frame"], **trip_frame_overrides}
 
     hard_constraint_overrides = overrides.get("hard_constraints", {})
+    allowed_constraint_keys = {
+        "date_window",
+        "duration_bounds",
+        "budget_ceiling",
+        "must_include_places",
+        "must_protect_experiences",
+        "mobility_constraints",
+        "lodging_constraints",
+        "visa_border_constraints",
+    }
+    unknown_constraint_keys = set(hard_constraint_overrides) - allowed_constraint_keys
+    if unknown_constraint_keys:
+        raise ValueError(
+            "unsupported hard constraint override keys: " f"{sorted(unknown_constraint_keys)}"
+        )
     date_window = {
         **profile_payload["hard_constraints"]["date_window"],
         **hard_constraint_overrides.get("date_window", {}),
     }
+    unknown_date_window_keys = set(date_window) - {"start", "end"}
+    if unknown_date_window_keys:
+        raise ValueError(
+            "unsupported date_window override keys: " f"{sorted(unknown_date_window_keys)}"
+        )
     duration_bounds = {
         **profile_payload["hard_constraints"]["duration_bounds"],
         **hard_constraint_overrides.get("duration_bounds", {}),
     }
+    unknown_duration_keys = set(duration_bounds) - {"min_days", "max_days"}
+    if unknown_duration_keys:
+        raise ValueError(
+            "unsupported duration_bounds override keys: " f"{sorted(unknown_duration_keys)}"
+        )
     merged_constraints = {
         **profile_payload["hard_constraints"],
         **hard_constraint_overrides,

--- a/tests/preferences/test_fixture_corpus.py
+++ b/tests/preferences/test_fixture_corpus.py
@@ -1,0 +1,72 @@
+from trip_planner.preferences.schema import TRADEOFF_DIMENSION_KEYS
+
+from tests.preferences.fixture_corpus import load_fixture_corpus, load_fixture_map
+
+
+def test_fixture_corpus_loads_and_instantiates_profiles() -> None:
+    fixtures = load_fixture_corpus()
+
+    assert len(fixtures) >= 10
+    assert {fixture.fixture_kind for fixture in fixtures} == {"archetype", "tension_case"}
+
+    for fixture in fixtures:
+        assert fixture.id
+        assert fixture.summary
+        assert fixture.raw_inputs["trip_brief"]
+        assert fixture.raw_inputs["stated_constraints"]
+        assert fixture.raw_inputs["planning_style_notes"]
+        assert fixture.intended_interpretation.qualitative_summary
+        assert fixture.intended_interpretation.dominant_dimensions
+        assert fixture.intended_interpretation.planning_implications
+        assert fixture.evidence
+        assert fixture.profile.to_dict()["profile_kind"] == "leisure"
+
+
+def test_fixture_corpus_covers_all_first_tier_dimensions() -> None:
+    fixtures = load_fixture_corpus()
+    covered_dimensions: set[str] = set()
+
+    for fixture in fixtures:
+        covered_dimensions.update(fixture.intended_interpretation.dominant_dimensions)
+        for record in fixture.evidence:
+            covered_dimensions.update(record.affected_dimensions)
+
+    assert covered_dimensions == set(TRADEOFF_DIMENSION_KEYS)
+
+
+def test_tension_cases_surface_real_conflicts() -> None:
+    fixtures = load_fixture_map()
+
+    breadth_case = fixtures["breadth-under-recovery-pressure"]
+    anchor_case = fixtures["elastic-discovery-with-fixed-anchors"]
+    budget_case = fixtures["quality-floors-under-budget-pressure"]
+
+    assert breadth_case.fixture_kind == "tension_case"
+    assert breadth_case.profile.tension_flags
+    assert {
+        "breadth_vs_depth",
+        "recovery_vs_intensity",
+    }.issubset(breadth_case.intended_interpretation.dominant_dimensions)
+
+    assert anchor_case.profile.hard_constraints.must_include_places == ["Istanbul", "Cappadocia"]
+    assert anchor_case.profile.anchors["calendar_anchors"]
+    assert anchor_case.profile.tradeoff_dimensions["structure_vs_elasticity"].value > 0.0
+
+    assert budget_case.profile.hard_constraints.budget_ceiling == 5200.0
+    assert budget_case.profile.anchors["quality_floor_anchors"]
+    assert budget_case.profile.budget_model.quality_floors["lodging"]
+
+
+def test_fixture_corpus_preserves_option_evidence_for_revealed_preferences() -> None:
+    fixtures = load_fixture_map()
+
+    rail_fixture = fixtures["scenic-rail-nomad"]
+    comfort_fixture = fixtures["comfort-floor-traveler"]
+
+    rail_option = rail_fixture.evidence[1].option_evidence
+    comfort_option = comfort_fixture.evidence[1].option_evidence
+
+    assert rail_option is not None
+    assert rail_option.option_kind == "mixed_bundle"
+    assert comfort_option is not None
+    assert comfort_option.option_kind == "transport"

--- a/tests/preferences/test_fixture_corpus.py
+++ b/tests/preferences/test_fixture_corpus.py
@@ -127,3 +127,31 @@ def test_fixture_corpus_rejects_missing_qualitative_summary(tmp_path: Path) -> N
         assert "qualitative_summary" in str(exc)
     else:
         raise AssertionError("Fixture corpus should reject missing qualitative summaries")
+
+
+def test_fixture_corpus_rejects_non_object_fixture_entries(tmp_path: Path) -> None:
+    payload = json.loads(fixture_corpus_path().read_text(encoding="utf-8"))
+    payload["fixtures"][0] = "not-a-fixture"
+    path = tmp_path / "bad-entry.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        load_fixture_corpus(path)
+    except ValueError as exc:
+        assert "index 0" in str(exc)
+    else:
+        raise AssertionError("Fixture corpus should reject non-object fixture entries")
+
+
+def test_fixture_corpus_rejects_unknown_hard_constraint_keys(tmp_path: Path) -> None:
+    payload = json.loads(fixture_corpus_path().read_text(encoding="utf-8"))
+    payload["fixtures"][8]["profile_overrides"]["hard_constraints"]["budget_ceiling_typo"] = 1000
+    path = tmp_path / "bad-hard-constraints.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        load_fixture_corpus(path)
+    except ValueError as exc:
+        assert "hard constraint override keys" in str(exc)
+    else:
+        raise AssertionError("Fixture corpus should reject unknown hard constraint override keys")

--- a/tests/preferences/test_fixture_corpus.py
+++ b/tests/preferences/test_fixture_corpus.py
@@ -1,6 +1,13 @@
+import json
+from pathlib import Path
+
 from trip_planner.preferences.schema import TRADEOFF_DIMENSION_KEYS
 
-from tests.preferences.fixture_corpus import load_fixture_corpus, load_fixture_map
+from tests.preferences.fixture_corpus import (
+    fixture_corpus_path,
+    load_fixture_corpus,
+    load_fixture_map,
+)
 
 
 def test_fixture_corpus_loads_and_instantiates_profiles() -> None:
@@ -63,10 +70,60 @@ def test_fixture_corpus_preserves_option_evidence_for_revealed_preferences() -> 
     rail_fixture = fixtures["scenic-rail-nomad"]
     comfort_fixture = fixtures["comfort-floor-traveler"]
 
-    rail_option = rail_fixture.evidence[1].option_evidence
-    comfort_option = comfort_fixture.evidence[1].option_evidence
+    rail_option = next(
+        record.option_evidence
+        for record in rail_fixture.evidence
+        if record.evidence_type == "option_selection"
+    )
+    comfort_option = next(
+        record.option_evidence
+        for record in comfort_fixture.evidence
+        if record.evidence_type == "option_selection"
+    )
 
     assert rail_option is not None
     assert rail_option.option_kind == "mixed_bundle"
     assert comfort_option is not None
     assert comfort_option.option_kind == "transport"
+
+
+def test_fixture_corpus_rejects_wrong_schema_version(tmp_path: Path) -> None:
+    payload = json.loads(fixture_corpus_path().read_text(encoding="utf-8"))
+    payload["schema_version"] = "9.9.9"
+    path = tmp_path / "bad-schema.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        load_fixture_corpus(path)
+    except ValueError as exc:
+        assert "schema_version" in str(exc)
+    else:
+        raise AssertionError("Fixture corpus should reject unsupported schema versions")
+
+
+def test_fixture_corpus_rejects_duplicate_ids(tmp_path: Path) -> None:
+    payload = json.loads(fixture_corpus_path().read_text(encoding="utf-8"))
+    payload["fixtures"][1]["id"] = payload["fixtures"][0]["id"]
+    path = tmp_path / "duplicate-ids.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        load_fixture_corpus(path)
+    except ValueError as exc:
+        assert "ids must be unique" in str(exc)
+    else:
+        raise AssertionError("Fixture corpus should reject duplicate fixture ids")
+
+
+def test_fixture_corpus_rejects_missing_qualitative_summary(tmp_path: Path) -> None:
+    payload = json.loads(fixture_corpus_path().read_text(encoding="utf-8"))
+    payload["fixtures"][0]["intended_interpretation"]["qualitative_summary"] = ""
+    path = tmp_path / "missing-summary.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    try:
+        load_fixture_corpus(path)
+    except ValueError as exc:
+        assert "qualitative_summary" in str(exc)
+    else:
+        raise AssertionError("Fixture corpus should reject missing qualitative summaries")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #509

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This preference engine will fail if it is tuned only against a single imagined traveler. Before implementing the resolver, the repo needs a compact but serious corpus of traveler archetypes and tension cases that can be used to validate whether the model captures real tradeoffs over a two- to six-week trip.

Parent epic: #506

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#506](https://github.com/stranske/trip-planner/issues/506)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define a fixture format for raw traveler inputs and evidence that can be reused across schema, evidence, resolver, and objective-derivation tests.
- [x] Add a set of serious leisure traveler archetypes covering materially different tradeoff patterns, such as: high-mobility scenic-transit traveler, depth-oriented urban historian, foodie with selective splurge behavior, discovery-oriented wanderer, high-social-energy but recovery-sensitive traveler, comfort-floor traveler, and route-coherence-first traveler.
- [x] Add explicit tension cases where the user wants conflicting things, such as high breadth plus high recovery need, elastic discovery plus many fixed anchors, or strong quality floors under budget pressure.
- [x] For each fixture, record the intended qualitative interpretation so later tests can assert directionality without overfitting to exact numeric outputs too early.
- [x] Document how fixtures should be extended as the preference engine evolves.
- [x] Add tests that load and validate the fixture corpus itself.

#### Acceptance criteria
- [x] The repo contains a reusable traveler fixture corpus with both archetypes and contradiction or tension cases.
- [x] The corpus covers the major first-tier dimensions rather than clustering around one travel style.
- [x] Each fixture includes enough context to support later evidence and resolver tests.
- [x] Fixture validation tests fail clearly on malformed or incomplete cases.
- [x] Contributors have documentation on how to add new archetypes without breaking comparability.

**Head SHA:** bbe8cac9c7841e1fb7841d0bd3425f987a5dc6aa
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/23123735166) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23123805894) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23123805901) |
| CI | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23123736960) |
| Claude Code Review | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23123736837) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23123736836) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23123736349) |
| Gate | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23123736976) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23123736851) |
<!-- auto-status-summary:end -->
