### PR TITLE
Issue #524: build inventory bundle and mixed option contracts

### DIFF
--- a/docs/contracts/inventory-bundle.md
+++ b/docs/contracts/inventory-bundle.md
@@ -1,0 +1,24 @@
+# InventoryBundle And MixedOption Contracts
+
+`InventoryBundle` and `MixedOption` sit downstream from the normalized destination and option contracts and upstream from later ranking or UI comparison work.
+
+## Boundary
+
+- `InventoryBundle` is the local assembly unit. It groups normalized `Destination`, `LodgingOption`, `TransportOption`, and `ActivityOption` objects that belong together as one coherent slice of an alternative.
+- `MixedOption` is the comparison-ready alternative. It can contain one bundle for a simple lodging-only or transport-plus-lodging comparison, or multiple bundles for a route-level alternative with distinct gateway and activity-rich phases.
+- `OptionSet` remains the planner’s presentation container. `MixedOption.to_option()` exists so this assembly layer can feed the shared `OptionSet` contract rather than competing with it.
+
+## What The Layer Adds
+
+- bundle-level feasibility with explicit blocking reasons for infeasible but still inspectable alternatives
+- route coherence and schedule-fit summaries that stay separate from raw transport or lodging detail
+- budget posture summaries that roll up category totals without flattening the underlying normalized objects
+- explanation metadata that keeps strengths and tradeoffs attached to the assembled alternative
+
+## What It Does Not Add
+
+- final ranking or scoring policy
+- live inventory fetching or combinatorial search
+- UI-specific rendering state
+
+Those remain later concerns. This layer exists to make cross-category alternatives stable, inspectable, and reusable across profile-learning and inventory-narrowing flows.

--- a/tests/fixtures/options/bundles/lodging_only_comparison.json
+++ b/tests/fixtures/options/bundles/lodging_only_comparison.json
@@ -1,0 +1,120 @@
+{
+  "option_id": "mixed-kyoto-single-base",
+  "trip_id": "trip-kyoto-spring",
+  "title": "Kyoto single-base recovery stay",
+  "supported_purposes": ["profile_learning", "inventory_narrowing"],
+  "comparison_label": "Central stay with low-friction evening recovery",
+  "summary": "Lodging-only comparison entry that preserves the full lodging contract while surfacing bundle-level fit.",
+  "route_coherence": {
+    "overall_signal": 0.72,
+    "route_shape": "single_base",
+    "movement_summary": "Single-city stay with no base changes.",
+    "destination_sequence": ["dest-city-kyoto"],
+    "base_change_count": 0,
+    "cohesion_signal": 0.84,
+    "recovery_signal": 0.9
+  },
+  "schedule_fit": {
+    "overall_signal": 0.83,
+    "pacing_signal": 0.87,
+    "arrival_alignment_signal": 0.74,
+    "recovery_window_signal": 0.91,
+    "buffer_signal": 0.8,
+    "overcommitment_risk_signal": 0.18
+  },
+  "budget_posture": {
+    "estimated_total": {"currency": "USD", "typical_amount": 840.0},
+    "lodging_total": {"currency": "USD", "typical_amount": 840.0},
+    "overall_signal": 0.7,
+    "within_target_budget": true
+  },
+  "explanation": {
+    "headline": "Strong recovery fit without adding route complexity.",
+    "strengths": ["Walkable central base.", "Keeps the comparison focused on lodging tradeoffs."],
+    "tradeoffs": ["Less contrast than a multi-base route."]
+  },
+  "bundles": [
+    {
+      "bundle_id": "bundle-kyoto-lodging-only",
+      "title": "Kyoto lodging baseline",
+      "bundle_context": "lodging_only",
+      "summary": "Single normalized lodging option for a Kyoto-first comparison set.",
+      "destinations": [
+        {
+          "destination_id": "dest-city-kyoto",
+          "place_kind": "city",
+          "name": "Kyoto",
+          "summary": "Compact cultural city core with strong walkable neighborhood identity.",
+          "geo": {
+            "latitude": 35.0116,
+            "longitude": 135.7681,
+            "country_code": "JP",
+            "region_code": "JP-26",
+            "time_zone": "Asia/Tokyo",
+            "locality_hint": "Historic city core"
+          }
+        }
+      ],
+      "lodging_options": [
+        {
+          "option_id": "lodg-kyoto-central-hotel",
+          "name": "Kyoto Central Garden Hotel",
+          "destination_id": "dest-city-kyoto",
+          "summary": "Central full-service hotel that favors access over deep quiet.",
+          "location_summary": {
+            "destination_id": "dest-city-kyoto",
+            "location_context": "urban_core",
+            "neighborhood": "Kawaramachi",
+            "access_summary": "Quick access to rail, food, and evening walking routes.",
+            "walk_minutes_to_anchor": 5,
+            "quiet_signal": 0.58,
+            "recovery_signal": 0.63,
+            "place_context_ids": ["dest-city-kyoto"]
+          },
+          "room_summary": {
+            "lodging_kind": "hotel",
+            "room_type": "Superior king",
+            "comfort_signal": 0.82,
+            "cleanliness_signal": 0.88,
+            "privacy_signal": 0.79
+          },
+          "cost_summary": {
+            "nightly": {"currency": "USD", "typical_amount": 210.0},
+            "total": {"currency": "USD", "typical_amount": 840.0}
+          },
+          "quality_summary": {"overall_signal": 0.81, "sleep_quality_signal": 0.68},
+          "value_summary": {"overall_signal": 0.73, "location_value_signal": 0.89},
+          "fit_summary": {"overall_signal": 0.76, "quiet_recovery_signal": 0.61, "location_fit_signal": 0.91},
+          "feasibility": {
+            "inventory_status": "available",
+            "available": true,
+            "business_approval_status": "approved"
+          },
+          "booking_links": ["https://example.com/kyoto-central-garden-hotel"],
+          "source_refs": [
+            {
+              "provenance_id": "prov-kyoto-central-inventory",
+              "source_id": "inventory-ota-1",
+              "source_category": "commercial_inventory",
+              "subject_kind": "option",
+              "subject_id": "lodg-kyoto-central-hotel",
+              "contribution_kind": "inventory",
+              "summary": "Primary inventory snapshot for room and booking terms."
+            }
+          ],
+          "tags": ["central", "walkable"]
+        }
+      ],
+      "feasibility": {
+        "available": true,
+        "internally_consistent": true
+      },
+      "explanation": {
+        "headline": "Single-base stay optimized for centrality.",
+        "strengths": ["Fast rail access.", "Strong walkability."],
+        "tradeoffs": ["Lower quiet signal than edge-of-center alternatives."]
+      }
+    }
+  ],
+  "tags": ["lodging-only", "single-base"]
+}

--- a/tests/fixtures/options/bundles/route_level_mixed_option.json
+++ b/tests/fixtures/options/bundles/route_level_mixed_option.json
@@ -1,0 +1,293 @@
+{
+  "option_id": "mixed-kyoto-osaka-culture-route",
+  "trip_id": "trip-kansai-dual-city",
+  "title": "Kyoto culture anchor with Osaka arrival buffer",
+  "supported_purposes": ["profile_learning", "inventory_narrowing", "final_selection"],
+  "comparison_label": "Route-level mixed option with activities",
+  "summary": "Two-bundle route-level mixed option that preserves normalized transport, lodging, and activity detail.",
+  "route_coherence": {
+    "overall_signal": 0.89,
+    "route_shape": "regional_cluster",
+    "movement_summary": "Gateway arrival in Osaka followed by a Kyoto cultural base.",
+    "destination_sequence": ["dest-kix", "dest-city-osaka", "dest-city-kyoto"],
+    "base_change_count": 2,
+    "cohesion_signal": 0.91,
+    "recovery_signal": 0.82
+  },
+  "schedule_fit": {
+    "overall_signal": 0.84,
+    "pacing_signal": 0.81,
+    "arrival_alignment_signal": 0.87,
+    "recovery_window_signal": 0.79,
+    "buffer_signal": 0.86,
+    "overcommitment_risk_signal": 0.29
+  },
+  "budget_posture": {
+    "estimated_total": {"currency": "USD", "typical_amount": 1331.0},
+    "lodging_total": {"currency": "USD", "typical_amount": 1140.0},
+    "transport_total": {"currency": "USD", "typical_amount": 167.0},
+    "activity_total": {"currency": "USD", "typical_amount": 24.0},
+    "overall_signal": 0.74,
+    "within_target_budget": true
+  },
+  "explanation": {
+    "headline": "Balanced two-city route with a strong cultural anchor day.",
+    "strengths": ["Arrival friction is front-loaded into the Osaka gateway bundle.", "Kyoto activity remains visible as a first-class normalized object."],
+    "tradeoffs": ["Requires one extra base change to keep Osaka and Kyoto roles distinct."]
+  },
+  "bundles": [
+    {
+      "bundle_id": "bundle-osaka-gateway",
+      "title": "Osaka arrival buffer",
+      "bundle_context": "transport_lodging",
+      "destinations": [
+        {
+          "destination_id": "dest-kix",
+          "place_kind": "site",
+          "name": "KIX Airport",
+          "geo": {
+            "latitude": 34.4342,
+            "longitude": 135.244,
+            "country_code": "JP",
+            "time_zone": "Asia/Tokyo"
+          }
+        },
+        {
+          "destination_id": "dest-city-osaka",
+          "place_kind": "city",
+          "name": "Osaka",
+          "geo": {
+            "latitude": 34.6937,
+            "longitude": 135.5023,
+            "country_code": "JP",
+            "region_code": "JP-27",
+            "time_zone": "Asia/Tokyo"
+          }
+        }
+      ],
+      "lodging_options": [
+        {
+          "option_id": "lodg-osaka-gateway",
+          "name": "Osaka Gateway Hotel",
+          "destination_id": "dest-city-osaka",
+          "location_summary": {
+            "destination_id": "dest-city-osaka",
+            "location_context": "urban_core",
+            "access_summary": "Ten-minute walk from Osaka Station.",
+            "walk_minutes_to_anchor": 10,
+            "recovery_signal": 0.64,
+            "place_context_ids": ["dest-city-osaka"]
+          },
+          "room_summary": {
+            "lodging_kind": "hotel",
+            "comfort_signal": 0.72,
+            "cleanliness_signal": 0.81,
+            "privacy_signal": 0.77
+          },
+          "cost_summary": {
+            "nightly": {"currency": "USD", "typical_amount": 150.0},
+            "total": {"currency": "USD", "typical_amount": 300.0}
+          },
+          "fit_summary": {"overall_signal": 0.71, "location_fit_signal": 0.88},
+          "feasibility": {
+            "inventory_status": "available",
+            "available": true,
+            "business_approval_status": "approved"
+          }
+        }
+      ],
+      "transport_options": [
+        {
+          "option_id": "transport-kix-osaka-rail",
+          "name": "Haruka + local rail transfer",
+          "transport_kind": "rail",
+          "origin_id": "dest-kix",
+          "destination_id": "dest-city-osaka",
+          "timing_summary": {
+            "departure_local": "2026-04-05T09:05:00+09:00",
+            "arrival_local": "2026-04-05T10:33:00+09:00",
+            "duration_minutes": 88
+          },
+          "segments": [
+            {
+              "segment_id": "seg-haruka",
+              "mode": "rail",
+              "origin_label": "KIX Airport Station",
+              "destination_label": "Osaka Station"
+            }
+          ],
+          "cost_summary": {
+            "total": {"currency": "USD", "typical_amount": 29.0}
+          },
+          "fit_summary": {"overall_signal": 0.86, "schedule_fit_signal": 0.84},
+          "policy_summary": {"business_approval_status": "approved"},
+          "feasibility": {"available": true, "availability_status": "available"}
+        }
+      ],
+      "feasibility": {
+        "available": true,
+        "internally_consistent": true
+      }
+    },
+    {
+      "bundle_id": "bundle-kyoto-culture-day",
+      "title": "Kyoto cultural anchor",
+      "bundle_context": "route_level",
+      "destinations": [
+        {
+          "destination_id": "dest-city-osaka",
+          "place_kind": "city",
+          "name": "Osaka",
+          "geo": {
+            "latitude": 34.6937,
+            "longitude": 135.5023,
+            "country_code": "JP",
+            "region_code": "JP-27",
+            "time_zone": "Asia/Tokyo"
+          }
+        },
+        {
+          "destination_id": "dest-city-kyoto",
+          "place_kind": "city",
+          "name": "Kyoto",
+          "geo": {
+            "latitude": 35.0116,
+            "longitude": 135.7681,
+            "country_code": "JP",
+            "region_code": "JP-26",
+            "time_zone": "Asia/Tokyo"
+          }
+        }
+      ],
+      "lodging_options": [
+        {
+          "option_id": "lodg-kyoto-central-hotel",
+          "name": "Kyoto Central Garden Hotel",
+          "destination_id": "dest-city-kyoto",
+          "location_summary": {
+            "destination_id": "dest-city-kyoto",
+            "location_context": "urban_core",
+            "access_summary": "Fast access to rail and museum districts.",
+            "walk_minutes_to_anchor": 5,
+            "quiet_signal": 0.58,
+            "recovery_signal": 0.63,
+            "place_context_ids": ["dest-city-kyoto"]
+          },
+          "room_summary": {
+            "lodging_kind": "hotel",
+            "comfort_signal": 0.82,
+            "cleanliness_signal": 0.88,
+            "privacy_signal": 0.79
+          },
+          "cost_summary": {
+            "nightly": {"currency": "USD", "typical_amount": 210.0},
+            "total": {"currency": "USD", "typical_amount": 840.0}
+          },
+          "fit_summary": {"overall_signal": 0.76, "location_fit_signal": 0.91},
+          "feasibility": {
+            "inventory_status": "available",
+            "available": true,
+            "business_approval_status": "approved"
+          }
+        }
+      ],
+      "transport_options": [
+        {
+          "option_id": "transport-osaka-kyoto-rail",
+          "name": "Regional rail transfer to Kyoto",
+          "transport_kind": "rail",
+          "origin_id": "dest-city-osaka",
+          "destination_id": "dest-city-kyoto",
+          "timing_summary": {
+            "departure_local": "2026-04-06T09:00:00+09:00",
+            "arrival_local": "2026-04-06T09:32:00+09:00",
+            "duration_minutes": 32
+          },
+          "segments": [
+            {
+              "segment_id": "seg-osaka-kyoto",
+              "mode": "rail",
+              "origin_label": "Osaka Station",
+              "destination_label": "Kyoto Station"
+            }
+          ],
+          "cost_summary": {
+            "total": {"currency": "USD", "typical_amount": 138.0}
+          },
+          "fit_summary": {"overall_signal": 0.9, "schedule_fit_signal": 0.82},
+          "policy_summary": {"business_approval_status": "approved"},
+          "feasibility": {"available": true, "availability_status": "available"}
+        }
+      ],
+      "activity_options": [
+        {
+          "option_id": "activity-major-museum",
+          "name": "National Museum anchor visit",
+          "activity_kind": "museum",
+          "destination_id": "dest-city-kyoto",
+          "place_id": "place-national-museum",
+          "category": {
+            "primary": "museum",
+            "secondary": ["art", "history"],
+            "tags": ["indoor", "anchor"]
+          },
+          "timing_summary": {
+            "duration_minutes": 180,
+            "typical_start_window": "09:30-13:30",
+            "timing_sensitivity_signal": 0.72,
+            "crowd_pressure_signal": 0.83,
+            "weather_dependency_signal": 0.04
+          },
+          "significance_summary": {
+            "overall_signal": 0.95,
+            "local_icon_signal": 0.91,
+            "cultural_signal": 0.96,
+            "anchor_worthy": true
+          },
+          "effort_summary": {
+            "effort_level": "moderate",
+            "walking_minutes": 70,
+            "standing_minutes": 100,
+            "intensity_signal": 0.34
+          },
+          "booking_terms": {
+            "activity_format": "timed_entry",
+            "booking_required": true,
+            "ticketed": true,
+            "booking_channel": "museum-direct"
+          },
+          "cost_summary": {
+            "total": {"currency": "USD", "typical_amount": 24.0}
+          },
+          "fit_summary": {
+            "overall_signal": 0.66,
+            "traveler_fit_signal": 0.64,
+            "weather_fit_signal": 0.93
+          },
+          "feasibility": {
+            "available": true,
+            "availability_status": "available",
+            "indoor_outdoor": "indoor"
+          },
+          "booking_links": ["https://example.com/museum"],
+          "source_refs": [
+            {
+              "provenance_id": "prov-major-museum",
+              "source_id": "museum-direct",
+              "source_category": "official_operational",
+              "subject_kind": "option",
+              "subject_id": "activity-major-museum",
+              "contribution_kind": "operational",
+              "summary": "Official museum site confirms ticketing and hours."
+            }
+          ]
+        }
+      ],
+      "feasibility": {
+        "available": true,
+        "internally_consistent": true
+      }
+    }
+  ],
+  "tags": ["route-level", "mixed-option", "activity-anchor"]
+}

--- a/tests/fixtures/options/bundles/transport_lodging_bundle.json
+++ b/tests/fixtures/options/bundles/transport_lodging_bundle.json
@@ -1,0 +1,180 @@
+{
+  "option_id": "mixed-osaka-rail-arrival",
+  "trip_id": "trip-kansai-connector",
+  "title": "Rail arrival with station-area lodging",
+  "supported_purposes": ["inventory_narrowing"],
+  "comparison_label": "Low-friction transport-plus-lodging bundle",
+  "summary": "Cross-category bundle that keeps the transport chain and destination lodging explicit.",
+  "route_coherence": {
+    "overall_signal": 0.81,
+    "route_shape": "gateway_transfer",
+    "movement_summary": "Direct airport-to-city movement with one destination lodging handoff.",
+    "destination_sequence": ["dest-kix", "dest-city-osaka"],
+    "base_change_count": 1,
+    "cohesion_signal": 0.83,
+    "recovery_signal": 0.71
+  },
+  "schedule_fit": {
+    "overall_signal": 0.79,
+    "pacing_signal": 0.76,
+    "arrival_alignment_signal": 0.86,
+    "recovery_window_signal": 0.66,
+    "buffer_signal": 0.78,
+    "overcommitment_risk_signal": 0.24
+  },
+  "budget_posture": {
+    "estimated_total": {"currency": "USD", "typical_amount": 467.0},
+    "lodging_total": {"currency": "USD", "typical_amount": 438.0},
+    "transport_total": {"currency": "USD", "typical_amount": 29.0},
+    "overall_signal": 0.83,
+    "within_target_budget": true
+  },
+  "explanation": {
+    "headline": "Keeps arrival movement and first-night stay in one inspectable bundle.",
+    "strengths": ["Low transport friction.", "Policy-friendly rail option."],
+    "tradeoffs": ["Station-area stay is more functional than atmospheric."]
+  },
+  "bundles": [
+    {
+      "bundle_id": "bundle-osaka-arrival",
+      "title": "Airport arrival bundle",
+      "bundle_context": "transport_lodging",
+      "destinations": [
+        {
+          "destination_id": "dest-kix",
+          "place_kind": "site",
+          "name": "KIX Airport",
+          "geo": {
+            "latitude": 34.4342,
+            "longitude": 135.244,
+            "country_code": "JP",
+            "time_zone": "Asia/Tokyo"
+          }
+        },
+        {
+          "destination_id": "dest-city-osaka",
+          "place_kind": "city",
+          "name": "Osaka",
+          "geo": {
+            "latitude": 34.6937,
+            "longitude": 135.5023,
+            "country_code": "JP",
+            "region_code": "JP-27",
+            "time_zone": "Asia/Tokyo"
+          }
+        }
+      ],
+      "lodging_options": [
+        {
+          "option_id": "lodg-osaka-station-hotel",
+          "name": "Osaka Station Business Hotel",
+          "destination_id": "dest-city-osaka",
+          "location_summary": {
+            "destination_id": "dest-city-osaka",
+            "location_context": "urban_core",
+            "neighborhood": "Umeda",
+            "access_summary": "Five-minute walk from Osaka Station.",
+            "walk_minutes_to_anchor": 5,
+            "quiet_signal": 0.47,
+            "recovery_signal": 0.58,
+            "business_access_signal": 0.93,
+            "place_context_ids": ["dest-city-osaka"]
+          },
+          "room_summary": {
+            "lodging_kind": "hotel",
+            "room_type": "Compact queen",
+            "workspace_signal": 0.74,
+            "comfort_signal": 0.69,
+            "cleanliness_signal": 0.82,
+            "privacy_signal": 0.75
+          },
+          "cost_summary": {
+            "nightly": {"currency": "USD", "typical_amount": 219.0},
+            "total": {"currency": "USD", "typical_amount": 438.0}
+          },
+          "fit_summary": {"overall_signal": 0.74, "location_fit_signal": 0.94},
+          "feasibility": {
+            "inventory_status": "available",
+            "available": true,
+            "business_approval_status": "preferred"
+          }
+        }
+      ],
+      "transport_options": [
+        {
+          "option_id": "transport-kix-osaka-rail",
+          "name": "Haruka + local rail transfer",
+          "transport_kind": "rail",
+          "origin_id": "dest-kix",
+          "destination_id": "dest-city-osaka",
+          "timing_summary": {
+            "departure_local": "2026-04-05T09:05:00+09:00",
+            "arrival_local": "2026-04-05T10:33:00+09:00",
+            "duration_minutes": 88,
+            "departure_timezone": "Asia/Tokyo",
+            "arrival_timezone": "Asia/Tokyo"
+          },
+          "segments": [
+            {
+              "segment_id": "seg-haruka",
+              "mode": "rail",
+              "origin_label": "KIX Airport Station",
+              "destination_label": "Osaka Station",
+              "departure_local": "2026-04-05T09:16:00+09:00",
+              "arrival_local": "2026-04-05T10:31:00+09:00",
+              "carrier": "JR West",
+              "service_number": "Haruka 14",
+              "duration_minutes": 75
+            }
+          ],
+          "transfer_burden": {
+            "transfer_count": 0,
+            "self_navigation_burden_signal": 0.18,
+            "baggage_complexity_signal": 0.2,
+            "schedule_protection_signal": 0.84
+          },
+          "cost_summary": {
+            "total": {"currency": "USD", "typical_amount": 29.0}
+          },
+          "fit_summary": {
+            "overall_signal": 0.86,
+            "schedule_fit_signal": 0.84,
+            "friction_fit_signal": 0.88,
+            "policy_fit_signal": 0.95
+          },
+          "policy_summary": {
+            "business_approval_status": "preferred",
+            "approved_booking_channel": true,
+            "class_of_service": "standard"
+          },
+          "feasibility": {
+            "available": true,
+            "availability_status": "available"
+          },
+          "booking_links": ["https://example.com/haruka"],
+          "source_refs": [
+            {
+              "provenance_id": "prov-haruka",
+              "source_id": "jr-west-haruka",
+              "source_category": "official_operational",
+              "subject_kind": "option",
+              "subject_id": "transport-kix-osaka-rail",
+              "contribution_kind": "operational",
+              "summary": "Official timetable confirms airport express timings."
+            }
+          ]
+        }
+      ],
+      "feasibility": {
+        "available": true,
+        "internally_consistent": true
+      },
+      "explanation": {
+        "headline": "One-touch arrival bundle.",
+        "strengths": ["Transport and lodging line up on the same destination.", "Clear policy posture."],
+        "tradeoffs": ["Lodging emphasizes convenience over atmosphere."]
+      }
+    }
+  ],
+  "tags": ["transport-plus-lodging", "arrival-bundle"]
+}

--- a/tests/options/test_bundles.py
+++ b/tests/options/test_bundles.py
@@ -33,7 +33,9 @@ def test_transport_plus_lodging_bundle_preserves_category_specific_detail() -> N
     assert bundle.transport_options[0].transport_kind == "rail"
     assert bundle.lodging_options[0].room_summary.lodging_kind == "hotel"
     assert bundle.transport_options[0].timing_summary.duration_minutes == 88
-    assert bundle.lodging_options[0].location_summary.business_access_signal == pytest.approx(0.93)
+    assert bundle.lodging_options[
+        0
+    ].location_summary.business_access_signal == pytest.approx(0.93)
 
 
 def test_route_level_mixed_option_round_trips_and_converts_to_option_entry() -> None:
@@ -51,11 +53,13 @@ def test_route_level_mixed_option_round_trips_and_converts_to_option_entry() -> 
 
 
 def test_inventory_bundle_accepts_explicitly_infeasible_but_explained_bundle() -> None:
-    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8")
+    )
     payload["bundles"][0]["feasibility"] = {
         "available": False,
         "internally_consistent": True,
-        "blocking_reasons": ["Rail maintenance blocks the arrival window."]
+        "blocking_reasons": ["Rail maintenance blocks the arrival window."],
     }
 
     mixed_option = MixedOption.from_dict(payload)
@@ -66,18 +70,32 @@ def test_inventory_bundle_accepts_explicitly_infeasible_but_explained_bundle() -
     ]
 
 
-def test_bundles_reject_inconsistent_destination_and_invalid_mixed_option_metadata() -> None:
-    payload = json.loads(_fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8"))
+def test_bundles_reject_inconsistent_destination_and_invalid_mixed_option_metadata() -> (
+    None
+):
+    payload = json.loads(
+        _fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8")
+    )
     payload["bundles"][1]["activity_options"][0]["destination_id"] = "dest-city-nara"
-    with pytest.raises(ValueError, match="destinations must include each destination referenced"):
+    with pytest.raises(
+        ValueError, match="destinations must include each destination referenced"
+    ):
         InventoryBundle.from_dict(payload["bundles"][1])
 
-    payload = json.loads(_fixture_path("lodging_only_comparison.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("lodging_only_comparison.json").read_text(encoding="utf-8")
+    )
     payload["supported_purposes"] = ["profile_learning", "profile_learning"]
-    with pytest.raises(ValueError, match="supported_purposes must not contain duplicates"):
+    with pytest.raises(
+        ValueError, match="supported_purposes must not contain duplicates"
+    ):
         MixedOption.from_dict(payload)
 
-    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8")
+    )
     payload["route_coherence"]["destination_sequence"] = ["dest-city-osaka"]
-    with pytest.raises(ValueError, match="route_coherence.destination_sequence must cover"):
+    with pytest.raises(
+        ValueError, match="route_coherence.destination_sequence must cover"
+    ):
         MixedOption.from_dict(payload)

--- a/tests/options/test_bundles.py
+++ b/tests/options/test_bundles.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.options import InventoryBundle, MixedOption
+
+
+def _fixture_path(name: str) -> Path:
+    return Path("tests/fixtures/options/bundles") / name
+
+
+def _load_mixed_option(name: str) -> MixedOption:
+    payload = json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+    return MixedOption.from_dict(payload)
+
+
+def test_bundle_fixtures_cover_representative_assembly_shapes() -> None:
+    lodging = _load_mixed_option("lodging_only_comparison.json")
+    arrival = _load_mixed_option("transport_lodging_bundle.json")
+    route = _load_mixed_option("route_level_mixed_option.json")
+
+    assert lodging.bundles[0].bundle_context == "lodging_only"
+    assert arrival.bundles[0].bundle_context == "transport_lodging"
+    assert route.bundles[1].bundle_context == "route_level"
+    assert route.bundles[1].activity_options[0].activity_kind == "museum"
+
+
+def test_transport_plus_lodging_bundle_preserves_category_specific_detail() -> None:
+    mixed_option = _load_mixed_option("transport_lodging_bundle.json")
+    bundle = mixed_option.bundles[0]
+
+    assert bundle.transport_options[0].transport_kind == "rail"
+    assert bundle.lodging_options[0].room_summary.lodging_kind == "hotel"
+    assert bundle.transport_options[0].timing_summary.duration_minutes == 88
+    assert bundle.lodging_options[0].location_summary.business_access_signal == pytest.approx(0.93)
+
+
+def test_route_level_mixed_option_round_trips_and_converts_to_option_entry() -> None:
+    mixed_option = _load_mixed_option("route_level_mixed_option.json")
+
+    payload = mixed_option.to_dict()
+    option = mixed_option.to_option()
+
+    assert payload["route_coherence"]["destination_sequence"][-1] == "dest-city-kyoto"
+    assert payload["bundles"][1]["activity_options"][0]["activity_kind"] == "museum"
+    assert option.kind == "mixed"
+    assert "route_coherence" in option.fit_signals
+    assert "dest-city-kyoto" in option.supporting_place_ids
+    assert "https://example.com/museum" in option.booking_links
+
+
+def test_inventory_bundle_accepts_explicitly_infeasible_but_explained_bundle() -> None:
+    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload["bundles"][0]["feasibility"] = {
+        "available": False,
+        "internally_consistent": True,
+        "blocking_reasons": ["Rail maintenance blocks the arrival window."]
+    }
+
+    mixed_option = MixedOption.from_dict(payload)
+
+    assert mixed_option.bundles[0].feasibility.available is False
+    assert mixed_option.bundles[0].feasibility.blocking_reasons == [
+        "Rail maintenance blocks the arrival window."
+    ]
+
+
+def test_bundles_reject_inconsistent_destination_and_invalid_mixed_option_metadata() -> None:
+    payload = json.loads(_fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8"))
+    payload["bundles"][1]["activity_options"][0]["destination_id"] = "dest-city-nara"
+    with pytest.raises(ValueError, match="destinations must include each destination referenced"):
+        InventoryBundle.from_dict(payload["bundles"][1])
+
+    payload = json.loads(_fixture_path("lodging_only_comparison.json").read_text(encoding="utf-8"))
+    payload["supported_purposes"] = ["profile_learning", "profile_learning"]
+    with pytest.raises(ValueError, match="supported_purposes must not contain duplicates"):
+        MixedOption.from_dict(payload)
+
+    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload["route_coherence"]["destination_sequence"] = ["dest-city-osaka"]
+    with pytest.raises(ValueError, match="route_coherence.destination_sequence must cover"):
+        MixedOption.from_dict(payload)

--- a/tests/options/test_bundles.py
+++ b/tests/options/test_bundles.py
@@ -70,6 +70,20 @@ def test_inventory_bundle_accepts_explicitly_infeasible_but_explained_bundle() -
     ]
 
 
+def test_transport_only_bundle_requires_destinations_for_transport_endpoints() -> None:
+    payload = json.loads(
+        _fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8")
+    )
+    bundle = payload["bundles"][0]
+    bundle["destinations"] = []
+    bundle["lodging_options"] = []
+
+    with pytest.raises(
+        ValueError, match="destinations must include each origin_id and destination_id"
+    ):
+        InventoryBundle.from_dict(bundle)
+
+
 def test_bundles_reject_inconsistent_destination_and_invalid_mixed_option_metadata() -> (
     None
 ):

--- a/trip_planner/contracts/__init__.py
+++ b/trip_planner/contracts/__init__.py
@@ -2,112 +2,110 @@
 
 from __future__ import annotations
 
-from importlib import import_module
-from typing import TYPE_CHECKING
+from .destinations import (
+    ADJACENCY_KINDS,
+    EXPERIENCE_SENTIMENTS,
+    EXPANSION_MODES,
+    MOBILITY_MODES,
+    OPERATIONAL_NOTE_IMPACTS,
+    OPERATIONAL_NOTE_KINDS,
+    PLACE_KINDS,
+    PLACE_RELATIONSHIP_KINDS,
+    PROVENANCE_ROLES,
+    SCHEMA_VERSION,
+    SEASONS,
+    SEASONAL_IMPACTS,
+    TAG_SCOPES,
+    AdjacencyKind,
+    Destination,
+    DestinationGeo,
+    DestinationSourceRef,
+    DestinationTag,
+    ExperienceSignal,
+    MobilityProfile,
+    NearbyDestinationRef,
+    OperationalNote,
+    PlaceHierarchyRef,
+    PlaceKind,
+    PlaceRelationshipKind,
+    RegionExpansionRef,
+    SeasonalSignal,
+)
+from .objectives import (
+    BudgetProtection,
+    CountRange,
+    DayStructureObjectives,
+    DiscoveryStrategy,
+    ItineraryObjectives,
+    LodgingStrategy,
+    MoveDensityTarget,
+    QualityFloorProtection,
+    RecoveryExpectations,
+    TransportStrategy,
+)
+from .options import (
+    ComparisonAxis,
+    MoneyRange,
+    Option,
+    OptionCostSummary,
+    OptionQualitySummary,
+    OptionSet,
+)
+from .trip import (
+    ProfileRefs,
+    TravelerPartySummary,
+    Trip,
+    TripArtifactRefs,
+    TripFrameSummary,
+)
 
-if TYPE_CHECKING:
-    from .objectives import (
-        BudgetProtection,
-        CountRange,
-        DayStructureObjectives,
-        DiscoveryStrategy,
-        ItineraryObjectives,
-        LodgingStrategy,
-        MoveDensityTarget,
-        QualityFloorProtection,
-        RecoveryExpectations,
-        TransportStrategy,
-    )
-
-    _OBJECTIVE_TYPE_CHECKING_EXPORTS = (
-        BudgetProtection,
-        CountRange,
-        DayStructureObjectives,
-        DiscoveryStrategy,
-        ItineraryObjectives,
-        LodgingStrategy,
-        MoveDensityTarget,
-        QualityFloorProtection,
-        RecoveryExpectations,
-        TransportStrategy,
-    )
-
-_DESTINATION_EXPORTS = {
+__all__ = [
     "ADJACENCY_KINDS",
-    "EXPERIENCE_SENTIMENTS",
-    "EXPANSION_MODES",
-    "MOBILITY_MODES",
-    "OPERATIONAL_NOTE_IMPACTS",
-    "OPERATIONAL_NOTE_KINDS",
-    "PLACE_KINDS",
-    "PLACE_RELATIONSHIP_KINDS",
-    "PROVENANCE_ROLES",
-    "SCHEMA_VERSION",
-    "SEASONS",
-    "SEASONAL_IMPACTS",
-    "TAG_SCOPES",
     "AdjacencyKind",
+    "BudgetProtection",
+    "ComparisonAxis",
+    "CountRange",
+    "DayStructureObjectives",
     "Destination",
     "DestinationGeo",
     "DestinationSourceRef",
     "DestinationTag",
-    "ExperienceSignal",
-    "MobilityProfile",
-    "NearbyDestinationRef",
-    "OperationalNote",
-    "PlaceHierarchyRef",
-    "PlaceKind",
-    "PlaceRelationshipKind",
-    "RegionExpansionRef",
-    "SeasonalSignal",
-}
-
-_OBJECTIVE_EXPORTS = {
-    "BudgetProtection",
-    "CountRange",
-    "DayStructureObjectives",
     "DiscoveryStrategy",
+    "EXPERIENCE_SENTIMENTS",
+    "ExperienceSignal",
+    "EXPANSION_MODES",
     "ItineraryObjectives",
     "LodgingStrategy",
-    "MoveDensityTarget",
-    "QualityFloorProtection",
-    "RecoveryExpectations",
-    "TransportStrategy",
-}
-
-_OPTION_EXPORTS = {
-    "ComparisonAxis",
+    "MOBILITY_MODES",
+    "MobilityProfile",
     "MoneyRange",
+    "MoveDensityTarget",
+    "NearbyDestinationRef",
+    "OPERATIONAL_NOTE_IMPACTS",
+    "OPERATIONAL_NOTE_KINDS",
+    "OperationalNote",
     "Option",
     "OptionCostSummary",
     "OptionQualitySummary",
     "OptionSet",
-}
-
-_TRIP_EXPORTS = {
+    "PLACE_KINDS",
+    "PLACE_RELATIONSHIP_KINDS",
+    "PROVENANCE_ROLES",
+    "PlaceHierarchyRef",
+    "PlaceKind",
+    "PlaceRelationshipKind",
     "ProfileRefs",
+    "QualityFloorProtection",
+    "RecoveryExpectations",
+    "RegionExpansionRef",
+    "SCHEMA_VERSION",
+    "SEASONS",
+    "SEASONAL_IMPACTS",
+    "SeasonalSignal",
+    "TAG_SCOPES",
+    "TransportStrategy",
     "TravelerPartySummary",
     "Trip",
     "TripArtifactRefs",
     "TripFrameSummary",
-}
-
-__all__ = sorted(
-    _DESTINATION_EXPORTS | _OBJECTIVE_EXPORTS | _OPTION_EXPORTS | _TRIP_EXPORTS
-)
-
-
-def __getattr__(name: str) -> object:
-    if name in _DESTINATION_EXPORTS:
-        module = import_module(".destinations", __name__)
-        return getattr(module, name)
-    if name in _OBJECTIVE_EXPORTS:
-        module = import_module(".objectives", __name__)
-        return getattr(module, name)
-    if name in _OPTION_EXPORTS:
-        module = import_module(".options", __name__)
-        return getattr(module, name)
-    if name in _TRIP_EXPORTS:
-        module = import_module(".trip", __name__)
-        return getattr(module, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+]

--- a/trip_planner/contracts/__init__.py
+++ b/trip_planner/contracts/__init__.py
@@ -19,6 +19,19 @@ if TYPE_CHECKING:
         TransportStrategy,
     )
 
+    _OBJECTIVE_TYPE_CHECKING_EXPORTS = (
+        BudgetProtection,
+        CountRange,
+        DayStructureObjectives,
+        DiscoveryStrategy,
+        ItineraryObjectives,
+        LodgingStrategy,
+        MoveDensityTarget,
+        QualityFloorProtection,
+        RecoveryExpectations,
+        TransportStrategy,
+    )
+
 _DESTINATION_EXPORTS = {
     "ADJACENCY_KINDS",
     "EXPERIENCE_SENTIMENTS",

--- a/trip_planner/contracts/__init__.py
+++ b/trip_planner/contracts/__init__.py
@@ -1,103 +1,85 @@
 """Canonical shared planning contracts for destinations, trips, options, and objectives."""
 
-from .destinations import (
-    ADJACENCY_KINDS,
-    EXPERIENCE_SENTIMENTS,
-    EXPANSION_MODES,
-    MOBILITY_MODES,
-    OPERATIONAL_NOTE_IMPACTS,
-    OPERATIONAL_NOTE_KINDS,
-    PLACE_KINDS,
-    PLACE_RELATIONSHIP_KINDS,
-    PROVENANCE_ROLES,
-    SCHEMA_VERSION,
-    SEASONS,
-    SEASONAL_IMPACTS,
-    TAG_SCOPES,
-    AdjacencyKind,
-    Destination,
-    DestinationGeo,
-    DestinationSourceRef,
-    DestinationTag,
-    ExperienceSignal,
-    MobilityProfile,
-    NearbyDestinationRef,
-    OperationalNote,
-    PlaceHierarchyRef,
-    PlaceKind,
-    PlaceRelationshipKind,
-    RegionExpansionRef,
-    SeasonalSignal,
-)
-from .objectives import (
-    BudgetProtection,
-    CountRange,
-    DayStructureObjectives,
-    DiscoveryStrategy,
-    ItineraryObjectives,
-    LodgingStrategy,
-    MoveDensityTarget,
-    QualityFloorProtection,
-    RecoveryExpectations,
-    TransportStrategy,
-)
-from .options import (
-    ComparisonAxis,
-    MoneyRange,
-    Option,
-    OptionCostSummary,
-    OptionQualitySummary,
-    OptionSet,
-)
-from .trip import ProfileRefs, TravelerPartySummary, Trip, TripArtifactRefs, TripFrameSummary
+from __future__ import annotations
 
-__all__ = [
+from importlib import import_module
+
+_DESTINATION_EXPORTS = {
     "ADJACENCY_KINDS",
+    "EXPERIENCE_SENTIMENTS",
+    "EXPANSION_MODES",
+    "MOBILITY_MODES",
+    "OPERATIONAL_NOTE_IMPACTS",
+    "OPERATIONAL_NOTE_KINDS",
+    "PLACE_KINDS",
+    "PLACE_RELATIONSHIP_KINDS",
+    "PROVENANCE_ROLES",
+    "SCHEMA_VERSION",
+    "SEASONS",
+    "SEASONAL_IMPACTS",
+    "TAG_SCOPES",
     "AdjacencyKind",
-    "BudgetProtection",
-    "ComparisonAxis",
-    "CountRange",
-    "DayStructureObjectives",
     "Destination",
     "DestinationGeo",
     "DestinationSourceRef",
     "DestinationTag",
-    "EXPERIENCE_SENTIMENTS",
     "ExperienceSignal",
-    "EXPANSION_MODES",
+    "MobilityProfile",
+    "NearbyDestinationRef",
+    "OperationalNote",
+    "PlaceHierarchyRef",
+    "PlaceKind",
+    "PlaceRelationshipKind",
+    "RegionExpansionRef",
+    "SeasonalSignal",
+}
+
+_OBJECTIVE_EXPORTS = {
+    "BudgetProtection",
+    "CountRange",
+    "DayStructureObjectives",
     "DiscoveryStrategy",
     "ItineraryObjectives",
     "LodgingStrategy",
-    "MOBILITY_MODES",
-    "MobilityProfile",
-    "MoneyRange",
     "MoveDensityTarget",
-    "NearbyDestinationRef",
+    "QualityFloorProtection",
+    "RecoveryExpectations",
+    "TransportStrategy",
+}
+
+_OPTION_EXPORTS = {
+    "ComparisonAxis",
+    "MoneyRange",
     "Option",
     "OptionCostSummary",
     "OptionQualitySummary",
     "OptionSet",
-    "OPERATIONAL_NOTE_IMPACTS",
-    "OPERATIONAL_NOTE_KINDS",
-    "OperationalNote",
-    "PLACE_KINDS",
-    "PLACE_RELATIONSHIP_KINDS",
-    "PlaceHierarchyRef",
-    "PlaceKind",
-    "PlaceRelationshipKind",
+}
+
+_TRIP_EXPORTS = {
     "ProfileRefs",
-    "PROVENANCE_ROLES",
-    "QualityFloorProtection",
-    "RecoveryExpectations",
-    "RegionExpansionRef",
-    "SCHEMA_VERSION",
-    "SEASONS",
-    "SEASONAL_IMPACTS",
-    "SeasonalSignal",
-    "TAG_SCOPES",
-    "TransportStrategy",
     "TravelerPartySummary",
     "Trip",
     "TripArtifactRefs",
     "TripFrameSummary",
-]
+}
+
+__all__ = sorted(
+    _DESTINATION_EXPORTS | _OBJECTIVE_EXPORTS | _OPTION_EXPORTS | _TRIP_EXPORTS
+)
+
+
+def __getattr__(name: str) -> object:
+    if name in _DESTINATION_EXPORTS:
+        module = import_module(".destinations", __name__)
+        return getattr(module, name)
+    if name in _OBJECTIVE_EXPORTS:
+        module = import_module(".objectives", __name__)
+        return getattr(module, name)
+    if name in _OPTION_EXPORTS:
+        module = import_module(".options", __name__)
+        return getattr(module, name)
+    if name in _TRIP_EXPORTS:
+        module = import_module(".trip", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/trip_planner/contracts/__init__.py
+++ b/trip_planner/contracts/__init__.py
@@ -3,6 +3,21 @@
 from __future__ import annotations
 
 from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .objectives import (
+        BudgetProtection,
+        CountRange,
+        DayStructureObjectives,
+        DiscoveryStrategy,
+        ItineraryObjectives,
+        LodgingStrategy,
+        MoveDensityTarget,
+        QualityFloorProtection,
+        RecoveryExpectations,
+        TransportStrategy,
+    )
 
 _DESTINATION_EXPORTS = {
     "ADJACENCY_KINDS",

--- a/trip_planner/options/__init__.py
+++ b/trip_planner/options/__init__.py
@@ -62,6 +62,17 @@ from .activities import (
     ActivityTimingSummary,
     ActivityValueSummary,
 )
+from .bundles import (
+    BUNDLE_CONTEXTS,
+    SCHEMA_VERSION as BUNDLE_SCHEMA_VERSION,
+    BudgetPostureSummary,
+    BundleExplanation,
+    BundleFeasibility,
+    InventoryBundle,
+    MixedOption,
+    RouteCoherenceSummary,
+    ScheduleFitSummary,
+)
 from .transport import (
     AVAILABILITY_STATUSES,
     CLASS_OF_SERVICE,
@@ -99,6 +110,11 @@ __all__ = [
     "ActivityTimingSummary",
     "ActivityValueSummary",
     "AVAILABILITY_STATUSES",
+    "BUNDLE_CONTEXTS",
+    "BUNDLE_SCHEMA_VERSION",
+    "BudgetPostureSummary",
+    "BundleExplanation",
+    "BundleFeasibility",
     "CLASS_OF_SERVICE",
     "Destination",
     "DestinationGeo",
@@ -122,6 +138,7 @@ __all__ = [
     "LodgingValueSummary",
     "MOBILITY_MODES",
     "MobilityProfile",
+    "MixedOption",
     "NearbyDestinationRef",
     "OPERATIONAL_NOTE_IMPACTS",
     "OPERATIONAL_NOTE_KINDS",
@@ -138,6 +155,7 @@ __all__ = [
     "SEASONAL_IMPACTS",
     "SEGMENT_MODES",
     "SeasonalSignal",
+    "ScheduleFitSummary",
     "TAG_SCOPES",
     "TRANSPORT_KINDS",
     "TRANSPORT_SCHEMA_VERSION",
@@ -152,4 +170,6 @@ __all__ = [
     "TransportTimingSummary",
     "TransportTransferBurden",
     "EFFORT_LEVELS",
+    "InventoryBundle",
+    "RouteCoherenceSummary",
 ]

--- a/trip_planner/options/bundles.py
+++ b/trip_planner/options/bundles.py
@@ -265,6 +265,10 @@ class InventoryBundle:
             raise ValueError(
                 "destinations must include each destination referenced by lodging or activity options"
             )
+        if transport_destination_ids and not represented_destination_ids:
+            raise ValueError(
+                "destinations must include each origin_id and destination_id referenced by transport options"
+            )
         if represented_destination_ids and not transport_destination_ids.issubset(
             represented_destination_ids
         ):

--- a/trip_planner/options/bundles.py
+++ b/trip_planner/options/bundles.py
@@ -58,7 +58,9 @@ def _optional_mapping_field(payload: dict[str, Any], field_name: str) -> dict[st
     return value
 
 
-def _parse_money_range(payload: dict[str, Any] | None, field_name: str) -> MoneyRange | None:
+def _parse_money_range(
+    payload: dict[str, Any] | None, field_name: str
+) -> MoneyRange | None:
     if payload is None:
         return None
     if not isinstance(payload, dict):
@@ -84,7 +86,9 @@ class BundleFeasibility:
         _require_string_list(self.dependencies, "dependencies")
         _require_string_list(self.accessibility_notes, "accessibility_notes")
         _require_string_list(self.notes, "notes")
-        if (not self.available or not self.internally_consistent) and not self.blocking_reasons:
+        if (
+            not self.available or not self.internally_consistent
+        ) and not self.blocking_reasons:
             raise ValueError(
                 "blocking_reasons must describe why the bundle is unavailable or inconsistent"
             )
@@ -222,7 +226,9 @@ class InventoryBundle:
             raise ValueError("destinations must contain Destination instances")
         if any(not isinstance(item, LodgingOption) for item in self.lodging_options):
             raise ValueError("lodging_options must contain LodgingOption instances")
-        if any(not isinstance(item, TransportOption) for item in self.transport_options):
+        if any(
+            not isinstance(item, TransportOption) for item in self.transport_options
+        ):
             raise ValueError("transport_options must contain TransportOption instances")
         if any(not isinstance(item, ActivityOption) for item in self.activity_options):
             raise ValueError("activity_options must contain ActivityOption instances")
@@ -231,16 +237,16 @@ class InventoryBundle:
         if not isinstance(self.explanation, BundleExplanation):
             raise ValueError("explanation must be a BundleExplanation")
         if not (
-            self.lodging_options
-            or self.transport_options
-            or self.activity_options
+            self.lodging_options or self.transport_options or self.activity_options
         ):
             raise ValueError(
                 "InventoryBundle must include at least one lodging, transport, or activity option"
             )
         _require_string_list(self.tags, "tags")
         _require_string_list(self.notes, "notes")
-        represented_destination_ids = {item.destination_id for item in self.destinations}
+        represented_destination_ids = {
+            item.destination_id for item in self.destinations
+        }
         referenced_destination_ids = {
             item.destination_id for item in self.lodging_options
         } | {item.destination_id for item in self.activity_options}
@@ -317,7 +323,9 @@ class MixedOption:
     supported_purposes: list[str] = field(
         default_factory=lambda: ["profile_learning", "inventory_narrowing"]
     )
-    route_coherence: RouteCoherenceSummary = field(default_factory=RouteCoherenceSummary)
+    route_coherence: RouteCoherenceSummary = field(
+        default_factory=RouteCoherenceSummary
+    )
     schedule_fit: ScheduleFitSummary = field(default_factory=ScheduleFitSummary)
     budget_posture: BudgetPostureSummary = field(default_factory=BudgetPostureSummary)
     explanation: BundleExplanation = field(default_factory=BundleExplanation)
@@ -349,7 +357,9 @@ class MixedOption:
             raise ValueError("explanation must be a BundleExplanation")
         _require_string_list(self.supported_purposes, "supported_purposes")
         invalid_purposes = [
-            purpose for purpose in self.supported_purposes if purpose not in OPTION_SET_PURPOSES
+            purpose
+            for purpose in self.supported_purposes
+            if purpose not in OPTION_SET_PURPOSES
         ]
         if invalid_purposes:
             raise ValueError(
@@ -371,7 +381,9 @@ class MixedOption:
                 for bundle in self.bundles
                 for destination_id in bundle.destination_ids
             }
-            if not bundle_destination_ids.issubset(set(self.route_coherence.destination_sequence)):
+            if not bundle_destination_ids.issubset(
+                set(self.route_coherence.destination_sequence)
+            ):
                 raise ValueError(
                     "route_coherence.destination_sequence must cover each destination in the included bundles"
                 )
@@ -379,12 +391,12 @@ class MixedOption:
     def _aggregate_booking_links(self) -> list[str]:
         values = list(self.booking_links)
         for bundle in self.bundles:
-            for option in bundle.lodging_options:
-                values.extend(option.booking_links)
-            for option in bundle.transport_options:
-                values.extend(option.booking_links)
-            for option in bundle.activity_options:
-                values.extend(option.booking_links)
+            for lodging_option in bundle.lodging_options:
+                values.extend(lodging_option.booking_links)
+            for transport_option in bundle.transport_options:
+                values.extend(transport_option.booking_links)
+            for activity_option in bundle.activity_options:
+                values.extend(activity_option.booking_links)
         return _dedupe_strings(values)
 
     def _aggregate_source_refs(self) -> list[str]:
@@ -392,12 +404,16 @@ class MixedOption:
         for bundle in self.bundles:
             for destination in bundle.destinations:
                 values.extend(item.provenance_id for item in destination.source_refs)
-            for option in bundle.lodging_options:
-                values.extend(item.provenance_id for item in option.source_refs)
-            for option in bundle.transport_options:
-                values.extend(item.provenance_id for item in option.source_refs)
-            for option in bundle.activity_options:
-                values.extend(item.provenance_id for item in option.source_refs)
+            for lodging_option in bundle.lodging_options:
+                values.extend(item.provenance_id for item in lodging_option.source_refs)
+            for transport_option in bundle.transport_options:
+                values.extend(
+                    item.provenance_id for item in transport_option.source_refs
+                )
+            for activity_option in bundle.activity_options:
+                values.extend(
+                    item.provenance_id for item in activity_option.source_refs
+                )
         return _dedupe_strings(values)
 
     def _aggregate_destination_ids(self) -> list[str]:
@@ -444,7 +460,8 @@ class MixedOption:
             booking_links=self._aggregate_booking_links(),
             source_refs=self._aggregate_source_refs(),
             supporting_place_ids=(
-                self.route_coherence.destination_sequence or self._aggregate_destination_ids()
+                self.route_coherence.destination_sequence
+                or self._aggregate_destination_ids()
             ),
             explanation=explanation,
         )

--- a/trip_planner/options/bundles.py
+++ b/trip_planner/options/bundles.py
@@ -1,0 +1,506 @@
+"""Canonical mixed inventory bundle contracts for normalized option assembly."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_optional_non_empty,
+    require_probability,
+    require_strings,
+)
+from trip_planner.contracts.options import (
+    OPTION_SET_PURPOSES,
+    MoneyRange,
+    Option,
+    OptionCostSummary,
+    OptionQualitySummary,
+)
+
+from .activities import ActivityOption
+from .destinations import Destination
+from .lodging import LodgingOption
+from .transport import TransportOption
+
+SCHEMA_VERSION = "0.1.0"
+
+BUNDLE_CONTEXTS: tuple[str, ...] = (
+    "lodging_only",
+    "transport_lodging",
+    "route_level",
+    "activity_cluster",
+    "mixed",
+)
+
+
+def _require_string_list(values: Any, field_name: str) -> None:
+    if not isinstance(values, list):
+        raise ValueError(f"{field_name} must be a list of non-empty strings")
+    require_strings(values, field_name)
+
+
+def _optional_list_field(payload: dict[str, Any], field_name: str) -> list[Any]:
+    value = payload.get(field_name, [])
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list when provided")
+    return value
+
+
+def _optional_mapping_field(payload: dict[str, Any], field_name: str) -> dict[str, Any]:
+    value = payload.get(field_name, {})
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be a mapping when provided")
+    return value
+
+
+def _parse_money_range(payload: dict[str, Any] | None, field_name: str) -> MoneyRange | None:
+    if payload is None:
+        return None
+    if not isinstance(payload, dict):
+        raise ValueError(f"{field_name} must be a mapping when provided")
+    return MoneyRange(**payload)
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+@dataclass(slots=True)
+class BundleFeasibility:
+    available: bool = True
+    internally_consistent: bool = True
+    blocking_reasons: list[str] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
+    accessibility_notes: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        _require_string_list(self.blocking_reasons, "blocking_reasons")
+        _require_string_list(self.dependencies, "dependencies")
+        _require_string_list(self.accessibility_notes, "accessibility_notes")
+        _require_string_list(self.notes, "notes")
+        if (not self.available or not self.internally_consistent) and not self.blocking_reasons:
+            raise ValueError(
+                "blocking_reasons must describe why the bundle is unavailable or inconsistent"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RouteCoherenceSummary:
+    overall_signal: float | None = None
+    route_shape: str = ""
+    movement_summary: str = ""
+    destination_sequence: list[str] = field(default_factory=list)
+    base_change_count: int = 0
+    cohesion_signal: float | None = None
+    recovery_signal: float | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        for field_name in ("overall_signal", "cohesion_signal", "recovery_signal"):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_probability(value, field_name)
+        require_optional_non_empty(self.route_shape or None, "route_shape")
+        require_optional_non_empty(self.movement_summary or None, "movement_summary")
+        require_non_negative(self.base_change_count, "base_change_count")
+        _require_string_list(self.destination_sequence, "destination_sequence")
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ScheduleFitSummary:
+    overall_signal: float | None = None
+    pacing_signal: float | None = None
+    arrival_alignment_signal: float | None = None
+    recovery_window_signal: float | None = None
+    buffer_signal: float | None = None
+    overcommitment_risk_signal: float | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "overall_signal",
+            "pacing_signal",
+            "arrival_alignment_signal",
+            "recovery_window_signal",
+            "buffer_signal",
+            "overcommitment_risk_signal",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_probability(value, field_name)
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class BudgetPostureSummary:
+    estimated_total: MoneyRange | None = None
+    lodging_total: MoneyRange | None = None
+    transport_total: MoneyRange | None = None
+    activity_total: MoneyRange | None = None
+    overall_signal: float | None = None
+    within_target_budget: bool | None = None
+    stretch_required: bool = False
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "estimated_total",
+            "lodging_total",
+            "transport_total",
+            "activity_total",
+        ):
+            value = getattr(self, field_name)
+            if value is not None and not isinstance(value, MoneyRange):
+                raise ValueError(f"{field_name} must be a MoneyRange when provided")
+        if self.overall_signal is not None:
+            require_probability(self.overall_signal, "overall_signal")
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class BundleExplanation:
+    headline: str = ""
+    strengths: list[str] = field(default_factory=list)
+    tradeoffs: list[str] = field(default_factory=list)
+    evidence: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_optional_non_empty(self.headline or None, "headline")
+        _require_string_list(self.strengths, "strengths")
+        _require_string_list(self.tradeoffs, "tradeoffs")
+        _require_string_list(self.evidence, "evidence")
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class InventoryBundle:
+    bundle_id: str
+    title: str
+    bundle_context: str = "mixed"
+    destinations: list[Destination] = field(default_factory=list)
+    lodging_options: list[LodgingOption] = field(default_factory=list)
+    transport_options: list[TransportOption] = field(default_factory=list)
+    activity_options: list[ActivityOption] = field(default_factory=list)
+    feasibility: BundleFeasibility = field(default_factory=BundleFeasibility)
+    explanation: BundleExplanation = field(default_factory=BundleExplanation)
+    summary: str = ""
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.bundle_id, "bundle_id")
+        require_non_empty(self.title, "title")
+        if self.bundle_context not in BUNDLE_CONTEXTS:
+            raise ValueError(f"bundle_context must be one of {BUNDLE_CONTEXTS}")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+        if any(not isinstance(item, Destination) for item in self.destinations):
+            raise ValueError("destinations must contain Destination instances")
+        if any(not isinstance(item, LodgingOption) for item in self.lodging_options):
+            raise ValueError("lodging_options must contain LodgingOption instances")
+        if any(not isinstance(item, TransportOption) for item in self.transport_options):
+            raise ValueError("transport_options must contain TransportOption instances")
+        if any(not isinstance(item, ActivityOption) for item in self.activity_options):
+            raise ValueError("activity_options must contain ActivityOption instances")
+        if not isinstance(self.feasibility, BundleFeasibility):
+            raise ValueError("feasibility must be a BundleFeasibility")
+        if not isinstance(self.explanation, BundleExplanation):
+            raise ValueError("explanation must be a BundleExplanation")
+        if not (
+            self.lodging_options
+            or self.transport_options
+            or self.activity_options
+        ):
+            raise ValueError(
+                "InventoryBundle must include at least one lodging, transport, or activity option"
+            )
+        _require_string_list(self.tags, "tags")
+        _require_string_list(self.notes, "notes")
+        represented_destination_ids = {item.destination_id for item in self.destinations}
+        referenced_destination_ids = {
+            item.destination_id for item in self.lodging_options
+        } | {item.destination_id for item in self.activity_options}
+        transport_destination_ids = {
+            endpoint
+            for item in self.transport_options
+            for endpoint in (item.origin_id, item.destination_id)
+        }
+        if referenced_destination_ids and not represented_destination_ids:
+            raise ValueError(
+                "destinations must include each destination referenced by lodging or activity options"
+            )
+        if represented_destination_ids and not referenced_destination_ids.issubset(
+            represented_destination_ids
+        ):
+            raise ValueError(
+                "destinations must include each destination referenced by lodging or activity options"
+            )
+        if represented_destination_ids and not transport_destination_ids.issubset(
+            represented_destination_ids
+        ):
+            raise ValueError(
+                "destinations must include each origin_id and destination_id referenced by transport options"
+            )
+
+    @property
+    def destination_ids(self) -> list[str]:
+        return [item.destination_id for item in self.destinations]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "InventoryBundle":
+        return cls(
+            bundle_id=payload["bundle_id"],
+            title=payload["title"],
+            bundle_context=payload.get("bundle_context", "mixed"),
+            destinations=[
+                Destination.from_dict(item)
+                for item in _optional_list_field(payload, "destinations")
+            ],
+            lodging_options=[
+                LodgingOption.from_dict(item)
+                for item in _optional_list_field(payload, "lodging_options")
+            ],
+            transport_options=[
+                TransportOption.from_dict(item)
+                for item in _optional_list_field(payload, "transport_options")
+            ],
+            activity_options=[
+                ActivityOption.from_dict(item)
+                for item in _optional_list_field(payload, "activity_options")
+            ],
+            feasibility=BundleFeasibility(
+                **_optional_mapping_field(payload, "feasibility")
+            ),
+            explanation=BundleExplanation(
+                **_optional_mapping_field(payload, "explanation")
+            ),
+            summary=payload.get("summary", ""),
+            tags=_optional_list_field(payload, "tags"),
+            notes=_optional_list_field(payload, "notes"),
+            schema_version=payload.get("schema_version", SCHEMA_VERSION),
+        )
+
+
+@dataclass(slots=True)
+class MixedOption:
+    option_id: str
+    trip_id: str
+    title: str
+    bundles: list[InventoryBundle]
+    supported_purposes: list[str] = field(
+        default_factory=lambda: ["profile_learning", "inventory_narrowing"]
+    )
+    route_coherence: RouteCoherenceSummary = field(default_factory=RouteCoherenceSummary)
+    schedule_fit: ScheduleFitSummary = field(default_factory=ScheduleFitSummary)
+    budget_posture: BudgetPostureSummary = field(default_factory=BudgetPostureSummary)
+    explanation: BundleExplanation = field(default_factory=BundleExplanation)
+    comparison_label: str = ""
+    summary: str = ""
+    booking_links: list[str] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.option_id, "option_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.title, "title")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+        if not self.bundles:
+            raise ValueError("bundles must contain at least one InventoryBundle")
+        if any(not isinstance(item, InventoryBundle) for item in self.bundles):
+            raise ValueError("bundles must contain InventoryBundle instances")
+        if not isinstance(self.route_coherence, RouteCoherenceSummary):
+            raise ValueError("route_coherence must be a RouteCoherenceSummary")
+        if not isinstance(self.schedule_fit, ScheduleFitSummary):
+            raise ValueError("schedule_fit must be a ScheduleFitSummary")
+        if not isinstance(self.budget_posture, BudgetPostureSummary):
+            raise ValueError("budget_posture must be a BudgetPostureSummary")
+        if not isinstance(self.explanation, BundleExplanation):
+            raise ValueError("explanation must be a BundleExplanation")
+        _require_string_list(self.supported_purposes, "supported_purposes")
+        invalid_purposes = [
+            purpose for purpose in self.supported_purposes if purpose not in OPTION_SET_PURPOSES
+        ]
+        if invalid_purposes:
+            raise ValueError(
+                f"supported_purposes must contain only {OPTION_SET_PURPOSES}"
+            )
+        if len(set(self.supported_purposes)) != len(self.supported_purposes):
+            raise ValueError("supported_purposes must not contain duplicates")
+        require_optional_non_empty(self.comparison_label or None, "comparison_label")
+        _require_string_list(self.booking_links, "booking_links")
+        _require_string_list(self.source_refs, "source_refs")
+        _require_string_list(self.tags, "tags")
+        _require_string_list(self.notes, "notes")
+        bundle_ids = [item.bundle_id for item in self.bundles]
+        if len(set(bundle_ids)) != len(bundle_ids):
+            raise ValueError("bundles must not contain duplicate bundle_id values")
+        if self.route_coherence.destination_sequence:
+            bundle_destination_ids = {
+                destination_id
+                for bundle in self.bundles
+                for destination_id in bundle.destination_ids
+            }
+            if not bundle_destination_ids.issubset(set(self.route_coherence.destination_sequence)):
+                raise ValueError(
+                    "route_coherence.destination_sequence must cover each destination in the included bundles"
+                )
+
+    def _aggregate_booking_links(self) -> list[str]:
+        values = list(self.booking_links)
+        for bundle in self.bundles:
+            for option in bundle.lodging_options:
+                values.extend(option.booking_links)
+            for option in bundle.transport_options:
+                values.extend(option.booking_links)
+            for option in bundle.activity_options:
+                values.extend(option.booking_links)
+        return _dedupe_strings(values)
+
+    def _aggregate_source_refs(self) -> list[str]:
+        values = list(self.source_refs)
+        for bundle in self.bundles:
+            for destination in bundle.destinations:
+                values.extend(item.provenance_id for item in destination.source_refs)
+            for option in bundle.lodging_options:
+                values.extend(item.provenance_id for item in option.source_refs)
+            for option in bundle.transport_options:
+                values.extend(item.provenance_id for item in option.source_refs)
+            for option in bundle.activity_options:
+                values.extend(item.provenance_id for item in option.source_refs)
+        return _dedupe_strings(values)
+
+    def _aggregate_destination_ids(self) -> list[str]:
+        return _dedupe_strings(
+            [
+                destination_id
+                for bundle in self.bundles
+                for destination_id in bundle.destination_ids
+            ]
+        )
+
+    def to_option(self) -> Option:
+        explanation = list(self.explanation.strengths)
+        if self.explanation.headline:
+            explanation.insert(0, self.explanation.headline)
+        return Option(
+            option_id=self.option_id,
+            kind="mixed",
+            label=self.title,
+            summary=self.summary,
+            fit_signals={
+                key: value
+                for key, value in {
+                    "route_coherence": self.route_coherence.overall_signal,
+                    "schedule_fit": self.schedule_fit.overall_signal,
+                    "budget_posture": self.budget_posture.overall_signal,
+                }.items()
+                if value is not None
+            },
+            cost_summary=OptionCostSummary(total=self.budget_posture.estimated_total),
+            quality_summary=OptionQualitySummary(
+                quality_signal=self.route_coherence.overall_signal,
+                value_signal=self.budget_posture.overall_signal,
+                fit_signal=self.schedule_fit.overall_signal,
+            ),
+            drawbacks=_dedupe_strings(
+                self.explanation.tradeoffs
+                + [
+                    reason
+                    for bundle in self.bundles
+                    for reason in bundle.feasibility.blocking_reasons
+                ]
+            ),
+            booking_links=self._aggregate_booking_links(),
+            source_refs=self._aggregate_source_refs(),
+            supporting_place_ids=(
+                self.route_coherence.destination_sequence or self._aggregate_destination_ids()
+            ),
+            explanation=explanation,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "MixedOption":
+        budget_payload = _optional_mapping_field(payload, "budget_posture")
+        return cls(
+            option_id=payload["option_id"],
+            trip_id=payload["trip_id"],
+            title=payload["title"],
+            bundles=[
+                InventoryBundle.from_dict(item)
+                for item in _optional_list_field(payload, "bundles")
+            ],
+            supported_purposes=_optional_list_field(payload, "supported_purposes")
+            or ["profile_learning", "inventory_narrowing"],
+            route_coherence=RouteCoherenceSummary(
+                **_optional_mapping_field(payload, "route_coherence")
+            ),
+            schedule_fit=ScheduleFitSummary(
+                **_optional_mapping_field(payload, "schedule_fit")
+            ),
+            budget_posture=BudgetPostureSummary(
+                estimated_total=_parse_money_range(
+                    budget_payload.get("estimated_total"),
+                    "budget_posture.estimated_total",
+                ),
+                lodging_total=_parse_money_range(
+                    budget_payload.get("lodging_total"),
+                    "budget_posture.lodging_total",
+                ),
+                transport_total=_parse_money_range(
+                    budget_payload.get("transport_total"),
+                    "budget_posture.transport_total",
+                ),
+                activity_total=_parse_money_range(
+                    budget_payload.get("activity_total"),
+                    "budget_posture.activity_total",
+                ),
+                overall_signal=budget_payload.get("overall_signal"),
+                within_target_budget=budget_payload.get("within_target_budget"),
+                stretch_required=budget_payload.get("stretch_required", False),
+                notes=budget_payload.get("notes", []),
+            ),
+            explanation=BundleExplanation(
+                **_optional_mapping_field(payload, "explanation")
+            ),
+            comparison_label=payload.get("comparison_label", ""),
+            summary=payload.get("summary", ""),
+            booking_links=_optional_list_field(payload, "booking_links"),
+            source_refs=_optional_list_field(payload, "source_refs"),
+            tags=_optional_list_field(payload, "tags"),
+            notes=_optional_list_field(payload, "notes"),
+            schema_version=payload.get("schema_version", SCHEMA_VERSION),
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #524

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner will rarely present raw lodging, transport, or activity records in isolation. It needs a way to assemble normalized inventory objects into coherent mixed bundles and option sets that can be shown to users, scored later, or exported to policy-ready workflows. Without that layer, the app will have object contracts but no stable container for assembling them into alternatives.

Parent epic: #519

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#519](https://github.com/stranske/trip-planner/issues/519)
- [#514](https://github.com/stranske/trip-planner/issues/514)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement typed contracts for `InventoryBundle`, `MixedOption`, and any supporting feasibility or explanation summary records needed to assemble cross-category alternatives.
- [x] Ensure the bundle layer can combine normalized `Destination`, `LodgingOption`, `TransportOption`, and `ActivityOption` objects without flattening their category-specific detail.
- [x] Add fields for bundle-level feasibility, route coherence, schedule fit, budget posture, and explanation metadata so later ranking and UI layers can consume assembled alternatives.
- [x] Ensure `MixedOption` can support both profile-learning comparisons and later inventory-narrowing comparisons.
- [x] Create representative fixtures or examples for at least: a lodging-only comparison set, a transport-plus-lodging bundle, and a route-level mixed option with activities.
- [x] Write unit tests covering serialization, validation failures, and examples where a bundle is internally inconsistent or infeasible.
- [x] Document how this layer relates to `OptionSet` from the shared contracts epic and to later ranking work.

#### Acceptance criteria
- [x] The repo contains a canonical inventory-bundle and mixed-option assembly layer downstream from normalized option contracts.
- [x] The layer preserves category-specific detail while exposing bundle-level feasibility and explanation summaries.
- [x] The same assembly structures can support both revealed-preference comparisons and later inventory-selection flows.
- [x] Tests cover at least one internally consistent bundle and one infeasible bundle.
- [x] Documentation clarifies the boundary between normalized option objects, mixed option bundles, and later ranking or search logic.

**Head SHA:** dfc2126545a6e6699f6d205e386e2b0534a9180e
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23809651106) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23809651036) |
<!-- auto-status-summary:end -->