### PR TITLE
Issue #506: define leisure preference epic sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ## Key Docs
 
 - [Implementation plan](docs/implementation-plan.md)
+- [Leisure preference epic plan](docs/leisure-preference-epic.md)
 - [Source ingestion epic plan](docs/source-ingestion-epic.md)
 - [Product and architecture brief](docs/product-architecture-brief.md)
 - [Leisure preference contract](docs/leisure-preference-contract.md)

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -15,6 +15,9 @@ The goal is to preserve the dependency order between planning layers instead of 
 - `#515` `BusinessTravelProfile`
 - `#517` source and provenance contracts
 
+Epic `#506` is the sequencing contract for the leisure preference foundation.
+See [leisure-preference-epic.md](leisure-preference-epic.md) for the dependency chain, shared design rules, and acceptance mapping spanning issues `#507` through `#512`.
+
 ### 2. Core Planning Engines
 
 - `#510` leisure preference resolution

--- a/docs/leisure-preference-epic.md
+++ b/docs/leisure-preference-epic.md
@@ -1,0 +1,88 @@
+# Leisure Preference Epic Plan
+
+This document records the implementation contract for epic `#506`.
+
+The goal is to sequence the leisure preference foundation so that contracts, evidence, fixtures, resolution, autonomy controls, and itinerary-objective derivation land in a stable order.
+
+## Epic Boundary
+
+Epic `#506` exists to define the delivery order and dependency rules for the first implementation pass of the leisure preference engine.
+
+It is complete when:
+
+- the child issues are shipped in dependency order
+- leisure preference evaluation remains explicitly upstream of itinerary ranking, candidate search, and live inventory work
+- the resulting modules expose reusable contracts and engine boundaries instead of extending the old script-era request shape
+- leisure and business preference logic remain separate at the contract level
+
+## Dependency Chain
+
+The leisure preference epic should establish the foundation in this order:
+
+1. `#507` canonical leisure preference contracts and package layout
+2. `#508` evidence model for direct statements, tradeoff choices, and scenario reactions
+3. `#509` traveler archetype fixtures and evaluation corpus
+4. `#510` preference resolution engine and contradiction handling
+5. `#511` planning-autonomy controls and revealed-preference updates
+6. `#512` itinerary-objective derivation from resolved leisure profiles
+
+Issue `#509` can mature alongside `#508` once the contract shape from `#507` is stable, but `#510` should not invent resolver behavior against ad hoc or fixture-only fields. The resolver should consume the canonical contracts and evidence surfaces first.
+
+## Shared Design Rules
+
+Every child issue in this epic should preserve these rules:
+
+- `LeisurePreferenceProfile` is the canonical leisure planning contract.
+- Evidence capture, resolution, autonomy, and objective derivation remain separate concerns with inspectable handoffs.
+- Legacy `request.json` fields stay a compatibility bridge, not the design center.
+- Contradictions, conditional preferences, and confidence levels must remain explicit rather than being flattened into one score.
+- Business-travel preference logic should reuse only truly shared infrastructure, not leisure-specific assumptions.
+
+## Child Issue Map
+
+| Issue | Role | Must Consume | Must Produce |
+|---:|---|---|---|
+| `#507` | Canonical leisure contract and package layout | existing design docs, legacy request surface | dataclass contracts, schema constants, package boundaries |
+| `#508` | Evidence model | contracts from `#507`, tradeoff taxonomy, anchor rules | evidence records, evidence catalog, confidence pathways |
+| `#509` | Traveler fixtures and evaluation corpus | contracts from `#507`, evidence surfaces from `#508` | archetype fixtures, tension cases, reusable regression corpus |
+| `#510` | Preference resolution engine | canonical contracts from `#507`, evidence from `#508`, fixtures from `#509` | resolved profiles, contradiction handling, explanation-ready outputs |
+| `#511` | Autonomy controls and revealed-preference updates | resolver outputs from `#510`, canonical contracts from `#507` | planning-autonomy controls, update rules, guarded preference revisions |
+| `#512` | Itinerary-objective derivation | resolved leisure profiles from `#510`, autonomy/revision guidance from `#511`, shared itinerary-objective contracts | explainable leisure itinerary objectives for downstream ranking |
+
+## Contract Surface
+
+The first pass of this epic should stabilize the following surfaces before ranking and UI work expands:
+
+- `trip_planner/preferences/` for leisure contracts, evidence, resolver logic, and autonomy controls
+- `trip_planner/itinerary/` for leisure itinerary-objective derivation that consumes resolved profiles
+- `tests/fixtures/preferences/` for representative traveler archetypes, contradictions, and revision scenarios
+- `tests/preferences/` for regression coverage across contracts, resolution, and revealed-preference handling
+
+This keeps downstream ranking, candidate generation, and orchestration work additive instead of forcing later PRs to retrofit structure into loosely defined preference fields.
+
+## Acceptance Mapping
+
+The epic acceptance criteria from `#506` map to child issue outcomes as follows:
+
+| Epic requirement | Owning issues |
+|---|---|
+| All child issues needed for the leisure preference engine foundation are complete | `#507` to `#512` |
+| Preference evaluation remains upstream of itinerary ranking and inventory optimization | `#507`, `#508`, `#510`, `#512` |
+| The foundation is strong enough to support later ranking, option generation, and interaction design without redoing the core leisure model | `#507`, `#508`, `#509`, `#510`, `#511`, `#512` |
+| Leisure and business preference logic remain separated at the contract level | `#507`, `#510`, `#512` |
+
+## Design References
+
+Use these documents together when implementing the child issues:
+
+- [Leisure preference engine](leisure-preference-engine.md)
+- [Leisure preference contract](leisure-preference-contract.md)
+- [Leisure preference schema draft](leisure-preference-schema.md)
+- [Preference learning model](preference-learning-model.md)
+- [Preference roadmap](preference-roadmap.md)
+- [Shared planning contracts](shared-planning-contracts.md)
+- [Business travel profile contract](business-travel-profile-contract.md)
+
+## Working Rule
+
+If a child issue needs to shortcut directly from raw questionnaire inputs to ranking weights without explicit contracts, evidence handling, and resolver outputs, the epic is being violated and the design should be corrected before the PR lands.


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #506

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo now has enough design direction to begin implementation planning for the leisure preference engine, but the actual codebase still only exposes a thin script-era preference surface (`must_see`, `nature_ratio`, `complexity_tolerance`, `cost_sensitivity`, `route_passions`). Before itinerary ranking, live inventory integration, or business-mode optimization, the project needs a stronger foundation for modeling how serious independent travelers make tradeoffs across a two- to six-week trip.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#507](https://github.com/stranske/trip-planner/issues/507)
- [#508](https://github.com/stranske/trip-planner/issues/508)
- [#509](https://github.com/stranske/trip-planner/issues/509)
- [#510](https://github.com/stranske/trip-planner/issues/510)
- [#511](https://github.com/stranske/trip-planner/issues/511)
- [#512](https://github.com/stranske/trip-planner/issues/512)
- [#505](https://github.com/stranske/trip-planner/issues/505)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] #507 Establish canonical leisure preference contracts and package layout
- [x] #508 Implement the leisure preference evidence model
- [x] #509 Create traveler archetype fixtures and evaluation corpus
- [x] #510 Build the preference resolution engine and interaction rules
- [x] #511 Add planning-autonomy controls and revealed-preference updates
- [x] #512 Derive itinerary objectives from resolved leisure profiles

#### Acceptance criteria
- [x] All child issues needed for the leisure preference engine foundation are completed.
- [x] Preference evaluation remains explicitly upstream of itinerary ranking and inventory optimization.
- [x] The resulting foundation is strong enough to support later ranking, option generation, and interaction design work without redoing the core leisure preference model.
- [x] Leisure and business preference logic remain separated at the contract level.

**Head SHA:** 7e35212c874ff1b1d3cf6bcef410b2cef28abb62
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23812979353) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23812979389) |
| Create Issue from Verification (DEPRECATED) | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23812276959) |
| Gate | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23812277044) |
<!-- auto-status-summary:end -->
