### PR TITLE
Issue #532: define ranking result contracts

### DIFF
--- a/docs/contracts/ranking-results.md
+++ b/docs/contracts/ranking-results.md
@@ -1,0 +1,37 @@
+# Ranking Result Contracts
+
+`trip_planner/ranking` defines the canonical output contract for every later ranking layer.
+
+## Boundary
+
+- Inputs should already be normalized options, candidate seeds, itinerary objectives, and later feasibility outputs.
+- Outputs are ranked results, explicit score breakdowns, adjustment records, confidence summaries, unresolved-risk flags, and explanation records.
+- This layer does not implement leisure ranking logic, business policy logic, or route search by itself.
+
+## What Must Be Explicit
+
+- component-level contributions instead of one opaque scalar
+- penalties, bonuses, and missing-data penalties as separate records
+- confidence and missing-data summaries that later UI or chat layers can surface directly
+- explanation records that keep both machine-readable factor keys and human-readable summaries
+- support for item-level results and bundle or route-level results in one shared result-set shape
+
+## Result Model
+
+Future ranking modules should emit `RankedResultSet` values built from:
+
+- `RankedResult` for each ranked candidate, bundle, or route
+- `ScoreBreakdown` with `ScoreContribution`, `ScoreAdjustment`, and missing-data penalties
+- `ScoreConfidenceSummary` for uncertainty and coverage
+- `RiskFlag` for unresolved risks that should survive into review or UI layers
+- `ExplanationRecord` for summary, promotion, penalty, risk, and confidence narratives
+
+## Working Rule
+
+When a future ranking layer emits results:
+
+1. Keep the result target explicit: item results should point to a ranked option, while bundle or route results should point to a stable bundle identifier.
+2. Preserve why the score changed: every meaningful promotion, penalty, and missing-data discount should be represented in the score breakdown or explanation records.
+3. Keep uncertainty inspectable: low-confidence inputs and unresolved risks should remain visible instead of being hidden inside the final score.
+
+If a future PR needs ranking output that cannot fit these contracts, extend `trip_planner/ranking` rather than inventing a parallel result container.

--- a/docs/ranking-route-search-epic.md
+++ b/docs/ranking-route-search-epic.md
@@ -79,6 +79,7 @@ Use these documents together when implementing the child issues:
 - [Core domain contracts](domain-contracts.md)
 - [Implementation plan](implementation-plan.md)
 - [Shared planning contracts](shared-planning-contracts.md)
+- [Ranking result contracts](contracts/ranking-results.md)
 - [Leisure itinerary-objective derivation boundary](itinerary-objective-derivation-boundary.md)
 - [Business objective derivation boundary](business-objective-derivation-boundary.md)
 - [Normalized inventory contracts epic](normalized-inventory-contracts-epic.md)

--- a/tests/fixtures/ranking/results/business_candidate_result.json
+++ b/tests/fixtures/ranking/results/business_candidate_result.json
@@ -1,0 +1,164 @@
+{
+  "result_set_id": "ranked-results:trip-business:policy_comparison",
+  "trip_id": "trip-business",
+  "purpose": "policy_comparison",
+  "scope": "mixed",
+  "title": "Business ranking",
+  "comparison_axes": [
+    {
+      "key": "policy_fit",
+      "label": "Policy fit",
+      "direction": "higher_better"
+    },
+    {
+      "key": "schedule_reliability",
+      "label": "Schedule reliability",
+      "direction": "higher_better"
+    }
+  ],
+  "results": [
+    {
+      "result_id": "ranked:item:chicago-conference-core",
+      "result_kind": "item",
+      "rank": 1,
+      "score": 0.63,
+      "target_option": {
+        "option_id": "candidate:chicago-conference-core",
+        "kind": "mixed",
+        "label": "Chicago conference core",
+        "summary": "Business-focused bundle with reliable arrival windows.",
+        "fit_signals": {
+          "policy_fit": 0.82,
+          "schedule_reliability": 0.71
+        },
+        "cost_summary": {
+          "total": {
+            "currency": "USD",
+            "typical_amount": 910.0
+          }
+        },
+        "quality_summary": {
+          "quality_signal": 0.74,
+          "value_signal": 0.63,
+          "fit_signal": 0.77
+        },
+        "drawbacks": [
+          "Hotel tax data is incomplete."
+        ],
+        "booking_links": [
+          "https://example.test/chicago-business"
+        ],
+        "source_refs": [
+          "src:chicago-conference-core"
+        ],
+        "supporting_place_ids": [
+          "dest-chicago"
+        ],
+        "explanation": [
+          "High policy fit with a small missing-data discount."
+        ]
+      },
+      "supporting_option_ids": [
+        "transport-ord-direct",
+        "lodg-conference-core"
+      ],
+      "supporting_destination_ids": [
+        "dest-chicago"
+      ],
+      "score_breakdown": {
+        "baseline_score": 0.35,
+        "component_contributions": [
+          {
+            "contribution_id": "policy-fit",
+            "label": "Policy fit",
+            "axis_key": "policy_fit",
+            "direction": "higher_better",
+            "raw_value": 0.82,
+            "normalized_signal": 0.82,
+            "weighted_impact": 0.18,
+            "summary": "Vendor channel and room rate remain within policy."
+          },
+          {
+            "contribution_id": "arrival-window",
+            "label": "Arrival window reliability",
+            "axis_key": "schedule_reliability",
+            "direction": "higher_better",
+            "raw_value": 0.71,
+            "normalized_signal": 0.71,
+            "weighted_impact": 0.15,
+            "summary": "Direct flight improves presentation-day reliability."
+          }
+        ],
+        "penalties": [],
+        "bonuses": [],
+        "missing_data_penalties": [
+          {
+            "adjustment_id": "missing-hotel-tax",
+            "label": "Missing hotel tax estimate",
+            "kind": "missing_data",
+            "amount": 0.05,
+            "reason_code": "missing_tax_estimate",
+            "summary": "The lodging source omitted a final tax estimate.",
+            "affected_factor_keys": [
+              "policy-fit"
+            ]
+          }
+        ],
+        "final_score": 0.63,
+        "notes": [
+          "Missing-data penalties stay explicit instead of being hidden in one score."
+        ]
+      },
+      "confidence_summary": {
+        "overall_confidence": 0.68,
+        "input_coverage": 0.79,
+        "data_freshness": 0.87,
+        "scoring_stability": 0.74,
+        "low_confidence_flags": [
+          "missing_tax_estimate"
+        ],
+        "missing_data_fields": [
+          "lodging.tax_summary"
+        ]
+      },
+      "explanation_records": [
+        {
+          "explanation_id": "summary:chicago-conference-core",
+          "record_type": "summary",
+          "target_kind": "item",
+          "target_id": "candidate:chicago-conference-core",
+          "headline": "Policy-ready with an explicit missing-data discount",
+          "summary": "The candidate remains preferred because policy and schedule fit are strong, but confidence is reduced by incomplete lodging tax data.",
+          "factor_keys": [
+            "policy-fit",
+            "arrival-window",
+            "missing-hotel-tax"
+          ],
+          "machine_context": {
+            "missing_field": "lodging.tax_summary",
+            "policy_status": "within_policy"
+          },
+          "human_summary": [
+            "Within policy",
+            "Reliable arrival",
+            "Missing final tax estimate"
+          ],
+          "source_refs": [
+            "src:chicago-conference-core"
+          ]
+        }
+      ],
+      "unresolved_risks": [
+        {
+          "risk_id": "risk:tax-estimate",
+          "code": "missing_tax_estimate",
+          "severity": "warning",
+          "summary": "Total trip cost may rise slightly once tax is confirmed."
+        }
+      ],
+      "source_refs": [
+        "src:chicago-conference-core"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ranking/results/leisure_candidate_result.json
+++ b/tests/fixtures/ranking/results/leisure_candidate_result.json
@@ -1,0 +1,176 @@
+{
+  "result_set_id": "ranked-results:trip-leisure:profile_learning",
+  "trip_id": "trip-leisure",
+  "purpose": "profile_learning",
+  "scope": "mixed",
+  "title": "Leisure candidate ranking",
+  "comparison_axes": [
+    {
+      "key": "enjoyment",
+      "label": "Enjoyment",
+      "direction": "higher_better",
+      "notes": "Normalized preference fit."
+    },
+    {
+      "key": "crowding",
+      "label": "Crowding risk",
+      "direction": "lower_better",
+      "notes": "High crowding should be penalized."
+    }
+  ],
+  "explanation": [
+    "Leisure ranking remains explainable and component-based."
+  ],
+  "source_refs": [
+    "candidate-set:trip-leisure:profile_learning"
+  ],
+  "results": [
+    {
+      "result_id": "ranked:item:kyoto-museum-day",
+      "result_kind": "item",
+      "rank": 1,
+      "score": 0.69,
+      "target_option": {
+        "option_id": "candidate:kyoto-museum-day",
+        "kind": "mixed",
+        "label": "Kyoto museum day",
+        "summary": "Walkable museum-heavy Kyoto bundle.",
+        "fit_signals": {
+          "enjoyment": 0.84,
+          "crowding": 0.31
+        },
+        "cost_summary": {
+          "total": {
+            "currency": "USD",
+            "typical_amount": 680.0
+          },
+          "notes": [
+            "Represents the expected bundle total."
+          ]
+        },
+        "quality_summary": {
+          "quality_signal": 0.8,
+          "value_signal": 0.72,
+          "fit_signal": 0.78,
+          "notes": [
+            "Derived from candidate generation."
+          ]
+        },
+        "drawbacks": [
+          "Peak-hour museum crowding remains possible."
+        ],
+        "booking_links": [
+          "https://example.test/kyoto-museum"
+        ],
+        "source_refs": [
+          "src:kyoto-museum-day"
+        ],
+        "supporting_place_ids": [
+          "dest-kyoto"
+        ],
+        "explanation": [
+          "Strong cultural fit and walkability."
+        ]
+      },
+      "supporting_option_ids": [
+        "lodg-kyoto-central",
+        "activity-museum-pass"
+      ],
+      "supporting_destination_ids": [
+        "dest-kyoto"
+      ],
+      "score_breakdown": {
+        "baseline_score": 0.4,
+        "component_contributions": [
+          {
+            "contribution_id": "interest-match",
+            "label": "Interest match",
+            "axis_key": "enjoyment",
+            "direction": "higher_better",
+            "raw_value": 4.2,
+            "normalized_signal": 0.84,
+            "weighted_impact": 0.21,
+            "summary": "Interests align strongly with museums and quiet walking.",
+            "evidence_refs": [
+              "objective:quiet-culture"
+            ]
+          },
+          {
+            "contribution_id": "walkability",
+            "label": "Walkability",
+            "axis_key": "enjoyment",
+            "direction": "higher_better",
+            "raw_value": 0.76,
+            "normalized_signal": 0.76,
+            "weighted_impact": 0.12,
+            "summary": "Low-transfer itinerary shape improves ease of use."
+          }
+        ],
+        "penalties": [
+          {
+            "adjustment_id": "crowding-penalty",
+            "label": "Crowding penalty",
+            "kind": "penalty",
+            "amount": 0.04,
+            "reason_code": "peak_crowding",
+            "summary": "Museum district congestion reduces comfort.",
+            "affected_factor_keys": [
+              "crowding"
+            ]
+          }
+        ],
+        "bonuses": [],
+        "missing_data_penalties": [],
+        "final_score": 0.69,
+        "notes": [
+          "Explained without route search."
+        ]
+      },
+      "confidence_summary": {
+        "overall_confidence": 0.83,
+        "input_coverage": 0.92,
+        "data_freshness": 0.76,
+        "scoring_stability": 0.8,
+        "low_confidence_flags": [],
+        "missing_data_fields": []
+      },
+      "explanation_records": [
+        {
+          "explanation_id": "summary:kyoto-museum-day",
+          "record_type": "summary",
+          "target_kind": "item",
+          "target_id": "candidate:kyoto-museum-day",
+          "headline": "Cultural fit with low-friction movement",
+          "summary": "The bundle ranks first because it combines strong museum fit with easy local movement.",
+          "factor_keys": [
+            "interest-match",
+            "walkability"
+          ],
+          "machine_context": {
+            "primary_axis": "enjoyment",
+            "penalty_code": "peak_crowding"
+          },
+          "human_summary": [
+            "Strong cultural fit",
+            "Simple day shape",
+            "Minor crowding risk"
+          ],
+          "source_refs": [
+            "src:kyoto-museum-day"
+          ]
+        }
+      ],
+      "unresolved_risks": [
+        {
+          "risk_id": "risk:crowding",
+          "code": "peak_crowding",
+          "severity": "warning",
+          "summary": "Crowding may degrade the midday museum block."
+        }
+      ],
+      "source_refs": [
+        "src:kyoto-museum-day"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/ranking/results/route_bundle_result.json
+++ b/tests/fixtures/ranking/results/route_bundle_result.json
@@ -1,0 +1,127 @@
+{
+  "result_set_id": "ranked-results:trip-route:final_selection",
+  "trip_id": "trip-route",
+  "purpose": "final_selection",
+  "scope": "route",
+  "title": "Route-level ranking",
+  "comparison_axes": [
+    {
+      "key": "coherence",
+      "label": "Route coherence",
+      "direction": "higher_better"
+    },
+    {
+      "key": "transfer_load",
+      "label": "Transfer load",
+      "direction": "lower_better"
+    }
+  ],
+  "results": [
+    {
+      "result_id": "ranked:route:jp-loop-lite",
+      "result_kind": "route",
+      "rank": 1,
+      "score": 0.57,
+      "target_bundle_id": "bundle:jp-loop-lite",
+      "supporting_option_ids": [
+        "transport-kix-kyoto",
+        "lodg-kyoto-central",
+        "activity-arashiyama-day"
+      ],
+      "supporting_destination_ids": [
+        "dest-osaka",
+        "dest-kyoto"
+      ],
+      "route_sequence": [
+        "dest-osaka",
+        "dest-kyoto"
+      ],
+      "score_breakdown": {
+        "baseline_score": 0.3,
+        "component_contributions": [
+          {
+            "contribution_id": "route-coherence",
+            "label": "Route coherence",
+            "axis_key": "coherence",
+            "direction": "higher_better",
+            "raw_value": 0.78,
+            "normalized_signal": 0.78,
+            "weighted_impact": 0.19,
+            "summary": "The destination order minimizes backtracking."
+          },
+          {
+            "contribution_id": "transfer-load",
+            "label": "Transfer load",
+            "axis_key": "transfer_load",
+            "direction": "lower_better",
+            "raw_value": 1.0,
+            "normalized_signal": 0.62,
+            "weighted_impact": 0.12,
+            "summary": "Only one meaningful transfer is required."
+          }
+        ],
+        "penalties": [
+          {
+            "adjustment_id": "late-arrival-risk",
+            "label": "Late arrival risk",
+            "kind": "penalty",
+            "amount": 0.04,
+            "reason_code": "tight_evening_connection",
+            "summary": "The first evening connection keeps recovery time thin."
+          }
+        ],
+        "bonuses": [],
+        "missing_data_penalties": [],
+        "final_score": 0.57
+      },
+      "confidence_summary": {
+        "overall_confidence": 0.72,
+        "input_coverage": 0.81,
+        "data_freshness": 0.73,
+        "scoring_stability": 0.69,
+        "low_confidence_flags": [
+          "transfer_time_estimate"
+        ],
+        "missing_data_fields": []
+      },
+      "explanation_records": [
+        {
+          "explanation_id": "summary:jp-loop-lite",
+          "record_type": "summary",
+          "target_kind": "route",
+          "target_id": "bundle:jp-loop-lite",
+          "headline": "Compact route with one thin connection",
+          "summary": "The route ranks well because it stays geographically coherent, but an evening transfer remains slightly fragile.",
+          "factor_keys": [
+            "route-coherence",
+            "transfer-load",
+            "late-arrival-risk"
+          ],
+          "machine_context": {
+            "route_shape": "two_stop_loop",
+            "fragile_leg": "osaka_to_kyoto_evening"
+          },
+          "human_summary": [
+            "Minimal backtracking",
+            "One transfer",
+            "Thin evening buffer"
+          ],
+          "source_refs": [
+            "route:jp-loop-lite"
+          ]
+        }
+      ],
+      "unresolved_risks": [
+        {
+          "risk_id": "risk:evening-transfer",
+          "code": "tight_evening_connection",
+          "severity": "warning",
+          "summary": "The route depends on one tight evening movement window."
+        }
+      ],
+      "source_refs": [
+        "route:jp-loop-lite"
+      ]
+    }
+  ]
+}

--- a/tests/ranking/test_models.py
+++ b/tests/ranking/test_models.py
@@ -1,0 +1,99 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.ranking import RankedResultSet
+
+
+def _fixture_path(name: str) -> Path:
+    return Path("tests/fixtures/ranking/results") / name
+
+
+def _load_result_set(name: str) -> RankedResultSet:
+    payload = json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+    return RankedResultSet.from_dict(payload)
+
+
+def test_leisure_ranking_fixture_round_trips_and_keeps_item_contracts() -> None:
+    result_set = _load_result_set("leisure_candidate_result.json")
+
+    assert result_set.purpose == "profile_learning"
+    assert result_set.scope == "mixed"
+    assert result_set.results[0].result_kind == "item"
+    assert result_set.results[0].target_option is not None
+    assert result_set.results[0].score_breakdown.final_score == pytest.approx(0.69)
+    assert (
+        result_set.results[0].explanation_records[0].machine_context["primary_axis"]
+        == "enjoyment"
+    )
+    assert result_set.to_dict()["results"][0]["target_option"]["option_id"] == (
+        "candidate:kyoto-museum-day"
+    )
+
+
+def test_business_ranking_fixture_preserves_missing_data_penalties() -> None:
+    result_set = _load_result_set("business_candidate_result.json")
+
+    result = result_set.results[0]
+    assert result.result_kind == "item"
+    assert result.score_breakdown.missing_data_penalties[0].reason_code == (
+        "missing_tax_estimate"
+    )
+    assert result.confidence_summary.low_confidence_flags == ["missing_tax_estimate"]
+    assert result.unresolved_risks[0].code == "missing_tax_estimate"
+
+
+def test_route_fixture_supports_route_level_results() -> None:
+    result_set = _load_result_set("route_bundle_result.json")
+
+    result = result_set.results[0]
+    assert result_set.scope == "route"
+    assert result.result_kind == "route"
+    assert result.target_bundle_id == "bundle:jp-loop-lite"
+    assert result.route_sequence == ["dest-osaka", "dest-kyoto"]
+    assert result.explanation_records[0].target_kind == "route"
+
+
+def test_ranked_result_requires_item_target_option() -> None:
+    payload = json.loads(_fixture_path("leisure_candidate_result.json").read_text())
+    payload["results"][0]["target_option"] = None
+
+    with pytest.raises(ValueError, match="target_option"):
+        RankedResultSet.from_dict(payload)
+
+
+def test_ranked_result_requires_route_sequence_for_route_results() -> None:
+    payload = json.loads(_fixture_path("route_bundle_result.json").read_text())
+    payload["results"][0]["route_sequence"] = []
+
+    with pytest.raises(ValueError, match="route_sequence"):
+        RankedResultSet.from_dict(payload)
+
+
+def test_ranked_result_set_rejects_duplicate_ranks() -> None:
+    payload = json.loads(_fixture_path("business_candidate_result.json").read_text())
+    duplicate = dict(payload["results"][0])
+    duplicate["result_id"] = "ranked:item:backup"
+    duplicate["rank"] = 1
+    duplicate["score"] = 0.63
+    payload["results"].append(duplicate)
+
+    with pytest.raises(ValueError, match="unique ranks"):
+        RankedResultSet.from_dict(payload)
+
+
+def test_score_breakdown_rejects_mismatched_final_score() -> None:
+    payload = json.loads(_fixture_path("business_candidate_result.json").read_text())
+    payload["results"][0]["score_breakdown"]["final_score"] = 0.61
+
+    with pytest.raises(ValueError, match="final_score"):
+        RankedResultSet.from_dict(payload)
+
+
+def test_risk_flags_validate_known_severities() -> None:
+    payload = json.loads(_fixture_path("route_bundle_result.json").read_text())
+    payload["results"][0]["unresolved_risks"][0]["severity"] = "urgent"
+
+    with pytest.raises(ValueError, match="severity"):
+        RankedResultSet.from_dict(payload)

--- a/trip_planner/ranking/__init__.py
+++ b/trip_planner/ranking/__init__.py
@@ -1,0 +1,37 @@
+"""Canonical ranking-result contracts shared by later ranking modules."""
+
+from .explanations import (
+    EXPLANATION_RECORD_TYPES,
+    EXPLANATION_TARGET_KINDS,
+    ExplanationRecord,
+)
+from .models import (
+    ADJUSTMENT_KINDS,
+    RANK_RESULT_KINDS,
+    RISK_SEVERITIES,
+    SCHEMA_VERSION,
+    RankedResult,
+    RankedResultSet,
+    RiskFlag,
+    ScoreAdjustment,
+    ScoreBreakdown,
+    ScoreConfidenceSummary,
+    ScoreContribution,
+)
+
+__all__ = [
+    "ADJUSTMENT_KINDS",
+    "EXPLANATION_RECORD_TYPES",
+    "EXPLANATION_TARGET_KINDS",
+    "RANK_RESULT_KINDS",
+    "RISK_SEVERITIES",
+    "SCHEMA_VERSION",
+    "ExplanationRecord",
+    "RankedResult",
+    "RankedResultSet",
+    "RiskFlag",
+    "ScoreAdjustment",
+    "ScoreBreakdown",
+    "ScoreConfidenceSummary",
+    "ScoreContribution",
+]

--- a/trip_planner/ranking/explanations.py
+++ b/trip_planner/ranking/explanations.py
@@ -1,0 +1,56 @@
+"""Shared explanation records for ranking and route-search outputs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+from trip_planner._validators import require_non_empty, require_strings
+
+EXPLANATION_RECORD_TYPES: tuple[str, ...] = (
+    "summary",
+    "promotion",
+    "penalty",
+    "risk",
+    "confidence",
+)
+EXPLANATION_TARGET_KINDS: tuple[str, ...] = ("item", "bundle", "route")
+
+
+def _require_string_mapping(values: dict[str, str], field_name: str) -> None:
+    if any(not isinstance(key, str) or not key for key in values):
+        raise ValueError(f"{field_name} must use non-empty string keys")
+    if any(not isinstance(value, str) or not value for value in values.values()):
+        raise ValueError(f"{field_name} must use non-empty string values")
+
+
+@dataclass(slots=True)
+class ExplanationRecord:
+    explanation_id: str
+    record_type: str = "summary"
+    target_kind: str = "item"
+    target_id: str = ""
+    headline: str = ""
+    summary: str = ""
+    factor_keys: list[str] = field(default_factory=list)
+    machine_context: dict[str, str] = field(default_factory=dict)
+    human_summary: list[str] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.explanation_id, "explanation_id")
+        require_non_empty(self.target_id, "target_id")
+        require_non_empty(self.headline, "headline")
+        require_non_empty(self.summary, "summary")
+        if self.record_type not in EXPLANATION_RECORD_TYPES:
+            raise ValueError(f"record_type must be one of {EXPLANATION_RECORD_TYPES}")
+        if self.target_kind not in EXPLANATION_TARGET_KINDS:
+            raise ValueError(f"target_kind must be one of {EXPLANATION_TARGET_KINDS}")
+        require_strings(self.factor_keys, "factor_keys")
+        _require_string_mapping(self.machine_context, "machine_context")
+        require_strings(self.human_summary, "human_summary")
+        require_strings(self.source_refs, "source_refs")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)

--- a/trip_planner/ranking/models.py
+++ b/trip_planner/ranking/models.py
@@ -1,0 +1,445 @@
+"""Canonical ranking-result contracts shared by later ranking layers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner._option_contracts import (
+    COMPARISON_DIRECTIONS,
+    OPTION_SET_PURPOSES,
+    OPTION_SET_SCOPES,
+    ComparisonAxis,
+    MoneyRange,
+    Option,
+    OptionCostSummary,
+    OptionQualitySummary,
+)
+from trip_planner._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_probability,
+    require_strings,
+)
+
+from .explanations import ExplanationRecord
+
+SCHEMA_VERSION = "0.1.0"
+RANK_RESULT_KINDS: tuple[str, ...] = ("item", "bundle", "route")
+ADJUSTMENT_KINDS: tuple[str, ...] = ("penalty", "bonus", "missing_data")
+RISK_SEVERITIES: tuple[str, ...] = ("info", "warning", "critical")
+
+
+def _optional_list_field(payload: dict[str, Any], field_name: str) -> list[Any]:
+    value = payload.get(field_name, [])
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list when provided")
+    return value
+
+
+def _optional_mapping_field(payload: dict[str, Any], field_name: str) -> dict[str, Any]:
+    value = payload.get(field_name, {})
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be a mapping when provided")
+    return value
+
+
+def _parse_money_range(payload: dict[str, Any] | None) -> MoneyRange | None:
+    if payload is None:
+        return None
+    if not isinstance(payload, dict):
+        raise ValueError("money range payload must be a mapping when provided")
+    return MoneyRange(**payload)
+
+
+def _parse_option(payload: dict[str, Any]) -> Option:
+    cost_payload = _optional_mapping_field(payload, "cost_summary")
+    quality_payload = _optional_mapping_field(payload, "quality_summary")
+    return Option(
+        option_id=payload["option_id"],
+        kind=payload["kind"],
+        label=payload["label"],
+        summary=payload.get("summary", ""),
+        fit_signals=dict(payload.get("fit_signals", {})),
+        cost_summary=OptionCostSummary(
+            total=_parse_money_range(cost_payload.get("total")),
+            per_unit=_parse_money_range(cost_payload.get("per_unit")),
+            notes=_optional_list_field(cost_payload, "notes"),
+        ),
+        quality_summary=OptionQualitySummary(
+            quality_signal=quality_payload.get("quality_signal"),
+            value_signal=quality_payload.get("value_signal"),
+            fit_signal=quality_payload.get("fit_signal"),
+            notes=_optional_list_field(quality_payload, "notes"),
+        ),
+        drawbacks=_optional_list_field(payload, "drawbacks"),
+        booking_links=_optional_list_field(payload, "booking_links"),
+        source_refs=_optional_list_field(payload, "source_refs"),
+        supporting_place_ids=_optional_list_field(payload, "supporting_place_ids"),
+        explanation=_optional_list_field(payload, "explanation"),
+    )
+
+
+@dataclass(slots=True)
+class ScoreContribution:
+    contribution_id: str
+    label: str
+    axis_key: str = ""
+    direction: str = "contextual"
+    raw_value: float | None = None
+    normalized_signal: float | None = None
+    weighted_impact: float = 0.0
+    summary: str = ""
+    evidence_refs: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.contribution_id, "contribution_id")
+        require_non_empty(self.label, "label")
+        if self.direction not in COMPARISON_DIRECTIONS:
+            raise ValueError(f"direction must be one of {COMPARISON_DIRECTIONS}")
+        if self.normalized_signal is not None:
+            require_probability(self.normalized_signal, "normalized_signal")
+        require_strings(self.evidence_refs, "evidence_refs")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ScoreAdjustment:
+    adjustment_id: str
+    label: str
+    kind: str
+    amount: float
+    reason_code: str
+    summary: str = ""
+    affected_factor_keys: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.adjustment_id, "adjustment_id")
+        require_non_empty(self.label, "label")
+        require_non_empty(self.reason_code, "reason_code")
+        require_non_negative(self.amount, "amount")
+        if self.kind not in ADJUSTMENT_KINDS:
+            raise ValueError(f"kind must be one of {ADJUSTMENT_KINDS}")
+        require_strings(self.affected_factor_keys, "affected_factor_keys")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ScoreConfidenceSummary:
+    overall_confidence: float | None = None
+    input_coverage: float | None = None
+    data_freshness: float | None = None
+    scoring_stability: float | None = None
+    low_confidence_flags: list[str] = field(default_factory=list)
+    missing_data_fields: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "overall_confidence",
+            "input_coverage",
+            "data_freshness",
+            "scoring_stability",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_probability(value, field_name)
+        require_strings(self.low_confidence_flags, "low_confidence_flags")
+        require_strings(self.missing_data_fields, "missing_data_fields")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RiskFlag:
+    risk_id: str
+    code: str
+    severity: str = "warning"
+    summary: str = ""
+    blocking: bool = False
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.risk_id, "risk_id")
+        require_non_empty(self.code, "code")
+        require_non_empty(self.summary, "summary")
+        if self.severity not in RISK_SEVERITIES:
+            raise ValueError(f"severity must be one of {RISK_SEVERITIES}")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ScoreBreakdown:
+    baseline_score: float = 0.0
+    component_contributions: list[ScoreContribution] = field(default_factory=list)
+    penalties: list[ScoreAdjustment] = field(default_factory=list)
+    bonuses: list[ScoreAdjustment] = field(default_factory=list)
+    missing_data_penalties: list[ScoreAdjustment] = field(default_factory=list)
+    final_score: float = 0.0
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if any(
+            not isinstance(item, ScoreContribution)
+            for item in self.component_contributions
+        ):
+            raise ValueError(
+                "component_contributions must contain ScoreContribution instances"
+            )
+        if any(not isinstance(item, ScoreAdjustment) for item in self.penalties):
+            raise ValueError("penalties must contain ScoreAdjustment instances")
+        if any(not isinstance(item, ScoreAdjustment) for item in self.bonuses):
+            raise ValueError("bonuses must contain ScoreAdjustment instances")
+        if any(
+            not isinstance(item, ScoreAdjustment)
+            for item in self.missing_data_penalties
+        ):
+            raise ValueError(
+                "missing_data_penalties must contain ScoreAdjustment instances"
+            )
+        if any(item.kind != "penalty" for item in self.penalties):
+            raise ValueError("penalties must only contain penalty adjustments")
+        if any(item.kind != "bonus" for item in self.bonuses):
+            raise ValueError("bonuses must only contain bonus adjustments")
+        if any(item.kind != "missing_data" for item in self.missing_data_penalties):
+            raise ValueError(
+                "missing_data_penalties must only contain missing_data adjustments"
+            )
+        require_strings(self.notes, "notes")
+
+        computed_score = self.baseline_score
+        computed_score += sum(
+            item.weighted_impact for item in self.component_contributions
+        )
+        computed_score += sum(item.amount for item in self.bonuses)
+        computed_score -= sum(item.amount for item in self.penalties)
+        computed_score -= sum(item.amount for item in self.missing_data_penalties)
+        if abs(self.final_score - computed_score) > 1e-9:
+            raise ValueError("final_score must match the summed score breakdown")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class RankedResult:
+    result_id: str
+    result_kind: str
+    rank: int
+    score: float
+    target_option: Option | None = None
+    target_bundle_id: str | None = None
+    supporting_option_ids: list[str] = field(default_factory=list)
+    supporting_destination_ids: list[str] = field(default_factory=list)
+    route_sequence: list[str] = field(default_factory=list)
+    score_breakdown: ScoreBreakdown = field(default_factory=ScoreBreakdown)
+    confidence_summary: ScoreConfidenceSummary = field(
+        default_factory=ScoreConfidenceSummary
+    )
+    explanation_records: list[ExplanationRecord] = field(default_factory=list)
+    unresolved_risks: list[RiskFlag] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.result_id, "result_id")
+        require_non_negative(self.rank, "rank")
+        if self.rank <= 0:
+            raise ValueError("rank must be positive")
+        if self.result_kind not in RANK_RESULT_KINDS:
+            raise ValueError(f"result_kind must be one of {RANK_RESULT_KINDS}")
+        if self.target_option is not None and not isinstance(
+            self.target_option, Option
+        ):
+            raise ValueError("target_option must be an Option when provided")
+        if not isinstance(self.score_breakdown, ScoreBreakdown):
+            raise ValueError("score_breakdown must be a ScoreBreakdown")
+        if not isinstance(self.confidence_summary, ScoreConfidenceSummary):
+            raise ValueError("confidence_summary must be a ScoreConfidenceSummary")
+        if any(
+            not isinstance(item, ExplanationRecord) for item in self.explanation_records
+        ):
+            raise ValueError(
+                "explanation_records must contain ExplanationRecord instances"
+            )
+        if any(not isinstance(item, RiskFlag) for item in self.unresolved_risks):
+            raise ValueError("unresolved_risks must contain RiskFlag instances")
+        require_strings(self.supporting_option_ids, "supporting_option_ids")
+        require_strings(self.supporting_destination_ids, "supporting_destination_ids")
+        require_strings(self.route_sequence, "route_sequence")
+        require_strings(self.source_refs, "source_refs")
+        require_strings(self.notes, "notes")
+        if self.score_breakdown.final_score != self.score:
+            raise ValueError("score must match score_breakdown.final_score")
+        if not self.explanation_records:
+            raise ValueError(
+                "explanation_records must contain at least one ExplanationRecord"
+            )
+
+        if self.result_kind == "item":
+            if self.target_option is None:
+                raise ValueError("item results must provide target_option")
+            if self.target_bundle_id is not None:
+                raise ValueError("item results cannot provide target_bundle_id")
+        else:
+            if not self.target_bundle_id:
+                raise ValueError(
+                    "bundle and route results must provide target_bundle_id"
+                )
+            if self.result_kind == "route" and not self.route_sequence:
+                raise ValueError("route results must provide route_sequence")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "RankedResult":
+        target_option_payload = payload.get("target_option")
+        return cls(
+            result_id=payload["result_id"],
+            result_kind=payload["result_kind"],
+            rank=payload["rank"],
+            score=payload["score"],
+            target_option=(
+                _parse_option(target_option_payload)
+                if target_option_payload is not None
+                else None
+            ),
+            target_bundle_id=payload.get("target_bundle_id"),
+            supporting_option_ids=_optional_list_field(
+                payload, "supporting_option_ids"
+            ),
+            supporting_destination_ids=_optional_list_field(
+                payload, "supporting_destination_ids"
+            ),
+            route_sequence=_optional_list_field(payload, "route_sequence"),
+            score_breakdown=ScoreBreakdown(
+                baseline_score=_optional_mapping_field(payload, "score_breakdown").get(
+                    "baseline_score", 0.0
+                ),
+                component_contributions=[
+                    ScoreContribution(**item)
+                    for item in _optional_list_field(
+                        _optional_mapping_field(payload, "score_breakdown"),
+                        "component_contributions",
+                    )
+                ],
+                penalties=[
+                    ScoreAdjustment(**item)
+                    for item in _optional_list_field(
+                        _optional_mapping_field(payload, "score_breakdown"), "penalties"
+                    )
+                ],
+                bonuses=[
+                    ScoreAdjustment(**item)
+                    for item in _optional_list_field(
+                        _optional_mapping_field(payload, "score_breakdown"), "bonuses"
+                    )
+                ],
+                missing_data_penalties=[
+                    ScoreAdjustment(**item)
+                    for item in _optional_list_field(
+                        _optional_mapping_field(payload, "score_breakdown"),
+                        "missing_data_penalties",
+                    )
+                ],
+                final_score=_optional_mapping_field(payload, "score_breakdown").get(
+                    "final_score", 0.0
+                ),
+                notes=_optional_list_field(
+                    _optional_mapping_field(payload, "score_breakdown"), "notes"
+                ),
+            ),
+            confidence_summary=ScoreConfidenceSummary(
+                **_optional_mapping_field(payload, "confidence_summary")
+            ),
+            explanation_records=[
+                ExplanationRecord(**item)
+                for item in _optional_list_field(payload, "explanation_records")
+            ],
+            unresolved_risks=[
+                RiskFlag(**item)
+                for item in _optional_list_field(payload, "unresolved_risks")
+            ],
+            source_refs=_optional_list_field(payload, "source_refs"),
+            notes=_optional_list_field(payload, "notes"),
+        )
+
+
+@dataclass(slots=True)
+class RankedResultSet:
+    result_set_id: str
+    trip_id: str
+    purpose: str
+    scope: str
+    title: str
+    results: list[RankedResult]
+    comparison_axes: list[ComparisonAxis] = field(default_factory=list)
+    explanation: list[str] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.result_set_id, "result_set_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.title, "title")
+        if self.purpose not in OPTION_SET_PURPOSES:
+            raise ValueError(f"purpose must be one of {OPTION_SET_PURPOSES}")
+        if self.scope not in OPTION_SET_SCOPES:
+            raise ValueError(f"scope must be one of {OPTION_SET_SCOPES}")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+        if not self.results:
+            raise ValueError("results must contain at least one RankedResult")
+        if any(not isinstance(item, RankedResult) for item in self.results):
+            raise ValueError("results must contain RankedResult instances")
+        if any(not isinstance(item, ComparisonAxis) for item in self.comparison_axes):
+            raise ValueError("comparison_axes must contain ComparisonAxis instances")
+        require_strings(self.explanation, "explanation")
+        require_strings(self.source_refs, "source_refs")
+
+        ranks = [item.rank for item in self.results]
+        if len(set(ranks)) != len(ranks):
+            raise ValueError("results must use unique ranks")
+        result_ids = [item.result_id for item in self.results]
+        if len(set(result_ids)) != len(result_ids):
+            raise ValueError("results must use unique result_ids")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "RankedResultSet":
+        return cls(
+            result_set_id=payload["result_set_id"],
+            trip_id=payload["trip_id"],
+            purpose=payload["purpose"],
+            scope=payload["scope"],
+            title=payload["title"],
+            results=[
+                RankedResult.from_dict(item)
+                for item in _optional_list_field(payload, "results")
+            ],
+            comparison_axes=[
+                ComparisonAxis(**item)
+                for item in _optional_list_field(payload, "comparison_axes")
+            ],
+            explanation=_optional_list_field(payload, "explanation"),
+            source_refs=_optional_list_field(payload, "source_refs"),
+            schema_version=payload.get("schema_version", SCHEMA_VERSION),
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #532

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Before implementing any ranking engine, the repo needs a canonical way to represent scores, penalties, bonuses, explanations, and ranked-result bundles. Without that contract, each later ranking module will invent its own output shape and the planner will not be able to explain why one option beat another.

Parent epic: #531

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#531](https://github.com/stranske/trip-planner/issues/531)
- [#514](https://github.com/stranske/trip-planner/issues/514)
- [#530](https://github.com/stranske/trip-planner/issues/530)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement typed contracts for ranked-result sets, score breakdowns, component contributions, penalties, bonuses, confidence summaries, and explanation records.
- [x] Ensure the contracts can represent both item-level ranking and bundle or route-level ranking outputs.
- [x] Add explicit support for unresolved-risk flags, missing-data penalties, and low-confidence scoring conditions.
- [x] Ensure explanation records can capture both machine-readable factors and human-readable summaries for later UI or chat use.
- [x] Create representative fixtures for at least a leisure ranking result, a business ranking result, and a route-level result bundle.
- [x] Write unit tests covering serialization, validation failures, and example score breakdowns with multiple contributing factors.
- [x] Document how all future ranking modules should emit results through this canonical contract.

#### Acceptance criteria
- [x] The repo contains canonical contracts for ranked results, score breakdowns, and explanation output.
- [x] The contracts can represent scalar rank, component-level contributions, uncertainty, and unresolved risks explicitly.
- [x] The same contracts can support leisure, business, and route-level ranking outputs.
- [x] Tests cover representative result shapes and malformed-input failures.
- [x] Documentation makes clear that ranking outputs must remain explainable and inspectable.

**Head SHA:** a8ee3c6412e1f7472108453b93dff7d24dec73d5
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Auto-Pilot | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730612) |
| Agents Bot Comment Handler | ⏹️ cancelled | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730691) |
| Agents Gate Followups | ⏹️ cancelled | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730952) |
| Agents Keepalive Loop | ⏹️ cancelled | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730871) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23839175358) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23839175258) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730774) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730663) |
| Copilot code review | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23838727678) |
| Create Issue from Verification (DEPRECATED) | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730776) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730820) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730803) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23838723519) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730821) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23838730934) |
<!-- auto-status-summary:end -->