### PR TITLE
Build the leisure preference resolution engine

### DIFF
--- a/tests/preferences/test_interactions.py
+++ b/tests/preferences/test_interactions.py
@@ -1,0 +1,64 @@
+from copy import deepcopy
+
+from tests.preferences.fixture_corpus import load_fixture_corpus
+from trip_planner.preferences import EvidenceSummary, resolve_leisure_profile
+
+
+def _resolution_seed(fixture_profile):
+    seed = deepcopy(fixture_profile)
+    for dimension in seed.tradeoff_dimensions.values():
+        dimension.confidence = 0.2
+        dimension.salience = 0.2
+        dimension.stability = 0.2
+    seed.interaction_rules = []
+    seed.tension_flags = []
+    seed.evidence_summary = EvidenceSummary()
+    return seed
+
+
+def _resolved_fixture(fixture_id: str):
+    fixture = next(item for item in load_fixture_corpus() if item.id == fixture_id)
+    return resolve_leisure_profile(_resolution_seed(fixture.profile), fixture.evidence)
+
+
+def test_movement_and_scenic_transit_interaction_activates() -> None:
+    result = _resolved_fixture("scenic-rail-nomad")
+
+    assert any(rule.id == "movement-x-scenic-transit" for rule in result.profile.interaction_rules)
+    assert any(
+        activation.rule_id == "movement-x-scenic-transit"
+        for activation in result.explanation.activated_interactions
+    )
+    assert result.profile.hybrid_factors["route_modes"].anchor_strength >= 0.62
+
+
+def test_breadth_and_recovery_interaction_produces_tension() -> None:
+    result = _resolved_fixture("breadth-under-recovery-pressure")
+
+    assert any(rule.id == "breadth-x-recovery" for rule in result.profile.interaction_rules)
+    assert any(flag.id == "breadth-recovery-conflict" for flag in result.profile.tension_flags)
+
+
+def test_structure_and_discovery_interaction_respects_fixed_anchors() -> None:
+    result = _resolved_fixture("elastic-discovery-with-fixed-anchors")
+
+    assert any(rule.id == "structure-x-discovery" for rule in result.profile.interaction_rules)
+    assert any(flag.id == "elasticity-anchor-conflict" for flag in result.profile.tension_flags)
+
+
+def test_budget_and_quality_floor_interaction_produces_guardrail_bias() -> None:
+    result = _resolved_fixture("quality-floors-under-budget-pressure")
+
+    assert any(rule.id == "budget-x-quality-floors" for rule in result.profile.interaction_rules)
+    assert any(flag.id == "quality-floor-budget-conflict" for flag in result.profile.tension_flags)
+    assert result.profile.tradeoff_dimensions["self_reliance_vs_convenience"].value >= 0.45
+
+
+def test_social_and_recovery_interaction_boosts_rest_hybrid_factor() -> None:
+    result = _resolved_fixture("social-recovery-balancer")
+
+    assert any(rule.id == "social-energy-x-recovery" for rule in result.profile.interaction_rules)
+    assert any(
+        flag.id == "social-energy-recovery-conflict" for flag in result.profile.tension_flags
+    )
+    assert result.profile.hybrid_factors["rest"].salience >= 0.84

--- a/tests/preferences/test_resolution.py
+++ b/tests/preferences/test_resolution.py
@@ -1,0 +1,67 @@
+from copy import deepcopy
+
+from tests.preferences.fixture_corpus import load_fixture_corpus
+from trip_planner.preferences import EvidenceSummary, resolve_leisure_profile
+
+EXPECTED_TENSION_IDS = {
+    "social-recovery-balancer": {"social-energy-recovery-conflict"},
+    "breadth-under-recovery-pressure": {"breadth-recovery-conflict"},
+    "elastic-discovery-with-fixed-anchors": {"elasticity-anchor-conflict"},
+    "quality-floors-under-budget-pressure": {"quality-floor-budget-conflict"},
+}
+
+
+def _resolution_seed(fixture_profile):
+    seed = deepcopy(fixture_profile)
+    for dimension in seed.tradeoff_dimensions.values():
+        dimension.confidence = 0.2
+        dimension.salience = 0.2
+        dimension.stability = 0.2
+    seed.interaction_rules = []
+    seed.tension_flags = []
+    seed.evidence_summary = EvidenceSummary()
+    return seed
+
+
+def _same_direction(left: float, right: float) -> bool:
+    if left == 0.0 or right == 0.0:
+        return left == right
+    return (left < 0 and right < 0) or (left > 0 and right > 0)
+
+
+def test_resolution_matches_fixture_directional_outcomes() -> None:
+    for fixture in load_fixture_corpus():
+        result = resolve_leisure_profile(_resolution_seed(fixture.profile), fixture.evidence)
+
+        for dimension_key in fixture.intended_interpretation.dominant_dimensions:
+            expected = fixture.profile.tradeoff_dimensions[dimension_key]
+            actual = result.profile.tradeoff_dimensions[dimension_key]
+            assert _same_direction(actual.value, expected.value)
+            assert actual.confidence > 0.2
+            assert actual.salience > 0.2
+            assert result.explanation.dimension_explanations[dimension_key].influences
+
+        if fixture.id in EXPECTED_TENSION_IDS:
+            actual_ids = {flag.id for flag in result.profile.tension_flags}
+            assert EXPECTED_TENSION_IDS[fixture.id].issubset(actual_ids)
+
+
+def test_resolution_emits_contradiction_tension_when_evidence_conflicts() -> None:
+    fixture = next(item for item in load_fixture_corpus() if item.id == "scenic-rail-nomad")
+    contradictory = deepcopy(fixture.evidence[0])
+    contradictory.id = "scenic-rail-nomad-ev-contradiction"
+    contradictory.signal_direction = "contradiction"
+    contradictory.contradictions = []
+    contradictory.note = "Traveler also says frequent transfers become exhausting after a week."
+
+    result = resolve_leisure_profile(
+        _resolution_seed(fixture.profile),
+        fixture.evidence + [contradictory],
+    )
+
+    assert any(
+        flag.id == "movement_vs_friction-contradiction" for flag in result.profile.tension_flags
+    )
+    assert "movement_vs_friction-contradiction" in (
+        result.explanation.dimension_explanations["movement_vs_friction"].tension_flag_ids
+    )

--- a/trip_planner/preferences/__init__.py
+++ b/trip_planner/preferences/__init__.py
@@ -8,6 +8,14 @@ from .evidence_catalog import (
     support_for_hybrid_factor,
     validate_evidence_support,
 )
+from .explanations import (
+    DimensionResolutionExplanation,
+    HybridFactorExplanation,
+    InteractionActivation,
+    MaterialInfluence,
+    ResolutionExplanation,
+    ResolvedLeisureProfile,
+)
 from .legacy_request_adapter import adapt_legacy_request, load_legacy_request
 from .models import (
     Anchor,
@@ -23,6 +31,7 @@ from .models import (
     TradeoffDimension,
     TripFrame,
 )
+from .resolution import resolve_leisure_profile
 
 __all__ = [
     "Anchor",
@@ -31,18 +40,25 @@ __all__ = [
     "ContradictionMarker",
     "DateWindow",
     "DurationBounds",
+    "DimensionResolutionExplanation",
     "EvidenceSummary",
     "HardConstraints",
     "HybridFactor",
+    "HybridFactorExplanation",
     "InteractionRule",
+    "InteractionActivation",
+    "MaterialInfluence",
     "LeisurePreferenceProfile",
     "OptionEvidence",
     "PreferenceEvidence",
+    "ResolutionExplanation",
+    "ResolvedLeisureProfile",
     "TensionFlag",
     "TradeoffDimension",
     "TripFrame",
     "adapt_legacy_request",
     "load_legacy_request",
+    "resolve_leisure_profile",
     "support_for_anchor_group",
     "support_for_dimension",
     "support_for_hybrid_factor",

--- a/trip_planner/preferences/explanations.py
+++ b/trip_planner/preferences/explanations.py
@@ -1,0 +1,82 @@
+"""Structured explanation output for leisure preference resolution."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class MaterialInfluence:
+    source_kind: str
+    source_id: str
+    weight: float
+    summary: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class DimensionResolutionExplanation:
+    dimension_key: str
+    resolved_value: float
+    confidence: float
+    salience: float
+    stability: float
+    influences: list[MaterialInfluence] = field(default_factory=list)
+    interaction_rule_ids: list[str] = field(default_factory=list)
+    tension_flag_ids: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class HybridFactorExplanation:
+    hybrid_factor_key: str
+    mode: str
+    salience: float
+    anchor_strength: float
+    influences: list[MaterialInfluence] = field(default_factory=list)
+    interaction_rule_ids: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class InteractionActivation:
+    rule_id: str
+    dimensions: list[str]
+    planning_biases: dict[str, float] = field(default_factory=dict)
+    triggered_tension_ids: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ResolutionExplanation:
+    dimension_explanations: dict[str, DimensionResolutionExplanation] = field(default_factory=dict)
+    hybrid_factor_explanations: dict[str, HybridFactorExplanation] = field(default_factory=dict)
+    activated_interactions: list[InteractionActivation] = field(default_factory=list)
+    tension_explanations: dict[str, list[MaterialInfluence]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ResolvedLeisureProfile:
+    profile: Any
+    explanation: ResolutionExplanation
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile": self.profile.to_dict(),
+            "explanation": self.explanation.to_dict(),
+        }

--- a/trip_planner/preferences/interactions.py
+++ b/trip_planner/preferences/interactions.py
@@ -1,0 +1,392 @@
+"""Interaction rules for leisure preference resolution."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from .explanations import InteractionActivation, MaterialInfluence, ResolutionExplanation
+from .models import InteractionRule, LeisurePreferenceProfile, TensionFlag
+
+
+def _clamp_probability(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _clamp_axis(value: float) -> float:
+    return max(-1.0, min(1.0, value))
+
+
+def _upsert_tension(
+    profile: LeisurePreferenceProfile,
+    explanation: ResolutionExplanation,
+    flag_id: str,
+    severity: float,
+    description: str,
+    influences: list[MaterialInfluence],
+) -> None:
+    existing = next((flag for flag in profile.tension_flags if flag.id == flag_id), None)
+    if existing is None:
+        profile.tension_flags.append(
+            TensionFlag(
+                id=flag_id,
+                severity=_clamp_probability(severity),
+                description=description,
+            )
+        )
+    else:
+        existing.severity = max(existing.severity, _clamp_probability(severity))
+    explanation.tension_explanations.setdefault(flag_id, []).extend(influences)
+
+
+def _record_rule_on_dimensions(
+    explanation: ResolutionExplanation,
+    rule_id: str,
+    dimension_keys: list[str],
+) -> None:
+    for key in dimension_keys:
+        detail = explanation.dimension_explanations[key]
+        if rule_id not in detail.interaction_rule_ids:
+            detail.interaction_rule_ids.append(rule_id)
+
+
+def _record_rule_on_hybrid(
+    explanation: ResolutionExplanation,
+    rule_id: str,
+    hybrid_key: str,
+) -> None:
+    detail = explanation.hybrid_factor_explanations[hybrid_key]
+    if rule_id not in detail.interaction_rule_ids:
+        detail.interaction_rule_ids.append(rule_id)
+
+
+def apply_interactions(
+    profile: LeisurePreferenceProfile,
+    explanation: ResolutionExplanation,
+) -> None:
+    dims = profile.tradeoff_dimensions
+    hybrids = profile.hybrid_factors
+
+    breadth = dims["breadth_vs_depth"]
+    recovery = dims["recovery_vs_intensity"]
+    movement = dims["movement_vs_friction"]
+    scenic = dims["scenic_transit_vs_destination_time"]
+    structure = dims["structure_vs_elasticity"]
+    discovery = dims["iconic_vs_discovery"]
+    route = dims["route_coherence_vs_eclectic_contrast"]
+    social = dims["social_energy_vs_solitude"]
+    self_reliance = dims["self_reliance_vs_convenience"]
+
+    if breadth.value <= -0.45 and recovery.value <= -0.45:
+        strength = _clamp_probability((abs(breadth.value) + abs(recovery.value)) / 2.0)
+        movement.value = _clamp_axis(movement.value + 0.12)
+        route.salience = max(route.salience, 0.72)
+        rule_id = "breadth-x-recovery"
+        profile.interaction_rules.append(
+            InteractionRule(
+                id=rule_id,
+                dimensions=["breadth_vs_depth", "recovery_vs_intensity"],
+                activation={
+                    "breadth_vs_depth": breadth.value,
+                    "recovery_vs_intensity": recovery.value,
+                },
+                effect={
+                    "planning_biases": {
+                        "cluster_bases": 0.92,
+                        "protect_recovery_blocks": 0.96,
+                    },
+                    "movement_bias_shift": 0.12,
+                },
+                strength=strength,
+                priority=0.95,
+            )
+        )
+        tension_id = "breadth-recovery-conflict"
+        influences = [
+            MaterialInfluence(
+                source_kind="interaction",
+                source_id=rule_id,
+                weight=strength,
+                summary="Breadth desire and recovery need require clustered routing and recovery blocks.",
+            )
+        ]
+        _upsert_tension(
+            profile,
+            explanation,
+            tension_id,
+            severity=max(0.75, strength),
+            description="Breadth ambitions conflict with recovery limits unless the route is tightly clustered.",
+            influences=influences,
+        )
+        _record_rule_on_dimensions(
+            explanation,
+            rule_id,
+            ["breadth_vs_depth", "recovery_vs_intensity", "movement_vs_friction"],
+        )
+        for key in ("breadth_vs_depth", "recovery_vs_intensity"):
+            if tension_id not in explanation.dimension_explanations[key].tension_flag_ids:
+                explanation.dimension_explanations[key].tension_flag_ids.append(tension_id)
+        explanation.activated_interactions.append(
+            InteractionActivation(
+                rule_id=rule_id,
+                dimensions=["breadth_vs_depth", "recovery_vs_intensity"],
+                planning_biases={
+                    "cluster_bases": 0.92,
+                    "protect_recovery_blocks": 0.96,
+                },
+                triggered_tension_ids=[tension_id],
+                notes=[
+                    "Move density should stay constrained even when breadth remains attractive."
+                ],
+            )
+        )
+
+    if movement.value <= -0.45 and scenic.value <= -0.45:
+        strength = _clamp_probability((abs(movement.value) + abs(scenic.value)) / 2.0)
+        hybrids["route_modes"].mode = "both"
+        hybrids["route_modes"].salience = max(hybrids["route_modes"].salience, 0.82)
+        hybrids["route_modes"].anchor_strength = max(hybrids["route_modes"].anchor_strength, 0.62)
+        route.salience = max(route.salience, 0.7)
+        rule_id = "movement-x-scenic-transit"
+        profile.interaction_rules.append(
+            InteractionRule(
+                id=rule_id,
+                dimensions=["movement_vs_friction", "scenic_transit_vs_destination_time"],
+                activation={
+                    "movement_vs_friction": movement.value,
+                    "scenic_transit_vs_destination_time": scenic.value,
+                },
+                effect={
+                    "planning_biases": {
+                        "prefer_overland_modes": 0.93,
+                        "treat_transit_as_experience": 0.95,
+                    },
+                    "route_mode_anchor_boost": 0.62,
+                },
+                strength=strength,
+                priority=0.88,
+            )
+        )
+        _record_rule_on_dimensions(
+            explanation,
+            rule_id,
+            ["movement_vs_friction", "scenic_transit_vs_destination_time"],
+        )
+        _record_rule_on_hybrid(explanation, rule_id, "route_modes")
+        explanation.activated_interactions.append(
+            InteractionActivation(
+                rule_id=rule_id,
+                dimensions=["movement_vs_friction", "scenic_transit_vs_destination_time"],
+                planning_biases={
+                    "prefer_overland_modes": 0.93,
+                    "treat_transit_as_experience": 0.95,
+                },
+                notes=["The route itself should be treated as part of the trip payoff."],
+            )
+        )
+
+    if structure.value >= 0.45 and discovery.value >= 0.45:
+        strength = _clamp_probability((structure.value + discovery.value) / 2.0)
+        rule_id = "structure-x-discovery"
+        profile.interaction_rules.append(
+            InteractionRule(
+                id=rule_id,
+                dimensions=["structure_vs_elasticity", "iconic_vs_discovery"],
+                activation={
+                    "structure_vs_elasticity": structure.value,
+                    "iconic_vs_discovery": discovery.value,
+                },
+                effect={
+                    "planning_biases": {
+                        "favor_wandering_zones": 0.94,
+                        "keep_daily_skeleton_light": 0.82,
+                    }
+                },
+                strength=strength,
+                priority=0.83,
+            )
+        )
+        _record_rule_on_dimensions(
+            explanation,
+            rule_id,
+            ["structure_vs_elasticity", "iconic_vs_discovery"],
+        )
+        if profile.anchors["place_anchors"] or profile.anchors["calendar_anchors"]:
+            tension_id = "elasticity-anchor-conflict"
+            influences = [
+                MaterialInfluence(
+                    source_kind="interaction",
+                    source_id=rule_id,
+                    weight=strength,
+                    summary="Open-ended discovery must coexist with fixed anchors and calendar commitments.",
+                )
+            ]
+            _upsert_tension(
+                profile,
+                explanation,
+                tension_id,
+                severity=max(0.72, strength),
+                description="Elastic discovery needs a route skeleton because anchors cannot be allowed to drift.",
+                influences=influences,
+            )
+            for key in ("structure_vs_elasticity", "iconic_vs_discovery"):
+                if tension_id not in explanation.dimension_explanations[key].tension_flag_ids:
+                    explanation.dimension_explanations[key].tension_flag_ids.append(tension_id)
+            tension_ids = [tension_id]
+        else:
+            tension_ids = []
+        explanation.activated_interactions.append(
+            InteractionActivation(
+                rule_id=rule_id,
+                dimensions=["structure_vs_elasticity", "iconic_vs_discovery"],
+                planning_biases={
+                    "favor_wandering_zones": 0.94,
+                    "keep_daily_skeleton_light": 0.82,
+                },
+                triggered_tension_ids=tension_ids,
+                notes=[
+                    "Discovery-heavy travelers still need directional wandering targets rather than empty free time."
+                ],
+            )
+        )
+
+    has_quality_floor = bool(
+        profile.anchors["quality_floor_anchors"] or profile.budget_model.quality_floors
+    )
+    has_budget_pressure = (
+        profile.budget_model.total_budget_sensitivity >= 0.55
+        or profile.hard_constraints.budget_ceiling is not None
+    )
+    if has_quality_floor and has_budget_pressure:
+        strength = _clamp_probability(0.5 + (profile.budget_model.total_budget_sensitivity * 0.4))
+        self_reliance.value = max(self_reliance.value, 0.45)
+        self_reliance.salience = max(self_reliance.salience, 0.7)
+        route.salience = max(route.salience, 0.62)
+        rule_id = "budget-x-quality-floors"
+        profile.interaction_rules.append(
+            InteractionRule(
+                id=rule_id,
+                dimensions=["self_reliance_vs_convenience"],
+                activation={
+                    "budget_sensitivity": profile.budget_model.total_budget_sensitivity,
+                    "quality_floor_anchor_count": len(profile.anchors["quality_floor_anchors"]),
+                },
+                effect={
+                    "planning_biases": {
+                        "compress_route_before_downgrading_lodging": 0.95,
+                        "protect_quality_floors": 0.92,
+                    }
+                },
+                strength=strength,
+                priority=0.9,
+            )
+        )
+        tension_id = "quality-floor-budget-conflict"
+        influences = [
+            MaterialInfluence(
+                source_kind="interaction",
+                source_id=rule_id,
+                weight=strength,
+                summary="Budget pressure should contract route ambition before comfort floors are silently violated.",
+            )
+        ]
+        _upsert_tension(
+            profile,
+            explanation,
+            tension_id,
+            severity=max(0.78, strength),
+            description="Budget pressure conflicts with comfort floors unless route scope or timing adjusts.",
+            influences=influences,
+        )
+        _record_rule_on_dimensions(explanation, rule_id, ["self_reliance_vs_convenience"])
+        if (
+            tension_id
+            not in explanation.dimension_explanations[
+                "self_reliance_vs_convenience"
+            ].tension_flag_ids
+        ):
+            explanation.dimension_explanations[
+                "self_reliance_vs_convenience"
+            ].tension_flag_ids.append(tension_id)
+        explanation.activated_interactions.append(
+            InteractionActivation(
+                rule_id=rule_id,
+                dimensions=["self_reliance_vs_convenience"],
+                planning_biases={
+                    "compress_route_before_downgrading_lodging": 0.95,
+                    "protect_quality_floors": 0.92,
+                },
+                triggered_tension_ids=[tension_id],
+                notes=[
+                    "Comfort floors should be protected by scope cuts before quiet lodging is sacrificed."
+                ],
+            )
+        )
+
+    if social.value <= -0.45 and recovery.value <= -0.45:
+        strength = _clamp_probability((abs(social.value) + abs(recovery.value)) / 2.0)
+        hybrids["rest"].mode = "both"
+        hybrids["rest"].salience = max(hybrids["rest"].salience, 0.84)
+        hybrids["rest"].anchor_strength = max(hybrids["rest"].anchor_strength, 0.52)
+        rule_id = "social-energy-x-recovery"
+        profile.interaction_rules.append(
+            InteractionRule(
+                id=rule_id,
+                dimensions=["social_energy_vs_solitude", "recovery_vs_intensity"],
+                activation={
+                    "social_energy_vs_solitude": social.value,
+                    "recovery_vs_intensity": recovery.value,
+                },
+                effect={
+                    "planning_biases": {
+                        "alternate_social_and_recovery_days": 0.96,
+                        "protect_slow_mornings": 0.9,
+                    }
+                },
+                strength=strength,
+                priority=0.9,
+            )
+        )
+        tension_id = "social-energy-recovery-conflict"
+        influences = [
+            MaterialInfluence(
+                source_kind="interaction",
+                source_id=rule_id,
+                weight=strength,
+                summary="Social-energy goals require explicit recovery protection instead of optimistic pacing.",
+            )
+        ]
+        _upsert_tension(
+            profile,
+            explanation,
+            tension_id,
+            severity=max(0.76, strength),
+            description="Social-energy preferences conflict with recovery limits unless late and quiet days alternate.",
+            influences=influences,
+        )
+        _record_rule_on_dimensions(
+            explanation,
+            rule_id,
+            ["social_energy_vs_solitude", "recovery_vs_intensity"],
+        )
+        _record_rule_on_hybrid(explanation, rule_id, "rest")
+        for key in ("social_energy_vs_solitude", "recovery_vs_intensity"):
+            if tension_id not in explanation.dimension_explanations[key].tension_flag_ids:
+                explanation.dimension_explanations[key].tension_flag_ids.append(tension_id)
+        explanation.activated_interactions.append(
+            InteractionActivation(
+                rule_id=rule_id,
+                dimensions=["social_energy_vs_solitude", "recovery_vs_intensity"],
+                planning_biases={
+                    "alternate_social_and_recovery_days": 0.96,
+                    "protect_slow_mornings": 0.9,
+                },
+                triggered_tension_ids=[tension_id],
+                notes=[
+                    "High-social-energy days should be paired with explicit decompression time."
+                ],
+            )
+        )
+
+    profile.tradeoff_dimensions["movement_vs_friction"] = replace(movement)
+    profile.tradeoff_dimensions["route_coherence_vs_eclectic_contrast"] = replace(route)
+    profile.tradeoff_dimensions["self_reliance_vs_convenience"] = replace(self_reliance)

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -1,0 +1,347 @@
+"""Resolution engine for leisure preference profiles."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from . import schema
+from .evidence import PreferenceEvidence
+from .evidence_catalog import (
+    support_for_anchor_group,
+    support_for_dimension,
+    support_for_hybrid_factor,
+)
+from .explanations import (
+    DimensionResolutionExplanation,
+    HybridFactorExplanation,
+    MaterialInfluence,
+    ResolutionExplanation,
+    ResolvedLeisureProfile,
+)
+from .interactions import apply_interactions
+from .models import LeisurePreferenceProfile, TensionFlag
+
+SUPPORT_WEIGHTS: dict[str, float] = {
+    "weak": 0.3,
+    "medium": 0.6,
+    "strong": 0.9,
+}
+ANCHOR_GROUP_DIMENSIONS: dict[str, list[str]] = {
+    "place_anchors": ["route_coherence_vs_eclectic_contrast", "breadth_vs_depth"],
+    "experience_anchors": ["breadth_vs_depth", "iconic_vs_discovery"],
+    "mode_anchors": ["movement_vs_friction", "scenic_transit_vs_destination_time"],
+    "rhythm_anchors": ["recovery_vs_intensity", "structure_vs_elasticity"],
+    "calendar_anchors": ["structure_vs_elasticity", "route_coherence_vs_eclectic_contrast"],
+    "quality_floor_anchors": [
+        "movement_vs_friction",
+        "self_reliance_vs_convenience",
+        "recovery_vs_intensity",
+    ],
+    "regional_adjacency_preferences": [
+        "route_coherence_vs_eclectic_contrast",
+        "scenic_transit_vs_destination_time",
+    ],
+}
+EVIDENCE_STAGE_BOOSTS: dict[str, dict[str, float]] = {
+    "direct_statement": {"initial_design": 0.15},
+    "hard_constraint_declaration": {"initial_design": 0.18, "inventory_selection": 0.08},
+    "anchor_declaration": {"initial_design": 0.18, "daily_activity_design": 0.06},
+    "forced_tradeoff_choice": {"initial_design": 0.16},
+    "scenario_reaction": {"initial_design": 0.14, "inventory_selection": 0.08},
+    "option_selection": {"inventory_selection": 0.18, "daily_activity_design": 0.08},
+    "option_rejection": {"inventory_selection": 0.14},
+    "trip_revision": {"in_trip_adjustment": 0.18, "daily_activity_design": 0.1},
+}
+
+
+def _clamp_probability(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _clamp_axis(value: float) -> float:
+    return max(-1.0, min(1.0, value))
+
+
+def _sorted_evidence(evidence_records: list[PreferenceEvidence]) -> list[PreferenceEvidence]:
+    return sorted(
+        evidence_records,
+        key=lambda record: (
+            record.sequence if record.sequence is not None else 10**6,
+            record.observed_at or "",
+            record.id,
+        ),
+    )
+
+
+def _influence_weight(record: PreferenceEvidence, support_level: str) -> float:
+    support_weight = SUPPORT_WEIGHTS[support_level]
+    contradiction_penalty = (
+        sum(marker.weakening_strength for marker in record.contradictions) * 0.12
+    )
+    return _clamp_probability(
+        support_weight * (0.5 + (record.confidence_hint * 0.3) + (record.salience_hint * 0.2))
+        - contradiction_penalty
+    )
+
+
+def _base_direction(value: float) -> float:
+    if value < 0:
+        return -1.0
+    if value > 0:
+        return 1.0
+    return 0.0
+
+
+def _new_dimension_explanation(
+    dimension_key: str, profile: LeisurePreferenceProfile
+) -> DimensionResolutionExplanation:
+    dimension = profile.tradeoff_dimensions[dimension_key]
+    return DimensionResolutionExplanation(
+        dimension_key=dimension_key,
+        resolved_value=dimension.value,
+        confidence=dimension.confidence,
+        salience=dimension.salience,
+        stability=dimension.stability,
+    )
+
+
+def _new_hybrid_explanation(
+    hybrid_key: str, profile: LeisurePreferenceProfile
+) -> HybridFactorExplanation:
+    factor = profile.hybrid_factors[hybrid_key]
+    return HybridFactorExplanation(
+        hybrid_factor_key=hybrid_key,
+        mode=factor.mode,
+        salience=factor.salience,
+        anchor_strength=factor.anchor_strength,
+    )
+
+
+def resolve_leisure_profile(
+    base_profile: LeisurePreferenceProfile,
+    evidence_records: list[PreferenceEvidence],
+) -> ResolvedLeisureProfile:
+    profile = deepcopy(base_profile)
+    profile.interaction_rules = []
+    profile.tension_flags = []
+    profile.evidence_summary.sources = {}
+    profile.evidence_summary.confidence_notes = []
+
+    explanation = ResolutionExplanation(
+        dimension_explanations={
+            key: _new_dimension_explanation(key, profile) for key in schema.TRADEOFF_DIMENSION_KEYS
+        },
+        hybrid_factor_explanations={
+            key: _new_hybrid_explanation(key, profile) for key in schema.HYBRID_FACTOR_KEYS
+        },
+    )
+    ordered_evidence = _sorted_evidence(evidence_records)
+
+    _apply_dimension_resolution(profile, ordered_evidence, explanation)
+    _apply_hybrid_resolution(profile, ordered_evidence, explanation)
+    _apply_anchor_and_constraint_precedence(profile, explanation)
+    apply_interactions(profile, explanation)
+    _finalize_explanations(profile, explanation)
+
+    return ResolvedLeisureProfile(profile=profile, explanation=explanation)
+
+
+def _apply_dimension_resolution(
+    profile: LeisurePreferenceProfile,
+    evidence_records: list[PreferenceEvidence],
+    explanation: ResolutionExplanation,
+) -> None:
+    for dimension_key in schema.TRADEOFF_DIMENSION_KEYS:
+        dimension = profile.tradeoff_dimensions[dimension_key]
+        base_direction = _base_direction(dimension.value)
+        base_magnitude = abs(dimension.value)
+        positive_support = 0.0
+        weakening_support = 0.0
+        contradiction_support = 0.0
+        salience_boost = 0.0
+        stability_bonus = 0.0
+        stage_boosts = {stage: 0.0 for stage in schema.PLANNING_STAGES}
+
+        for record in evidence_records:
+            if dimension_key not in record.affected_dimensions:
+                continue
+            support_level = support_for_dimension(dimension_key, record.evidence_type)
+            if support_level is None:
+                continue
+            weight = _influence_weight(record, support_level)
+            influence = MaterialInfluence(
+                source_kind="evidence",
+                source_id=record.id,
+                weight=weight,
+                summary=record.note or f"{record.evidence_type} affected {dimension_key}",
+            )
+            explanation.dimension_explanations[dimension_key].influences.append(influence)
+            profile.evidence_summary.sources.setdefault(dimension_key, []).append(record.id)
+            if record.signal_direction == "positive":
+                positive_support += weight
+            else:
+                weakening_support += weight
+            contradiction_support += sum(
+                marker.weakening_strength * weight * 0.65 for marker in record.contradictions
+            )
+            if record.signal_direction == "contradiction":
+                contradiction_support += weight * 0.5
+            salience_boost += weight * record.salience_hint * 0.45
+            stability_bonus += weight * 0.12
+            for stage, boost in EVIDENCE_STAGE_BOOSTS.get(record.evidence_type, {}).items():
+                stage_boosts[stage] = max(stage_boosts[stage], boost)
+
+        if base_direction != 0.0:
+            magnitude = _clamp_probability(
+                base_magnitude + (positive_support * 0.2) - (weakening_support * 0.1)
+            )
+            value = _clamp_axis(base_direction * magnitude)
+        else:
+            value = 0.0
+        dimension.value = value
+        dimension.confidence = _clamp_probability(
+            max(dimension.confidence, 0.25)
+            + (positive_support * 0.32)
+            - (contradiction_support * 0.18)
+        )
+        dimension.salience = _clamp_probability(
+            max(dimension.salience, 0.22) + salience_boost + (positive_support * 0.12)
+        )
+        dimension.stability = _clamp_probability(
+            max(dimension.stability, 0.2) + stability_bonus - (contradiction_support * 0.18)
+        )
+        for stage in schema.PLANNING_STAGES:
+            dimension.trip_stage_sensitivity[stage] = _clamp_probability(
+                max(dimension.trip_stage_sensitivity[stage], stage_boosts[stage])
+            )
+        if contradiction_support >= 0.18:
+            tension_id = f"{dimension_key}-contradiction"
+            flag = TensionFlag(
+                id=tension_id,
+                severity=_clamp_probability(0.45 + contradiction_support),
+                description=(f"Contradictory evidence remains unresolved for {dimension_key}."),
+            )
+            profile.tension_flags.append(flag)
+            explanation.tension_explanations[tension_id] = list(
+                explanation.dimension_explanations[dimension_key].influences
+            )
+            explanation.dimension_explanations[dimension_key].tension_flag_ids.append(tension_id)
+            profile.evidence_summary.confidence_notes.append(
+                f"{dimension_key} includes contradictory evidence that should remain visible downstream."
+            )
+
+
+def _apply_hybrid_resolution(
+    profile: LeisurePreferenceProfile,
+    evidence_records: list[PreferenceEvidence],
+    explanation: ResolutionExplanation,
+) -> None:
+    for hybrid_key in schema.HYBRID_FACTOR_KEYS:
+        factor = profile.hybrid_factors[hybrid_key]
+        salience_boost = 0.0
+        anchor_boost = 0.0
+        for record in evidence_records:
+            if hybrid_key not in record.affected_hybrid_factors:
+                continue
+            support_level = support_for_hybrid_factor(hybrid_key, record.evidence_type)
+            if support_level is None:
+                continue
+            weight = _influence_weight(record, support_level)
+            explanation.hybrid_factor_explanations[hybrid_key].influences.append(
+                MaterialInfluence(
+                    source_kind="evidence",
+                    source_id=record.id,
+                    weight=weight,
+                    summary=record.note or f"{record.evidence_type} affected {hybrid_key}",
+                )
+            )
+            profile.evidence_summary.sources.setdefault(hybrid_key, []).append(record.id)
+            if record.signal_direction == "positive":
+                salience_boost += weight * 0.42
+                if factor.mode in {"anchor", "both"}:
+                    anchor_boost += weight * 0.32
+            else:
+                salience_boost -= weight * 0.12
+        factor.salience = _clamp_probability(max(factor.salience, 0.18) + salience_boost)
+        factor.anchor_strength = _clamp_probability(max(factor.anchor_strength, 0.0) + anchor_boost)
+
+
+def _apply_anchor_and_constraint_precedence(
+    profile: LeisurePreferenceProfile,
+    explanation: ResolutionExplanation,
+) -> None:
+    for anchor_group, anchors in profile.anchors.items():
+        if not anchors:
+            continue
+        average_strength = sum(anchor.strength for anchor in anchors) / len(anchors)
+        flexibility_discount = sum(anchor.flexibility for anchor in anchors) / len(anchors)
+        effective_weight = _clamp_probability(
+            average_strength * (1.0 - (flexibility_discount * 0.35))
+        )
+        for dimension_key in ANCHOR_GROUP_DIMENSIONS.get(anchor_group, []):
+            dimension = profile.tradeoff_dimensions[dimension_key]
+            dimension.salience = _clamp_probability(
+                max(dimension.salience, 0.3) + (effective_weight * 0.22)
+            )
+            dimension.confidence = _clamp_probability(
+                max(dimension.confidence, 0.28) + (effective_weight * 0.12)
+            )
+            explanation.dimension_explanations[dimension_key].influences.append(
+                MaterialInfluence(
+                    source_kind="anchor_group",
+                    source_id=anchor_group,
+                    weight=effective_weight,
+                    summary=f"{anchor_group} raises the salience of {dimension_key}.",
+                )
+            )
+            if anchor_group not in profile.evidence_summary.sources:
+                profile.evidence_summary.sources[anchor_group] = [
+                    anchor.label for anchor in anchors
+                ]
+
+    if profile.hard_constraints.budget_ceiling is not None:
+        profile.evidence_summary.confidence_notes.append(
+            "Budget ceiling is treated as a hard constraint that later planning layers must protect."
+        )
+    if profile.anchors["quality_floor_anchors"] or profile.budget_model.quality_floors:
+        dimension = profile.tradeoff_dimensions["self_reliance_vs_convenience"]
+        dimension.value = max(dimension.value, 0.35)
+        dimension.salience = max(dimension.salience, 0.66)
+        dimension.confidence = max(dimension.confidence, 0.62)
+        explanation.dimension_explanations["self_reliance_vs_convenience"].influences.append(
+            MaterialInfluence(
+                source_kind="quality_floor_guardrail",
+                source_id="quality_floor_protection",
+                weight=0.72,
+                summary="Quality floors protect smoother arrivals and more reliable lodging choices.",
+            )
+        )
+
+
+def _finalize_explanations(
+    profile: LeisurePreferenceProfile,
+    explanation: ResolutionExplanation,
+) -> None:
+    for key, dimension in profile.tradeoff_dimensions.items():
+        detail = explanation.dimension_explanations[key]
+        detail.resolved_value = dimension.value
+        detail.confidence = dimension.confidence
+        detail.salience = dimension.salience
+        detail.stability = dimension.stability
+        if not detail.influences:
+            detail.notes.append(
+                "No direct evidence was attached; value came from the seed profile."
+            )
+        if detail.interaction_rule_ids:
+            detail.notes.append(
+                "Interaction rules materially affected this dimension during resolution."
+            )
+    for key, factor in profile.hybrid_factors.items():
+        hybrid_detail = explanation.hybrid_factor_explanations[key]
+        hybrid_detail.mode = factor.mode
+        hybrid_detail.salience = factor.salience
+        hybrid_detail.anchor_strength = factor.anchor_strength
+        if not hybrid_detail.influences:
+            hybrid_detail.notes.append(
+                "No direct evidence was attached; hybrid factor stayed close to the seed profile."
+            )


### PR DESCRIPTION
Closes #510

## Summary
- add the first-pass leisure resolution engine with structured explanation output
- implement the agreed interaction rules for breadth/recovery, movement/scenic transit, structure/discovery, budget/quality floors, and social energy/recovery
- add regression tests against the fixture corpus plus contradiction handling coverage

## Testing
- python3 -m pytest tests/preferences/test_resolution.py tests/preferences/test_interactions.py -q
- python3 -m black --check --line-length 100 trip_planner/preferences tests/preferences
- python3 -m mypy trip_planner tests
- python3 -m pytest -q