### PR TITLE
Add planning autonomy and revealed preference contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The target product should handle:
 - [Implementation plan](docs/implementation-plan.md)
 - [Product and architecture brief](docs/product-architecture-brief.md)
 - [Leisure preference contract](docs/leisure-preference-contract.md)
+- [Planning autonomy and revealed preference contracts](docs/contracts/planning-autonomy.md)
 - [Shared planning contracts](docs/shared-planning-contracts.md)
 - [Business travel profile contract](docs/business-travel-profile-contract.md)
 - [Policy-facing proposal contracts](docs/contracts/trip-plan-proposal.md)

--- a/docs/contracts/planning-autonomy.md
+++ b/docs/contracts/planning-autonomy.md
@@ -1,0 +1,79 @@
+# Planning Autonomy And Revealed Preference Contracts
+
+These contracts define how later chat and orchestration layers should decide:
+
+- how much work the planner should do before returning to the user
+- how quickly concrete options should be surfaced
+- how option selections and rejections should feed back into the leisure profile without erasing earlier evidence
+
+## Planning Autonomy
+
+`PlanningAutonomyProfile` is intentionally more granular than fixed modes.
+
+It tracks stage-specific preferences for:
+
+- `system_initiative`
+- `checkpoint_frequency`
+- `option_preview_timing`
+- `exploration_depth`
+- `explanation_depth`
+
+That lets the planner handle signals like:
+
+- "do more before asking me again"
+- "show me options sooner"
+- "ask me earlier when you are about to change the route"
+
+without forcing the traveler into a binary delegated-vs-collaborative mode.
+
+`PlannerBehaviorMetadata` is the developer-facing output that later orchestration layers should consume.
+
+It turns the autonomy profile into concrete planning behavior such as:
+
+- whether to ask before the next major change
+- how many research passes to attempt before checking back
+- how many options to gather before surfacing them
+- whether options should be surfaced early
+- whether the explanation style should be lean, standard, or detailed
+
+## Revealed Preference Updates
+
+`RevealedPreferenceSignal` represents a concrete reaction to an option or option set.
+
+Examples:
+
+- selected an exploratory neighborhood bundle
+- rejected a hotel because arrival logistics looked fragile
+- requested more options like a rail-heavy route
+- ignored a one-off option without real commitment
+
+The planner should not mutate the resolved profile directly from such reactions.
+
+Instead, `build_revealed_preference_update()` emits new `PreferenceEvidence` plus metadata about:
+
+- protected targets
+- blocked overwrites
+- transient reactions
+- notes for later resolver or orchestration layers
+
+That preserves the evidence history so the resolution engine can decide how much weight the reaction deserves.
+
+## Guardrails
+
+Revealed-preference updates should not silently overwrite:
+
+- hard constraints
+- anchors
+- stable, high-salience tradeoff dimensions
+
+When a reaction conflicts with a stable preference, the update should emit contradiction-style evidence and record the blocked overwrite instead of silently flipping the profile.
+
+## Later Consumption
+
+Later orchestration and chat layers should use these contracts in this order:
+
+1. read `PlanningAutonomyProfile` for the current trip stage
+2. derive `PlannerBehaviorMetadata` for pacing and checkpoint behavior
+3. capture option reactions as `RevealedPreferenceSignal`
+4. convert those reactions into `PreferenceEvidence` through `RevealedPreferenceUpdate`
+5. feed the accumulated evidence back into the resolver rather than overwriting the leisure profile directly

--- a/tests/preferences/test_autonomy.py
+++ b/tests/preferences/test_autonomy.py
@@ -1,0 +1,65 @@
+from trip_planner.preferences.autonomy import (
+    AutonomyFeedback,
+    PlanningAutonomyProfile,
+)
+
+
+def test_autonomy_feedback_supports_more_system_initiative() -> None:
+    profile = PlanningAutonomyProfile()
+    updated = profile.apply_feedback(
+        AutonomyFeedback(
+            feedback_kind="do_more_before_asking",
+            trip_stage="initial_design",
+            strength=0.8,
+            note="Do more before asking me again.",
+        )
+    )
+
+    before = profile.behavior_for_stage("initial_design")
+    after = updated.behavior_for_stage("initial_design")
+
+    assert after.target_research_passes > before.target_research_passes
+    assert (
+        updated.preference_for_stage("initial_design").checkpoint_frequency
+        < profile.preference_for_stage("initial_design").checkpoint_frequency
+    )
+
+
+def test_autonomy_feedback_supports_showing_options_sooner() -> None:
+    profile = PlanningAutonomyProfile()
+    updated = profile.apply_feedback(
+        AutonomyFeedback(
+            feedback_kind="show_options_sooner",
+            trip_stage="inventory_selection",
+            strength=0.9,
+            note="Show me options sooner.",
+        )
+    )
+
+    behavior = updated.behavior_for_stage("inventory_selection")
+
+    assert behavior.surface_options_early is True
+    assert behavior.target_options_before_checkpoint < 4
+
+
+def test_autonomy_profile_can_vary_by_stage() -> None:
+    profile = PlanningAutonomyProfile()
+    updated = profile.apply_feedback(
+        AutonomyFeedback(
+            feedback_kind="do_more_before_asking",
+            trip_stage="initial_design",
+            strength=0.7,
+        )
+    )
+    updated = updated.apply_feedback(
+        AutonomyFeedback(
+            feedback_kind="ask_me_earlier",
+            trip_stage="in_trip_adjustment",
+            strength=0.7,
+        )
+    )
+
+    assert (
+        updated.preference_for_stage("initial_design").checkpoint_frequency
+        < updated.preference_for_stage("in_trip_adjustment").checkpoint_frequency
+    )

--- a/tests/preferences/test_revealed_preference.py
+++ b/tests/preferences/test_revealed_preference.py
@@ -1,0 +1,82 @@
+from copy import deepcopy
+
+from tests.preferences.fixture_corpus import load_fixture_corpus
+from trip_planner.preferences.revealed_preference import (
+    RevealedPreferenceSignal,
+    build_revealed_preference_update,
+)
+
+
+def test_revealed_preference_update_emits_option_evidence() -> None:
+    fixture = next(item for item in load_fixture_corpus() if item.id == "discovery-wanderer")
+    signal = RevealedPreferenceSignal(
+        signal_id="signal-1",
+        trip_stage="inventory_selection",
+        reaction_type="selected",
+        option_set_id="options-1",
+        option_id="option-1",
+        option_kind="destination_bundle",
+        signal_strength=0.8,
+        dimension_biases={
+            "structure_vs_elasticity": 0.7,
+            "iconic_vs_discovery": 0.8,
+        },
+        hybrid_biases={"rest": 0.4},
+        summary="Traveler chose the loose-structure discovery set over the fixed landmark schedule.",
+    )
+
+    update = build_revealed_preference_update(fixture.profile, signal)
+
+    assert update.transient is False
+    assert update.blocked_overwrites == []
+    assert update.emitted_evidence[0].evidence_type == "option_selection"
+    assert set(update.emitted_evidence[0].affected_dimensions) == {
+        "structure_vs_elasticity",
+        "iconic_vs_discovery",
+    }
+
+
+def test_revealed_preference_guardrail_blocks_overwrite_of_stable_dimension() -> None:
+    fixture = next(item for item in load_fixture_corpus() if item.id == "urban-historian")
+    profile = deepcopy(fixture.profile)
+    profile.tradeoff_dimensions["breadth_vs_depth"].salience = 0.92
+    profile.tradeoff_dimensions["breadth_vs_depth"].stability = 0.9
+
+    signal = RevealedPreferenceSignal(
+        signal_id="signal-2",
+        trip_stage="inventory_selection",
+        reaction_type="selected",
+        option_set_id="options-2",
+        option_id="option-2",
+        option_kind="destination_bundle",
+        signal_strength=0.9,
+        dimension_biases={"breadth_vs_depth": -0.9},
+        summary="Traveler clicked a wider multi-city option once.",
+    )
+
+    update = build_revealed_preference_update(profile, signal)
+
+    assert update.blocked_overwrites == ["breadth_vs_depth"]
+    assert update.emitted_evidence[0].signal_direction == "contradiction"
+    assert "anchors" in update.protected_targets or "hard_constraints" in update.protected_targets
+
+
+def test_revealed_preference_marks_transient_clicks() -> None:
+    fixture = next(item for item in load_fixture_corpus() if item.id == "food-splurger")
+    signal = RevealedPreferenceSignal(
+        signal_id="signal-3",
+        trip_stage="inventory_selection",
+        reaction_type="ignored",
+        option_set_id="options-3",
+        option_id="option-3",
+        option_kind="lodging",
+        signal_strength=0.3,
+        dimension_biases={"self_reliance_vs_convenience": 0.4},
+        summary="Traveler glanced at a hotel but did not meaningfully engage.",
+    )
+
+    update = build_revealed_preference_update(fixture.profile, signal)
+
+    assert update.transient is True
+    assert update.emitted_evidence[0].confidence_hint < 0.2
+    assert any("transient" in note for note in update.notes)

--- a/trip_planner/preferences/__init__.py
+++ b/trip_planner/preferences/__init__.py
@@ -1,5 +1,12 @@
 """Leisure preference contracts and narrow legacy compatibility adapters."""
 
+from .autonomy import (
+    AutonomyFeedback,
+    AutonomyGuardrails,
+    AutonomyPreference,
+    PlannerBehaviorMetadata,
+    PlanningAutonomyProfile,
+)
 from .evidence import ContradictionMarker, OptionEvidence, PreferenceEvidence
 from .evidence_catalog import (
     ANCHOR_SIGNAL_GUIDANCE,
@@ -31,12 +38,21 @@ from .models import (
     TradeoffDimension,
     TripFrame,
 )
+from .revealed_preference import (
+    RevealedPreferenceSignal,
+    RevealedPreferenceUpdate,
+    build_revealed_preference_update,
+)
 from .resolution import resolve_leisure_profile
 
 __all__ = [
     "Anchor",
     "ANCHOR_SIGNAL_GUIDANCE",
+    "AutonomyFeedback",
+    "AutonomyGuardrails",
+    "AutonomyPreference",
     "BudgetModel",
+    "build_revealed_preference_update",
     "ContradictionMarker",
     "DateWindow",
     "DurationBounds",
@@ -50,7 +66,11 @@ __all__ = [
     "MaterialInfluence",
     "LeisurePreferenceProfile",
     "OptionEvidence",
+    "PlannerBehaviorMetadata",
+    "PlanningAutonomyProfile",
     "PreferenceEvidence",
+    "RevealedPreferenceSignal",
+    "RevealedPreferenceUpdate",
     "ResolutionExplanation",
     "ResolvedLeisureProfile",
     "TensionFlag",

--- a/trip_planner/preferences/autonomy.py
+++ b/trip_planner/preferences/autonomy.py
@@ -1,0 +1,197 @@
+"""Planning-autonomy controls for leisure trip workflows."""
+
+from __future__ import annotations
+
+from math import ceil
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any
+
+from . import schema
+
+AUTONOMY_FEEDBACK_KINDS: tuple[str, ...] = (
+    "do_more_before_asking",
+    "show_options_sooner",
+    "ask_me_earlier",
+    "explain_more",
+    "explain_less",
+)
+
+
+def _require_probability(value: float, field_name: str) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{field_name} must be between 0.0 and 1.0")
+
+
+def _default_stage_preferences() -> dict[str, "AutonomyPreference"]:
+    return {stage: AutonomyPreference() for stage in schema.PLANNING_STAGES}
+
+
+@dataclass(slots=True)
+class AutonomyPreference:
+    system_initiative: float = 0.5
+    checkpoint_frequency: float = 0.5
+    option_preview_timing: float = 0.5
+    exploration_depth: float = 0.5
+    explanation_depth: float = 0.5
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "system_initiative",
+            "checkpoint_frequency",
+            "option_preview_timing",
+            "exploration_depth",
+            "explanation_depth",
+        ):
+            _require_probability(getattr(self, field_name), field_name)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class AutonomyGuardrails:
+    max_unconfirmed_major_steps: int = 3
+    require_confirmation_for_anchor_changes: bool = True
+    require_confirmation_for_budget_tradeoffs: bool = True
+    require_confirmation_for_constraint_relaxation: bool = True
+
+    def __post_init__(self) -> None:
+        if self.max_unconfirmed_major_steps <= 0:
+            raise ValueError("max_unconfirmed_major_steps must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class AutonomyFeedback:
+    feedback_kind: str
+    trip_stage: str
+    strength: float = 0.7
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        if self.feedback_kind not in AUTONOMY_FEEDBACK_KINDS:
+            raise ValueError(f"feedback_kind must be one of {AUTONOMY_FEEDBACK_KINDS}")
+        if self.trip_stage not in schema.PLANNING_STAGES:
+            raise ValueError(f"trip_stage must be one of {schema.PLANNING_STAGES}")
+        _require_probability(self.strength, "strength")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PlannerBehaviorMetadata:
+    trip_stage: str
+    ask_before_next_major_change: bool
+    target_research_passes: int
+    target_options_before_checkpoint: int
+    surface_options_early: bool
+    explanation_density: str
+
+    def __post_init__(self) -> None:
+        if self.trip_stage not in schema.PLANNING_STAGES:
+            raise ValueError(f"trip_stage must be one of {schema.PLANNING_STAGES}")
+        if self.target_research_passes <= 0:
+            raise ValueError("target_research_passes must be positive")
+        if self.target_options_before_checkpoint <= 0:
+            raise ValueError("target_options_before_checkpoint must be positive")
+        if self.explanation_density not in {"lean", "standard", "detailed"}:
+            raise ValueError("explanation_density must be lean, standard, or detailed")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PlanningAutonomyProfile:
+    default_preference: AutonomyPreference = field(default_factory=AutonomyPreference)
+    stage_preferences: dict[str, AutonomyPreference] = field(
+        default_factory=_default_stage_preferences
+    )
+    guardrails: AutonomyGuardrails = field(default_factory=AutonomyGuardrails)
+    feedback_history: list[AutonomyFeedback] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if set(self.stage_preferences) != set(schema.PLANNING_STAGES):
+            raise ValueError(
+                f"stage_preferences must define every stage in {schema.PLANNING_STAGES}"
+            )
+        if any(
+            not isinstance(preference, AutonomyPreference)
+            for preference in self.stage_preferences.values()
+        ):
+            raise ValueError("stage_preferences must contain AutonomyPreference instances")
+        if any(not isinstance(item, AutonomyFeedback) for item in self.feedback_history):
+            raise ValueError("feedback_history must contain AutonomyFeedback instances")
+
+    def preference_for_stage(self, trip_stage: str) -> AutonomyPreference:
+        if trip_stage not in schema.PLANNING_STAGES:
+            raise ValueError(f"trip_stage must be one of {schema.PLANNING_STAGES}")
+        stage_preference = self.stage_preferences[trip_stage]
+        return AutonomyPreference(
+            system_initiative=stage_preference.system_initiative,
+            checkpoint_frequency=stage_preference.checkpoint_frequency,
+            option_preview_timing=stage_preference.option_preview_timing,
+            exploration_depth=stage_preference.exploration_depth,
+            explanation_depth=stage_preference.explanation_depth,
+        )
+
+    def behavior_for_stage(self, trip_stage: str) -> PlannerBehaviorMetadata:
+        preference = self.preference_for_stage(trip_stage)
+        target_research_passes = max(
+            1,
+            ceil(1 + (preference.system_initiative * 3) + (preference.exploration_depth * 2)),
+        )
+        target_options_before_checkpoint = max(
+            1,
+            round(2 + ((1.0 - preference.option_preview_timing) * 4)),
+        )
+        if preference.explanation_depth >= 0.72:
+            explanation_density = "detailed"
+        elif preference.explanation_depth <= 0.35:
+            explanation_density = "lean"
+        else:
+            explanation_density = "standard"
+        return PlannerBehaviorMetadata(
+            trip_stage=trip_stage,
+            ask_before_next_major_change=preference.checkpoint_frequency >= 0.65,
+            target_research_passes=target_research_passes,
+            target_options_before_checkpoint=target_options_before_checkpoint,
+            surface_options_early=preference.option_preview_timing >= 0.65,
+            explanation_density=explanation_density,
+        )
+
+    def apply_feedback(self, feedback: AutonomyFeedback) -> "PlanningAutonomyProfile":
+        updated = replace(
+            self,
+            stage_preferences={
+                stage: replace(preference) for stage, preference in self.stage_preferences.items()
+            },
+            feedback_history=[*self.feedback_history, feedback],
+        )
+        preference = updated.stage_preferences[feedback.trip_stage]
+        delta = feedback.strength * 0.25
+
+        if feedback.feedback_kind == "do_more_before_asking":
+            preference.system_initiative = min(1.0, preference.system_initiative + delta)
+            preference.exploration_depth = min(1.0, preference.exploration_depth + delta)
+            preference.checkpoint_frequency = max(0.0, preference.checkpoint_frequency - delta)
+        elif feedback.feedback_kind == "show_options_sooner":
+            preference.option_preview_timing = min(1.0, preference.option_preview_timing + delta)
+            preference.checkpoint_frequency = min(
+                1.0, preference.checkpoint_frequency + (delta * 0.4)
+            )
+            preference.exploration_depth = max(0.0, preference.exploration_depth - (delta * 0.5))
+        elif feedback.feedback_kind == "ask_me_earlier":
+            preference.checkpoint_frequency = min(1.0, preference.checkpoint_frequency + delta)
+            preference.system_initiative = max(0.0, preference.system_initiative - (delta * 0.5))
+        elif feedback.feedback_kind == "explain_more":
+            preference.explanation_depth = min(1.0, preference.explanation_depth + delta)
+        elif feedback.feedback_kind == "explain_less":
+            preference.explanation_depth = max(0.0, preference.explanation_depth - delta)
+        return updated
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/trip_planner/preferences/revealed_preference.py
+++ b/trip_planner/preferences/revealed_preference.py
@@ -1,0 +1,196 @@
+"""Revealed-preference update contracts for leisure planning."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from . import schema
+from .evidence import ContradictionMarker, OptionEvidence, PreferenceEvidence
+from .models import LeisurePreferenceProfile
+
+REACTION_TYPES: tuple[str, ...] = (
+    "selected",
+    "rejected",
+    "saved_for_later",
+    "ignored",
+    "requested_more_like_this",
+    "requested_less_like_this",
+)
+
+
+def _require_probability(value: float, field_name: str) -> None:
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{field_name} must be between 0.0 and 1.0")
+
+
+def _require_axis(value: float, field_name: str) -> None:
+    if not -1.0 <= value <= 1.0:
+        raise ValueError(f"{field_name} must be between -1.0 and 1.0")
+
+
+@dataclass(slots=True)
+class RevealedPreferenceSignal:
+    signal_id: str
+    trip_stage: str
+    reaction_type: str
+    option_set_id: str
+    option_id: str
+    option_kind: str
+    signal_strength: float
+    dimension_biases: dict[str, float] = field(default_factory=dict)
+    hybrid_biases: dict[str, float] = field(default_factory=dict)
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.signal_id:
+            raise ValueError("signal_id is required")
+        if self.trip_stage not in schema.PLANNING_STAGES:
+            raise ValueError(f"trip_stage must be one of {schema.PLANNING_STAGES}")
+        if self.reaction_type not in REACTION_TYPES:
+            raise ValueError(f"reaction_type must be one of {REACTION_TYPES}")
+        if not self.option_set_id:
+            raise ValueError("option_set_id is required")
+        if not self.option_id:
+            raise ValueError("option_id is required")
+        if self.option_kind not in {
+            "lodging",
+            "transport",
+            "activity",
+            "destination_bundle",
+            "mixed_bundle",
+        }:
+            raise ValueError("option_kind must be a supported option evidence kind")
+        _require_probability(self.signal_strength, "signal_strength")
+        invalid_dimensions = set(self.dimension_biases) - set(schema.TRADEOFF_DIMENSION_KEYS)
+        if invalid_dimensions:
+            raise ValueError(f"unsupported dimension_biases keys: {sorted(invalid_dimensions)}")
+        invalid_hybrid = set(self.hybrid_biases) - set(schema.HYBRID_FACTOR_KEYS)
+        if invalid_hybrid:
+            raise ValueError(f"unsupported hybrid_biases keys: {sorted(invalid_hybrid)}")
+        for key, value in self.dimension_biases.items():
+            _require_axis(value, f"dimension_biases[{key}]")
+        for key, value in self.hybrid_biases.items():
+            _require_axis(value, f"hybrid_biases[{key}]")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RevealedPreferenceUpdate:
+    signal: RevealedPreferenceSignal
+    emitted_evidence: list[PreferenceEvidence] = field(default_factory=list)
+    protected_targets: list[str] = field(default_factory=list)
+    blocked_overwrites: list[str] = field(default_factory=list)
+    transient: bool = False
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if any(not isinstance(item, PreferenceEvidence) for item in self.emitted_evidence):
+            raise ValueError("emitted_evidence must contain PreferenceEvidence instances")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def build_revealed_preference_update(
+    profile: LeisurePreferenceProfile,
+    signal: RevealedPreferenceSignal,
+) -> RevealedPreferenceUpdate:
+    if not isinstance(profile, LeisurePreferenceProfile):
+        raise ValueError("profile must be a LeisurePreferenceProfile")
+
+    reaction_direction = {
+        "selected": "positive",
+        "saved_for_later": "positive",
+        "requested_more_like_this": "positive",
+        "rejected": "negative",
+        "requested_less_like_this": "negative",
+        "ignored": "negative",
+    }[signal.reaction_type]
+    transient = (
+        signal.reaction_type in {"ignored", "saved_for_later"} or signal.signal_strength < 0.45
+    )
+    confidence_hint = min(1.0, max(0.1, signal.signal_strength * (0.45 if transient else 0.85)))
+    salience_hint = min(1.0, max(0.1, signal.signal_strength * (0.4 if transient else 0.8)))
+
+    contradictions: list[ContradictionMarker] = []
+    blocked_overwrites: list[str] = []
+    protected_targets: list[str] = []
+    notes: list[str] = []
+
+    for dimension_key, bias in signal.dimension_biases.items():
+        current_dimension = profile.tradeoff_dimensions[dimension_key]
+        if (
+            current_dimension.salience >= 0.75
+            and current_dimension.stability >= 0.75
+            and current_dimension.value != 0.0
+            and (current_dimension.value < 0 < bias or current_dimension.value > 0 > bias)
+        ):
+            blocked_overwrites.append(dimension_key)
+            contradictions.append(
+                ContradictionMarker(
+                    previous_evidence_id=f"stable:{dimension_key}",
+                    reason="Revealed preference conflicts with a stable high-salience dimension.",
+                    weakening_strength=0.8,
+                )
+            )
+            notes.append(
+                f"{dimension_key} was protected because the reaction conflicts with a stable preference."
+            )
+
+    if (
+        profile.hard_constraints.must_include_places
+        or profile.hard_constraints.must_protect_experiences
+    ):
+        protected_targets.extend(["hard_constraints"])
+    if any(
+        profile.anchors[group]
+        for group in ("place_anchors", "experience_anchors", "calendar_anchors")
+    ):
+        protected_targets.extend(["anchors"])
+    if protected_targets:
+        notes.append(
+            "Hard constraints and anchors remain protected from one-off revealed preference updates."
+        )
+
+    evidence_type = (
+        "option_selection"
+        if signal.reaction_type in {"selected", "saved_for_later", "requested_more_like_this"}
+        else "option_rejection"
+    )
+    emitted = PreferenceEvidence(
+        id=f"{signal.signal_id}-evidence",
+        evidence_type=evidence_type,
+        source_type="option_menu",
+        affected_dimensions=list(signal.dimension_biases),
+        affected_hybrid_factors=list(signal.hybrid_biases),
+        signal_direction="contradiction" if blocked_overwrites else reaction_direction,
+        confidence_hint=confidence_hint,
+        salience_hint=salience_hint,
+        sequence=0,
+        note=signal.summary or "Revealed preference update from concrete option feedback.",
+        option_evidence=OptionEvidence(
+            option_set_id=signal.option_set_id,
+            option_id=signal.option_id,
+            option_kind=signal.option_kind,
+            presented_option_ids=[signal.option_id],
+            comparison_label="revealed_preference",
+        ),
+        contradictions=contradictions,
+    )
+
+    if transient:
+        notes.append(
+            "Reaction is treated as transient evidence and should not outweigh stable preferences on its own."
+        )
+
+    return RevealedPreferenceUpdate(
+        signal=signal,
+        emitted_evidence=[emitted],
+        protected_targets=sorted(set(protected_targets)),
+        blocked_overwrites=sorted(set(blocked_overwrites)),
+        transient=transient,
+        notes=notes,
+    )


### PR DESCRIPTION
Closes #511

## Summary
- add stage-aware planning autonomy contracts and developer-facing planner behavior metadata
- add revealed-preference signal/update contracts that preserve evidence history instead of mutating profiles directly
- document how later orchestration and chat layers should consume autonomy and revealed-preference updates

## Testing
- python3 -m pytest tests/preferences/test_autonomy.py tests/preferences/test_revealed_preference.py -q
- python3 -m black --check --line-length 100 trip_planner/preferences tests/preferences
- python3 -m mypy trip_planner/preferences tests/preferences
- python3 -m pytest -q