### PR TITLE
Issue #514: establish shared planning contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The target product should handle:
 - [Implementation plan](docs/implementation-plan.md)
 - [Product and architecture brief](docs/product-architecture-brief.md)
 - [Leisure preference contract](docs/leisure-preference-contract.md)
+- [Shared planning contracts](docs/shared-planning-contracts.md)
 - [Source channel strategy](docs/source-channel-strategy.md)
 - [Legacy itinerary methodology](docs/methodology.md)
 - [CI system guide](docs/CI_SYSTEM_GUIDE.md)
@@ -34,9 +35,10 @@ The implementation in this repository is still mostly a script-based generator f
 - `scripts/generate_itins.py`
 - `scripts/build_html.py`
 
-The first canonical application package now starts in:
+The first canonical application packages now start in:
 
 - `trip_planner/preferences/`
+- `trip_planner/contracts/`
 
 The old script flow is not the default design path for new work. It remains only where a narrow compatibility bridge is still useful, and older static-demo artifacts have been moved under `archive/legacy-static-demo/`.
 

--- a/docs/shared-planning-contracts.md
+++ b/docs/shared-planning-contracts.md
@@ -1,0 +1,36 @@
+# Shared Planning Contracts
+
+The canonical shared planning contracts now live in `trip_planner/contracts/`.
+
+These contracts are the first cross-mode planning layer that sits above the leisure preference package and below later ranking, orchestration, persistence, and policy integration work.
+
+## Canonical Modules
+
+- `trip_planner/contracts/trip.py`
+  - `Trip`, `TripFrameSummary`, mode-specific profile references, and artifact references
+- `trip_planner/contracts/options.py`
+  - `OptionSet`, `Option`, comparison axes, and cost/quality summaries
+- `trip_planner/contracts/objectives.py`
+  - `ItineraryObjectives` and the deterministic objective subcontracts used by later search and ranking work
+
+## Design Intent
+
+- `Trip` is the shared planning container, not a bag of inlined downstream payloads.
+- Leisure and business profiles stay separate; `Trip` references them rather than collapsing them into one schema.
+- `OptionSet` is first-class because the planner is expected to learn from concrete choices, not only from direct statements.
+- `ItineraryObjectives` is the handoff contract between profile resolution and later ranking or route assembly.
+
+## Current Boundaries
+
+The contracts added here are intentionally lightweight:
+
+- they are implementation-facing Python contracts
+- they are not yet frontend API schemas
+- they are not final booking or inventory adapters
+- they do not replace the later business-policy export objects
+
+## Usage Guidance
+
+- New cross-mode planning work should import from `trip_planner/contracts/`.
+- Preference-specific logic should continue to use `trip_planner/preferences/`.
+- Legacy script JSON should not be treated as the source of truth for new planning code.

--- a/tests/contracts/test_objectives.py
+++ b/tests/contracts/test_objectives.py
@@ -1,0 +1,82 @@
+from trip_planner.contracts import (
+    BudgetProtection,
+    CountRange,
+    DayStructureObjectives,
+    DiscoveryStrategy,
+    ItineraryObjectives,
+    LodgingStrategy,
+    MoveDensityTarget,
+    QualityFloorProtection,
+    RecoveryExpectations,
+    TransportStrategy,
+)
+
+
+def test_itinerary_objectives_serialize_for_leisure_trip() -> None:
+    objectives = ItineraryObjectives(
+        objective_id="obj-1",
+        trip_id="trip-leisure-1",
+        route_shape="regional_cluster",
+        target_base_count=CountRange(min_value=2, max_value=4),
+        move_density=MoveDensityTarget(
+            max_moves=3,
+            cadence_days=5,
+            notes=["Prefer clustered moves over frequent backtracking."],
+        ),
+        recovery_expectations=RecoveryExpectations(
+            buffer_days=2,
+            recovery_priority=0.82,
+            notes=["Protect a recovery block after dense city stretches."],
+        ),
+        day_structure=DayStructureObjectives(
+            structure_level="elastic",
+            wandering_support_level=0.88,
+            reservation_density=0.24,
+        ),
+        discovery_strategy=DiscoveryStrategy(
+            style="discovery_forward",
+            protect_open_blocks=True,
+            notes=["Use strong wandering zones instead of overbooking."],
+        ),
+        budget_protection=BudgetProtection(
+            protected_categories=["food", "lodging_location"],
+            sensitivity=0.68,
+        ),
+        quality_floor_protection=QualityFloorProtection(
+            required_categories=["lodging", "arrival_reliability"],
+        ),
+        lodging_strategy=LodgingStrategy(
+            base_style="few_bases",
+            arrival_buffer_priority=0.74,
+        ),
+        transport_strategy=TransportStrategy(
+            preferred_modes=["rail"],
+            avoid_modes=["short_haul_flight"],
+            transit_is_feature=True,
+        ),
+        explanations=["Preference engine resolved toward elastic discovery with route coherence."],
+    )
+
+    payload = objectives.to_dict()
+
+    assert payload["route_shape"] == "regional_cluster"
+    assert payload["day_structure"]["structure_level"] == "elastic"
+    assert payload["transport_strategy"]["transit_is_feature"] is True
+
+
+def test_itinerary_objectives_reject_invalid_route_shape() -> None:
+    try:
+        ItineraryObjectives(objective_id="obj-2", trip_id="trip-leisure-2", route_shape="starfish")
+    except ValueError as exc:
+        assert "route_shape" in str(exc)
+    else:
+        raise AssertionError("ItineraryObjectives should reject unsupported route shapes")
+
+
+def test_count_range_rejects_inverted_bounds() -> None:
+    try:
+        CountRange(min_value=5, max_value=2)
+    except ValueError as exc:
+        assert "min_value" in str(exc)
+    else:
+        raise AssertionError("CountRange should reject inverted bounds")

--- a/tests/contracts/test_options.py
+++ b/tests/contracts/test_options.py
@@ -1,0 +1,99 @@
+from trip_planner.contracts import (
+    ComparisonAxis,
+    MoneyRange,
+    Option,
+    OptionCostSummary,
+    OptionQualitySummary,
+    OptionSet,
+)
+
+
+def test_option_set_serializes_profile_learning_bundle() -> None:
+    option_set = OptionSet(
+        option_set_id="optset-1",
+        trip_id="trip-leisure-1",
+        purpose="profile_learning",
+        scope="mixed",
+        title="Early route and lodging styles",
+        options=[
+            Option(
+                option_id="opt-rail-route",
+                kind="route",
+                label="Rail-first slower route",
+                fit_signals={"movement_fit": 0.88, "scenic_transit_fit": 0.92},
+                cost_summary=OptionCostSummary(
+                    total=MoneyRange(currency="USD", typical_amount=2650.0),
+                ),
+                quality_summary=OptionQualitySummary(
+                    fit_signal=0.9,
+                    value_signal=0.72,
+                ),
+                drawbacks=["More hotel changes."],
+                source_refs=["src-rail"],
+                explanation=["Prioritizes scenic transit and coherent progression."],
+            ),
+            Option(
+                option_id="opt-single-base",
+                kind="lodging",
+                label="Fewer bases with better recovery",
+                fit_signals={"recovery_fit": 0.84},
+                cost_summary=OptionCostSummary(
+                    total=MoneyRange(currency="USD", typical_amount=2380.0),
+                ),
+                quality_summary=OptionQualitySummary(
+                    fit_signal=0.8,
+                    quality_signal=0.76,
+                ),
+                drawbacks=["Less regional coverage."],
+                source_refs=["src-lodging"],
+                explanation=["Protects recovery and arrival simplicity."],
+            ),
+        ],
+        comparison_axes=[
+            ComparisonAxis(
+                key="recovery_fit",
+                label="Recovery fit",
+                direction="higher_better",
+            ),
+            ComparisonAxis(
+                key="move_count",
+                label="Move count",
+                direction="lower_better",
+            ),
+        ],
+        explanation=["Used to learn whether the traveler prefers breadth or rhythm."],
+        source_refs=["planner-generated"],
+        selection_limit=1,
+    )
+
+    payload = option_set.to_dict()
+
+    assert payload["purpose"] == "profile_learning"
+    assert payload["options"][0]["kind"] == "route"
+    assert payload["comparison_axes"][1]["direction"] == "lower_better"
+
+
+def test_option_set_rejects_invalid_selection_limit() -> None:
+    try:
+        OptionSet(
+            option_set_id="optset-2",
+            trip_id="trip-leisure-2",
+            purpose="inventory_narrowing",
+            scope="lodging",
+            title="Hotel options",
+            options=[Option(option_id="opt-1", kind="lodging", label="Central hotel")],
+            selection_limit=2,
+        )
+    except ValueError as exc:
+        assert "selection_limit" in str(exc)
+    else:
+        raise AssertionError("OptionSet should reject selection_limit values above option count")
+
+
+def test_option_rejects_invalid_kind() -> None:
+    try:
+        Option(option_id="opt-2", kind="museum", label="Invalid")
+    except ValueError as exc:
+        assert "kind" in str(exc)
+    else:
+        raise AssertionError("Option should reject unsupported kinds")

--- a/tests/contracts/test_options.py
+++ b/tests/contracts/test_options.py
@@ -97,3 +97,17 @@ def test_option_rejects_invalid_kind() -> None:
         assert "kind" in str(exc)
     else:
         raise AssertionError("Option should reject unsupported kinds")
+
+
+def test_option_rejects_non_string_fit_signal_keys() -> None:
+    try:
+        Option(
+            option_id="opt-3",
+            kind="route",
+            label="Broken fit signal mapping",
+            fit_signals={1: 0.8},  # type: ignore[dict-item]
+        )
+    except ValueError as exc:
+        assert "fit_signals" in str(exc)
+    else:
+        raise AssertionError("Option should reject non-string fit_signals keys")

--- a/tests/contracts/test_trip.py
+++ b/tests/contracts/test_trip.py
@@ -1,0 +1,110 @@
+from trip_planner.contracts import (
+    ProfileRefs,
+    TravelerPartySummary,
+    Trip,
+    TripArtifactRefs,
+    TripFrameSummary,
+)
+
+
+def test_trip_serializes_valid_leisure_container() -> None:
+    trip = Trip(
+        trip_id="trip-leisure-1",
+        user_id="user-1",
+        mode="leisure",
+        status="draft",
+        title="Autumn rail trip",
+        trip_frame=TripFrameSummary(
+            start_date="2026-10-01",
+            end_date="2026-10-28",
+            duration_days=28,
+            primary_regions=["Japan"],
+            traveler_party=TravelerPartySummary(kind="pair", traveler_count=2),
+        ),
+        profile_refs=ProfileRefs(leisure_profile_id="leisure-profile-1"),
+        artifacts=TripArtifactRefs(
+            objective_id="obj-1",
+            option_set_ids=["optset-1", "optset-2"],
+            itinerary_state_id="itin-1",
+            budget_state_id="budget-1",
+        ),
+    )
+
+    payload = trip.to_dict()
+
+    assert payload["mode"] == "leisure"
+    assert payload["profile_refs"]["leisure_profile_id"] == "leisure-profile-1"
+    assert payload["artifacts"]["option_set_ids"] == ["optset-1", "optset-2"]
+
+
+def test_trip_serializes_valid_business_container() -> None:
+    trip = Trip(
+        trip_id="trip-business-1",
+        user_id="user-2",
+        mode="business",
+        status="active",
+        title="Client meeting trip",
+        trip_frame=TripFrameSummary(
+            start_date="2026-05-04",
+            end_date="2026-05-06",
+            duration_days=3,
+            primary_regions=["Chicago", "New York"],
+            traveler_party=TravelerPartySummary(kind="solo", traveler_count=1),
+        ),
+        profile_refs=ProfileRefs(business_profile_id="business-profile-1"),
+        artifacts=TripArtifactRefs(
+            objective_id="obj-business-1",
+            option_set_ids=["optset-business-1"],
+            itinerary_state_id="itin-business-1",
+            budget_state_id="budget-business-1",
+            policy_state_id="policy-business-1",
+        ),
+    )
+
+    payload = trip.to_dict()
+
+    assert payload["mode"] == "business"
+    assert payload["profile_refs"]["business_profile_id"] == "business-profile-1"
+    assert payload["artifacts"]["policy_state_id"] == "policy-business-1"
+
+
+def test_trip_rejects_missing_mode_specific_profile_ref() -> None:
+    try:
+        Trip(
+            trip_id="trip-leisure-2",
+            user_id="user-3",
+            mode="leisure",
+            status="draft",
+            trip_frame=TripFrameSummary(duration_days=14),
+            profile_refs=ProfileRefs(),
+        )
+    except ValueError as exc:
+        assert "leisure_profile_id" in str(exc)
+    else:
+        raise AssertionError("Leisure trip should require a leisure profile reference")
+
+
+def test_trip_rejects_duplicate_option_set_refs() -> None:
+    try:
+        TripArtifactRefs(option_set_ids=["optset-1", "optset-1"])
+    except ValueError as exc:
+        assert "option_set_ids" in str(exc)
+    else:
+        raise AssertionError("TripArtifactRefs should reject duplicate option set references")
+
+
+def test_trip_rejects_policy_state_for_leisure_mode() -> None:
+    try:
+        Trip(
+            trip_id="trip-leisure-3",
+            user_id="user-4",
+            mode="leisure",
+            status="active",
+            trip_frame=TripFrameSummary(duration_days=12),
+            profile_refs=ProfileRefs(leisure_profile_id="leisure-profile-2"),
+            artifacts=TripArtifactRefs(policy_state_id="policy-1"),
+        )
+    except ValueError as exc:
+        assert "policy_state_id" in str(exc)
+    else:
+        raise AssertionError("Leisure trip should reject business-only policy state references")

--- a/trip_planner/contracts/__init__.py
+++ b/trip_planner/contracts/__init__.py
@@ -1,0 +1,47 @@
+"""Canonical shared planning contracts for trips, options, and itinerary objectives."""
+
+from .objectives import (
+    BudgetProtection,
+    CountRange,
+    DayStructureObjectives,
+    DiscoveryStrategy,
+    ItineraryObjectives,
+    LodgingStrategy,
+    MoveDensityTarget,
+    QualityFloorProtection,
+    RecoveryExpectations,
+    TransportStrategy,
+)
+from .options import (
+    ComparisonAxis,
+    MoneyRange,
+    Option,
+    OptionCostSummary,
+    OptionQualitySummary,
+    OptionSet,
+)
+from .trip import ProfileRefs, TravelerPartySummary, Trip, TripArtifactRefs, TripFrameSummary
+
+__all__ = [
+    "BudgetProtection",
+    "ComparisonAxis",
+    "CountRange",
+    "DayStructureObjectives",
+    "DiscoveryStrategy",
+    "ItineraryObjectives",
+    "LodgingStrategy",
+    "MoneyRange",
+    "MoveDensityTarget",
+    "Option",
+    "OptionCostSummary",
+    "OptionQualitySummary",
+    "OptionSet",
+    "ProfileRefs",
+    "QualityFloorProtection",
+    "RecoveryExpectations",
+    "TransportStrategy",
+    "TravelerPartySummary",
+    "Trip",
+    "TripArtifactRefs",
+    "TripFrameSummary",
+]

--- a/trip_planner/contracts/_validators.py
+++ b/trip_planner/contracts/_validators.py
@@ -1,0 +1,42 @@
+"""Shared validation helpers for lightweight planning contracts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def require_non_empty(value: str, field_name: str) -> None:
+    if not value:
+        raise ValueError(f"{field_name} is required")
+
+
+def require_optional_non_empty(value: str | None, field_name: str) -> None:
+    if value is not None and not value:
+        raise ValueError(f"{field_name} must be non-empty when provided")
+
+
+def require_probability(value: float, field_name: str) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{field_name} must be between 0.0 and 1.0")
+
+
+def require_non_negative(value: float | int, field_name: str) -> None:
+    if value < 0:
+        raise ValueError(f"{field_name} cannot be negative")
+
+
+def require_strings(values: list[str], field_name: str) -> None:
+    if any(not isinstance(item, str) or not item for item in values):
+        raise ValueError(f"{field_name} must contain only non-empty strings")
+
+
+def require_float_mapping(mapping: dict[str, float], field_name: str) -> None:
+    if any(not isinstance(key, str) or not key for key in mapping):
+        raise ValueError(f"{field_name} must use non-empty string keys")
+    for key, value in mapping.items():
+        require_probability(value, f"{field_name}[{key}]")
+
+
+def require_string_mapping(mapping: dict[str, Any], field_name: str) -> None:
+    if any(not isinstance(key, str) or not key for key in mapping):
+        raise ValueError(f"{field_name} must use non-empty string keys")

--- a/trip_planner/contracts/objectives.py
+++ b/trip_planner/contracts/objectives.py
@@ -1,0 +1,209 @@
+"""Shared itinerary-objective contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from ._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_probability,
+    require_strings,
+)
+
+ROUTE_SHAPES: tuple[str, ...] = ("hub_and_spoke", "linear", "regional_cluster", "mixed")
+STRUCTURE_LEVELS: tuple[str, ...] = ("high", "moderate", "elastic")
+DISCOVERY_STYLES: tuple[str, ...] = ("iconic", "balanced", "discovery_forward")
+LODGING_BASE_STYLES: tuple[str, ...] = ("single_base", "few_bases", "multi_base", "mixed")
+
+
+@dataclass(slots=True)
+class CountRange:
+    min_value: int | None = None
+    max_value: int | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in ("min_value", "max_value"):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_non_negative(value, field_name)
+        if (
+            self.min_value is not None
+            and self.max_value is not None
+            and self.min_value > self.max_value
+        ):
+            raise ValueError("min_value cannot exceed max_value")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class MoveDensityTarget:
+    max_moves: int | None = None
+    cadence_days: int | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.max_moves is not None:
+            require_non_negative(self.max_moves, "max_moves")
+        if self.cadence_days is not None:
+            if self.cadence_days <= 0:
+                raise ValueError("cadence_days must be positive when provided")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RecoveryExpectations:
+    buffer_days: int | None = None
+    recovery_priority: float = 0.0
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.buffer_days is not None:
+            require_non_negative(self.buffer_days, "buffer_days")
+        require_probability(self.recovery_priority, "recovery_priority")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class DayStructureObjectives:
+    structure_level: str = "moderate"
+    wandering_support_level: float = 0.0
+    reservation_density: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.structure_level not in STRUCTURE_LEVELS:
+            raise ValueError(f"structure_level must be one of {STRUCTURE_LEVELS}")
+        require_probability(self.wandering_support_level, "wandering_support_level")
+        require_probability(self.reservation_density, "reservation_density")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class DiscoveryStrategy:
+    style: str = "balanced"
+    protect_open_blocks: bool = False
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.style not in DISCOVERY_STYLES:
+            raise ValueError(f"style must be one of {DISCOVERY_STYLES}")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class BudgetProtection:
+    protected_categories: list[str] = field(default_factory=list)
+    sensitivity: float = 0.0
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_strings(self.protected_categories, "protected_categories")
+        require_probability(self.sensitivity, "sensitivity")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class QualityFloorProtection:
+    required_categories: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_strings(self.required_categories, "required_categories")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class LodgingStrategy:
+    base_style: str = "mixed"
+    arrival_buffer_priority: float = 0.0
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.base_style not in LODGING_BASE_STYLES:
+            raise ValueError(f"base_style must be one of {LODGING_BASE_STYLES}")
+        require_probability(self.arrival_buffer_priority, "arrival_buffer_priority")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class TransportStrategy:
+    preferred_modes: list[str] = field(default_factory=list)
+    avoid_modes: list[str] = field(default_factory=list)
+    transit_is_feature: bool = False
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_strings(self.preferred_modes, "preferred_modes")
+        require_strings(self.avoid_modes, "avoid_modes")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ItineraryObjectives:
+    objective_id: str
+    trip_id: str
+    route_shape: str
+    target_base_count: CountRange = field(default_factory=CountRange)
+    move_density: MoveDensityTarget = field(default_factory=MoveDensityTarget)
+    recovery_expectations: RecoveryExpectations = field(default_factory=RecoveryExpectations)
+    day_structure: DayStructureObjectives = field(default_factory=DayStructureObjectives)
+    discovery_strategy: DiscoveryStrategy = field(default_factory=DiscoveryStrategy)
+    budget_protection: BudgetProtection = field(default_factory=BudgetProtection)
+    quality_floor_protection: QualityFloorProtection = field(default_factory=QualityFloorProtection)
+    lodging_strategy: LodgingStrategy = field(default_factory=LodgingStrategy)
+    transport_strategy: TransportStrategy = field(default_factory=TransportStrategy)
+    explanations: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.objective_id, "objective_id")
+        require_non_empty(self.trip_id, "trip_id")
+        if self.route_shape not in ROUTE_SHAPES:
+            raise ValueError(f"route_shape must be one of {ROUTE_SHAPES}")
+        if not isinstance(self.target_base_count, CountRange):
+            raise ValueError("target_base_count must be a CountRange")
+        if not isinstance(self.move_density, MoveDensityTarget):
+            raise ValueError("move_density must be a MoveDensityTarget")
+        if not isinstance(self.recovery_expectations, RecoveryExpectations):
+            raise ValueError("recovery_expectations must be a RecoveryExpectations")
+        if not isinstance(self.day_structure, DayStructureObjectives):
+            raise ValueError("day_structure must be a DayStructureObjectives")
+        if not isinstance(self.discovery_strategy, DiscoveryStrategy):
+            raise ValueError("discovery_strategy must be a DiscoveryStrategy")
+        if not isinstance(self.budget_protection, BudgetProtection):
+            raise ValueError("budget_protection must be a BudgetProtection")
+        if not isinstance(self.quality_floor_protection, QualityFloorProtection):
+            raise ValueError("quality_floor_protection must be a QualityFloorProtection")
+        if not isinstance(self.lodging_strategy, LodgingStrategy):
+            raise ValueError("lodging_strategy must be a LodgingStrategy")
+        if not isinstance(self.transport_strategy, TransportStrategy):
+            raise ValueError("transport_strategy must be a TransportStrategy")
+        require_strings(self.explanations, "explanations")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/trip_planner/contracts/options.py
+++ b/trip_planner/contracts/options.py
@@ -6,9 +6,9 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from ._validators import (
+    require_float_mapping,
     require_non_empty,
     require_non_negative,
-    require_optional_non_empty,
     require_probability,
     require_strings,
 )
@@ -124,9 +124,7 @@ class Option:
             raise ValueError("cost_summary must be an OptionCostSummary")
         if not isinstance(self.quality_summary, OptionQualitySummary):
             raise ValueError("quality_summary must be an OptionQualitySummary")
-        for key, value in self.fit_signals.items():
-            require_optional_non_empty(key, f"fit_signals[{key}]")
-            require_probability(value, f"fit_signals[{key}]")
+        require_float_mapping(self.fit_signals, "fit_signals")
         require_strings(self.drawbacks, "drawbacks")
         require_strings(self.booking_links, "booking_links")
         require_strings(self.source_refs, "source_refs")

--- a/trip_planner/contracts/options.py
+++ b/trip_planner/contracts/options.py
@@ -1,0 +1,176 @@
+"""Shared option and option-set contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from ._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_optional_non_empty,
+    require_probability,
+    require_strings,
+)
+
+OPTION_SET_PURPOSES: tuple[str, ...] = (
+    "profile_learning",
+    "inventory_narrowing",
+    "final_selection",
+    "policy_comparison",
+)
+OPTION_SET_SCOPES: tuple[str, ...] = ("route", "lodging", "transport", "activity", "mixed")
+OPTION_KINDS: tuple[str, ...] = ("route", "lodging", "flight", "rail", "car", "activity", "mixed")
+COMPARISON_DIRECTIONS: tuple[str, ...] = ("higher_better", "lower_better", "contextual")
+
+
+@dataclass(slots=True)
+class MoneyRange:
+    currency: str = "USD"
+    typical_amount: float | None = None
+    min_amount: float | None = None
+    max_amount: float | None = None
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.currency, "currency")
+        for field_name in ("typical_amount", "min_amount", "max_amount"):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_non_negative(value, field_name)
+        if (
+            self.min_amount is not None
+            and self.max_amount is not None
+            and self.min_amount > self.max_amount
+        ):
+            raise ValueError("min_amount cannot exceed max_amount")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class OptionCostSummary:
+    total: MoneyRange | None = None
+    per_unit: MoneyRange | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.total is not None and not isinstance(self.total, MoneyRange):
+            raise ValueError("total must be a MoneyRange when provided")
+        if self.per_unit is not None and not isinstance(self.per_unit, MoneyRange):
+            raise ValueError("per_unit must be a MoneyRange when provided")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class OptionQualitySummary:
+    quality_signal: float | None = None
+    value_signal: float | None = None
+    fit_signal: float | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        for field_name in ("quality_signal", "value_signal", "fit_signal"):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_probability(value, field_name)
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ComparisonAxis:
+    key: str
+    label: str
+    direction: str = "contextual"
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.key, "key")
+        require_non_empty(self.label, "label")
+        if self.direction not in COMPARISON_DIRECTIONS:
+            raise ValueError(f"direction must be one of {COMPARISON_DIRECTIONS}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class Option:
+    option_id: str
+    kind: str
+    label: str
+    summary: str = ""
+    fit_signals: dict[str, float] = field(default_factory=dict)
+    cost_summary: OptionCostSummary = field(default_factory=OptionCostSummary)
+    quality_summary: OptionQualitySummary = field(default_factory=OptionQualitySummary)
+    drawbacks: list[str] = field(default_factory=list)
+    booking_links: list[str] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    supporting_place_ids: list[str] = field(default_factory=list)
+    explanation: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.option_id, "option_id")
+        require_non_empty(self.label, "label")
+        if self.kind not in OPTION_KINDS:
+            raise ValueError(f"kind must be one of {OPTION_KINDS}")
+        if not isinstance(self.cost_summary, OptionCostSummary):
+            raise ValueError("cost_summary must be an OptionCostSummary")
+        if not isinstance(self.quality_summary, OptionQualitySummary):
+            raise ValueError("quality_summary must be an OptionQualitySummary")
+        for key, value in self.fit_signals.items():
+            require_optional_non_empty(key, f"fit_signals[{key}]")
+            require_probability(value, f"fit_signals[{key}]")
+        require_strings(self.drawbacks, "drawbacks")
+        require_strings(self.booking_links, "booking_links")
+        require_strings(self.source_refs, "source_refs")
+        require_strings(self.supporting_place_ids, "supporting_place_ids")
+        require_strings(self.explanation, "explanation")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class OptionSet:
+    option_set_id: str
+    trip_id: str
+    purpose: str
+    scope: str
+    title: str
+    options: list[Option]
+    comparison_axes: list[ComparisonAxis] = field(default_factory=list)
+    explanation: list[str] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    selection_limit: int | None = None
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.option_set_id, "option_set_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.title, "title")
+        if self.purpose not in OPTION_SET_PURPOSES:
+            raise ValueError(f"purpose must be one of {OPTION_SET_PURPOSES}")
+        if self.scope not in OPTION_SET_SCOPES:
+            raise ValueError(f"scope must be one of {OPTION_SET_SCOPES}")
+        if not self.options:
+            raise ValueError("options must contain at least one Option")
+        if any(not isinstance(option, Option) for option in self.options):
+            raise ValueError("options must contain Option instances")
+        if any(not isinstance(axis, ComparisonAxis) for axis in self.comparison_axes):
+            raise ValueError("comparison_axes must contain ComparisonAxis instances")
+        require_strings(self.explanation, "explanation")
+        require_strings(self.source_refs, "source_refs")
+        if self.selection_limit is not None:
+            if self.selection_limit <= 0:
+                raise ValueError("selection_limit must be positive when provided")
+            if self.selection_limit > len(self.options):
+                raise ValueError("selection_limit cannot exceed the number of options")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/trip_planner/contracts/trip.py
+++ b/trip_planner/contracts/trip.py
@@ -1,0 +1,134 @@
+"""Shared trip container contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from ._validators import require_non_empty, require_strings
+
+TRIP_MODES: tuple[str, ...] = ("leisure", "business")
+TRIP_STATUSES: tuple[str, ...] = ("draft", "active", "booked", "in_trip", "completed", "archived")
+TRAVELER_PARTY_KINDS: tuple[str, ...] = ("solo", "pair", "family", "friends", "team")
+
+
+@dataclass(slots=True)
+class TravelerPartySummary:
+    kind: str = "solo"
+    traveler_count: int = 1
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if self.kind not in TRAVELER_PARTY_KINDS:
+            raise ValueError(f"kind must be one of {TRAVELER_PARTY_KINDS}")
+        if self.traveler_count <= 0:
+            raise ValueError("traveler_count must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class TripFrameSummary:
+    start_date: str | None = None
+    end_date: str | None = None
+    duration_days: int | None = None
+    primary_regions: list[str] = field(default_factory=list)
+    traveler_party: TravelerPartySummary = field(default_factory=TravelerPartySummary)
+
+    def __post_init__(self) -> None:
+        if self.start_date is not None and not self.start_date:
+            raise ValueError("start_date must be non-empty when provided")
+        if self.end_date is not None and not self.end_date:
+            raise ValueError("end_date must be non-empty when provided")
+        if self.duration_days is not None and self.duration_days <= 0:
+            raise ValueError("duration_days must be positive when provided")
+        require_strings(self.primary_regions, "primary_regions")
+        if not isinstance(self.traveler_party, TravelerPartySummary):
+            raise ValueError("traveler_party must be a TravelerPartySummary")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ProfileRefs:
+    leisure_profile_id: str | None = None
+    business_profile_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.leisure_profile_id is not None and not self.leisure_profile_id:
+            raise ValueError("leisure_profile_id must be non-empty when provided")
+        if self.business_profile_id is not None and not self.business_profile_id:
+            raise ValueError("business_profile_id must be non-empty when provided")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class TripArtifactRefs:
+    objective_id: str | None = None
+    option_set_ids: list[str] = field(default_factory=list)
+    itinerary_state_id: str | None = None
+    budget_state_id: str | None = None
+    policy_state_id: str | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "objective_id",
+            "itinerary_state_id",
+            "budget_state_id",
+            "policy_state_id",
+        ):
+            value = getattr(self, field_name)
+            if value is not None and not value:
+                raise ValueError(f"{field_name} must be non-empty when provided")
+        require_strings(self.option_set_ids, "option_set_ids")
+        if len(set(self.option_set_ids)) != len(self.option_set_ids):
+            raise ValueError("option_set_ids cannot contain duplicates")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class Trip:
+    trip_id: str
+    user_id: str
+    mode: str
+    status: str
+    trip_frame: TripFrameSummary
+    profile_refs: ProfileRefs
+    artifacts: TripArtifactRefs = field(default_factory=TripArtifactRefs)
+    title: str = ""
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.user_id, "user_id")
+        if self.mode not in TRIP_MODES:
+            raise ValueError(f"mode must be one of {TRIP_MODES}")
+        if self.status not in TRIP_STATUSES:
+            raise ValueError(f"status must be one of {TRIP_STATUSES}")
+        if not isinstance(self.trip_frame, TripFrameSummary):
+            raise ValueError("trip_frame must be a TripFrameSummary")
+        if not isinstance(self.profile_refs, ProfileRefs):
+            raise ValueError("profile_refs must be a ProfileRefs")
+        if not isinstance(self.artifacts, TripArtifactRefs):
+            raise ValueError("artifacts must be a TripArtifactRefs")
+        if self.mode == "leisure":
+            if self.profile_refs.leisure_profile_id is None:
+                raise ValueError("leisure trips require leisure_profile_id")
+            if self.profile_refs.business_profile_id is not None:
+                raise ValueError("leisure trips cannot also carry business_profile_id")
+            if self.artifacts.policy_state_id is not None:
+                raise ValueError("leisure trips cannot carry policy_state_id")
+        if self.mode == "business":
+            if self.profile_refs.business_profile_id is None:
+                raise ValueError("business trips require business_profile_id")
+            if self.profile_refs.leisure_profile_id is not None:
+                raise ValueError("business trips cannot also carry leisure_profile_id")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #514

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The design now calls for `Trip`, `OptionSet`, `ItineraryObjectives`, and related shared contracts, but the current repo still behaves mostly like a script bundle with ad hoc JSON and function inputs. Before the business profile, source layer, or later ranking logic can be implemented cleanly, the repo needs stable shared planning contracts that all later modules can reference.

Parent epic: #513

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#513](https://github.com/stranske/trip-planner/issues/513)
- [#505](https://github.com/stranske/trip-planner/issues/505)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Create a reusable shared package boundary for cross-mode planning contracts, for example `trip_planner/core/` or `trip_planner/contracts/`, and update packaging so the modules are importable in tests and CI.
- [x] Implement typed contracts for `Trip`, `TripMode`, `TripStatus`, `OptionSet`, `Option`, and `ItineraryObjectives`.
- [x] Ensure `Trip` references profiles, objectives, option sets, itinerary state, budget state, and policy state without inlining every downstream artifact.
- [x] Ensure `OptionSet` supports both profile-learning sets and later inventory-selection sets, with explicit purpose, scope, comparison axes, and explanation fields.
- [x] Ensure `ItineraryObjectives` is modeled as a deterministic contract between preference/business resolution and later ranking or search layers.
- [x] Add serialization and validation tests for the shared contracts, including representative leisure and business trip examples.
- [x] Update docs so contributors know these are the canonical shared planning contracts.

#### Acceptance criteria
- [x] A reusable shared planning contract package exists and is discoverable by the repository’s packaging and test configuration.
- [x] `Trip`, `OptionSet`, `Option`, and `ItineraryObjectives` can be instantiated, serialized, and validated in tests.
- [x] The contracts can represent both leisure and business trip containers without collapsing the profile models into one schema.
- [x] Tests cover at least one valid leisure case, one valid business case, and validation failures for malformed references or missing required fields.
- [x] Documentation points future work at the canonical shared contracts rather than ad hoc script JSON.

**Head SHA:** 2405bc71c9483d6d71a192e01432bc3da9a7602f
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/23123766563) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23123809566) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23123809560) |
| CI | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23123767940) |
| Claude Code Review | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23123767854) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23123767859) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23123767218) |
| Gate | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23123767921) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23123767847) |
<!-- auto-status-summary:end -->
