### PR TITLE
Follow up verifier findings for #510

### DIFF
--- a/tests/preferences/test_resolution.py
+++ b/tests/preferences/test_resolution.py
@@ -65,3 +65,20 @@ def test_resolution_emits_contradiction_tension_when_evidence_conflicts() -> Non
     assert "movement_vs_friction-contradiction" in (
         result.explanation.dimension_explanations["movement_vs_friction"].tension_flag_ids
     )
+
+
+def test_resolution_flags_dimensions_that_need_directional_seed() -> None:
+    fixture = next(item for item in load_fixture_corpus() if item.id == "discovery-wanderer")
+    seed = _resolution_seed(fixture.profile)
+    seed.tradeoff_dimensions["iconic_vs_discovery"].value = 0.0
+
+    result = resolve_leisure_profile(seed, fixture.evidence)
+
+    assert any(
+        flag.id == "iconic_vs_discovery-needs-directional-seed"
+        for flag in result.profile.tension_flags
+    )
+    assert any(
+        "zero-direction seed value" in note
+        for note in result.profile.evidence_summary.confidence_notes
+    )

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -179,7 +179,7 @@ def _apply_dimension_resolution(
             profile.evidence_summary.sources.setdefault(dimension_key, []).append(record.id)
             if record.signal_direction == "positive":
                 positive_support += weight
-            else:
+            elif record.signal_direction == "negative":
                 weakening_support += weight
             contradiction_support += sum(
                 marker.weakening_strength * weight * 0.65 for marker in record.contradictions
@@ -198,6 +198,25 @@ def _apply_dimension_resolution(
             value = _clamp_axis(base_direction * magnitude)
         else:
             value = 0.0
+            if positive_support > 0.0 or weakening_support > 0.0 or contradiction_support > 0.0:
+                tension_id = f"{dimension_key}-needs-directional-seed"
+                flag = TensionFlag(
+                    id=tension_id,
+                    severity=_clamp_probability(0.45 + positive_support + contradiction_support),
+                    description=(
+                        f"{dimension_key} has evidence support but still needs directional seeding."
+                    ),
+                )
+                profile.tension_flags.append(flag)
+                explanation.tension_explanations[tension_id] = list(
+                    explanation.dimension_explanations[dimension_key].influences
+                )
+                explanation.dimension_explanations[dimension_key].tension_flag_ids.append(
+                    tension_id
+                )
+                profile.evidence_summary.confidence_notes.append(
+                    f"{dimension_key} received evidence but remained at a zero-direction seed value."
+                )
         dimension.value = value
         dimension.confidence = _clamp_probability(
             max(dimension.confidence, 0.25)


### PR DESCRIPTION
## Summary
- stop double-counting contradiction evidence as ordinary weakening support
- flag dimensions that receive evidence while still sitting at a zero-direction seed
- add regression coverage for the zero-direction seeding guardrail

## Testing
- python3 -m pytest tests/preferences/test_resolution.py -q
- python3 -m black --check --line-length 100 trip_planner/preferences tests/preferences
- python3 -m mypy trip_planner/preferences tests/preferences
- python3 -m pytest -q

## Context
This is the verifier follow-up for [PR #570](https://github.com/stranske/trip-planner/pull/570).