### PR TITLE
Implement source and provenance contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The target product should handle:
 - [Shared planning contracts](docs/shared-planning-contracts.md)
 - [Business travel profile contract](docs/business-travel-profile-contract.md)
 - [Policy-facing proposal contracts](docs/contracts/trip-plan-proposal.md)
+- [Source and provenance contracts](docs/contracts/source-provenance.md)
 - [Source channel strategy](docs/source-channel-strategy.md)
 - [Legacy itinerary methodology](docs/methodology.md)
 - [CI system guide](docs/CI_SYSTEM_GUIDE.md)
@@ -42,6 +43,7 @@ The first canonical application packages now start in:
 - `trip_planner/preferences/`
 - `trip_planner/contracts/`
 - `trip_planner/business/`
+- `trip_planner/sources/`
 
 The old script flow is not the default design path for new work. It remains only where a narrow compatibility bridge is still useful, and older static-demo artifacts have been moved under `archive/legacy-static-demo/`.
 

--- a/docs/contracts/source-provenance.md
+++ b/docs/contracts/source-provenance.md
@@ -1,0 +1,54 @@
+# Source And Provenance Contracts
+
+The source layer exists so later planners and option models do not collapse every signal into one opaque score.
+
+## Core Contracts
+
+- `SourceRecord`: a normalized description of a source channel or provider
+- `SourceTrustSignals`: reusable trust metadata for freshness, commerciality, editorial independence, operational reliability, and review consistency
+- `QualityValueFitSummary`: reusable summary that keeps quality, value, and traveler fit distinct
+- `ProvenanceReference`: a reusable attribution object that can attach a source contribution to a destination, option, option set, proposal, or policy evaluation
+
+## Source Categories
+
+The canonical categories are:
+
+- `commercial_inventory`
+- `ratings_reviews`
+- `editorial`
+- `specialist_non_commercial`
+- `official_operational`
+- `managed_travel_policy`
+
+These categories are broad enough for both leisure and business planning while still distinguishing the main trust and usage differences between booking, review, editorial, operational, and policy sources.
+
+## Quality, Value, And Fit
+
+These should not be collapsed into one signal:
+
+- `quality`: the intrinsic or observed standard of the thing being evaluated
+- `value`: what the traveler gets relative to cost, effort, or restrictions
+- `fit`: how well the option matches the traveler profile, trip context, or business policy
+
+Example:
+
+- a hotel can have strong `quality`
+- weak `value` for a budget-sensitive traveler
+- and strong `fit` for a business traveler who needs walkable access and reliable Wi-Fi
+
+## Provenance Flow
+
+Later contracts should treat source provenance as a first-class dependency:
+
+1. `SourceRecord` defines the normalized source and its trust signals.
+2. Candidate-generation or normalization code creates `ProvenanceReference` records for specific destination, option, or policy contributions.
+3. Option and destination contracts store provenance reference ids in `source_refs`.
+4. Proposal and evaluation layers use those references to justify selected channels, comparables, and exception narratives.
+
+This keeps explanations auditable without forcing every downstream object to duplicate source metadata inline.
+
+## Relationship To Source Strategy
+
+Use [Source channel strategy](../source-channel-strategy.md) for the initial operating shortlist and market rationale.
+
+Use these contracts for the code-level representation of those sources once the planner begins ingesting or normalizing them.

--- a/tests/sources/test_source_models.py
+++ b/tests/sources/test_source_models.py
@@ -1,0 +1,123 @@
+from trip_planner.sources import QualityValueFitSummary, SourceRecord, SourceTrustSignals
+
+
+def test_source_record_supports_editorial_leisure_source() -> None:
+    record = SourceRecord(
+        source_id="michelin-green-guide",
+        provider_name="Michelin",
+        display_name="Michelin Green Guide",
+        category="editorial",
+        coverage_scope="regional",
+        supported_option_kinds=["route", "activity"],
+        coverage_regions=["France"],
+        base_url="https://guide.michelin.com/",
+        default_locale="en-US",
+        trust_signals=SourceTrustSignals(
+            freshness_days=30,
+            freshness_confidence=0.6,
+            commerciality=0.2,
+            editorial_independence=0.8,
+            operational_reliability=0.5,
+            review_consistency=0.4,
+            notes=["Useful for route-based discovery rather than live inventory."],
+        ),
+        quality_summary=QualityValueFitSummary(
+            quality_signal=0.8,
+            value_signal=0.6,
+            fit_signal=0.7,
+            confidence=0.7,
+            notes=["Strong curation for travelers who like independent wandering."],
+        ),
+        notes=["Leisure discovery source."],
+    )
+
+    payload = record.to_dict()
+
+    assert payload["category"] == "editorial"
+    assert payload["quality_summary"]["fit_signal"] == 0.7
+    assert payload["trust_signals"]["editorial_independence"] == 0.8
+
+
+def test_source_record_supports_managed_travel_source() -> None:
+    record = SourceRecord(
+        source_id="navan-travel",
+        provider_name="Navan",
+        display_name="Navan Travel",
+        category="managed_travel_policy",
+        coverage_scope="global",
+        supported_option_kinds=["flight", "lodging", "car", "policy"],
+        base_url="https://navan.com/",
+        trust_signals=SourceTrustSignals(
+            freshness_days=2,
+            freshness_confidence=0.9,
+            commerciality=0.8,
+            editorial_independence=0.2,
+            operational_reliability=0.8,
+            review_consistency=0.6,
+        ),
+        business_approval_status="preferred",
+        business_approval_notes=["Default managed-travel channel for enterprise clients."],
+    )
+
+    assert record.business_approval_status == "preferred"
+    assert "policy" in record.supported_option_kinds
+
+
+def test_source_record_supports_official_operational_source() -> None:
+    record = SourceRecord(
+        source_id="amtrak-service-alerts",
+        provider_name="Amtrak",
+        display_name="Amtrak Service Alerts",
+        category="official_operational",
+        coverage_scope="national",
+        supported_option_kinds=["rail"],
+        trust_signals=SourceTrustSignals(
+            freshness_days=0,
+            freshness_confidence=1.0,
+            commerciality=0.3,
+            editorial_independence=0.4,
+            operational_reliability=0.9,
+            review_consistency=0.5,
+        ),
+    )
+
+    assert record.category == "official_operational"
+    assert record.trust_signals.operational_reliability == 0.9
+
+
+def test_source_record_rejects_invalid_category() -> None:
+    try:
+        SourceRecord(
+            source_id="x",
+            provider_name="Provider",
+            display_name="Display",
+            category="blogspam",
+        )
+    except ValueError as exc:
+        assert "category" in str(exc)
+    else:
+        raise AssertionError("SourceRecord should reject unsupported categories")
+
+
+def test_source_record_rejects_invalid_supported_option_kind() -> None:
+    try:
+        SourceRecord(
+            source_id="x",
+            provider_name="Provider",
+            display_name="Display",
+            category="ratings_reviews",
+            supported_option_kinds=["spaceship"],
+        )
+    except ValueError as exc:
+        assert "supported_option_kinds" in str(exc)
+    else:
+        raise AssertionError("SourceRecord should reject unsupported option kinds")
+
+
+def test_source_trust_signals_reject_negative_freshness_days() -> None:
+    try:
+        SourceTrustSignals(freshness_days=-1)
+    except ValueError as exc:
+        assert "freshness_days" in str(exc)
+    else:
+        raise AssertionError("SourceTrustSignals should reject negative freshness days")

--- a/tests/sources/test_source_provenance.py
+++ b/tests/sources/test_source_provenance.py
@@ -1,0 +1,113 @@
+from trip_planner.sources import (
+    ProvenanceReference,
+    QualityValueFitSummary,
+    SourceTrustSignals,
+)
+
+
+def test_provenance_reference_supports_option_explanation() -> None:
+    reference = ProvenanceReference(
+        provenance_id="prov-lodging-1",
+        source_id="booking-dot-com",
+        source_category="commercial_inventory",
+        subject_kind="option",
+        subject_id="lodging-option-1",
+        contribution_kind="pricing",
+        summary="Provided the working nightly rate and cancellation terms.",
+        locator="https://booking.example/hotel/123",
+        captured_at="2026-03-15T10:00:00Z",
+        freshness_days_at_capture=1,
+        trust_snapshot=SourceTrustSignals(
+            freshness_days=1,
+            freshness_confidence=0.9,
+            commerciality=0.8,
+            editorial_independence=0.1,
+            operational_reliability=0.7,
+            review_consistency=0.6,
+        ),
+        quality_value_fit=QualityValueFitSummary(
+            quality_signal=0.7,
+            value_signal=0.8,
+            fit_signal=0.6,
+            confidence=0.75,
+            notes=["Useful for price realism, not final taste judgment."],
+        ),
+        notes=["Attach this reference to the eventual LodgingOption source_refs list."],
+    )
+
+    payload = reference.to_dict()
+
+    assert payload["subject_kind"] == "option"
+    assert payload["quality_value_fit"]["value_signal"] == 0.8
+    assert payload["trust_snapshot"]["freshness_confidence"] == 0.9
+
+
+def test_provenance_reference_supports_policy_ready_proposal() -> None:
+    reference = ProvenanceReference(
+        provenance_id="prov-proposal-1",
+        source_id="concur-travel",
+        source_category="managed_travel_policy",
+        subject_kind="proposal",
+        subject_id="proposal-1",
+        contribution_kind="policy",
+        summary="Confirmed the chosen fare and hotel were inside approved channels.",
+        locator="policy://org/demo/travel",
+        captured_at="2026-03-15T12:00:00Z",
+        freshness_days_at_capture=0,
+        notes=["Retain this record in the approval packet for downstream audit trails."],
+    )
+
+    assert reference.subject_kind == "proposal"
+    assert reference.contribution_kind == "policy"
+
+
+def test_provenance_reference_rejects_invalid_subject_kind() -> None:
+    try:
+        ProvenanceReference(
+            provenance_id="prov-bad-subject",
+            source_id="tripadvisor",
+            source_category="ratings_reviews",
+            subject_kind="city_vibe",
+            subject_id="destination-1",
+            contribution_kind="review",
+            summary="Invalid subject kind.",
+        )
+    except ValueError as exc:
+        assert "subject_kind" in str(exc)
+    else:
+        raise AssertionError("ProvenanceReference should reject invalid subject kinds")
+
+
+def test_provenance_reference_rejects_invalid_contribution_kind() -> None:
+    try:
+        ProvenanceReference(
+            provenance_id="prov-bad-contribution",
+            source_id="tripadvisor",
+            source_category="ratings_reviews",
+            subject_kind="destination",
+            subject_id="destination-1",
+            contribution_kind="vibes",
+            summary="Invalid contribution kind.",
+        )
+    except ValueError as exc:
+        assert "contribution_kind" in str(exc)
+    else:
+        raise AssertionError("ProvenanceReference should reject invalid contribution kinds")
+
+
+def test_provenance_reference_rejects_negative_capture_freshness() -> None:
+    try:
+        ProvenanceReference(
+            provenance_id="prov-negative-freshness",
+            source_id="city-guide",
+            source_category="editorial",
+            subject_kind="destination",
+            subject_id="destination-2",
+            contribution_kind="editorial",
+            summary="Negative freshness is invalid.",
+            freshness_days_at_capture=-2,
+        )
+    except ValueError as exc:
+        assert "freshness_days_at_capture" in str(exc)
+    else:
+        raise AssertionError("ProvenanceReference should reject negative freshness_days_at_capture")

--- a/trip_planner/sources/__init__.py
+++ b/trip_planner/sources/__init__.py
@@ -1,0 +1,11 @@
+"""Canonical source and provenance contracts."""
+
+from .models import QualityValueFitSummary, SourceRecord, SourceTrustSignals
+from .provenance import ProvenanceReference
+
+__all__ = [
+    "ProvenanceReference",
+    "QualityValueFitSummary",
+    "SourceRecord",
+    "SourceTrustSignals",
+]

--- a/trip_planner/sources/models.py
+++ b/trip_planner/sources/models.py
@@ -1,0 +1,116 @@
+"""Canonical source and source-signal contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_optional_non_empty,
+    require_probability,
+    require_strings,
+)
+
+from . import schema
+
+
+@dataclass(slots=True)
+class SourceTrustSignals:
+    freshness_days: int | None = None
+    freshness_confidence: float | None = None
+    commerciality: float | None = None
+    editorial_independence: float | None = None
+    operational_reliability: float | None = None
+    review_consistency: float | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.freshness_days is not None:
+            require_non_negative(self.freshness_days, "freshness_days")
+        for field_name in (
+            "freshness_confidence",
+            "commerciality",
+            "editorial_independence",
+            "operational_reliability",
+            "review_consistency",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_probability(value, field_name)
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class QualityValueFitSummary:
+    quality_signal: float | None = None
+    value_signal: float | None = None
+    fit_signal: float | None = None
+    confidence: float | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        for field_name in ("quality_signal", "value_signal", "fit_signal", "confidence"):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_probability(value, field_name)
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class SourceRecord:
+    source_id: str
+    provider_name: str
+    display_name: str
+    category: str
+    coverage_scope: str = "global"
+    supported_option_kinds: list[str] = field(default_factory=list)
+    coverage_regions: list[str] = field(default_factory=list)
+    base_url: str = ""
+    default_locale: str = ""
+    trust_signals: SourceTrustSignals = field(default_factory=SourceTrustSignals)
+    quality_summary: QualityValueFitSummary = field(default_factory=QualityValueFitSummary)
+    business_approval_status: str = "unknown"
+    business_approval_notes: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    schema_version: str = schema.SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.source_id, "source_id")
+        require_non_empty(self.provider_name, "provider_name")
+        require_non_empty(self.display_name, "display_name")
+        if self.category not in schema.SOURCE_CATEGORIES:
+            raise ValueError(f"category must be one of {schema.SOURCE_CATEGORIES}")
+        if self.coverage_scope not in schema.COVERAGE_SCOPES:
+            raise ValueError(f"coverage_scope must be one of {schema.COVERAGE_SCOPES}")
+        if self.schema_version != schema.SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {schema.SCHEMA_VERSION!r}")
+        require_optional_non_empty(self.base_url or None, "base_url")
+        require_optional_non_empty(self.default_locale or None, "default_locale")
+        require_strings(self.coverage_regions, "coverage_regions")
+        require_strings(self.business_approval_notes, "business_approval_notes")
+        require_strings(self.notes, "notes")
+        for kind in self.supported_option_kinds:
+            if kind not in schema.SOURCE_OPTION_KINDS:
+                raise ValueError(
+                    "supported_option_kinds must contain only "
+                    f"{schema.SOURCE_OPTION_KINDS!r} members"
+                )
+        if not isinstance(self.trust_signals, SourceTrustSignals):
+            raise ValueError("trust_signals must be a SourceTrustSignals")
+        if not isinstance(self.quality_summary, QualityValueFitSummary):
+            raise ValueError("quality_summary must be a QualityValueFitSummary")
+        if self.business_approval_status not in schema.BUSINESS_APPROVAL_STATUSES:
+            raise ValueError(
+                "business_approval_status must be one of " f"{schema.BUSINESS_APPROVAL_STATUSES}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/trip_planner/sources/provenance.py
+++ b/trip_planner/sources/provenance.py
@@ -1,0 +1,61 @@
+"""Reusable provenance references for source-backed planning objects."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_optional_non_empty,
+    require_strings,
+)
+
+from . import schema
+from .models import QualityValueFitSummary, SourceTrustSignals
+
+
+@dataclass(slots=True)
+class ProvenanceReference:
+    provenance_id: str
+    source_id: str
+    source_category: str
+    subject_kind: str
+    subject_id: str
+    contribution_kind: str
+    summary: str
+    locator: str = ""
+    captured_at: str = ""
+    freshness_days_at_capture: int | None = None
+    trust_snapshot: SourceTrustSignals | None = None
+    quality_value_fit: QualityValueFitSummary | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.provenance_id, "provenance_id")
+        require_non_empty(self.source_id, "source_id")
+        require_non_empty(self.subject_id, "subject_id")
+        require_non_empty(self.summary, "summary")
+        if self.source_category not in schema.SOURCE_CATEGORIES:
+            raise ValueError(f"source_category must be one of {schema.SOURCE_CATEGORIES}")
+        if self.subject_kind not in schema.PROVENANCE_SUBJECT_KINDS:
+            raise ValueError(f"subject_kind must be one of {schema.PROVENANCE_SUBJECT_KINDS}")
+        if self.contribution_kind not in schema.CONTRIBUTION_KINDS:
+            raise ValueError(f"contribution_kind must be one of {schema.CONTRIBUTION_KINDS}")
+        require_optional_non_empty(self.locator or None, "locator")
+        require_optional_non_empty(self.captured_at or None, "captured_at")
+        if self.freshness_days_at_capture is not None:
+            require_non_negative(self.freshness_days_at_capture, "freshness_days_at_capture")
+        if self.trust_snapshot is not None and not isinstance(
+            self.trust_snapshot, SourceTrustSignals
+        ):
+            raise ValueError("trust_snapshot must be a SourceTrustSignals when provided")
+        if self.quality_value_fit is not None and not isinstance(
+            self.quality_value_fit, QualityValueFitSummary
+        ):
+            raise ValueError("quality_value_fit must be a QualityValueFitSummary when provided")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/trip_planner/sources/schema.py
+++ b/trip_planner/sources/schema.py
@@ -1,0 +1,64 @@
+"""Schema constants for source and provenance contracts."""
+
+from __future__ import annotations
+
+SCHEMA_VERSION = "0.1.0"
+
+SOURCE_CATEGORIES: tuple[str, ...] = (
+    "commercial_inventory",
+    "ratings_reviews",
+    "editorial",
+    "specialist_non_commercial",
+    "official_operational",
+    "managed_travel_policy",
+)
+
+COVERAGE_SCOPES: tuple[str, ...] = (
+    "global",
+    "national",
+    "regional",
+    "local",
+    "route",
+    "property",
+    "event",
+)
+
+SOURCE_OPTION_KINDS: tuple[str, ...] = (
+    "route",
+    "lodging",
+    "flight",
+    "rail",
+    "car",
+    "activity",
+    "mixed",
+    "policy",
+)
+
+BUSINESS_APPROVAL_STATUSES: tuple[str, ...] = (
+    "unknown",
+    "approved",
+    "preferred",
+    "restricted",
+    "disallowed",
+)
+
+PROVENANCE_SUBJECT_KINDS: tuple[str, ...] = (
+    "destination",
+    "place",
+    "option",
+    "option_set",
+    "proposal",
+    "policy_evaluation",
+)
+
+CONTRIBUTION_KINDS: tuple[str, ...] = (
+    "inventory",
+    "pricing",
+    "rating",
+    "review",
+    "editorial",
+    "operational",
+    "policy",
+    "availability",
+    "comparison",
+)


### PR DESCRIPTION
Closes #517

## Summary
- add canonical `trip_planner.sources` contracts for source records, trust signals, quality/value/fit summaries, and provenance references
- add representative tests for leisure, official-operational, and managed-travel source categories plus provenance validation failures
- document how later options and policy-ready proposals should carry source provenance without collapsing quality, value, and fit

## Testing
- python3 -m pytest tests/sources/test_source_models.py tests/sources/test_source_provenance.py -q
- python3 -m black --check --line-length 100 trip_planner tests
- python3 -m mypy trip_planner tests
- python3 -m pytest -q

<!-- pr-preamble:start -->
> **Source:** Issue #517

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner is supposed to combine commercial inventory, ratings, editorial guidance, specialist sources, and business-approved channels, but the repo does not yet have a stable source/provenance contract. Before heavy ingestion work or option generation begins, the codebase needs a canonical way to represent source type, trust signals, quality/value/fit outputs, and business approval status.

Parent epic: #513

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#513](https://github.com/stranske/trip-planner/issues/513)
- [#505](https://github.com/stranske/trip-planner/issues/505)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Implement typed contracts for normalized source records, source categories, trust-signal records, provenance references, and quality/value/fit summaries.
- [ ] Encode the source categories described in the design docs: commercial inventory, ratings/reviews, editorial, specialist/non-commercial, official/operational, and managed-travel/policy sources.
- [ ] Ensure source records can carry freshness, commerciality, editorial independence, operational reliability, review consistency, and business approval status where relevant.
- [ ] Implement reusable provenance references so options, destinations, and policy-ready proposals can explain why a source contributed to a recommendation.
- [ ] Add tests for source-record validation and for representative examples from both leisure and business contexts.
- [ ] Document how later option contracts should use quality, value, and fit as separate concepts rather than collapsing them into one score.

#### Acceptance criteria
- [ ] The repo contains canonical source/provenance contracts that can be reused by options and policy-ready proposals.
- [ ] Source records support both consumer-travel and managed-travel use cases.
- [ ] Quality, value, and fit are modeled as distinct reusable summaries.
- [ ] Tests cover representative examples across at least three source categories and include validation failures.
- [ ] Documentation explains how source provenance should flow into later option generation and explanation layers.

**Head SHA:** 614eb7d5c9a32c97776e7e795ee94c917f9b1c17
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/23125566129) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23125569342) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23125569349) |
| CI | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23125569336) |
| Claude Code Review | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23125569237) |
| Copilot code review | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23125570097) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23125569236) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23125569341) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23125569238) |
<!-- auto-status-summary:end -->