### PR TITLE
Issue #534: add leisure candidate ranking engine

### DIFF
--- a/docs/contracts/leisure-ranking.md
+++ b/docs/contracts/leisure-ranking.md
@@ -1,0 +1,24 @@
+# Leisure Ranking
+
+`trip_planner/ranking/leisure.py` is the first-pass leisure ranking engine for candidate bundles.
+
+## Boundary
+
+- Inputs should already be resolved leisure preferences, itinerary objectives, candidate bundles, and feasibility outputs.
+- This layer ranks bundles; it does not replace preference resolution, objective derivation, candidate generation, or feasibility evaluation.
+- Outputs must stay explainable through canonical `RankedResultSet` records, confidence summaries, penalties, and risks.
+
+## What The Leisure Scorer Must Keep Explicit
+
+- first-tier leisure dimension alignment such as discovery vs iconic, movement vs friction, recovery vs intensity, and route coherence vs eclectic contrast
+- anchors, quality floors, budget posture, and salient hybrid factors
+- tension flags and low-confidence preference areas
+- feasibility blockers, route warnings, and missing-data penalties
+
+## Working Rule
+
+When leisure ranking changes:
+
+1. Keep the scorer deterministic and inspectable.
+2. Preserve why a bundle moved up or down through score contributions and explanation records.
+3. Keep preference-resolution and objective-derivation logic upstream; extend those layers instead of duplicating them here.

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -116,7 +116,9 @@ def _generate_guard_blocked_followup(
     """Generate a minimal follow-up issue that routes to human review."""
 
     title = f"[Follow-up] Human review required for PR #{pr_number}"
-    issue_number_text = str(original_issue_number) if original_issue_number else "unknown"
+    issue_number_text = (
+        str(original_issue_number) if original_issue_number else "unknown"
+    )
     issue_title_text = original_issue_title or "unknown"
 
     body_parts = [
@@ -268,7 +270,9 @@ def _resolve_verdict_policy(
 # Pre-computed normalized aliases for efficient section resolution.
 # Maps normalized alias string -> section key
 _NORMALIZED_ALIAS_MAP: dict[str, str] = {
-    _normalize_heading(alias): key for key, aliases in SECTION_ALIASES.items() for alias in aliases
+    _normalize_heading(alias): key
+    for key, aliases in SECTION_ALIASES.items()
+    for alias in aliases
 }
 
 # Prompts for multi-round LLM interaction
@@ -603,8 +607,14 @@ def extract_verification_data(comment_body: str) -> VerificationData:
     )
     if single_verdict and not data.provider_verdicts:
         verdict = (single_verdict.group(1) or single_verdict.group(2) or "").strip()
-        confidence_match = re.search(r"Verdict:.*?@?\s*([0-9.]+%?)", comment_body, re.IGNORECASE)
-        confidence = _parse_confidence_value(confidence_match.group(1)) if confidence_match else 0
+        confidence_match = re.search(
+            r"Verdict:.*?@?\s*([0-9.]+%?)", comment_body, re.IGNORECASE
+        )
+        confidence = (
+            _parse_confidence_value(confidence_match.group(1))
+            if confidence_match
+            else 0
+        )
         data.provider_verdicts["default"] = {
             "verdict": verdict,
             "confidence": confidence,
@@ -645,7 +655,9 @@ def extract_verification_data(comment_body: str) -> VerificationData:
 
     # Try plain label format: "Concerns:" followed by bullets
     concerns_label_matches = re.findall(
-        r"^Concerns:\s*\n((?:\s*-\s+[^\n]+\n?)+)", comment_body, re.IGNORECASE | re.MULTILINE
+        r"^Concerns:\s*\n((?:\s*-\s+[^\n]+\n?)+)",
+        comment_body,
+        re.IGNORECASE | re.MULTILINE,
     )
     for match in concerns_label_matches:
         for line in match.split("\n"):
@@ -710,7 +722,9 @@ def extract_verification_data(comment_body: str) -> VerificationData:
     if iter_match:
         data.iteration_count = int(iter_match.group(1))
 
-    remaining_match = re.search(r"Remaining unchecked items?:\s*(\d+)\s*of\s*(\d+)", comment_body)
+    remaining_match = re.search(
+        r"Remaining unchecked items?:\s*(\d+)\s*of\s*(\d+)", comment_body
+    )
     if remaining_match:
         unchecked, total = int(remaining_match.group(1)), int(remaining_match.group(2))
         data.tasks_attempted = total
@@ -718,7 +732,9 @@ def extract_verification_data(comment_body: str) -> VerificationData:
 
     # Extract non-actionable items
     non_actionable_match = re.search(
-        r"Non-actionable items.*?:\s*\n([\s\S]*?)(?=\n\n|\n###|\n##|$)", comment_body, re.IGNORECASE
+        r"Non-actionable items.*?:\s*\n([\s\S]*?)(?=\n\n|\n###|\n##|$)",
+        comment_body,
+        re.IGNORECASE,
     )
     if non_actionable_match:
         items_text = non_actionable_match.group(1)
@@ -730,11 +746,15 @@ def extract_verification_data(comment_body: str) -> VerificationData:
 
     # Extract structural issues
     structural_match = re.search(
-        r"### ⚠️ Issues Detected.*?\n([\s\S]*?)(?=\n##|\n---|\Z)", comment_body, re.IGNORECASE
+        r"### ⚠️ Issues Detected.*?\n([\s\S]*?)(?=\n##|\n---|\Z)",
+        comment_body,
+        re.IGNORECASE,
     )
     if structural_match:
         issues_text = structural_match.group(1)
-        problem_pattern = re.compile(r"\*\*Problem:\*\*\s*(.+?)(?=\n\*\*|\n-|\Z)", re.DOTALL)
+        problem_pattern = re.compile(
+            r"\*\*Problem:\*\*\s*(.+?)(?=\n\*\*|\n-|\Z)", re.DOTALL
+        )
         for match in problem_pattern.finditer(issues_text):
             data.structural_issues.append(match.group(1).strip())
 
@@ -909,7 +929,9 @@ def _build_llm_config(
         env_pr = os.environ.get("PR_NUMBER", "")
         env_issue = os.environ.get("ISSUE_NUMBER", "")
         issue_or_pr = (
-            env_pr if env_pr.isdigit() else env_issue if env_issue.isdigit() else "unknown"
+            env_pr
+            if env_pr.isdigit()
+            else env_issue if env_issue.isdigit() else "unknown"
         )
     metadata = {
         "repo": repo,
@@ -1108,7 +1130,9 @@ def _extract_json(text: str) -> dict[str, Any]:
 
 def _strip_markdown_fence(text: str) -> str:
     """Remove surrounding markdown code fences from a string if present."""
-    fence_match = re.match(r"^```(?:[a-zA-Z0-9_-]+)?\s*\n([\s\S]*?)\n```\s*$", text.strip())
+    fence_match = re.match(
+        r"^```(?:[a-zA-Z0-9_-]+)?\s*\n([\s\S]*?)\n```\s*$", text.strip()
+    )
     if fence_match:
         return fence_match.group(1).strip()
     return text.strip()
@@ -1314,7 +1338,9 @@ def _generate_with_llm(
     # Round 3: Generate acceptance criteria (use standard model)
     ac_prompt = GENERATE_ACCEPTANCE_CRITERIA_PROMPT.format(
         tasks_json=json.dumps(tasks_data.get("tasks", []), indent=2),
-        unmet_criteria=json.dumps(analysis.get("rewritten_acceptance_criteria", []), indent=2),
+        unmet_criteria=json.dumps(
+            analysis.get("rewritten_acceptance_criteria", []), indent=2
+        ),
     )
 
     ac_response, trace_id_3, trace_url_3 = _invoke_llm(
@@ -1341,7 +1367,9 @@ def _generate_with_llm(
         verdict=verdict,
         why_section=why_section,
         tasks_json=json.dumps(tasks_data.get("tasks", []), indent=2),
-        acceptance_criteria_json=json.dumps(ac_data.get("acceptance_criteria", []), indent=2),
+        acceptance_criteria_json=json.dumps(
+            ac_data.get("acceptance_criteria", []), indent=2
+        ),
         deferred_tasks_json=json.dumps(tasks_data.get("deferred", []), indent=2),
         background_analysis=json.dumps(
             {
@@ -1605,12 +1633,16 @@ def _build_why_section(
         )
 
     if verification_data.structural_issues:
-        parts.append("The original issue had structural problems that may have hindered progress.")
+        parts.append(
+            "The original issue had structural problems that may have hindered progress."
+        )
 
     if needs_human_reason:
         parts.append(needs_human_reason)
 
-    parts.append("This follow-up addresses the remaining gaps with improved task structure.")
+    parts.append(
+        "This follow-up addresses the remaining gaps with improved task structure."
+    )
 
     return " ".join(parts)
 
@@ -1736,10 +1768,12 @@ def main() -> int:
     # Debug: show extracted data
     print(f"Extracted {len(verification_data.concerns)} concerns", file=sys.stderr)
     print(
-        f"Extracted {len(verification_data.provider_verdicts)} provider verdicts", file=sys.stderr
+        f"Extracted {len(verification_data.provider_verdicts)} provider verdicts",
+        file=sys.stderr,
     )
     print(
-        f"Extracted {len(original_issue.acceptance_criteria)} acceptance criteria", file=sys.stderr
+        f"Extracted {len(original_issue.acceptance_criteria)} acceptance criteria",
+        file=sys.stderr,
     )
     print(f"Extracted {len(original_issue.tasks)} tasks", file=sys.stderr)
     if verification_data.concerns:

--- a/tests/business/test_business_objective_derivation.py
+++ b/tests/business/test_business_objective_derivation.py
@@ -62,7 +62,10 @@ def test_client_meeting_profile_protects_schedule_and_exception_readiness() -> N
     assert objectives.schedule_protection.arrival_buffer_preference == "conservative"
     assert objectives.compliant_first_path.active is True
     assert objectives.policy_nearest_fallback.active is True
-    assert "mission_critical_schedule" in objectives.policy_nearest_fallback.trigger_signals
+    assert (
+        "mission_critical_schedule"
+        in objectives.policy_nearest_fallback.trigger_signals
+    )
     assert objectives.justification_readiness.maintain_exception_packet is True
     assert objectives.exception_path_posture.posture == "exception_ready"
     assert objectives.cost_control_posture.posture == "policy_first"
@@ -86,8 +89,13 @@ def test_site_visit_profile_derives_policy_nearest_exception_posture() -> None:
     assert objectives.policy_nearest_fallback.mode == "policy_nearest"
     assert objectives.exception_path_posture.posture == "policy_nearest"
     assert objectives.exception_path_posture.fallback_mode == "manual_review"
-    assert "fatigue_management" in objectives.exception_path_posture.allowed_exception_types
-    assert objectives.comparable_requirements.additional_comparables_for_exception is True
+    assert (
+        "fatigue_management"
+        in objectives.exception_path_posture.allowed_exception_types
+    )
+    assert (
+        objectives.comparable_requirements.additional_comparables_for_exception is True
+    )
     assert objectives.comfort_floor_protection.preserve_arrival_readiness is True
     assert "transport" in objectives.comfort_floor_protection.required_categories
     assert (
@@ -130,7 +138,9 @@ def test_derivation_sorts_unordered_business_inputs() -> None:
     profile = _load_profile("client_meeting_profile.json")
     constraint_set = _load_constraint_set("policy_round_trip_exception.json")
 
-    profile.policy_constraints.required_booking_channels = cast(Any, {"Direct", "Concur"})
+    profile.policy_constraints.required_booking_channels = cast(
+        Any, {"Direct", "Concur"}
+    )
     profile.documentation_requirements.justification_fields = cast(
         Any,
         {
@@ -147,7 +157,9 @@ def test_derivation_sorts_unordered_business_inputs() -> None:
     )
     profile.approval_targets.approval_roles = cast(Any, {"manager", "finance"})
     constraint_set.required_booking_channels = cast(Any, {"TravelDesk", "Concur"})
-    constraint_set.documentation_rules = cast(Any, {"receipt retention", "manager note"})
+    constraint_set.documentation_rules = cast(
+        Any, {"receipt retention", "manager note"}
+    )
     constraint_set.allowed_exception_types = cast(
         Any,
         {
@@ -187,12 +199,17 @@ def test_derivation_sorts_unordered_business_inputs() -> None:
     assert "justification_fields:agenda,client impact" in objectives.explanations
     assert "approval_roles:finance,manager" in objectives.explanations
     assert (
-        "allowed_exception_types:fatigue_management,schedule_protection" in objectives.explanations
+        "allowed_exception_types:fatigue_management,schedule_protection"
+        in objectives.explanations
     )
     assert objectives.explanation_bundle.summary == objectives.explanations
 
 
 @pytest.mark.parametrize("value", ["2", 2.5, True])
 def test_comparable_requirement_objectives_reject_non_int_values(value: object) -> None:
-    with pytest.raises(ValueError, match=r"required_categories\[lodging\] must be an int"):
-        ComparableRequirementObjectives(required_categories={"lodging": cast(Any, value)})
+    with pytest.raises(
+        ValueError, match=r"required_categories\[lodging\] must be an int"
+    ):
+        ComparableRequirementObjectives(
+            required_categories={"lodging": cast(Any, value)}
+        )

--- a/tests/business/test_business_objectives.py
+++ b/tests/business/test_business_objectives.py
@@ -9,7 +9,9 @@ from trip_planner.business import (
 )
 
 
-def test_business_planning_objectives_serialize_structured_paths_and_explanations() -> None:
+def test_business_planning_objectives_serialize_structured_paths_and_explanations() -> (
+    None
+):
     objectives = BusinessPlanningObjectives(
         objective_id="obj-business-1",
         trip_id="trip-business-1",
@@ -47,8 +49,12 @@ def test_business_planning_objectives_serialize_structured_paths_and_explanation
 
 
 @pytest.mark.parametrize("value", ["not-a-list", {"bad": "shape"}, True])
-def test_objective_explanation_bundle_rejects_non_list_category_reasons(value: object) -> None:
-    with pytest.raises(ValueError, match=r"category_reasons\[planning_paths\] must be a list"):
+def test_objective_explanation_bundle_rejects_non_list_category_reasons(
+    value: object,
+) -> None:
+    with pytest.raises(
+        ValueError, match=r"category_reasons\[planning_paths\] must be a list"
+    ):
         ObjectiveExplanationBundle(
             summary=[],
             category_reasons={"planning_paths": cast(Any, value)},

--- a/tests/business/test_policy_contracts.py
+++ b/tests/business/test_policy_contracts.py
@@ -56,7 +56,9 @@ def test_policy_round_trip_exception_case() -> None:
 
 def test_policy_constraint_set_rejects_missing_policy_id() -> None:
     try:
-        PolicyConstraintSet(policy_id="", organization_id="org", policy_version="2026.1")
+        PolicyConstraintSet(
+            policy_id="", organization_id="org", policy_version="2026.1"
+        )
     except ValueError as exc:
         assert "policy_id" in str(exc)
     else:
@@ -121,7 +123,9 @@ def test_policy_evaluation_result_rejects_invalid_status() -> None:
     except ValueError as exc:
         assert "status" in str(exc)
     else:
-        raise AssertionError("PolicyEvaluationResult should reject unsupported statuses")
+        raise AssertionError(
+            "PolicyEvaluationResult should reject unsupported statuses"
+        )
 
 
 def test_policy_evaluation_result_rejects_non_list_exception_guidance() -> None:
@@ -133,12 +137,16 @@ def test_policy_evaluation_result_rejects_non_list_exception_guidance() -> None:
     except ValueError as exc:
         assert "exception_guidance" in str(exc)
     else:
-        raise AssertionError("PolicyEvaluationResult should reject non-list exception_guidance")
+        raise AssertionError(
+            "PolicyEvaluationResult should reject non-list exception_guidance"
+        )
 
 
 def test_policy_evaluation_result_rejects_non_list_notes() -> None:
     scenario = _load_scenario("policy_round_trip_non_compliant.json")
-    scenario["evaluation_result"]["notes"] = {"summary": "use preferred booking channel"}
+    scenario["evaluation_result"]["notes"] = {
+        "summary": "use preferred booking channel"
+    }
 
     try:
         PolicyEvaluationResult.from_dict(scenario["evaluation_result"])

--- a/tests/business/test_profile.py
+++ b/tests/business/test_profile.py
@@ -78,8 +78,12 @@ def test_business_and_leisure_profiles_remain_separate_contracts() -> None:
         trip_frame=TripFrame(duration_days=7),
         hard_constraints=HardConstraints(),
         budget_model=BudgetModel(),
-        tradeoff_dimensions={key: TradeoffDimension() for key in TRADEOFF_DIMENSION_KEYS},
-        hybrid_factors={key: HybridFactor(mode="tradeoff") for key in HYBRID_FACTOR_KEYS},
+        tradeoff_dimensions={
+            key: TradeoffDimension() for key in TRADEOFF_DIMENSION_KEYS
+        },
+        hybrid_factors={
+            key: HybridFactor(mode="tradeoff") for key in HYBRID_FACTOR_KEYS
+        },
     )
 
     assert business_profile.profile_kind == "business"

--- a/tests/contracts/test_destination_contracts.py
+++ b/tests/contracts/test_destination_contracts.py
@@ -47,7 +47,9 @@ def test_contracts_namespace_exposes_place_context_contracts() -> None:
 
 def test_contracts_namespace_exposes_lodging_contracts() -> None:
     payload = json.loads(
-        Path("tests/fixtures/options/lodging/conference_hotel.json").read_text(encoding="utf-8")
+        Path("tests/fixtures/options/lodging/conference_hotel.json").read_text(
+            encoding="utf-8"
+        )
     )
 
     lodging = LodgingOption.from_dict(payload)
@@ -58,7 +60,9 @@ def test_contracts_namespace_exposes_lodging_contracts() -> None:
 
 def test_contracts_namespace_exposes_activity_contracts() -> None:
     payload = json.loads(
-        Path("tests/fixtures/options/activities/major_museum.json").read_text(encoding="utf-8")
+        Path("tests/fixtures/options/activities/major_museum.json").read_text(
+            encoding="utf-8"
+        )
     )
 
     activity = ActivityOption.from_dict(payload)

--- a/tests/contracts/test_objectives.py
+++ b/tests/contracts/test_objectives.py
@@ -54,7 +54,9 @@ def test_itinerary_objectives_serialize_for_leisure_trip() -> None:
             avoid_modes=["short_haul_flight"],
             transit_is_feature=True,
         ),
-        explanations=["Preference engine resolved toward elastic discovery with route coherence."],
+        explanations=[
+            "Preference engine resolved toward elastic discovery with route coherence."
+        ],
     )
 
     payload = objectives.to_dict()
@@ -66,11 +68,15 @@ def test_itinerary_objectives_serialize_for_leisure_trip() -> None:
 
 def test_itinerary_objectives_reject_invalid_route_shape() -> None:
     try:
-        ItineraryObjectives(objective_id="obj-2", trip_id="trip-leisure-2", route_shape="starfish")
+        ItineraryObjectives(
+            objective_id="obj-2", trip_id="trip-leisure-2", route_shape="starfish"
+        )
     except ValueError as exc:
         assert "route_shape" in str(exc)
     else:
-        raise AssertionError("ItineraryObjectives should reject unsupported route shapes")
+        raise AssertionError(
+            "ItineraryObjectives should reject unsupported route shapes"
+        )
 
 
 def test_count_range_rejects_inverted_bounds() -> None:

--- a/tests/contracts/test_options.py
+++ b/tests/contracts/test_options.py
@@ -92,7 +92,9 @@ def test_option_set_rejects_invalid_selection_limit() -> None:
     except ValueError as exc:
         assert "selection_limit" in str(exc)
     else:
-        raise AssertionError("OptionSet should reject selection_limit values above option count")
+        raise AssertionError(
+            "OptionSet should reject selection_limit values above option count"
+        )
 
 
 def test_option_rejects_invalid_kind() -> None:

--- a/tests/contracts/test_trip.py
+++ b/tests/contracts/test_trip.py
@@ -90,7 +90,9 @@ def test_trip_rejects_duplicate_option_set_refs() -> None:
     except ValueError as exc:
         assert "option_set_ids" in str(exc)
     else:
-        raise AssertionError("TripArtifactRefs should reject duplicate option set references")
+        raise AssertionError(
+            "TripArtifactRefs should reject duplicate option set references"
+        )
 
 
 def test_trip_rejects_policy_state_for_leisure_mode() -> None:
@@ -107,4 +109,6 @@ def test_trip_rejects_policy_state_for_leisure_mode() -> None:
     except ValueError as exc:
         assert "policy_state_id" in str(exc)
     else:
-        raise AssertionError("Leisure trip should reject business-only policy state references")
+        raise AssertionError(
+            "Leisure trip should reject business-only policy state references"
+        )

--- a/tests/fixtures/ranking/leisure_candidate_showcase.json
+++ b/tests/fixtures/ranking/leisure_candidate_showcase.json
@@ -1,0 +1,223 @@
+{
+  "trip_id": "trip-leisure-ranking-showcase",
+  "candidates": [
+    {
+      "candidate_id": "candidate:urban-depth",
+      "bundle_id": "bundle:urban-depth",
+      "title": "Urban depth museum stay",
+      "summary": "Single-base urban stay built around a major museum anchor and easy neighborhood movement.",
+      "bundle_context": "mixed",
+      "tags": ["urban", "museum", "walkable", "depth"],
+      "strengths": [
+        "Strong museum anchor with easy central access.",
+        "Single-base layout keeps urban exploration compact."
+      ],
+      "tradeoffs": [
+        "Less discovery-forward than the wandering bundle.",
+        "Scenic transit is not the main value driver."
+      ],
+      "notes": ["Optimized for deeper city immersion over route breadth."],
+      "destinations": [
+        {"path": "tests/fixtures/options/destinations/kyoto_city.json"},
+        {"path": "tests/fixtures/options/destinations/gion_neighborhood.json"}
+      ],
+      "lodging_options": [
+        {"path": "tests/fixtures/options/lodging/central_urban_hotel.json"}
+      ],
+      "transport_options": [
+        {
+          "path": "tests/fixtures/options/transport/downtown_local_ground.json",
+          "overrides": {
+            "option_id": "transport-kyoto-gion-hop",
+            "name": "Central Kyoto to Gion local hop",
+            "origin_id": "dest-city-kyoto",
+            "destination_id": "dest-neighborhood-gion",
+            "fit_summary": {
+              "overall_signal": 0.74,
+              "schedule_fit_signal": 0.83,
+              "friction_fit_signal": 0.8,
+              "experiential_fit_signal": 0.4,
+              "policy_fit_signal": 0.9
+            },
+            "tags": ["urban-transfer", "museum-hop"]
+          }
+        }
+      ],
+      "activity_options": [
+        {
+          "path": "tests/fixtures/options/activities/major_museum.json",
+          "overrides": {
+            "destination_id": "dest-city-kyoto",
+            "place_id": "place-kyoto-national-museum"
+          }
+        }
+      ]
+    },
+    {
+      "candidate_id": "candidate:scenic-corridor",
+      "bundle_id": "bundle:scenic-corridor",
+      "title": "Scenic corridor rail loop",
+      "summary": "A scenic-transit-first bundle that turns movement into part of the trip rather than a pure cost.",
+      "bundle_context": "mixed",
+      "tags": ["scenic", "rail", "route", "outdoors"],
+      "strengths": [
+        "Scenic rail is itself a meaningful part of the experience.",
+        "Pairs movement with a high-scenic-value outdoor anchor."
+      ],
+      "tradeoffs": [
+        "Travel time is higher than the single-base bundles.",
+        "Recovery posture is weaker than the comfort-focused option."
+      ],
+      "notes": ["Designed to reward profiles that treat transit and scenery as part of the trip."],
+      "destinations": [
+        {"path": "tests/fixtures/options/destinations/kansai_region.json"},
+        {"path": "tests/fixtures/options/destinations/kyoto_city.json"},
+        {"path": "tests/fixtures/options/destinations/fushimi_inari_site.json"}
+      ],
+      "lodging_options": [
+        {
+          "path": "tests/fixtures/options/lodging/vacation_rental.json",
+          "overrides": {
+            "destination_id": "dest-city-kyoto",
+            "tags": ["machiya", "scenic-base", "walkable"]
+          }
+        }
+      ],
+      "transport_options": [
+        {
+          "path": "tests/fixtures/options/transport/scenic_rail.json",
+          "overrides": {
+            "option_id": "transport-kansai-scenic-rail",
+            "origin_id": "dest-region-kansai",
+            "destination_id": "dest-city-kyoto"
+          }
+        },
+        {
+          "path": "tests/fixtures/options/transport/downtown_local_ground.json",
+          "overrides": {
+            "option_id": "transport-kyoto-fushimi-link",
+            "name": "Kyoto to Fushimi local link",
+            "origin_id": "dest-city-kyoto",
+            "destination_id": "dest-site-fushimi-inari",
+            "fit_summary": {
+              "overall_signal": 0.72,
+              "schedule_fit_signal": 0.78,
+              "friction_fit_signal": 0.68,
+              "experiential_fit_signal": 0.41,
+              "policy_fit_signal": 0.92
+            }
+          }
+        }
+      ],
+      "activity_options": [
+        {
+          "path": "tests/fixtures/options/activities/landscape_hike.json",
+          "overrides": {
+            "destination_id": "dest-site-fushimi-inari",
+            "place_id": "place-fushimi-ridge-overlook",
+            "timing_summary": {
+              "duration_minutes": 210,
+              "typical_start_window": "10:00-15:30",
+              "timing_sensitivity_signal": 0.72,
+              "closure_risk_signal": 0.27,
+              "crowd_pressure_signal": 0.36,
+              "weather_dependency_signal": 0.88,
+              "daylight_dependency": true
+            }
+          }
+        }
+      ]
+    },
+    {
+      "candidate_id": "candidate:discovery-drift",
+      "bundle_id": "bundle:discovery-drift",
+      "title": "Discovery-forward neighborhood drift",
+      "summary": "Open-ended wandering bundle that favors elastic discovery over heavy anchors or route complexity.",
+      "bundle_context": "mixed",
+      "tags": ["wander", "district", "open-ended", "discovery"],
+      "strengths": [
+        "Open-ended district time works well for discovery-first profiles.",
+        "Low booking overhead preserves elastic planning room."
+      ],
+      "tradeoffs": [
+        "Less iconic than the museum-centered candidate.",
+        "Quality-floor travelers may prefer a stronger lodging or anchor signal."
+      ],
+      "notes": ["Built to surface discovery fit explicitly rather than as accidental leftover time."],
+      "destinations": [
+        {"path": "tests/fixtures/options/destinations/kyoto_city.json"},
+        {"path": "tests/fixtures/options/destinations/gion_neighborhood.json"}
+      ],
+      "lodging_options": [
+        {
+          "path": "tests/fixtures/options/lodging/vacation_rental.json",
+          "overrides": {
+            "destination_id": "dest-city-kyoto",
+            "tags": ["machiya", "quiet", "wander-base"]
+          }
+        }
+      ],
+      "transport_options": [
+        {
+          "path": "tests/fixtures/options/transport/downtown_local_ground.json",
+          "overrides": {
+            "option_id": "transport-kyoto-gion-drift-link",
+            "name": "Kyoto to Gion drift link",
+            "origin_id": "dest-city-kyoto",
+            "destination_id": "dest-neighborhood-gion",
+            "fit_summary": {
+              "overall_signal": 0.77,
+              "schedule_fit_signal": 0.75,
+              "friction_fit_signal": 0.81,
+              "experiential_fit_signal": 0.38,
+              "policy_fit_signal": 0.9
+            }
+          }
+        }
+      ],
+      "activity_options": [
+        {
+          "path": "tests/fixtures/options/activities/wandering_district.json",
+          "overrides": {
+            "destination_id": "dest-neighborhood-gion",
+            "place_id": "place-gion-laneway-quarter"
+          }
+        }
+      ]
+    },
+    {
+      "candidate_id": "candidate:comfort-floor",
+      "bundle_id": "bundle:comfort-floor",
+      "title": "Comfort floor protected stay",
+      "summary": "Quiet, recovery-friendly stay that protects lodging quality and minimizes fragile logistics.",
+      "bundle_context": "mixed",
+      "tags": ["quiet", "recovery", "quality-floor", "single-base"],
+      "strengths": [
+        "Quiet lodging and strong recovery posture protect quality floors.",
+        "Minimal movement keeps logistics resilient."
+      ],
+      "tradeoffs": [
+        "Less scenic transit upside than the corridor route.",
+        "Less open-ended wandering room than the discovery bundle."
+      ],
+      "notes": ["Designed for profiles that will spend more to avoid fragile or noisy plans."],
+      "destinations": [
+        {"path": "tests/fixtures/options/destinations/kyoto_city.json"}
+      ],
+      "lodging_options": [
+        {"path": "tests/fixtures/options/lodging/quiet_outer_area_hotel.json"}
+      ],
+      "transport_options": [],
+      "activity_options": [
+        {
+          "path": "tests/fixtures/options/activities/ticketed_event.json",
+          "overrides": {
+            "destination_id": "dest-city-kyoto",
+            "place_id": "place-kyoto-evening-performance",
+            "tags": ["performance", "structured", "quality-floor"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/itinerary/test_feasibility.py
+++ b/tests/itinerary/test_feasibility.py
@@ -6,7 +6,13 @@ from trip_planner.options import InventoryBundle
 
 
 def _fixture_path(name: str) -> Path:
-    return Path(__file__).resolve().parent.parent / "fixtures" / "itinerary" / "feasibility" / name
+    return (
+        Path(__file__).resolve().parent.parent
+        / "fixtures"
+        / "itinerary"
+        / "feasibility"
+        / name
+    )
 
 
 def _load_bundle(name: str) -> InventoryBundle:
@@ -15,7 +21,9 @@ def _load_bundle(name: str) -> InventoryBundle:
 
 
 def test_coherent_route_is_feasible_with_low_friction() -> None:
-    assessment = evaluate_bundle_feasibility(_load_bundle("coherent_low_friction_route.json"))
+    assessment = evaluate_bundle_feasibility(
+        _load_bundle("coherent_low_friction_route.json")
+    )
 
     assert assessment.feasible is True
     assert assessment.recommended_for_ranking is True
@@ -34,7 +42,8 @@ def test_excessive_transfer_route_stays_rankable_but_penalized() -> None:
     assert assessment.total_transfer_count >= 2
     assert assessment.friction_penalty_total > 0.7
     assert any(
-        "high_transfer_burden" in move_cost.warnings for move_cost in assessment.move_costs
+        "high_transfer_burden" in move_cost.warnings
+        for move_cost in assessment.move_costs
     )
 
 
@@ -71,14 +80,19 @@ def test_missing_activity_window_is_reported_without_hard_block() -> None:
     assessment = evaluate_bundle_feasibility(InventoryBundle.from_dict(payload))
 
     assert assessment.feasible is True
-    assert "activity:activity-kyoto-museum:typical_start_window" in assessment.missing_data_fields
+    assert (
+        "activity:activity-kyoto-museum:typical_start_window"
+        in assessment.missing_data_fields
+    )
 
 
 def test_malformed_times_do_not_crash_feasibility_evaluation() -> None:
     payload = json.loads(
         _fixture_path("coherent_low_friction_route.json").read_text(encoding="utf-8")
     )
-    payload["transport_options"][0]["timing_summary"]["arrival_local"] = "not-a-timestamp"
+    payload["transport_options"][0]["timing_summary"][
+        "arrival_local"
+    ] = "not-a-timestamp"
     payload["lodging_options"][0]["booking_terms"]["checkin_window"] = "not-a-window"
 
     assessment = evaluate_bundle_feasibility(InventoryBundle.from_dict(payload))
@@ -98,7 +112,9 @@ def test_candidate_seed_uses_representative_travel_totals() -> None:
     alternate_transport["option_id"] = "transport-kyoto-osaka-slow"
     alternate_transport["name"] = "Slow regional detour"
     alternate_transport["timing_summary"]["duration_minutes"] = 480
-    alternate_transport["timing_summary"]["departure_local"] = "2026-04-10T06:00:00+09:00"
+    alternate_transport["timing_summary"][
+        "departure_local"
+    ] = "2026-04-10T06:00:00+09:00"
     alternate_transport["timing_summary"]["arrival_local"] = "2026-04-10T14:00:00+09:00"
     alternate_transport["transfer_burden"]["transfer_count"] = 3
     alternate_transport["transfer_burden"]["self_navigation_burden_signal"] = 0.8
@@ -108,13 +124,13 @@ def test_candidate_seed_uses_representative_travel_totals() -> None:
     payload["transport_options"].append(alternate_transport)
     payload["composition_summary"]["component_option_ids"] = [
         item["option_id"]
-        for item in payload["lodging_options"] + payload["transport_options"] + payload["activity_options"]
+        for item in payload["lodging_options"]
+        + payload["transport_options"]
+        + payload["activity_options"]
     ]
 
     assessment = evaluate_bundle_feasibility(InventoryBundle.from_dict(payload))
 
     assert assessment.total_travel_minutes == 32
     assert assessment.total_transfer_count == 0
-    assert any(
-        "lowest-friction transport option" in note for note in assessment.notes
-    )
+    assert any("lowest-friction transport option" in note for note in assessment.notes)

--- a/tests/itinerary/test_objective_derivation.py
+++ b/tests/itinerary/test_objective_derivation.py
@@ -45,8 +45,10 @@ def test_materially_different_fixtures_produce_distinct_objective_signals() -> N
         "route_shape": scenic_obj.route_shape != comfort_obj.route_shape,
         "base_count": scenic_obj.target_base_count.to_dict()
         != comfort_obj.target_base_count.to_dict(),
-        "move_density": scenic_obj.move_density.to_dict() != comfort_obj.move_density.to_dict(),
-        "day_structure": scenic_obj.day_structure.to_dict() != comfort_obj.day_structure.to_dict(),
+        "move_density": scenic_obj.move_density.to_dict()
+        != comfort_obj.move_density.to_dict(),
+        "day_structure": scenic_obj.day_structure.to_dict()
+        != comfort_obj.day_structure.to_dict(),
         "discovery_style": scenic_obj.discovery_strategy.style
         != comfort_obj.discovery_strategy.style,
         "transport_strategy": scenic_obj.transport_strategy.to_dict()
@@ -103,7 +105,9 @@ def test_interaction_biases_change_objective_bundle() -> None:
     without_interactions.explanation.activated_interactions = []
 
     with_biases = derive_itinerary_objectives(resolved, trip_id="trip-bias")
-    without_biases = derive_itinerary_objectives(without_interactions, trip_id="trip-bias")
+    without_biases = derive_itinerary_objectives(
+        without_interactions, trip_id="trip-bias"
+    )
 
     with_min = with_biases.target_base_count.min_value
     without_min = without_biases.target_base_count.min_value
@@ -141,13 +145,19 @@ def test_derivation_carries_forward_hard_constraint_guidance() -> None:
     min_value = objectives.target_base_count.min_value
     assert min_value is not None
     assert min_value >= 2
-    assert any("Hard budget ceiling=4200" in note for note in objectives.budget_protection.notes)
     assert any(
-        line.startswith("hard_constraints:must_include_places=") for line in objectives.explanations
+        "Hard budget ceiling=4200" in note
+        for note in objectives.budget_protection.notes
+    )
+    assert any(
+        line.startswith("hard_constraints:must_include_places=")
+        for line in objectives.explanations
     )
 
 
-def test_short_trip_base_count_respects_duration_cap_with_many_required_places() -> None:
+def test_short_trip_base_count_respects_duration_cap_with_many_required_places() -> (
+    None
+):
     profile = build_profile_from_overrides(
         {
             "trip_frame": {"duration_days": 3},

--- a/tests/options/test_activities.py
+++ b/tests/options/test_activities.py
@@ -17,7 +17,11 @@ from trip_planner.options import (
     ActivityTimingSummary,
     ActivityValueSummary,
 )
-from trip_planner.sources import ProvenanceReference, QualityValueFitSummary, SourceTrustSignals
+from trip_planner.sources import (
+    ProvenanceReference,
+    QualityValueFitSummary,
+    SourceTrustSignals,
+)
 
 
 def _fixture_path(name: str) -> Path:
@@ -50,7 +54,9 @@ def test_activity_examples_keep_significance_and_fit_distinct() -> None:
 
     assert museum.significance_summary.overall_signal is not None
     assert museum.fit_summary.overall_signal is not None
-    assert museum.significance_summary.overall_signal > museum.fit_summary.overall_signal
+    assert (
+        museum.significance_summary.overall_signal > museum.fit_summary.overall_signal
+    )
     assert hike.significance_summary.anchor_worthy is True
     assert district.category.open_ended is True
 
@@ -116,7 +122,9 @@ def test_activity_round_trips_nested_contracts_and_provenance() -> None:
             available=True,
             availability_status="available",
             indoor_outdoor="mixed",
-            accessibility_notes=["Mostly flat route with occasional crowd bottlenecks."],
+            accessibility_notes=[
+                "Mostly flat route with occasional crowd bottlenecks."
+            ],
         ),
         booking_links=["https://example.com/night-market-tour"],
         source_refs=[
@@ -178,14 +186,18 @@ def test_activity_rejects_invalid_nested_values() -> None:
     with pytest.raises(ValueError, match="effort_level"):
         ActivityEffortSummary(effort_level="extreme")
 
-    payload = json.loads(_fixture_path("ticketed_event.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("ticketed_event.json").read_text(encoding="utf-8")
+    )
     payload["source_refs"][0]["source_category"] = "unsupported"
     with pytest.raises(ValueError, match="source_category"):
         ActivityOption.from_dict(payload)
 
 
 def test_activity_requires_non_empty_list_fields() -> None:
-    payload = json.loads(_fixture_path("wandering_district.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("wandering_district.json").read_text(encoding="utf-8")
+    )
     payload["booking_links"] = "https://example.com/not-a-list"
     with pytest.raises(ValueError, match="booking_links must be a list"):
         ActivityOption.from_dict(payload)

--- a/tests/options/test_bundles.py
+++ b/tests/options/test_bundles.py
@@ -34,7 +34,9 @@ def test_transport_plus_lodging_bundle_preserves_category_specific_detail() -> N
     assert bundle.transport_options[0].transport_kind == "rail"
     assert bundle.lodging_options[0].room_summary.lodging_kind == "hotel"
     assert bundle.transport_options[0].timing_summary.duration_minutes == 88
-    assert bundle.lodging_options[0].location_summary.business_access_signal == pytest.approx(0.93)
+    assert bundle.lodging_options[
+        0
+    ].location_summary.business_access_signal == pytest.approx(0.93)
     assert bundle.composition_summary.component_option_ids == [
         "lodg-osaka-station-hotel",
         "transport-kix-osaka-rail",
@@ -51,7 +53,10 @@ def test_route_level_mixed_option_round_trips_and_converts_to_option_entry() -> 
 
     assert payload["route_coherence"]["destination_sequence"][-1] == "dest-city-kyoto"
     assert payload["bundles"][1]["activity_options"][0]["activity_kind"] == "museum"
-    assert payload["composition_summary"]["component_option_ids"][-1] == "activity-major-museum"
+    assert (
+        payload["composition_summary"]["component_option_ids"][-1]
+        == "activity-major-museum"
+    )
     assert option.kind == "mixed"
     assert "route_coherence" in option.fit_signals
     assert "dest-city-kyoto" in option.supporting_place_ids
@@ -78,11 +83,15 @@ def test_mixed_option_imports_through_public_packages_and_feeds_option_set() -> 
     payload = option_set.to_dict()
 
     assert payload["options"][0]["kind"] == "mixed"
-    assert payload["options"][0]["fit_signals"]["route_coherence"] == pytest.approx(0.89)
+    assert payload["options"][0]["fit_signals"]["route_coherence"] == pytest.approx(
+        0.89
+    )
     assert payload["source_refs"] == ["prov-major-museum"]
 
 
-def test_mixed_option_keeps_normalized_contracts_distinct_while_assembling_shared_option() -> None:
+def test_mixed_option_keeps_normalized_contracts_distinct_while_assembling_shared_option() -> (
+    None
+):
     mixed_option = _load_mixed_option("route_level_mixed_option.json")
     cultural_bundle = mixed_option.bundles[1]
     lodging_option = cultural_bundle.lodging_options[0]
@@ -112,7 +121,9 @@ def test_mixed_option_keeps_normalized_contracts_distinct_while_assembling_share
 
 
 def test_inventory_bundle_accepts_explicitly_infeasible_but_explained_bundle() -> None:
-    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8")
+    )
     payload["bundles"][0]["feasibility"] = {
         "available": False,
         "internally_consistent": True,
@@ -125,11 +136,16 @@ def test_inventory_bundle_accepts_explicitly_infeasible_but_explained_bundle() -
     assert mixed_option.bundles[0].feasibility.blocking_reasons == [
         "Rail maintenance blocks the arrival window."
     ]
-    assert "Rail maintenance blocks the arrival window." in mixed_option.to_option().drawbacks
+    assert (
+        "Rail maintenance blocks the arrival window."
+        in mixed_option.to_option().drawbacks
+    )
 
 
 def test_transport_only_bundle_requires_destinations_for_transport_endpoints() -> None:
-    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8")
+    )
     bundle = payload["bundles"][0]
     bundle["destinations"] = []
     bundle["lodging_options"] = []
@@ -140,48 +156,72 @@ def test_transport_only_bundle_requires_destinations_for_transport_endpoints() -
         InventoryBundle.from_dict(bundle)
 
 
-def test_bundles_reject_inconsistent_destination_and_invalid_mixed_option_metadata() -> None:
-    payload = json.loads(_fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8"))
+def test_bundles_reject_inconsistent_destination_and_invalid_mixed_option_metadata() -> (
+    None
+):
+    payload = json.loads(
+        _fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8")
+    )
     payload["bundles"][1]["activity_options"][0]["destination_id"] = "dest-city-nara"
-    with pytest.raises(ValueError, match="destinations must include each destination referenced"):
+    with pytest.raises(
+        ValueError, match="destinations must include each destination referenced"
+    ):
         InventoryBundle.from_dict(payload["bundles"][1])
 
-    payload = json.loads(_fixture_path("lodging_only_comparison.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("lodging_only_comparison.json").read_text(encoding="utf-8")
+    )
     payload["supported_purposes"] = ["profile_learning", "profile_learning"]
-    with pytest.raises(ValueError, match="supported_purposes must not contain duplicates"):
+    with pytest.raises(
+        ValueError, match="supported_purposes must not contain duplicates"
+    ):
         MixedOption.from_dict(payload)
 
-    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8")
+    )
     payload["route_coherence"]["destination_sequence"] = ["dest-city-osaka"]
-    with pytest.raises(ValueError, match="route_coherence.destination_sequence must cover"):
+    with pytest.raises(
+        ValueError, match="route_coherence.destination_sequence must cover"
+    ):
         MixedOption.from_dict(payload)
 
-    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8")
+    )
     payload["bundles"][0]["composition_summary"]["component_option_ids"] = [
         "lodg-osaka-station-hotel"
     ]
     with pytest.raises(
-        ValueError, match="composition_summary.component_option_ids must match the options"
+        ValueError,
+        match="composition_summary.component_option_ids must match the options",
     ):
         InventoryBundle.from_dict(payload["bundles"][0])
 
-    payload = json.loads(_fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8")
+    )
     payload["provenance_summary"]["source_refs"] = ["prov-not-present"]
     with pytest.raises(
         ValueError, match="source_refs and provenance_summary.source_refs must be drawn"
     ):
         MixedOption.from_dict(payload)
 
-    payload = json.loads(_fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("route_level_mixed_option.json").read_text(encoding="utf-8")
+    )
     payload["source_refs"] = ["prov-not-present"]
     with pytest.raises(
         ValueError, match="source_refs and provenance_summary.source_refs must be drawn"
     ):
         MixedOption.from_dict(payload)
 
-    payload = json.loads(_fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("transport_lodging_bundle.json").read_text(encoding="utf-8")
+    )
     payload["booking_links"] = ["https://example.com/not-a-real-bundle-link"]
     with pytest.raises(
-        ValueError, match="booking_links and provenance_summary.booking_links must be drawn"
+        ValueError,
+        match="booking_links and provenance_summary.booking_links must be drawn",
     ):
         MixedOption.from_dict(payload)

--- a/tests/options/test_destinations.py
+++ b/tests/options/test_destinations.py
@@ -45,10 +45,16 @@ def test_city_destination_preserves_hierarchy_and_expansion_context() -> None:
     assert destination.adjacency_refs[0].destination_id == "dest-city-osaka"
     assert destination.region_expansion_refs[0].relationship_kind == "day_trip"
     assert destination.region_expansion_refs[0].expansion_mode == "day_trip"
-    assert destination.region_expansion_refs[0].trigger_tags == ["culture", "rail-access"]
+    assert destination.region_expansion_refs[0].trigger_tags == [
+        "culture",
+        "rail-access",
+    ]
     assert destination.tags[0].scope == "experience"
     assert destination.mobility_profile.local_modes == ["walk", "transit", "bike"]
-    assert destination.mobility_profile.interchange_hubs == ["Kyoto Station", "Karasuma Oike"]
+    assert destination.mobility_profile.interchange_hubs == [
+        "Kyoto Station",
+        "Karasuma Oike",
+    ]
     assert destination.experience_signals[0].key == "culture_density"
 
 
@@ -60,7 +66,9 @@ def test_site_destination_carries_operational_notes_and_source_refs() -> None:
     assert payload["operational_notes"][0]["summary"].startswith("Expect early")
     assert payload["source_refs"][0]["provenance_id"] == "prov-site-editorial"
     assert payload["source_refs"][1]["source_category"] == "specialist_non_commercial"
-    assert payload["operational_notes"][0]["source_ref_ids"] == ["prov-site-operational"]
+    assert payload["operational_notes"][0]["source_ref_ids"] == [
+        "prov-site-operational"
+    ]
     assert payload["parent_refs"][0]["destination_id"] == "dest-city-kyoto"
 
 
@@ -98,7 +106,9 @@ def test_destination_supporting_records_round_trip() -> None:
                 impact="high",
                 applies_in_months=[3, 4, 11],
                 source_ref_ids=["prov-arashiyama-editorial"],
-                notes=["Crowding pressure spikes during spring and autumn demand peaks."],
+                notes=[
+                    "Crowding pressure spikes during spring and autumn demand peaks."
+                ],
             )
         ],
     )
@@ -109,7 +119,9 @@ def test_destination_supporting_records_round_trip() -> None:
     assert payload["source_refs"][0]["role"] == "experience"
     assert payload["source_refs"][0]["source_id"] == "arashiyama-guide"
     assert payload["operational_notes"][0]["impact"] == "high"
-    assert payload["operational_notes"][0]["source_ref_ids"] == ["prov-arashiyama-editorial"]
+    assert payload["operational_notes"][0]["source_ref_ids"] == [
+        "prov-arashiyama-editorial"
+    ]
 
 
 def test_place_context_can_be_derived_from_destination() -> None:
@@ -201,7 +213,9 @@ def test_destination_rejects_invalid_geo_and_adjacency_values() -> None:
         Destination.from_dict(payload)
 
 
-def test_destination_rejects_invalid_tag_provenance_and_operational_note_values() -> None:
+def test_destination_rejects_invalid_tag_provenance_and_operational_note_values() -> (
+    None
+):
     with pytest.raises(ValueError, match="scope"):
         DestinationTag(key="culture", label="Culture", scope="ranking")
 

--- a/tests/options/test_lodging.py
+++ b/tests/options/test_lodging.py
@@ -15,7 +15,11 @@ from trip_planner.options import (
     LodgingRoomSummary,
     LodgingValueSummary,
 )
-from trip_planner.sources import ProvenanceReference, QualityValueFitSummary, SourceTrustSignals
+from trip_planner.sources import (
+    ProvenanceReference,
+    QualityValueFitSummary,
+    SourceTrustSignals,
+)
 
 
 def _fixture_path(name: str) -> Path:
@@ -100,7 +104,9 @@ def test_lodging_round_trips_nested_contracts_and_provenance() -> None:
             ),
             total=MoneyRange(currency="USD", typical_amount=660.0),
         ),
-        quality_summary=LodgingQualitySummary(overall_signal=0.77, sleep_quality_signal=0.82),
+        quality_summary=LodgingQualitySummary(
+            overall_signal=0.77, sleep_quality_signal=0.82
+        ),
         value_summary=LodgingValueSummary(overall_signal=0.86, space_value_signal=0.91),
         fit_summary=LodgingFitSummary(overall_signal=0.9, quiet_recovery_signal=0.92),
         feasibility=LodgingFeasibility(
@@ -149,7 +155,9 @@ def test_lodging_rejects_invalid_kind_approval_and_schema_values() -> None:
     with pytest.raises(ValueError, match="business_approval_status"):
         LodgingFeasibility(business_approval_status="escalate")
 
-    payload = json.loads(_fixture_path("central_urban_hotel.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("central_urban_hotel.json").read_text(encoding="utf-8")
+    )
     payload["schema_version"] = "9.9.9"
     with pytest.raises(ValueError, match="schema_version"):
         LodgingOption.from_dict(payload)
@@ -163,7 +171,9 @@ def test_lodging_rejects_invalid_nested_values() -> None:
             walk_minutes_to_anchor=-1,
         )
 
-    payload = json.loads(_fixture_path("conference_hotel.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("conference_hotel.json").read_text(encoding="utf-8")
+    )
     payload["source_refs"][0]["source_category"] = "unsupported"
     with pytest.raises(ValueError, match="source_category"):
         LodgingOption.from_dict(payload)
@@ -200,7 +210,9 @@ def test_lodging_rejects_plain_strings_for_list_fields() -> None:
             booking_links="https://example.com/not-a-list",  # type: ignore[arg-type]
         )
 
-    payload = json.loads(_fixture_path("central_urban_hotel.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("central_urban_hotel.json").read_text(encoding="utf-8")
+    )
     payload["cost_summary"]["notes"] = "not-a-list"
     with pytest.raises(ValueError, match="notes must be a list"):
         LodgingOption.from_dict(payload)

--- a/tests/options/test_transport.py
+++ b/tests/options/test_transport.py
@@ -16,7 +16,11 @@ from trip_planner.options import (
     TransportTimingSummary,
     TransportTransferBurden,
 )
-from trip_planner.sources import ProvenanceReference, QualityValueFitSummary, SourceTrustSignals
+from trip_planner.sources import (
+    ProvenanceReference,
+    QualityValueFitSummary,
+    SourceTrustSignals,
+)
 
 
 def _fixture_path(name: str) -> Path:
@@ -54,7 +58,9 @@ def test_transport_examples_keep_cheapest_easiest_and_best_fit_distinct() -> Non
     assert flight.cost_summary.total.typical_amount is not None
     assert rail.fit_summary.overall_signal is not None
     assert flight.fit_summary.overall_signal is not None
-    assert car.cost_summary.total.typical_amount < flight.cost_summary.total.typical_amount
+    assert (
+        car.cost_summary.total.typical_amount < flight.cost_summary.total.typical_amount
+    )
     assert flight.transfer_burden.transfer_count < rail.transfer_burden.transfer_count
     assert rail.fit_summary.overall_signal > flight.fit_summary.overall_signal
 
@@ -188,7 +194,9 @@ def test_transport_rejects_invalid_kind_segment_and_schema_values() -> None:
             destination_label="B",
         )
 
-    payload = json.loads(_fixture_path("coastal_flight.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("coastal_flight.json").read_text(encoding="utf-8")
+    )
     payload["schema_version"] = "9.9.9"
     with pytest.raises(ValueError, match="schema_version"):
         TransportOption.from_dict(payload)
@@ -212,7 +220,9 @@ def test_transport_rejects_invalid_nested_values() -> None:
 
 
 def test_transport_normalizes_legacy_rental_car_kind() -> None:
-    payload = json.loads(_fixture_path("regional_rental_car.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("regional_rental_car.json").read_text(encoding="utf-8")
+    )
     payload["transport_kind"] = "rental_car"
 
     option = TransportOption.from_dict(payload)
@@ -237,7 +247,9 @@ def test_transport_requires_non_empty_segments_and_list_fields() -> None:
             segments=[],
         )
 
-    payload = json.loads(_fixture_path("regional_rental_car.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("regional_rental_car.json").read_text(encoding="utf-8")
+    )
     payload["booking_links"] = "https://example.com/not-a-list"
     with pytest.raises(ValueError, match="booking_links must be a list"):
         TransportOption.from_dict(payload)

--- a/tests/preferences/fixture_corpus.py
+++ b/tests/preferences/fixture_corpus.py
@@ -71,7 +71,9 @@ def load_fixture_corpus(path: Path | None = None) -> list[TravelerFixture]:
     fixtures = payload.get("fixtures", [])
     if not isinstance(fixtures, list):
         raise ValueError("fixtures must be a list")
-    fixture_objects = [_build_fixture(index, entry) for index, entry in enumerate(fixtures)]
+    fixture_objects = [
+        _build_fixture(index, entry) for index, entry in enumerate(fixtures)
+    ]
     fixture_ids = [fixture.id for fixture in fixture_objects]
     if len(set(fixture_ids)) != len(fixture_ids):
         raise ValueError("fixture corpus ids must be unique")
@@ -91,7 +93,9 @@ def _build_fixture(index: int, payload: Any) -> TravelerFixture:
             raise ValueError(f"fixture {fixture_id!r} must define {required_field}")
     intended = payload.get("intended_interpretation", {})
     if not isinstance(intended, dict):
-        raise ValueError(f"fixture {fixture_id!r} intended_interpretation must be an object")
+        raise ValueError(
+            f"fixture {fixture_id!r} intended_interpretation must be an object"
+        )
     raw_inputs = payload.get("raw_inputs", {})
     if not isinstance(raw_inputs, dict):
         raise ValueError(f"fixture {fixture_id!r} raw_inputs must be an object")
@@ -122,7 +126,10 @@ def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreference
     profile_payload = _default_profile_payload()
 
     trip_frame_overrides = overrides.get("trip_frame", {})
-    profile_payload["trip_frame"] = {**profile_payload["trip_frame"], **trip_frame_overrides}
+    profile_payload["trip_frame"] = {
+        **profile_payload["trip_frame"],
+        **trip_frame_overrides,
+    }
 
     hard_constraint_overrides = overrides.get("hard_constraints", {})
     allowed_constraint_keys = {
@@ -138,7 +145,8 @@ def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreference
     unknown_constraint_keys = set(hard_constraint_overrides) - allowed_constraint_keys
     if unknown_constraint_keys:
         raise ValueError(
-            "unsupported hard constraint override keys: " f"{sorted(unknown_constraint_keys)}"
+            "unsupported hard constraint override keys: "
+            f"{sorted(unknown_constraint_keys)}"
         )
     date_window = {
         **profile_payload["hard_constraints"]["date_window"],
@@ -147,7 +155,8 @@ def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreference
     unknown_date_window_keys = set(date_window) - {"start", "end"}
     if unknown_date_window_keys:
         raise ValueError(
-            "unsupported date_window override keys: " f"{sorted(unknown_date_window_keys)}"
+            "unsupported date_window override keys: "
+            f"{sorted(unknown_date_window_keys)}"
         )
     duration_bounds = {
         **profile_payload["hard_constraints"]["duration_bounds"],
@@ -156,7 +165,8 @@ def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreference
     unknown_duration_keys = set(duration_bounds) - {"min_days", "max_days"}
     if unknown_duration_keys:
         raise ValueError(
-            "unsupported duration_bounds override keys: " f"{sorted(unknown_duration_keys)}"
+            "unsupported duration_bounds override keys: "
+            f"{sorted(unknown_duration_keys)}"
         )
     merged_constraints = {
         **profile_payload["hard_constraints"],
@@ -167,7 +177,10 @@ def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreference
     profile_payload["hard_constraints"] = merged_constraints
 
     budget_overrides = overrides.get("budget_model", {})
-    profile_payload["budget_model"] = {**profile_payload["budget_model"], **budget_overrides}
+    profile_payload["budget_model"] = {
+        **profile_payload["budget_model"],
+        **budget_overrides,
+    }
 
     for key, values in overrides.get("tradeoff_dimensions", {}).items():
         if key not in profile_payload["tradeoff_dimensions"]:
@@ -203,7 +216,9 @@ def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreference
     return LeisurePreferenceProfile(
         trip_frame=TripFrame(**profile_payload["trip_frame"]),
         hard_constraints=HardConstraints(
-            date_window=DateWindow(**profile_payload["hard_constraints"]["date_window"]),
+            date_window=DateWindow(
+                **profile_payload["hard_constraints"]["date_window"]
+            ),
             duration_bounds=DurationBounds(
                 **profile_payload["hard_constraints"]["duration_bounds"]
             ),
@@ -234,13 +249,16 @@ def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreference
             for key, values in profile_payload["tradeoff_dimensions"].items()
         },
         hybrid_factors={
-            key: HybridFactor(**values) for key, values in profile_payload["hybrid_factors"].items()
+            key: HybridFactor(**values)
+            for key, values in profile_payload["hybrid_factors"].items()
         },
         conditional_overrides=list(profile_payload["conditional_overrides"]),
         interaction_rules=[
             InteractionRule(**rule) for rule in profile_payload["interaction_rules"]
         ],
-        tension_flags=[TensionFlag(**flag) for flag in profile_payload["tension_flags"]],
+        tension_flags=[
+            TensionFlag(**flag) for flag in profile_payload["tension_flags"]
+        ],
         evidence_summary=EvidenceSummary(**profile_payload["evidence_summary"]),
     )
 

--- a/tests/preferences/test_autonomy.py
+++ b/tests/preferences/test_autonomy.py
@@ -75,9 +75,13 @@ def test_default_preference_backfills_missing_stage_preferences() -> None:
             exploration_depth=0.7,
             explanation_depth=0.4,
         ),
-        stage_preferences={"initial_design": AutonomyPreference(checkpoint_frequency=0.9)},
+        stage_preferences={
+            "initial_design": AutonomyPreference(checkpoint_frequency=0.9)
+        },
     )
 
     assert profile.preference_for_stage("inventory_selection").system_initiative == 0.8
-    assert profile.preference_for_stage("inventory_selection").option_preview_timing == 0.9
+    assert (
+        profile.preference_for_stage("inventory_selection").option_preview_timing == 0.9
+    )
     assert profile.preference_for_stage("initial_design").checkpoint_frequency == 0.9

--- a/tests/preferences/test_evidence.py
+++ b/tests/preferences/test_evidence.py
@@ -93,7 +93,9 @@ def test_option_evidence_requires_selected_option_in_presented_list() -> None:
     except ValueError as exc:
         assert "must include option_id" in str(exc)
     else:
-        raise AssertionError("Presented option lists should include the selected option")
+        raise AssertionError(
+            "Presented option lists should include the selected option"
+        )
 
 
 def test_preference_evidence_rejects_option_payload_on_non_option_types() -> None:
@@ -151,4 +153,6 @@ def test_option_rejection_cannot_have_positive_signal_direction() -> None:
     except ValueError as exc:
         assert "cannot use a positive signal_direction" in str(exc)
     else:
-        raise AssertionError("Option rejection should not allow positive signal direction")
+        raise AssertionError(
+            "Option rejection should not allow positive signal direction"
+        )

--- a/tests/preferences/test_evidence_catalog.py
+++ b/tests/preferences/test_evidence_catalog.py
@@ -52,7 +52,9 @@ def test_validate_evidence_support_rejects_invalid_dimension_combo() -> None:
     except ValueError as exc:
         assert "not valid evidence for dimension" in str(exc)
     else:
-        raise AssertionError("Invalid dimension evidence combinations should fail clearly")
+        raise AssertionError(
+            "Invalid dimension evidence combinations should fail clearly"
+        )
 
 
 def test_validate_evidence_support_rejects_invalid_hybrid_combo() -> None:

--- a/tests/preferences/test_fixture_corpus.py
+++ b/tests/preferences/test_fixture_corpus.py
@@ -14,7 +14,10 @@ def test_fixture_corpus_loads_and_instantiates_profiles() -> None:
     fixtures = load_fixture_corpus()
 
     assert len(fixtures) >= 10
-    assert {fixture.fixture_kind for fixture in fixtures} == {"archetype", "tension_case"}
+    assert {fixture.fixture_kind for fixture in fixtures} == {
+        "archetype",
+        "tension_case",
+    }
 
     for fixture in fixtures:
         assert fixture.id
@@ -55,9 +58,14 @@ def test_tension_cases_surface_real_conflicts() -> None:
         "recovery_vs_intensity",
     }.issubset(breadth_case.intended_interpretation.dominant_dimensions)
 
-    assert anchor_case.profile.hard_constraints.must_include_places == ["Istanbul", "Cappadocia"]
+    assert anchor_case.profile.hard_constraints.must_include_places == [
+        "Istanbul",
+        "Cappadocia",
+    ]
     assert anchor_case.profile.anchors["calendar_anchors"]
-    assert anchor_case.profile.tradeoff_dimensions["structure_vs_elasticity"].value > 0.0
+    assert (
+        anchor_case.profile.tradeoff_dimensions["structure_vs_elasticity"].value > 0.0
+    )
 
     assert budget_case.profile.hard_constraints.budget_ceiling == 5200.0
     assert budget_case.profile.anchors["quality_floor_anchors"]
@@ -126,7 +134,9 @@ def test_fixture_corpus_rejects_missing_qualitative_summary(tmp_path: Path) -> N
     except ValueError as exc:
         assert "qualitative_summary" in str(exc)
     else:
-        raise AssertionError("Fixture corpus should reject missing qualitative summaries")
+        raise AssertionError(
+            "Fixture corpus should reject missing qualitative summaries"
+        )
 
 
 def test_fixture_corpus_rejects_non_object_fixture_entries(tmp_path: Path) -> None:
@@ -145,7 +155,9 @@ def test_fixture_corpus_rejects_non_object_fixture_entries(tmp_path: Path) -> No
 
 def test_fixture_corpus_rejects_unknown_hard_constraint_keys(tmp_path: Path) -> None:
     payload = json.loads(fixture_corpus_path().read_text(encoding="utf-8"))
-    payload["fixtures"][8]["profile_overrides"]["hard_constraints"]["budget_ceiling_typo"] = 1000
+    payload["fixtures"][8]["profile_overrides"]["hard_constraints"][
+        "budget_ceiling_typo"
+    ] = 1000
     path = tmp_path / "bad-hard-constraints.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
 
@@ -154,4 +166,6 @@ def test_fixture_corpus_rejects_unknown_hard_constraint_keys(tmp_path: Path) -> 
     except ValueError as exc:
         assert "hard constraint override keys" in str(exc)
     else:
-        raise AssertionError("Fixture corpus should reject unknown hard constraint override keys")
+        raise AssertionError(
+            "Fixture corpus should reject unknown hard constraint override keys"
+        )

--- a/tests/preferences/test_interactions.py
+++ b/tests/preferences/test_interactions.py
@@ -24,7 +24,10 @@ def _resolved_fixture(fixture_id: str):
 def test_movement_and_scenic_transit_interaction_activates() -> None:
     result = _resolved_fixture("scenic-rail-nomad")
 
-    assert any(rule.id == "movement-x-scenic-transit" for rule in result.profile.interaction_rules)
+    assert any(
+        rule.id == "movement-x-scenic-transit"
+        for rule in result.profile.interaction_rules
+    )
     assert any(
         activation.rule_id == "movement-x-scenic-transit"
         for activation in result.explanation.activated_interactions
@@ -35,30 +38,50 @@ def test_movement_and_scenic_transit_interaction_activates() -> None:
 def test_breadth_and_recovery_interaction_produces_tension() -> None:
     result = _resolved_fixture("breadth-under-recovery-pressure")
 
-    assert any(rule.id == "breadth-x-recovery" for rule in result.profile.interaction_rules)
-    assert any(flag.id == "breadth-recovery-conflict" for flag in result.profile.tension_flags)
+    assert any(
+        rule.id == "breadth-x-recovery" for rule in result.profile.interaction_rules
+    )
+    assert any(
+        flag.id == "breadth-recovery-conflict" for flag in result.profile.tension_flags
+    )
 
 
 def test_structure_and_discovery_interaction_respects_fixed_anchors() -> None:
     result = _resolved_fixture("elastic-discovery-with-fixed-anchors")
 
-    assert any(rule.id == "structure-x-discovery" for rule in result.profile.interaction_rules)
-    assert any(flag.id == "elasticity-anchor-conflict" for flag in result.profile.tension_flags)
+    assert any(
+        rule.id == "structure-x-discovery" for rule in result.profile.interaction_rules
+    )
+    assert any(
+        flag.id == "elasticity-anchor-conflict" for flag in result.profile.tension_flags
+    )
 
 
 def test_budget_and_quality_floor_interaction_produces_guardrail_bias() -> None:
     result = _resolved_fixture("quality-floors-under-budget-pressure")
 
-    assert any(rule.id == "budget-x-quality-floors" for rule in result.profile.interaction_rules)
-    assert any(flag.id == "quality-floor-budget-conflict" for flag in result.profile.tension_flags)
-    assert result.profile.tradeoff_dimensions["self_reliance_vs_convenience"].value >= 0.45
+    assert any(
+        rule.id == "budget-x-quality-floors"
+        for rule in result.profile.interaction_rules
+    )
+    assert any(
+        flag.id == "quality-floor-budget-conflict"
+        for flag in result.profile.tension_flags
+    )
+    assert (
+        result.profile.tradeoff_dimensions["self_reliance_vs_convenience"].value >= 0.45
+    )
 
 
 def test_social_and_recovery_interaction_boosts_rest_hybrid_factor() -> None:
     result = _resolved_fixture("social-recovery-balancer")
 
-    assert any(rule.id == "social-energy-x-recovery" for rule in result.profile.interaction_rules)
     assert any(
-        flag.id == "social-energy-recovery-conflict" for flag in result.profile.tension_flags
+        rule.id == "social-energy-x-recovery"
+        for rule in result.profile.interaction_rules
+    )
+    assert any(
+        flag.id == "social-energy-recovery-conflict"
+        for flag in result.profile.tension_flags
     )
     assert result.profile.hybrid_factors["rest"].salience >= 0.84

--- a/tests/preferences/test_models.py
+++ b/tests/preferences/test_models.py
@@ -21,7 +21,9 @@ from trip_planner.preferences.schema import (
 
 def _make_profile() -> LeisurePreferenceProfile:
     anchors: dict[str, list[Anchor]] = {group: [] for group in ANCHOR_GROUPS}
-    anchors["place_anchors"] = [Anchor(type="place", label="Kyoto", strength=0.9, flexibility=0.2)]
+    anchors["place_anchors"] = [
+        Anchor(type="place", label="Kyoto", strength=0.9, flexibility=0.2)
+    ]
     return LeisurePreferenceProfile(
         trip_frame=TripFrame(
             duration_days=28,
@@ -40,10 +42,14 @@ def _make_profile() -> LeisurePreferenceProfile:
             spending_priorities={"lodging_location": 0.8},
         ),
         tradeoff_dimensions={
-            key: TradeoffDimension(value=0.0, confidence=0.2, salience=0.2, stability=0.2)
+            key: TradeoffDimension(
+                value=0.0, confidence=0.2, salience=0.2, stability=0.2
+            )
             for key in TRADEOFF_DIMENSION_KEYS
         },
-        hybrid_factors={key: HybridFactor(mode="tradeoff") for key in HYBRID_FACTOR_KEYS},
+        hybrid_factors={
+            key: HybridFactor(mode="tradeoff") for key in HYBRID_FACTOR_KEYS
+        },
         interaction_rules=[
             InteractionRule(
                 id="breadth_x_recovery",
@@ -83,8 +89,12 @@ def test_profile_defaults_anchor_groups_when_not_provided() -> None:
         trip_frame=TripFrame(duration_days=14),
         hard_constraints=HardConstraints(),
         budget_model=BudgetModel(),
-        tradeoff_dimensions={key: TradeoffDimension() for key in TRADEOFF_DIMENSION_KEYS},
-        hybrid_factors={key: HybridFactor(mode="tradeoff") for key in HYBRID_FACTOR_KEYS},
+        tradeoff_dimensions={
+            key: TradeoffDimension() for key in TRADEOFF_DIMENSION_KEYS
+        },
+        hybrid_factors={
+            key: HybridFactor(mode="tradeoff") for key in HYBRID_FACTOR_KEYS
+        },
     )
 
     assert set(profile.anchors) == set(ANCHOR_GROUPS)

--- a/tests/preferences/test_resolution.py
+++ b/tests/preferences/test_resolution.py
@@ -31,7 +31,9 @@ def _same_direction(left: float, right: float) -> bool:
 
 def test_resolution_matches_fixture_directional_outcomes() -> None:
     for fixture in load_fixture_corpus():
-        result = resolve_leisure_profile(_resolution_seed(fixture.profile), fixture.evidence)
+        result = resolve_leisure_profile(
+            _resolution_seed(fixture.profile), fixture.evidence
+        )
 
         for dimension_key in fixture.intended_interpretation.dominant_dimensions:
             expected = fixture.profile.tradeoff_dimensions[dimension_key]
@@ -47,12 +49,16 @@ def test_resolution_matches_fixture_directional_outcomes() -> None:
 
 
 def test_resolution_emits_contradiction_tension_when_evidence_conflicts() -> None:
-    fixture = next(item for item in load_fixture_corpus() if item.id == "scenic-rail-nomad")
+    fixture = next(
+        item for item in load_fixture_corpus() if item.id == "scenic-rail-nomad"
+    )
     contradictory = deepcopy(fixture.evidence[0])
     contradictory.id = "scenic-rail-nomad-ev-contradiction"
     contradictory.signal_direction = "contradiction"
     contradictory.contradictions = []
-    contradictory.note = "Traveler also says frequent transfers become exhausting after a week."
+    contradictory.note = (
+        "Traveler also says frequent transfers become exhausting after a week."
+    )
 
     result = resolve_leisure_profile(
         _resolution_seed(fixture.profile),
@@ -60,15 +66,20 @@ def test_resolution_emits_contradiction_tension_when_evidence_conflicts() -> Non
     )
 
     assert any(
-        flag.id == "movement_vs_friction-contradiction" for flag in result.profile.tension_flags
+        flag.id == "movement_vs_friction-contradiction"
+        for flag in result.profile.tension_flags
     )
     assert "movement_vs_friction-contradiction" in (
-        result.explanation.dimension_explanations["movement_vs_friction"].tension_flag_ids
+        result.explanation.dimension_explanations[
+            "movement_vs_friction"
+        ].tension_flag_ids
     )
 
 
 def test_resolution_flags_dimensions_that_need_directional_seed() -> None:
-    fixture = next(item for item in load_fixture_corpus() if item.id == "discovery-wanderer")
+    fixture = next(
+        item for item in load_fixture_corpus() if item.id == "discovery-wanderer"
+    )
     seed = _resolution_seed(fixture.profile)
     seed.tradeoff_dimensions["iconic_vs_discovery"].value = 0.0
 
@@ -85,7 +96,9 @@ def test_resolution_flags_dimensions_that_need_directional_seed() -> None:
 
 
 def test_directional_seed_artifacts_removed_after_interaction_moves_off_zero() -> None:
-    fixture = next(item for item in load_fixture_corpus() if item.id == "discovery-wanderer")
+    fixture = next(
+        item for item in load_fixture_corpus() if item.id == "discovery-wanderer"
+    )
     seed = _resolution_seed(fixture.profile)
     seed.tradeoff_dimensions["movement_vs_friction"].value = 0.0
     seed.tradeoff_dimensions["breadth_vs_depth"].value = -0.6
@@ -100,10 +113,13 @@ def test_directional_seed_artifacts_removed_after_interaction_moves_off_zero() -
     )
     assert (
         "movement_vs_friction-needs-directional-seed"
-        not in result.explanation.dimension_explanations["movement_vs_friction"].tension_flag_ids
+        not in result.explanation.dimension_explanations[
+            "movement_vs_friction"
+        ].tension_flag_ids
     )
     assert (
-        "movement_vs_friction-needs-directional-seed" not in result.explanation.tension_explanations
+        "movement_vs_friction-needs-directional-seed"
+        not in result.explanation.tension_explanations
     )
     assert all(
         "movement_vs_friction received evidence but remained at a zero-direction seed value."

--- a/tests/preferences/test_resolution_directional_seed_cleanup.py
+++ b/tests/preferences/test_resolution_directional_seed_cleanup.py
@@ -17,7 +17,9 @@ def _resolution_seed(fixture_profile):
 
 
 def test_resolution_clears_directional_seed_artifacts_after_interactions() -> None:
-    fixture = next(item for item in load_fixture_corpus() if item.id == "scenic-rail-nomad")
+    fixture = next(
+        item for item in load_fixture_corpus() if item.id == "scenic-rail-nomad"
+    )
     seed = _resolution_seed(fixture.profile)
     seed.tradeoff_dimensions["movement_vs_friction"].value = 0.0
     seed.tradeoff_dimensions["breadth_vs_depth"].value = -0.6
@@ -25,14 +27,14 @@ def test_resolution_clears_directional_seed_artifacts_after_interactions() -> No
 
     result = resolve_leisure_profile(seed, fixture.evidence)
     tension_id = "movement_vs_friction-needs-directional-seed"
-    confidence_note = (
-        "movement_vs_friction received evidence but remained at a zero-direction seed value."
-    )
+    confidence_note = "movement_vs_friction received evidence but remained at a zero-direction seed value."
 
     assert result.profile.tradeoff_dimensions["movement_vs_friction"].value > 0.0
     assert tension_id not in {flag.id for flag in result.profile.tension_flags}
     assert tension_id not in result.explanation.tension_explanations
     assert tension_id not in (
-        result.explanation.dimension_explanations["movement_vs_friction"].tension_flag_ids
+        result.explanation.dimension_explanations[
+            "movement_vs_friction"
+        ].tension_flag_ids
     )
     assert confidence_note not in result.profile.evidence_summary.confidence_notes

--- a/tests/preferences/test_revealed_preference.py
+++ b/tests/preferences/test_revealed_preference.py
@@ -10,7 +10,9 @@ from trip_planner.preferences.revealed_preference import (
 
 
 def test_revealed_preference_update_emits_option_evidence() -> None:
-    fixture = next(item for item in load_fixture_corpus() if item.id == "discovery-wanderer")
+    fixture = next(
+        item for item in load_fixture_corpus() if item.id == "discovery-wanderer"
+    )
     signal = RevealedPreferenceSignal(
         signal_id="signal-1",
         trip_stage="inventory_selection",
@@ -40,7 +42,9 @@ def test_revealed_preference_update_emits_option_evidence() -> None:
 
 
 def test_revealed_preference_guardrail_blocks_overwrite_of_stable_dimension() -> None:
-    fixture = next(item for item in load_fixture_corpus() if item.id == "urban-historian")
+    fixture = next(
+        item for item in load_fixture_corpus() if item.id == "urban-historian"
+    )
     profile = deepcopy(fixture.profile)
     profile.tradeoff_dimensions["breadth_vs_depth"].salience = 0.92
     profile.tradeoff_dimensions["breadth_vs_depth"].stability = 0.9
@@ -61,7 +65,10 @@ def test_revealed_preference_guardrail_blocks_overwrite_of_stable_dimension() ->
 
     assert update.blocked_overwrites == ["breadth_vs_depth"]
     assert update.emitted_evidence[0].signal_direction == "contradiction"
-    assert "anchors" in update.protected_targets or "hard_constraints" in update.protected_targets
+    assert (
+        "anchors" in update.protected_targets
+        or "hard_constraints" in update.protected_targets
+    )
 
 
 def test_revealed_preference_marks_transient_clicks() -> None:

--- a/tests/ranking/test_leisure.py
+++ b/tests/ranking/test_leisure.py
@@ -3,8 +3,6 @@ from copy import deepcopy
 from pathlib import Path
 
 from trip_planner.candidates import CandidateSeed, CandidateSet
-from trip_planner.candidates.generation import _aggregate_booking_links, _aggregate_source_refs
-from trip_planner.candidates.generation import _mean_or_none as _candidate_mean_or_none
 from trip_planner.itinerary import derive_itinerary_objectives
 from trip_planner.options import (
     ActivityOption,
@@ -52,17 +50,56 @@ def _load_entry(entry: dict, parser):
 
 
 def _mean_or_none(values: list[float | None]) -> float | None:
-    return _candidate_mean_or_none(values)
+    numeric = [value for value in values if value is not None]
+    if not numeric:
+        return None
+    return round(sum(numeric) / len(numeric), 4)
+
+
+def _aggregate_source_refs(*collections) -> list[str]:
+    seen: set[str] = set()
+    refs: list[str] = []
+    for collection in collections:
+        for option in collection:
+            for source_ref in option.source_refs:
+                provenance_id = getattr(source_ref, "provenance_id", "")
+                if provenance_id and provenance_id not in seen:
+                    seen.add(provenance_id)
+                    refs.append(provenance_id)
+    return refs
+
+
+def _aggregate_booking_links(*collections) -> list[str]:
+    seen: set[str] = set()
+    links: list[str] = []
+    for collection in collections:
+        for option in collection:
+            for link in option.booking_links:
+                if link and link not in seen:
+                    seen.add(link)
+                    links.append(link)
+    return links
 
 
 def _load_candidate_set(name: str) -> CandidateSet:
     payload = _load_json(_fixture_path(name))
     seeds: list[CandidateSeed] = []
     for index, item in enumerate(payload["candidates"]):
-        destinations = [_load_entry(entry, Destination.from_dict) for entry in item["destinations"]]
-        lodging_options = [_load_entry(entry, LodgingOption.from_dict) for entry in item["lodging_options"]]
-        transport_options = [_load_entry(entry, TransportOption.from_dict) for entry in item["transport_options"]]
-        activity_options = [_load_entry(entry, ActivityOption.from_dict) for entry in item["activity_options"]]
+        destinations = [
+            _load_entry(entry, Destination.from_dict) for entry in item["destinations"]
+        ]
+        lodging_options = [
+            _load_entry(entry, LodgingOption.from_dict)
+            for entry in item["lodging_options"]
+        ]
+        transport_options = [
+            _load_entry(entry, TransportOption.from_dict)
+            for entry in item["transport_options"]
+        ]
+        activity_options = [
+            _load_entry(entry, ActivityOption.from_dict)
+            for entry in item["activity_options"]
+        ]
         bundle = InventoryBundle(
             bundle_id=item["bundle_id"],
             title=item["title"],
@@ -96,19 +133,37 @@ def _load_candidate_set(name: str) -> CandidateSet:
             ),
             quality_value_fit=BundleQualityValueFitSummary(
                 quality_signal=_mean_or_none(
-                    [option.quality_summary.overall_signal for option in lodging_options]
-                    + [option.quality_summary.overall_signal for option in activity_options]
-                    + [option.experience_summary.comfort_signal for option in transport_options]
+                    [
+                        option.quality_summary.overall_signal
+                        for option in lodging_options
+                    ]
+                    + [
+                        option.quality_summary.overall_signal
+                        for option in activity_options
+                    ]
+                    + [
+                        option.experience_summary.comfort_signal
+                        for option in transport_options
+                    ]
                 ),
                 value_signal=_mean_or_none(
                     [option.value_summary.overall_signal for option in lodging_options]
-                    + [option.value_summary.overall_signal for option in activity_options]
-                    + [option.fit_summary.policy_fit_signal for option in transport_options]
+                    + [
+                        option.value_summary.overall_signal
+                        for option in activity_options
+                    ]
+                    + [
+                        option.fit_summary.policy_fit_signal
+                        for option in transport_options
+                    ]
                 ),
                 fit_signal=_mean_or_none(
                     [option.fit_summary.overall_signal for option in lodging_options]
                     + [option.fit_summary.overall_signal for option in activity_options]
-                    + [option.fit_summary.overall_signal for option in transport_options]
+                    + [
+                        option.fit_summary.overall_signal
+                        for option in transport_options
+                    ]
                 ),
             ),
             feasibility=BundleFeasibility(
@@ -140,7 +195,9 @@ def _load_candidate_set(name: str) -> CandidateSet:
         trip_id=payload["trip_id"],
         purpose="profile_learning",
         seeds=seeds,
-        explanation=["Representative candidate showcase for deterministic leisure ranking tests."],
+        explanation=[
+            "Representative candidate showcase for deterministic leisure ranking tests."
+        ],
         source_refs=[
             source_ref
             for seed in seeds
@@ -172,7 +229,9 @@ def test_rank_leisure_candidates_emits_bundle_rankings_with_explanations() -> No
     assert result_set.results[0].score_breakdown.component_contributions
 
 
-def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> None:
+def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> (
+    None
+):
     candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
     fixtures = load_fixture_map()
 
@@ -198,7 +257,10 @@ def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles
 
     assert urban_ranked.results[0].target_bundle_id == "bundle:discovery-drift"
     assert quality_ranked.results[0].target_bundle_id == "bundle:comfort-floor"
-    assert urban_ranked.results[0].target_bundle_id != quality_ranked.results[0].target_bundle_id
+    assert (
+        urban_ranked.results[0].target_bundle_id
+        != quality_ranked.results[0].target_bundle_id
+    )
 
 
 def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> None:
@@ -218,7 +280,9 @@ def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> N
         penalty.reason_code == "preference_tension"
         for penalty in first_result.score_breakdown.penalties
     )
-    assert any(risk.code == "preference_tension" for risk in first_result.unresolved_risks)
+    assert any(
+        risk.code == "preference_tension" for risk in first_result.unresolved_risks
+    )
 
 
 def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
@@ -234,4 +298,26 @@ def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
 
     assert len(result_set.results) == len(candidate_set.seeds)
     assert result_set.results[0].target_bundle_id is not None
-    assert result_set.results[0].score == result_set.results[0].score_breakdown.final_score
+    assert (
+        result_set.results[0].score == result_set.results[0].score_breakdown.final_score
+    )
+
+
+def test_rank_leisure_candidates_filters_empty_human_summary_entries() -> None:
+    candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
+    first_bundle = candidate_set.seeds[0].bundle
+    first_bundle.summary = ""
+    first_bundle.explanation.strengths = []
+
+    fixture = load_fixture_map()["discovery-wanderer"]
+    resolved = resolve_leisure_profile(fixture.profile, fixture.evidence)
+
+    result_set = rank_leisure_candidates(
+        trip_id=candidate_set.trip_id,
+        resolved_profile=resolved,
+        candidate_set=candidate_set,
+    )
+
+    for record in result_set.results[0].explanation_records:
+        assert record.human_summary
+        assert all(item for item in record.human_summary)

--- a/tests/ranking/test_leisure.py
+++ b/tests/ranking/test_leisure.py
@@ -86,20 +86,15 @@ def _load_candidate_set(name: str) -> CandidateSet:
     payload = _load_json(_fixture_path(name))
     seeds: list[CandidateSeed] = []
     for index, item in enumerate(payload["candidates"]):
-        destinations = [
-            _load_entry(entry, Destination.from_dict) for entry in item["destinations"]
-        ]
+        destinations = [_load_entry(entry, Destination.from_dict) for entry in item["destinations"]]
         lodging_options = [
-            _load_entry(entry, LodgingOption.from_dict)
-            for entry in item["lodging_options"]
+            _load_entry(entry, LodgingOption.from_dict) for entry in item["lodging_options"]
         ]
         transport_options = [
-            _load_entry(entry, TransportOption.from_dict)
-            for entry in item["transport_options"]
+            _load_entry(entry, TransportOption.from_dict) for entry in item["transport_options"]
         ]
         activity_options = [
-            _load_entry(entry, ActivityOption.from_dict)
-            for entry in item["activity_options"]
+            _load_entry(entry, ActivityOption.from_dict) for entry in item["activity_options"]
         ]
         bundle = InventoryBundle(
             bundle_id=item["bundle_id"],
@@ -134,37 +129,19 @@ def _load_candidate_set(name: str) -> CandidateSet:
             ),
             quality_value_fit=BundleQualityValueFitSummary(
                 quality_signal=_mean_or_none(
-                    [
-                        option.quality_summary.overall_signal
-                        for option in lodging_options
-                    ]
-                    + [
-                        option.quality_summary.overall_signal
-                        for option in activity_options
-                    ]
-                    + [
-                        option.experience_summary.comfort_signal
-                        for option in transport_options
-                    ]
+                    [option.quality_summary.overall_signal for option in lodging_options]
+                    + [option.quality_summary.overall_signal for option in activity_options]
+                    + [option.experience_summary.comfort_signal for option in transport_options]
                 ),
                 value_signal=_mean_or_none(
                     [option.value_summary.overall_signal for option in lodging_options]
-                    + [
-                        option.value_summary.overall_signal
-                        for option in activity_options
-                    ]
-                    + [
-                        option.fit_summary.policy_fit_signal
-                        for option in transport_options
-                    ]
+                    + [option.value_summary.overall_signal for option in activity_options]
+                    + [option.fit_summary.policy_fit_signal for option in transport_options]
                 ),
                 fit_signal=_mean_or_none(
                     [option.fit_summary.overall_signal for option in lodging_options]
                     + [option.fit_summary.overall_signal for option in activity_options]
-                    + [
-                        option.fit_summary.overall_signal
-                        for option in transport_options
-                    ]
+                    + [option.fit_summary.overall_signal for option in transport_options]
                 ),
             ),
             feasibility=BundleFeasibility(
@@ -196,9 +173,7 @@ def _load_candidate_set(name: str) -> CandidateSet:
         trip_id=payload["trip_id"],
         purpose="profile_learning",
         seeds=seeds,
-        explanation=[
-            "Representative candidate showcase for deterministic leisure ranking tests."
-        ],
+        explanation=["Representative candidate showcase for deterministic leisure ranking tests."],
         source_refs=[
             source_ref
             for seed in seeds
@@ -230,9 +205,7 @@ def test_rank_leisure_candidates_emits_bundle_rankings_with_explanations() -> No
     assert result_set.results[0].score_breakdown.component_contributions
 
 
-def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> (
-    None
-):
+def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> None:
     candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
     fixtures = load_fixture_map()
 
@@ -258,10 +231,7 @@ def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles
 
     assert urban_ranked.results[0].target_bundle_id == "bundle:discovery-drift"
     assert quality_ranked.results[0].target_bundle_id == "bundle:comfort-floor"
-    assert (
-        urban_ranked.results[0].target_bundle_id
-        != quality_ranked.results[0].target_bundle_id
-    )
+    assert urban_ranked.results[0].target_bundle_id != quality_ranked.results[0].target_bundle_id
 
 
 def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> None:
@@ -281,9 +251,7 @@ def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> N
         penalty.reason_code == "preference_tension"
         for penalty in first_result.score_breakdown.penalties
     )
-    assert any(
-        risk.code == "preference_tension" for risk in first_result.unresolved_risks
-    )
+    assert any(risk.code == "preference_tension" for risk in first_result.unresolved_risks)
 
 
 def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
@@ -299,9 +267,7 @@ def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
 
     assert len(result_set.results) == len(candidate_set.seeds)
     assert result_set.results[0].target_bundle_id is not None
-    assert (
-        result_set.results[0].score == result_set.results[0].score_breakdown.final_score
-    )
+    assert result_set.results[0].score == result_set.results[0].score_breakdown.final_score
 
 
 def test_rank_leisure_candidates_filters_empty_human_summary_entries() -> None:
@@ -349,9 +315,7 @@ def test_rank_leisure_candidates_preserves_zero_signals() -> None:
     )
 
     first_result = next(
-        result
-        for result in result_set.results
-        if result.target_bundle_id == first_bundle.bundle_id
+        result for result in result_set.results if result.target_bundle_id == first_bundle.bundle_id
     )
     bundle_fit = next(
         contribution
@@ -366,9 +330,6 @@ def test_rank_leisure_candidates_preserves_zero_signals() -> None:
 
     assert bundle_fit.normalized_signal == 0.0
     assert quality_value.normalized_signal is not None
-    assert (
-        quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
-    )
-    assert (
-        "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes
-    )
+    assert first_bundle.quality_value_fit.quality_signal is not None
+    assert quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
+    assert "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes

--- a/tests/ranking/test_leisure.py
+++ b/tests/ranking/test_leisure.py
@@ -86,15 +86,20 @@ def _load_candidate_set(name: str) -> CandidateSet:
     payload = _load_json(_fixture_path(name))
     seeds: list[CandidateSeed] = []
     for index, item in enumerate(payload["candidates"]):
-        destinations = [_load_entry(entry, Destination.from_dict) for entry in item["destinations"]]
+        destinations = [
+            _load_entry(entry, Destination.from_dict) for entry in item["destinations"]
+        ]
         lodging_options = [
-            _load_entry(entry, LodgingOption.from_dict) for entry in item["lodging_options"]
+            _load_entry(entry, LodgingOption.from_dict)
+            for entry in item["lodging_options"]
         ]
         transport_options = [
-            _load_entry(entry, TransportOption.from_dict) for entry in item["transport_options"]
+            _load_entry(entry, TransportOption.from_dict)
+            for entry in item["transport_options"]
         ]
         activity_options = [
-            _load_entry(entry, ActivityOption.from_dict) for entry in item["activity_options"]
+            _load_entry(entry, ActivityOption.from_dict)
+            for entry in item["activity_options"]
         ]
         bundle = InventoryBundle(
             bundle_id=item["bundle_id"],
@@ -129,19 +134,37 @@ def _load_candidate_set(name: str) -> CandidateSet:
             ),
             quality_value_fit=BundleQualityValueFitSummary(
                 quality_signal=_mean_or_none(
-                    [option.quality_summary.overall_signal for option in lodging_options]
-                    + [option.quality_summary.overall_signal for option in activity_options]
-                    + [option.experience_summary.comfort_signal for option in transport_options]
+                    [
+                        option.quality_summary.overall_signal
+                        for option in lodging_options
+                    ]
+                    + [
+                        option.quality_summary.overall_signal
+                        for option in activity_options
+                    ]
+                    + [
+                        option.experience_summary.comfort_signal
+                        for option in transport_options
+                    ]
                 ),
                 value_signal=_mean_or_none(
                     [option.value_summary.overall_signal for option in lodging_options]
-                    + [option.value_summary.overall_signal for option in activity_options]
-                    + [option.fit_summary.policy_fit_signal for option in transport_options]
+                    + [
+                        option.value_summary.overall_signal
+                        for option in activity_options
+                    ]
+                    + [
+                        option.fit_summary.policy_fit_signal
+                        for option in transport_options
+                    ]
                 ),
                 fit_signal=_mean_or_none(
                     [option.fit_summary.overall_signal for option in lodging_options]
                     + [option.fit_summary.overall_signal for option in activity_options]
-                    + [option.fit_summary.overall_signal for option in transport_options]
+                    + [
+                        option.fit_summary.overall_signal
+                        for option in transport_options
+                    ]
                 ),
             ),
             feasibility=BundleFeasibility(
@@ -173,7 +196,9 @@ def _load_candidate_set(name: str) -> CandidateSet:
         trip_id=payload["trip_id"],
         purpose="profile_learning",
         seeds=seeds,
-        explanation=["Representative candidate showcase for deterministic leisure ranking tests."],
+        explanation=[
+            "Representative candidate showcase for deterministic leisure ranking tests."
+        ],
         source_refs=[
             source_ref
             for seed in seeds
@@ -205,7 +230,9 @@ def test_rank_leisure_candidates_emits_bundle_rankings_with_explanations() -> No
     assert result_set.results[0].score_breakdown.component_contributions
 
 
-def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> None:
+def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> (
+    None
+):
     candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
     fixtures = load_fixture_map()
 
@@ -231,7 +258,10 @@ def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles
 
     assert urban_ranked.results[0].target_bundle_id == "bundle:discovery-drift"
     assert quality_ranked.results[0].target_bundle_id == "bundle:comfort-floor"
-    assert urban_ranked.results[0].target_bundle_id != quality_ranked.results[0].target_bundle_id
+    assert (
+        urban_ranked.results[0].target_bundle_id
+        != quality_ranked.results[0].target_bundle_id
+    )
 
 
 def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> None:
@@ -251,7 +281,9 @@ def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> N
         penalty.reason_code == "preference_tension"
         for penalty in first_result.score_breakdown.penalties
     )
-    assert any(risk.code == "preference_tension" for risk in first_result.unresolved_risks)
+    assert any(
+        risk.code == "preference_tension" for risk in first_result.unresolved_risks
+    )
 
 
 def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
@@ -267,7 +299,9 @@ def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
 
     assert len(result_set.results) == len(candidate_set.seeds)
     assert result_set.results[0].target_bundle_id is not None
-    assert result_set.results[0].score == result_set.results[0].score_breakdown.final_score
+    assert (
+        result_set.results[0].score == result_set.results[0].score_breakdown.final_score
+    )
 
 
 def test_rank_leisure_candidates_filters_empty_human_summary_entries() -> None:
@@ -315,7 +349,9 @@ def test_rank_leisure_candidates_preserves_zero_signals() -> None:
     )
 
     first_result = next(
-        result for result in result_set.results if result.target_bundle_id == first_bundle.bundle_id
+        result
+        for result in result_set.results
+        if result.target_bundle_id == first_bundle.bundle_id
     )
     bundle_fit = next(
         contribution
@@ -331,5 +367,9 @@ def test_rank_leisure_candidates_preserves_zero_signals() -> None:
     assert bundle_fit.normalized_signal == 0.0
     assert quality_value.normalized_signal is not None
     assert first_bundle.quality_value_fit.quality_signal is not None
-    assert quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
-    assert "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes
+    assert (
+        quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
+    )
+    assert (
+        "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes
+    )

--- a/tests/ranking/test_leisure.py
+++ b/tests/ranking/test_leisure.py
@@ -1,0 +1,237 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from trip_planner.candidates import CandidateSeed, CandidateSet
+from trip_planner.candidates.generation import _aggregate_booking_links, _aggregate_source_refs
+from trip_planner.candidates.generation import _mean_or_none as _candidate_mean_or_none
+from trip_planner.itinerary import derive_itinerary_objectives
+from trip_planner.options import (
+    ActivityOption,
+    BundleCompositionSummary,
+    BundleExplanation,
+    BundleFeasibility,
+    BundleProvenanceSummary,
+    BundleQualityValueFitSummary,
+    Destination,
+    InventoryBundle,
+    LodgingOption,
+    TransportOption,
+)
+from trip_planner.preferences import resolve_leisure_profile
+from trip_planner.ranking import rank_leisure_candidates
+from tests.preferences.fixture_corpus import load_fixture_map
+
+
+def _fixture_path(name: str) -> Path:
+    return Path("tests/fixtures/ranking") / name
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _deep_merge(base: dict, patch: dict) -> dict:
+    merged = deepcopy(base)
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def _load_entry(entry: dict, parser):
+    if "path" in entry:
+        payload = _load_json(Path(entry["path"]))
+    else:
+        payload = deepcopy(entry["payload"])
+    if "overrides" in entry:
+        payload = _deep_merge(payload, entry["overrides"])
+    return parser(payload)
+
+
+def _mean_or_none(values: list[float | None]) -> float | None:
+    return _candidate_mean_or_none(values)
+
+
+def _load_candidate_set(name: str) -> CandidateSet:
+    payload = _load_json(_fixture_path(name))
+    seeds: list[CandidateSeed] = []
+    for index, item in enumerate(payload["candidates"]):
+        destinations = [_load_entry(entry, Destination.from_dict) for entry in item["destinations"]]
+        lodging_options = [_load_entry(entry, LodgingOption.from_dict) for entry in item["lodging_options"]]
+        transport_options = [_load_entry(entry, TransportOption.from_dict) for entry in item["transport_options"]]
+        activity_options = [_load_entry(entry, ActivityOption.from_dict) for entry in item["activity_options"]]
+        bundle = InventoryBundle(
+            bundle_id=item["bundle_id"],
+            title=item["title"],
+            bundle_context=item.get("bundle_context", "mixed"),
+            destinations=destinations,
+            lodging_options=lodging_options,
+            transport_options=transport_options,
+            activity_options=activity_options,
+            composition_summary=BundleCompositionSummary(
+                sequence_index=index,
+                assembly_role="candidate_seed",
+                primary_destination_id=destinations[0].destination_id,
+                component_option_ids=[
+                    option.option_id
+                    for option in lodging_options + transport_options + activity_options
+                ],
+                notes=["Representative ranking showcase candidate."],
+            ),
+            provenance_summary=BundleProvenanceSummary(
+                source_refs=_aggregate_source_refs(
+                    destinations,
+                    lodging_options,
+                    transport_options,
+                    activity_options,
+                ),
+                booking_links=_aggregate_booking_links(
+                    lodging_options,
+                    transport_options,
+                    activity_options,
+                ),
+            ),
+            quality_value_fit=BundleQualityValueFitSummary(
+                quality_signal=_mean_or_none(
+                    [option.quality_summary.overall_signal for option in lodging_options]
+                    + [option.quality_summary.overall_signal for option in activity_options]
+                    + [option.experience_summary.comfort_signal for option in transport_options]
+                ),
+                value_signal=_mean_or_none(
+                    [option.value_summary.overall_signal for option in lodging_options]
+                    + [option.value_summary.overall_signal for option in activity_options]
+                    + [option.fit_summary.policy_fit_signal for option in transport_options]
+                ),
+                fit_signal=_mean_or_none(
+                    [option.fit_summary.overall_signal for option in lodging_options]
+                    + [option.fit_summary.overall_signal for option in activity_options]
+                    + [option.fit_summary.overall_signal for option in transport_options]
+                ),
+            ),
+            feasibility=BundleFeasibility(
+                available=True,
+                internally_consistent=True,
+            ),
+            explanation=BundleExplanation(
+                headline=item["title"],
+                strengths=list(item.get("strengths", [])),
+                tradeoffs=list(item.get("tradeoffs", [])),
+                evidence=["Built from representative ranking showcase fixtures."],
+            ),
+            summary=item["summary"],
+            tags=list(item.get("tags", [])),
+            notes=list(item.get("notes", [])),
+        )
+        seeds.append(
+            CandidateSeed(
+                candidate_id=item["candidate_id"],
+                bundle=bundle,
+                supported_purposes=["profile_learning"],
+                inclusion_reasons=list(item.get("strengths", [])),
+                unresolved_risks=list(item.get("tradeoffs", [])),
+                policy_ready=True,
+            )
+        )
+    return CandidateSet(
+        candidate_set_id=f"candidate-set:{payload['trip_id']}:showcase",
+        trip_id=payload["trip_id"],
+        purpose="profile_learning",
+        seeds=seeds,
+        explanation=["Representative candidate showcase for deterministic leisure ranking tests."],
+        source_refs=[
+            source_ref
+            for seed in seeds
+            for source_ref in seed.bundle.provenance_summary.source_refs
+        ],
+        selection_limit=len(seeds),
+    )
+
+
+def test_rank_leisure_candidates_emits_bundle_rankings_with_explanations() -> None:
+    candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
+    fixture = load_fixture_map()["discovery-wanderer"]
+    resolved = resolve_leisure_profile(fixture.profile, fixture.evidence)
+    objectives = derive_itinerary_objectives(resolved, trip_id=candidate_set.trip_id)
+
+    result_set = rank_leisure_candidates(
+        trip_id=candidate_set.trip_id,
+        resolved_profile=resolved,
+        candidate_set=candidate_set,
+        objectives=objectives,
+    )
+
+    assert result_set.title == "Leisure candidate ranking"
+    assert len(result_set.results) == 4
+    assert result_set.results[0].result_kind == "bundle"
+    assert result_set.results[0].target_bundle_id is not None
+    assert result_set.results[0].explanation_records
+    assert result_set.results[0].confidence_summary.overall_confidence is not None
+    assert result_set.results[0].score_breakdown.component_contributions
+
+
+def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> None:
+    candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
+    fixtures = load_fixture_map()
+
+    urban = resolve_leisure_profile(
+        fixtures["urban-historian"].profile,
+        fixtures["urban-historian"].evidence,
+    )
+    quality_floor = resolve_leisure_profile(
+        fixtures["quality-floors-under-budget-pressure"].profile,
+        fixtures["quality-floors-under-budget-pressure"].evidence,
+    )
+
+    urban_ranked = rank_leisure_candidates(
+        trip_id=candidate_set.trip_id,
+        resolved_profile=urban,
+        candidate_set=candidate_set,
+    )
+    quality_ranked = rank_leisure_candidates(
+        trip_id=candidate_set.trip_id,
+        resolved_profile=quality_floor,
+        candidate_set=candidate_set,
+    )
+
+    assert urban_ranked.results[0].target_bundle_id == "bundle:discovery-drift"
+    assert quality_ranked.results[0].target_bundle_id == "bundle:comfort-floor"
+    assert urban_ranked.results[0].target_bundle_id != quality_ranked.results[0].target_bundle_id
+
+
+def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> None:
+    candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
+    fixture = load_fixture_map()["breadth-under-recovery-pressure"]
+    resolved = resolve_leisure_profile(fixture.profile, fixture.evidence)
+
+    result_set = rank_leisure_candidates(
+        trip_id=candidate_set.trip_id,
+        resolved_profile=resolved,
+        candidate_set=candidate_set,
+    )
+
+    first_result = result_set.results[0]
+    assert first_result.confidence_summary.low_confidence_flags
+    assert any(
+        penalty.reason_code == "preference_tension"
+        for penalty in first_result.score_breakdown.penalties
+    )
+    assert any(risk.code == "preference_tension" for risk in first_result.unresolved_risks)
+
+
+def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
+    candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
+    fixture = load_fixture_map()["route-coherence-first"]
+    resolved = resolve_leisure_profile(fixture.profile, fixture.evidence)
+
+    result_set = rank_leisure_candidates(
+        trip_id=candidate_set.trip_id,
+        resolved_profile=resolved,
+        bundles=[seed.bundle for seed in candidate_set.seeds],
+    )
+
+    assert len(result_set.results) == len(candidate_set.seeds)
+    assert result_set.results[0].target_bundle_id is not None
+    assert result_set.results[0].score == result_set.results[0].score_breakdown.final_score

--- a/tests/ranking/test_leisure.py
+++ b/tests/ranking/test_leisure.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from trip_planner.candidates import CandidateSeed, CandidateSet
 from trip_planner.itinerary import derive_itinerary_objectives
+from trip_planner.itinerary.feasibility import FeasibilityAssessment
 from trip_planner.options import (
     ActivityOption,
     BundleCompositionSummary,
@@ -85,20 +86,15 @@ def _load_candidate_set(name: str) -> CandidateSet:
     payload = _load_json(_fixture_path(name))
     seeds: list[CandidateSeed] = []
     for index, item in enumerate(payload["candidates"]):
-        destinations = [
-            _load_entry(entry, Destination.from_dict) for entry in item["destinations"]
-        ]
+        destinations = [_load_entry(entry, Destination.from_dict) for entry in item["destinations"]]
         lodging_options = [
-            _load_entry(entry, LodgingOption.from_dict)
-            for entry in item["lodging_options"]
+            _load_entry(entry, LodgingOption.from_dict) for entry in item["lodging_options"]
         ]
         transport_options = [
-            _load_entry(entry, TransportOption.from_dict)
-            for entry in item["transport_options"]
+            _load_entry(entry, TransportOption.from_dict) for entry in item["transport_options"]
         ]
         activity_options = [
-            _load_entry(entry, ActivityOption.from_dict)
-            for entry in item["activity_options"]
+            _load_entry(entry, ActivityOption.from_dict) for entry in item["activity_options"]
         ]
         bundle = InventoryBundle(
             bundle_id=item["bundle_id"],
@@ -133,37 +129,19 @@ def _load_candidate_set(name: str) -> CandidateSet:
             ),
             quality_value_fit=BundleQualityValueFitSummary(
                 quality_signal=_mean_or_none(
-                    [
-                        option.quality_summary.overall_signal
-                        for option in lodging_options
-                    ]
-                    + [
-                        option.quality_summary.overall_signal
-                        for option in activity_options
-                    ]
-                    + [
-                        option.experience_summary.comfort_signal
-                        for option in transport_options
-                    ]
+                    [option.quality_summary.overall_signal for option in lodging_options]
+                    + [option.quality_summary.overall_signal for option in activity_options]
+                    + [option.experience_summary.comfort_signal for option in transport_options]
                 ),
                 value_signal=_mean_or_none(
                     [option.value_summary.overall_signal for option in lodging_options]
-                    + [
-                        option.value_summary.overall_signal
-                        for option in activity_options
-                    ]
-                    + [
-                        option.fit_summary.policy_fit_signal
-                        for option in transport_options
-                    ]
+                    + [option.value_summary.overall_signal for option in activity_options]
+                    + [option.fit_summary.policy_fit_signal for option in transport_options]
                 ),
                 fit_signal=_mean_or_none(
                     [option.fit_summary.overall_signal for option in lodging_options]
                     + [option.fit_summary.overall_signal for option in activity_options]
-                    + [
-                        option.fit_summary.overall_signal
-                        for option in transport_options
-                    ]
+                    + [option.fit_summary.overall_signal for option in transport_options]
                 ),
             ),
             feasibility=BundleFeasibility(
@@ -195,9 +173,7 @@ def _load_candidate_set(name: str) -> CandidateSet:
         trip_id=payload["trip_id"],
         purpose="profile_learning",
         seeds=seeds,
-        explanation=[
-            "Representative candidate showcase for deterministic leisure ranking tests."
-        ],
+        explanation=["Representative candidate showcase for deterministic leisure ranking tests."],
         source_refs=[
             source_ref
             for seed in seeds
@@ -229,9 +205,7 @@ def test_rank_leisure_candidates_emits_bundle_rankings_with_explanations() -> No
     assert result_set.results[0].score_breakdown.component_contributions
 
 
-def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> (
-    None
-):
+def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> None:
     candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
     fixtures = load_fixture_map()
 
@@ -257,10 +231,7 @@ def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles
 
     assert urban_ranked.results[0].target_bundle_id == "bundle:discovery-drift"
     assert quality_ranked.results[0].target_bundle_id == "bundle:comfort-floor"
-    assert (
-        urban_ranked.results[0].target_bundle_id
-        != quality_ranked.results[0].target_bundle_id
-    )
+    assert urban_ranked.results[0].target_bundle_id != quality_ranked.results[0].target_bundle_id
 
 
 def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> None:
@@ -280,9 +251,7 @@ def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> N
         penalty.reason_code == "preference_tension"
         for penalty in first_result.score_breakdown.penalties
     )
-    assert any(
-        risk.code == "preference_tension" for risk in first_result.unresolved_risks
-    )
+    assert any(risk.code == "preference_tension" for risk in first_result.unresolved_risks)
 
 
 def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
@@ -298,9 +267,7 @@ def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
 
     assert len(result_set.results) == len(candidate_set.seeds)
     assert result_set.results[0].target_bundle_id is not None
-    assert (
-        result_set.results[0].score == result_set.results[0].score_breakdown.final_score
-    )
+    assert result_set.results[0].score == result_set.results[0].score_breakdown.final_score
 
 
 def test_rank_leisure_candidates_filters_empty_human_summary_entries() -> None:
@@ -321,3 +288,47 @@ def test_rank_leisure_candidates_filters_empty_human_summary_entries() -> None:
     for record in result_set.results[0].explanation_records:
         assert record.human_summary
         assert all(item for item in record.human_summary)
+
+
+def test_rank_leisure_candidates_preserves_zero_signals() -> None:
+    candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
+    first_bundle = candidate_set.seeds[0].bundle
+    first_bundle.quality_value_fit.value_signal = 0.0
+    first_bundle.quality_value_fit.fit_signal = 0.0
+    feasibility = FeasibilityAssessment(
+        assessment_id=f"assessment:{first_bundle.bundle_id}",
+        bundle_id=first_bundle.bundle_id,
+        feasible=True,
+        recommended_for_ranking=True,
+        schedule_protection_required=False,
+        confidence_signal=0.0,
+    )
+
+    fixture = load_fixture_map()["discovery-wanderer"]
+    resolved = resolve_leisure_profile(fixture.profile, fixture.evidence)
+
+    result_set = rank_leisure_candidates(
+        trip_id=candidate_set.trip_id,
+        resolved_profile=resolved,
+        candidate_set=candidate_set,
+        feasibility_by_bundle_id={first_bundle.bundle_id: feasibility},
+    )
+
+    first_result = next(
+        result for result in result_set.results if result.target_bundle_id == first_bundle.bundle_id
+    )
+    bundle_fit = next(
+        contribution
+        for contribution in first_result.score_breakdown.component_contributions
+        if contribution.axis_key == "bundle_fit"
+    )
+    quality_value = next(
+        contribution
+        for contribution in first_result.score_breakdown.component_contributions
+        if contribution.axis_key == "quality_value"
+    )
+
+    assert bundle_fit.normalized_signal == 0.0
+    assert quality_value.normalized_signal is not None
+    assert quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
+    assert "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes

--- a/tests/ranking/test_leisure.py
+++ b/tests/ranking/test_leisure.py
@@ -86,15 +86,20 @@ def _load_candidate_set(name: str) -> CandidateSet:
     payload = _load_json(_fixture_path(name))
     seeds: list[CandidateSeed] = []
     for index, item in enumerate(payload["candidates"]):
-        destinations = [_load_entry(entry, Destination.from_dict) for entry in item["destinations"]]
+        destinations = [
+            _load_entry(entry, Destination.from_dict) for entry in item["destinations"]
+        ]
         lodging_options = [
-            _load_entry(entry, LodgingOption.from_dict) for entry in item["lodging_options"]
+            _load_entry(entry, LodgingOption.from_dict)
+            for entry in item["lodging_options"]
         ]
         transport_options = [
-            _load_entry(entry, TransportOption.from_dict) for entry in item["transport_options"]
+            _load_entry(entry, TransportOption.from_dict)
+            for entry in item["transport_options"]
         ]
         activity_options = [
-            _load_entry(entry, ActivityOption.from_dict) for entry in item["activity_options"]
+            _load_entry(entry, ActivityOption.from_dict)
+            for entry in item["activity_options"]
         ]
         bundle = InventoryBundle(
             bundle_id=item["bundle_id"],
@@ -129,19 +134,37 @@ def _load_candidate_set(name: str) -> CandidateSet:
             ),
             quality_value_fit=BundleQualityValueFitSummary(
                 quality_signal=_mean_or_none(
-                    [option.quality_summary.overall_signal for option in lodging_options]
-                    + [option.quality_summary.overall_signal for option in activity_options]
-                    + [option.experience_summary.comfort_signal for option in transport_options]
+                    [
+                        option.quality_summary.overall_signal
+                        for option in lodging_options
+                    ]
+                    + [
+                        option.quality_summary.overall_signal
+                        for option in activity_options
+                    ]
+                    + [
+                        option.experience_summary.comfort_signal
+                        for option in transport_options
+                    ]
                 ),
                 value_signal=_mean_or_none(
                     [option.value_summary.overall_signal for option in lodging_options]
-                    + [option.value_summary.overall_signal for option in activity_options]
-                    + [option.fit_summary.policy_fit_signal for option in transport_options]
+                    + [
+                        option.value_summary.overall_signal
+                        for option in activity_options
+                    ]
+                    + [
+                        option.fit_summary.policy_fit_signal
+                        for option in transport_options
+                    ]
                 ),
                 fit_signal=_mean_or_none(
                     [option.fit_summary.overall_signal for option in lodging_options]
                     + [option.fit_summary.overall_signal for option in activity_options]
-                    + [option.fit_summary.overall_signal for option in transport_options]
+                    + [
+                        option.fit_summary.overall_signal
+                        for option in transport_options
+                    ]
                 ),
             ),
             feasibility=BundleFeasibility(
@@ -173,7 +196,9 @@ def _load_candidate_set(name: str) -> CandidateSet:
         trip_id=payload["trip_id"],
         purpose="profile_learning",
         seeds=seeds,
-        explanation=["Representative candidate showcase for deterministic leisure ranking tests."],
+        explanation=[
+            "Representative candidate showcase for deterministic leisure ranking tests."
+        ],
         source_refs=[
             source_ref
             for seed in seeds
@@ -205,7 +230,9 @@ def test_rank_leisure_candidates_emits_bundle_rankings_with_explanations() -> No
     assert result_set.results[0].score_breakdown.component_contributions
 
 
-def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> None:
+def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> (
+    None
+):
     candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
     fixtures = load_fixture_map()
 
@@ -231,7 +258,10 @@ def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles
 
     assert urban_ranked.results[0].target_bundle_id == "bundle:discovery-drift"
     assert quality_ranked.results[0].target_bundle_id == "bundle:comfort-floor"
-    assert urban_ranked.results[0].target_bundle_id != quality_ranked.results[0].target_bundle_id
+    assert (
+        urban_ranked.results[0].target_bundle_id
+        != quality_ranked.results[0].target_bundle_id
+    )
 
 
 def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> None:
@@ -251,7 +281,9 @@ def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> N
         penalty.reason_code == "preference_tension"
         for penalty in first_result.score_breakdown.penalties
     )
-    assert any(risk.code == "preference_tension" for risk in first_result.unresolved_risks)
+    assert any(
+        risk.code == "preference_tension" for risk in first_result.unresolved_risks
+    )
 
 
 def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
@@ -267,7 +299,9 @@ def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
 
     assert len(result_set.results) == len(candidate_set.seeds)
     assert result_set.results[0].target_bundle_id is not None
-    assert result_set.results[0].score == result_set.results[0].score_breakdown.final_score
+    assert (
+        result_set.results[0].score == result_set.results[0].score_breakdown.final_score
+    )
 
 
 def test_rank_leisure_candidates_filters_empty_human_summary_entries() -> None:
@@ -315,7 +349,9 @@ def test_rank_leisure_candidates_preserves_zero_signals() -> None:
     )
 
     first_result = next(
-        result for result in result_set.results if result.target_bundle_id == first_bundle.bundle_id
+        result
+        for result in result_set.results
+        if result.target_bundle_id == first_bundle.bundle_id
     )
     bundle_fit = next(
         contribution
@@ -330,5 +366,9 @@ def test_rank_leisure_candidates_preserves_zero_signals() -> None:
 
     assert bundle_fit.normalized_signal == 0.0
     assert quality_value.normalized_signal is not None
-    assert quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
-    assert "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes
+    assert (
+        quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
+    )
+    assert (
+        "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes
+    )

--- a/tests/ranking/test_leisure.py
+++ b/tests/ranking/test_leisure.py
@@ -86,20 +86,15 @@ def _load_candidate_set(name: str) -> CandidateSet:
     payload = _load_json(_fixture_path(name))
     seeds: list[CandidateSeed] = []
     for index, item in enumerate(payload["candidates"]):
-        destinations = [
-            _load_entry(entry, Destination.from_dict) for entry in item["destinations"]
-        ]
+        destinations = [_load_entry(entry, Destination.from_dict) for entry in item["destinations"]]
         lodging_options = [
-            _load_entry(entry, LodgingOption.from_dict)
-            for entry in item["lodging_options"]
+            _load_entry(entry, LodgingOption.from_dict) for entry in item["lodging_options"]
         ]
         transport_options = [
-            _load_entry(entry, TransportOption.from_dict)
-            for entry in item["transport_options"]
+            _load_entry(entry, TransportOption.from_dict) for entry in item["transport_options"]
         ]
         activity_options = [
-            _load_entry(entry, ActivityOption.from_dict)
-            for entry in item["activity_options"]
+            _load_entry(entry, ActivityOption.from_dict) for entry in item["activity_options"]
         ]
         bundle = InventoryBundle(
             bundle_id=item["bundle_id"],
@@ -134,37 +129,19 @@ def _load_candidate_set(name: str) -> CandidateSet:
             ),
             quality_value_fit=BundleQualityValueFitSummary(
                 quality_signal=_mean_or_none(
-                    [
-                        option.quality_summary.overall_signal
-                        for option in lodging_options
-                    ]
-                    + [
-                        option.quality_summary.overall_signal
-                        for option in activity_options
-                    ]
-                    + [
-                        option.experience_summary.comfort_signal
-                        for option in transport_options
-                    ]
+                    [option.quality_summary.overall_signal for option in lodging_options]
+                    + [option.quality_summary.overall_signal for option in activity_options]
+                    + [option.experience_summary.comfort_signal for option in transport_options]
                 ),
                 value_signal=_mean_or_none(
                     [option.value_summary.overall_signal for option in lodging_options]
-                    + [
-                        option.value_summary.overall_signal
-                        for option in activity_options
-                    ]
-                    + [
-                        option.fit_summary.policy_fit_signal
-                        for option in transport_options
-                    ]
+                    + [option.value_summary.overall_signal for option in activity_options]
+                    + [option.fit_summary.policy_fit_signal for option in transport_options]
                 ),
                 fit_signal=_mean_or_none(
                     [option.fit_summary.overall_signal for option in lodging_options]
                     + [option.fit_summary.overall_signal for option in activity_options]
-                    + [
-                        option.fit_summary.overall_signal
-                        for option in transport_options
-                    ]
+                    + [option.fit_summary.overall_signal for option in transport_options]
                 ),
             ),
             feasibility=BundleFeasibility(
@@ -196,9 +173,7 @@ def _load_candidate_set(name: str) -> CandidateSet:
         trip_id=payload["trip_id"],
         purpose="profile_learning",
         seeds=seeds,
-        explanation=[
-            "Representative candidate showcase for deterministic leisure ranking tests."
-        ],
+        explanation=["Representative candidate showcase for deterministic leisure ranking tests."],
         source_refs=[
             source_ref
             for seed in seeds
@@ -230,9 +205,7 @@ def test_rank_leisure_candidates_emits_bundle_rankings_with_explanations() -> No
     assert result_set.results[0].score_breakdown.component_contributions
 
 
-def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> (
-    None
-):
+def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles() -> None:
     candidate_set = _load_candidate_set("leisure_candidate_showcase.json")
     fixtures = load_fixture_map()
 
@@ -258,10 +231,7 @@ def test_rank_leisure_candidates_reorders_same_candidates_for_different_profiles
 
     assert urban_ranked.results[0].target_bundle_id == "bundle:discovery-drift"
     assert quality_ranked.results[0].target_bundle_id == "bundle:comfort-floor"
-    assert (
-        urban_ranked.results[0].target_bundle_id
-        != quality_ranked.results[0].target_bundle_id
-    )
+    assert urban_ranked.results[0].target_bundle_id != quality_ranked.results[0].target_bundle_id
 
 
 def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> None:
@@ -281,9 +251,7 @@ def test_rank_leisure_candidates_keeps_tension_and_low_confidence_visible() -> N
         penalty.reason_code == "preference_tension"
         for penalty in first_result.score_breakdown.penalties
     )
-    assert any(
-        risk.code == "preference_tension" for risk in first_result.unresolved_risks
-    )
+    assert any(risk.code == "preference_tension" for risk in first_result.unresolved_risks)
 
 
 def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
@@ -299,9 +267,7 @@ def test_rank_leisure_candidates_accepts_raw_bundles() -> None:
 
     assert len(result_set.results) == len(candidate_set.seeds)
     assert result_set.results[0].target_bundle_id is not None
-    assert (
-        result_set.results[0].score == result_set.results[0].score_breakdown.final_score
-    )
+    assert result_set.results[0].score == result_set.results[0].score_breakdown.final_score
 
 
 def test_rank_leisure_candidates_filters_empty_human_summary_entries() -> None:
@@ -349,9 +315,7 @@ def test_rank_leisure_candidates_preserves_zero_signals() -> None:
     )
 
     first_result = next(
-        result
-        for result in result_set.results
-        if result.target_bundle_id == first_bundle.bundle_id
+        result for result in result_set.results if result.target_bundle_id == first_bundle.bundle_id
     )
     bundle_fit = next(
         contribution
@@ -367,9 +331,5 @@ def test_rank_leisure_candidates_preserves_zero_signals() -> None:
     assert bundle_fit.normalized_signal == 0.0
     assert quality_value.normalized_signal is not None
     assert first_bundle.quality_value_fit.quality_signal is not None
-    assert (
-        quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
-    )
-    assert (
-        "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes
-    )
+    assert quality_value.normalized_signal < first_bundle.quality_value_fit.quality_signal
+    assert "Feasibility confidence signal=0.00." in first_result.confidence_summary.notes

--- a/tests/sources/test_snapshots.py
+++ b/tests/sources/test_snapshots.py
@@ -131,7 +131,9 @@ def test_snapshot_requires_query_scope_and_kind_match() -> None:
     except ValueError as exc:
         assert "query.entity_scope" in str(exc) or "query.option_kind" in str(exc)
     else:
-        raise AssertionError("RawSnapshot should reject inconsistent query scope or option kind")
+        raise AssertionError(
+            "RawSnapshot should reject inconsistent query scope or option kind"
+        )
 
 
 def test_snapshot_requires_record_scope_match() -> None:
@@ -163,4 +165,6 @@ def test_snapshot_requires_record_scope_match() -> None:
     except ValueError as exc:
         assert "record.entity_scope" in str(exc)
     else:
-        raise AssertionError("RawSnapshot should reject records with a mismatched entity_scope")
+        raise AssertionError(
+            "RawSnapshot should reject records with a mismatched entity_scope"
+        )

--- a/tests/sources/test_source_models.py
+++ b/tests/sources/test_source_models.py
@@ -1,4 +1,8 @@
-from trip_planner.sources import QualityValueFitSummary, SourceRecord, SourceTrustSignals
+from trip_planner.sources import (
+    QualityValueFitSummary,
+    SourceRecord,
+    SourceTrustSignals,
+)
 
 
 def test_source_record_supports_editorial_leisure_source() -> None:
@@ -56,7 +60,9 @@ def test_source_record_supports_managed_travel_source() -> None:
             review_consistency=0.6,
         ),
         business_approval_status="preferred",
-        business_approval_notes=["Default managed-travel channel for enterprise clients."],
+        business_approval_notes=[
+            "Default managed-travel channel for enterprise clients."
+        ],
     )
 
     assert record.business_approval_status == "preferred"

--- a/tests/sources/test_source_provenance.py
+++ b/tests/sources/test_source_provenance.py
@@ -54,7 +54,9 @@ def test_provenance_reference_supports_policy_ready_proposal() -> None:
         locator="policy://org/demo/travel",
         captured_at="2026-03-15T12:00:00Z",
         freshness_days_at_capture=0,
-        notes=["Retain this record in the approval packet for downstream audit trails."],
+        notes=[
+            "Retain this record in the approval packet for downstream audit trails."
+        ],
     )
 
     assert reference.subject_kind == "proposal"
@@ -92,7 +94,9 @@ def test_provenance_reference_rejects_invalid_contribution_kind() -> None:
     except ValueError as exc:
         assert "contribution_kind" in str(exc)
     else:
-        raise AssertionError("ProvenanceReference should reject invalid contribution kinds")
+        raise AssertionError(
+            "ProvenanceReference should reject invalid contribution kinds"
+        )
 
 
 def test_provenance_reference_rejects_negative_capture_freshness() -> None:
@@ -110,4 +114,6 @@ def test_provenance_reference_rejects_negative_capture_freshness() -> None:
     except ValueError as exc:
         assert "freshness_days_at_capture" in str(exc)
     else:
-        raise AssertionError("ProvenanceReference should reject negative freshness_days_at_capture")
+        raise AssertionError(
+            "ProvenanceReference should reject negative freshness_days_at_capture"
+        )

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -54,4 +54,6 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
         if dependency not in lock_versions and normalised not in lock_versions:
             missing.append(dependency)
 
-    assert not missing, "requirements.lock is missing pinned versions for: " + ", ".join(missing)
+    assert (
+        not missing
+    ), "requirements.lock is missing pinned versions for: " + ", ".join(missing)

--- a/tests/test_generate_segments.py
+++ b/tests/test_generate_segments.py
@@ -16,7 +16,9 @@ def fake_chat_completion(*args, **kwargs):
     fake_resp.choices = [
         MagicMock(
             message=MagicMock(
-                content=json.dumps([{"id": "SEG1", "Nat": 3, "Cult": 2, "GS": 4, "EB": 3}])
+                content=json.dumps(
+                    [{"id": "SEG1", "Nat": 3, "Cult": 2, "GS": 4, "EB": 3}]
+                )
             )
         )
     ]

--- a/trip_planner/business/objective_derivation.py
+++ b/trip_planner/business/objective_derivation.py
@@ -32,7 +32,9 @@ def _effective_required_channels(
     profile: BusinessTravelProfile,
     constraint_set: PolicyConstraintSet | None,
 ) -> list[str]:
-    constraint_channels = constraint_set.required_booking_channels if constraint_set else []
+    constraint_channels = (
+        constraint_set.required_booking_channels if constraint_set else []
+    )
     return _merge_unique(
         constraint_channels,
         profile.policy_constraints.required_booking_channels,
@@ -44,7 +46,9 @@ def _effective_documentation_rules(
     constraint_set: PolicyConstraintSet | None,
 ) -> list[str]:
     constraint_rules = constraint_set.documentation_rules if constraint_set else []
-    return _merge_unique(constraint_rules, profile.policy_constraints.documentation_rules)
+    return _merge_unique(
+        constraint_rules, profile.policy_constraints.documentation_rules
+    )
 
 
 def _effective_allowed_exception_types(
@@ -69,9 +73,13 @@ def _channel_strategy(
 
     notes = []
     if required_channels:
-        notes.append("Prioritize required booking channels before evaluating convenience.")
+        notes.append(
+            "Prioritize required booking channels before evaluating convenience."
+        )
     if profile.vendor_constraints.approved_vendors:
-        notes.append("Approved vendors remain preferred after channel compliance is satisfied.")
+        notes.append(
+            "Approved vendors remain preferred after channel compliance is satisfied."
+        )
     if profile.vendor_constraints.disallowed_vendors:
         notes.append("Disallowed vendors should be excluded from option assembly.")
     return BookingChannelObjectives(
@@ -98,7 +106,9 @@ def _schedule_protection(
         f"Required presence windows={len(profile.trip_purpose.required_presence_windows)}.",
     ]
     if profile.schedule_requirements.same_day_return_tolerance <= 0.25:
-        notes.append("Avoid same-day return plans unless they clearly preserve readiness.")
+        notes.append(
+            "Avoid same-day return plans unless they clearly preserve readiness."
+        )
     if profile.schedule_requirements.red_eye_tolerance == 0.0:
         notes.append("Red-eye options should not be preferred in default planning.")
     return ScheduleProtectionObjectives(
@@ -137,7 +147,9 @@ def _justification_readiness(
     profile: BusinessTravelProfile,
     constraint_set: PolicyConstraintSet | None,
 ) -> JustificationReadinessObjectives:
-    required_fields = _sorted_strings(profile.documentation_requirements.justification_fields)
+    required_fields = _sorted_strings(
+        profile.documentation_requirements.justification_fields
+    )
     if profile.approval_targets.needs_exception_preclearance:
         required_fields = _merge_unique(required_fields, ["exception rationale"])
     documentation_rules = _effective_documentation_rules(profile, constraint_set)
@@ -177,7 +189,9 @@ def _cost_control_posture(profile: BusinessTravelProfile) -> CostControlObjectiv
     if profile.cost_controls.splurge_requires_justification:
         notes.append("Higher-comfort upgrades require explicit justification support.")
     if convenience >= 0.7:
-        notes.append("Traveler convenience remains material once policy gates are satisfied.")
+        notes.append(
+            "Traveler convenience remains material once policy gates are satisfied."
+        )
     return CostControlObjectives(
         posture=posture,
         overall_cost_priority=overall,
@@ -235,7 +249,9 @@ def _exception_path(
     if allowed_exception_types:
         notes.append("Allowed exception types: " + ", ".join(allowed_exception_types))
     if profile.exception_strategy.require_additional_comparables:
-        notes.append("Prepare additional comparables before escalating exception paths.")
+        notes.append(
+            "Prepare additional comparables before escalating exception paths."
+        )
     return ExceptionPathObjectives(
         posture=posture,
         fallback_mode=fallback_mode,
@@ -294,7 +310,9 @@ def _planning_paths(
             "Use the nearest policy fit when a clean compliant plan may not preserve the trip objective.",
         ]
         + (
-            ["Retain comparables and justification material so review can explain the fallback."]
+            [
+                "Retain comparables and justification material so review can explain the fallback."
+            ]
             if fallback_active
             else []
         ),
@@ -328,14 +346,19 @@ def _build_explanations(
         "comparison_requirements:"
         + ",".join(
             f"{key}={value}"
-            for key, value in sorted(profile.vendor_constraints.comparison_requirements.items())
+            for key, value in sorted(
+                profile.vendor_constraints.comparison_requirements.items()
+            )
         ),
         "justification_fields:"
         + ",".join(
-            _sorted_strings(profile.documentation_requirements.justification_fields) or ["none"]
+            _sorted_strings(profile.documentation_requirements.justification_fields)
+            or ["none"]
         ),
         "approval_roles:"
-        + ",".join(_sorted_strings(profile.approval_targets.approval_roles) or ["none"]),
+        + ",".join(
+            _sorted_strings(profile.approval_targets.approval_roles) or ["none"]
+        ),
         f"fallback_mode:{profile.exception_strategy.fallback_mode}",
         f"compliant_first_active:{str(compliant_first_path.active).lower()}",
         f"policy_nearest_fallback_active:{str(policy_nearest_fallback.active).lower()}",

--- a/trip_planner/business/objectives.py
+++ b/trip_planner/business/objectives.py
@@ -37,7 +37,9 @@ def _require_positive_int_mapping(mapping: dict[str, int], field_name: str) -> N
             raise ValueError(f"{field_name}[{key}] must be positive")
 
 
-def _require_string_list_mapping(mapping: dict[str, list[str]], field_name: str) -> None:
+def _require_string_list_mapping(
+    mapping: dict[str, list[str]], field_name: str
+) -> None:
     if any(not isinstance(key, str) or not key for key in mapping):
         raise ValueError(f"{field_name} must use non-empty string keys")
     for key, value in mapping.items():
@@ -102,10 +104,13 @@ class ScheduleProtectionObjectives:
 
     def __post_init__(self) -> None:
         if self.protection_level not in SCHEDULE_PROTECTION_LEVELS:
-            raise ValueError(f"protection_level must be one of {SCHEDULE_PROTECTION_LEVELS}")
+            raise ValueError(
+                f"protection_level must be one of {SCHEDULE_PROTECTION_LEVELS}"
+            )
         if self.arrival_buffer_preference not in schema.ARRIVAL_BUFFER_PREFERENCES:
             raise ValueError(
-                "arrival_buffer_preference must be one of " f"{schema.ARRIVAL_BUFFER_PREFERENCES}"
+                "arrival_buffer_preference must be one of "
+                f"{schema.ARRIVAL_BUFFER_PREFERENCES}"
             )
         require_probability(self.same_day_return_tolerance, "same_day_return_tolerance")
         require_probability(self.red_eye_tolerance, "red_eye_tolerance")
@@ -200,7 +205,9 @@ class ExceptionPathObjectives:
         if self.posture not in EXCEPTION_PATH_POSTURES:
             raise ValueError(f"posture must be one of {EXCEPTION_PATH_POSTURES}")
         if self.fallback_mode not in schema.EXCEPTION_FALLBACK_MODES:
-            raise ValueError(f"fallback_mode must be one of {schema.EXCEPTION_FALLBACK_MODES}")
+            raise ValueError(
+                f"fallback_mode must be one of {schema.EXCEPTION_FALLBACK_MODES}"
+            )
         require_strings(self.allowed_exception_types, "allowed_exception_types")
         require_strings(self.approval_roles, "approval_roles")
         require_strings(self.notes, "notes")
@@ -213,11 +220,17 @@ class ExceptionPathObjectives:
 class BusinessPlanningObjectives:
     objective_id: str
     trip_id: str
-    compliant_first_path: PlanningPathObjectives = field(default_factory=PlanningPathObjectives)
-    policy_nearest_fallback: PlanningPathObjectives = field(
-        default_factory=lambda: PlanningPathObjectives(mode="policy_nearest", active=False)
+    compliant_first_path: PlanningPathObjectives = field(
+        default_factory=PlanningPathObjectives
     )
-    channel_strategy: BookingChannelObjectives = field(default_factory=BookingChannelObjectives)
+    policy_nearest_fallback: PlanningPathObjectives = field(
+        default_factory=lambda: PlanningPathObjectives(
+            mode="policy_nearest", active=False
+        )
+    )
+    channel_strategy: BookingChannelObjectives = field(
+        default_factory=BookingChannelObjectives
+    )
     schedule_protection: ScheduleProtectionObjectives = field(
         default_factory=ScheduleProtectionObjectives
     )
@@ -227,9 +240,15 @@ class BusinessPlanningObjectives:
     justification_readiness: JustificationReadinessObjectives = field(
         default_factory=JustificationReadinessObjectives
     )
-    cost_control_posture: CostControlObjectives = field(default_factory=CostControlObjectives)
-    comfort_floor_protection: ComfortFloorObjectives = field(default_factory=ComfortFloorObjectives)
-    exception_path_posture: ExceptionPathObjectives = field(default_factory=ExceptionPathObjectives)
+    cost_control_posture: CostControlObjectives = field(
+        default_factory=CostControlObjectives
+    )
+    comfort_floor_protection: ComfortFloorObjectives = field(
+        default_factory=ComfortFloorObjectives
+    )
+    exception_path_posture: ExceptionPathObjectives = field(
+        default_factory=ExceptionPathObjectives
+    )
     explanation_bundle: ObjectiveExplanationBundle = field(
         default_factory=ObjectiveExplanationBundle
     )
@@ -245,17 +264,31 @@ class BusinessPlanningObjectives:
         if not isinstance(self.channel_strategy, BookingChannelObjectives):
             raise ValueError("channel_strategy must be a BookingChannelObjectives")
         if not isinstance(self.schedule_protection, ScheduleProtectionObjectives):
-            raise ValueError("schedule_protection must be a ScheduleProtectionObjectives")
-        if not isinstance(self.comparable_requirements, ComparableRequirementObjectives):
-            raise ValueError("comparable_requirements must be a ComparableRequirementObjectives")
-        if not isinstance(self.justification_readiness, JustificationReadinessObjectives):
-            raise ValueError("justification_readiness must be a JustificationReadinessObjectives")
+            raise ValueError(
+                "schedule_protection must be a ScheduleProtectionObjectives"
+            )
+        if not isinstance(
+            self.comparable_requirements, ComparableRequirementObjectives
+        ):
+            raise ValueError(
+                "comparable_requirements must be a ComparableRequirementObjectives"
+            )
+        if not isinstance(
+            self.justification_readiness, JustificationReadinessObjectives
+        ):
+            raise ValueError(
+                "justification_readiness must be a JustificationReadinessObjectives"
+            )
         if not isinstance(self.cost_control_posture, CostControlObjectives):
             raise ValueError("cost_control_posture must be a CostControlObjectives")
         if not isinstance(self.comfort_floor_protection, ComfortFloorObjectives):
-            raise ValueError("comfort_floor_protection must be a ComfortFloorObjectives")
+            raise ValueError(
+                "comfort_floor_protection must be a ComfortFloorObjectives"
+            )
         if not isinstance(self.exception_path_posture, ExceptionPathObjectives):
-            raise ValueError("exception_path_posture must be an ExceptionPathObjectives")
+            raise ValueError(
+                "exception_path_posture must be an ExceptionPathObjectives"
+            )
         if not isinstance(self.explanation_bundle, ObjectiveExplanationBundle):
             raise ValueError("explanation_bundle must be an ObjectiveExplanationBundle")
         require_strings(self.explanations, "explanations")

--- a/trip_planner/business/profile.py
+++ b/trip_planner/business/profile.py
@@ -42,7 +42,8 @@ class TravelerContext:
             raise ValueError(f"employee_type must be one of {schema.EMPLOYEE_TYPES}")
         if self.traveler_experience not in schema.TRAVELER_EXPERIENCE_LEVELS:
             raise ValueError(
-                "traveler_experience must be one of " f"{schema.TRAVELER_EXPERIENCE_LEVELS}"
+                "traveler_experience must be one of "
+                f"{schema.TRAVELER_EXPERIENCE_LEVELS}"
             )
         require_non_empty(self.home_airport, "home_airport")
         require_strings(self.loyalty_programs, "loyalty_programs")
@@ -56,7 +57,9 @@ class TravelerContext:
 class TripPurpose:
     purpose_type: str
     business_justification: str
-    required_presence_windows: list[RequiredPresenceWindow] = field(default_factory=list)
+    required_presence_windows: list[RequiredPresenceWindow] = field(
+        default_factory=list
+    )
     trip_criticality: str = "medium"
 
     def __post_init__(self) -> None:
@@ -64,7 +67,9 @@ class TripPurpose:
             raise ValueError(f"purpose_type must be one of {schema.PURPOSE_TYPES}")
         require_non_empty(self.business_justification, "business_justification")
         if self.trip_criticality not in schema.TRIP_CRITICALITY_LEVELS:
-            raise ValueError(f"trip_criticality must be one of {schema.TRIP_CRITICALITY_LEVELS}")
+            raise ValueError(
+                f"trip_criticality must be one of {schema.TRIP_CRITICALITY_LEVELS}"
+            )
         if any(
             not isinstance(window, RequiredPresenceWindow)
             for window in self.required_presence_windows
@@ -111,7 +116,9 @@ class VendorConstraints:
         require_strings(self.preferred_vendors, "preferred_vendors")
         require_strings(self.approved_vendors, "approved_vendors")
         require_strings(self.disallowed_vendors, "disallowed_vendors")
-        if any(not isinstance(key, str) or not key for key in self.comparison_requirements):
+        if any(
+            not isinstance(key, str) or not key for key in self.comparison_requirements
+        ):
             raise ValueError("comparison_requirements must use non-empty string keys")
         for key, value in self.comparison_requirements.items():
             if value <= 0:
@@ -131,9 +138,12 @@ class ScheduleRequirements:
     def __post_init__(self) -> None:
         if self.arrival_buffer_preference not in schema.ARRIVAL_BUFFER_PREFERENCES:
             raise ValueError(
-                "arrival_buffer_preference must be one of " f"{schema.ARRIVAL_BUFFER_PREFERENCES}"
+                "arrival_buffer_preference must be one of "
+                f"{schema.ARRIVAL_BUFFER_PREFERENCES}"
             )
-        require_probability(self.meeting_protection_priority, "meeting_protection_priority")
+        require_probability(
+            self.meeting_protection_priority, "meeting_protection_priority"
+        )
         require_probability(self.same_day_return_tolerance, "same_day_return_tolerance")
         require_probability(self.red_eye_tolerance, "red_eye_tolerance")
 
@@ -150,8 +160,12 @@ class CostControls:
 
     def __post_init__(self) -> None:
         require_probability(self.overall_cost_priority, "overall_cost_priority")
-        require_probability(self.policy_compliance_priority, "policy_compliance_priority")
-        require_probability(self.employee_convenience_priority, "employee_convenience_priority")
+        require_probability(
+            self.policy_compliance_priority, "policy_compliance_priority"
+        )
+        require_probability(
+            self.employee_convenience_priority, "employee_convenience_priority"
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -211,7 +225,9 @@ class ExceptionStrategy:
 
     def __post_init__(self) -> None:
         if self.fallback_mode not in schema.EXCEPTION_FALLBACK_MODES:
-            raise ValueError(f"fallback_mode must be one of {schema.EXCEPTION_FALLBACK_MODES}")
+            raise ValueError(
+                f"fallback_mode must be one of {schema.EXCEPTION_FALLBACK_MODES}"
+            )
         require_strings(self.notes, "notes")
 
     def to_dict(self) -> dict[str, Any]:
@@ -275,16 +291,24 @@ class BusinessTravelProfile:
             traveler_context=TravelerContext(**payload["traveler_context"]),
             trip_purpose=TripPurpose(
                 purpose_type=payload["trip_purpose"]["purpose_type"],
-                business_justification=payload["trip_purpose"]["business_justification"],
+                business_justification=payload["trip_purpose"][
+                    "business_justification"
+                ],
                 required_presence_windows=[
                     RequiredPresenceWindow(**item)
-                    for item in payload["trip_purpose"].get("required_presence_windows", [])
+                    for item in payload["trip_purpose"].get(
+                        "required_presence_windows", []
+                    )
                 ],
-                trip_criticality=payload["trip_purpose"].get("trip_criticality", "medium"),
+                trip_criticality=payload["trip_purpose"].get(
+                    "trip_criticality", "medium"
+                ),
             ),
             policy_constraints=PolicyConstraints(**payload["policy_constraints"]),
             vendor_constraints=VendorConstraints(**payload["vendor_constraints"]),
-            schedule_requirements=ScheduleRequirements(**payload["schedule_requirements"]),
+            schedule_requirements=ScheduleRequirements(
+                **payload["schedule_requirements"]
+            ),
             cost_controls=CostControls(**payload["cost_controls"]),
             comfort_floors=ComfortFloors(**payload["comfort_floors"]),
             documentation_requirements=DocumentationRequirements(

--- a/trip_planner/business/schema.py
+++ b/trip_planner/business/schema.py
@@ -18,7 +18,11 @@ PURPOSE_TYPES: Final[tuple[str, ...]] = (
     "other",
 )
 TRIP_CRITICALITY_LEVELS: Final[tuple[str, ...]] = ("low", "medium", "high")
-ARRIVAL_BUFFER_PREFERENCES: Final[tuple[str, ...]] = ("tight", "moderate", "conservative")
+ARRIVAL_BUFFER_PREFERENCES: Final[tuple[str, ...]] = (
+    "tight",
+    "moderate",
+    "conservative",
+)
 EXCEPTION_FALLBACK_MODES: Final[tuple[str, ...]] = (
     "nearest_compliant",
     "document_exception_candidate",

--- a/trip_planner/contracts/objectives.py
+++ b/trip_planner/contracts/objectives.py
@@ -15,7 +15,12 @@ from ._validators import (
 ROUTE_SHAPES: tuple[str, ...] = ("hub_and_spoke", "linear", "regional_cluster", "mixed")
 STRUCTURE_LEVELS: tuple[str, ...] = ("high", "moderate", "elastic")
 DISCOVERY_STYLES: tuple[str, ...] = ("iconic", "balanced", "discovery_forward")
-LODGING_BASE_STYLES: tuple[str, ...] = ("single_base", "few_bases", "multi_base", "mixed")
+LODGING_BASE_STYLES: tuple[str, ...] = (
+    "single_base",
+    "few_bases",
+    "multi_base",
+    "mixed",
+)
 
 
 @dataclass(slots=True)
@@ -171,11 +176,17 @@ class ItineraryObjectives:
     route_shape: str
     target_base_count: CountRange = field(default_factory=CountRange)
     move_density: MoveDensityTarget = field(default_factory=MoveDensityTarget)
-    recovery_expectations: RecoveryExpectations = field(default_factory=RecoveryExpectations)
-    day_structure: DayStructureObjectives = field(default_factory=DayStructureObjectives)
+    recovery_expectations: RecoveryExpectations = field(
+        default_factory=RecoveryExpectations
+    )
+    day_structure: DayStructureObjectives = field(
+        default_factory=DayStructureObjectives
+    )
     discovery_strategy: DiscoveryStrategy = field(default_factory=DiscoveryStrategy)
     budget_protection: BudgetProtection = field(default_factory=BudgetProtection)
-    quality_floor_protection: QualityFloorProtection = field(default_factory=QualityFloorProtection)
+    quality_floor_protection: QualityFloorProtection = field(
+        default_factory=QualityFloorProtection
+    )
     lodging_strategy: LodgingStrategy = field(default_factory=LodgingStrategy)
     transport_strategy: TransportStrategy = field(default_factory=TransportStrategy)
     explanations: list[str] = field(default_factory=list)
@@ -198,7 +209,9 @@ class ItineraryObjectives:
         if not isinstance(self.budget_protection, BudgetProtection):
             raise ValueError("budget_protection must be a BudgetProtection")
         if not isinstance(self.quality_floor_protection, QualityFloorProtection):
-            raise ValueError("quality_floor_protection must be a QualityFloorProtection")
+            raise ValueError(
+                "quality_floor_protection must be a QualityFloorProtection"
+            )
         if not isinstance(self.lodging_strategy, LodgingStrategy):
             raise ValueError("lodging_strategy must be a LodgingStrategy")
         if not isinstance(self.transport_strategy, TransportStrategy):

--- a/trip_planner/contracts/trip.py
+++ b/trip_planner/contracts/trip.py
@@ -8,7 +8,14 @@ from typing import Any
 from ._validators import require_non_empty, require_strings
 
 TRIP_MODES: tuple[str, ...] = ("leisure", "business")
-TRIP_STATUSES: tuple[str, ...] = ("draft", "active", "booked", "in_trip", "completed", "archived")
+TRIP_STATUSES: tuple[str, ...] = (
+    "draft",
+    "active",
+    "booked",
+    "in_trip",
+    "completed",
+    "archived",
+)
 TRAVELER_PARTY_KINDS: tuple[str, ...] = ("solo", "pair", "family", "friends", "team")
 
 

--- a/trip_planner/itinerary/feasibility.py
+++ b/trip_planner/itinerary/feasibility.py
@@ -110,14 +110,23 @@ class FeasibilityAssessment:
         require_strings(self.missing_data_fields, "missing_data_fields")
         require_strings(self.blocking_reasons, "blocking_reasons")
         require_strings(self.notes, "notes")
-        if any(not isinstance(item, TravelTimeEstimate) for item in self.travel_time_estimates):
-            raise ValueError("travel_time_estimates must contain TravelTimeEstimate instances")
+        if any(
+            not isinstance(item, TravelTimeEstimate)
+            for item in self.travel_time_estimates
+        ):
+            raise ValueError(
+                "travel_time_estimates must contain TravelTimeEstimate instances"
+            )
         if any(not isinstance(item, MoveCostSummary) for item in self.move_costs):
             raise ValueError("move_costs must contain MoveCostSummary instances")
         if any(not isinstance(item, TimingConflict) for item in self.timing_conflicts):
             raise ValueError("timing_conflicts must contain TimingConflict instances")
-        if any(not isinstance(item, RouteContinuityWarning) for item in self.route_warnings):
-            raise ValueError("route_warnings must contain RouteContinuityWarning instances")
+        if any(
+            not isinstance(item, RouteContinuityWarning) for item in self.route_warnings
+        ):
+            raise ValueError(
+                "route_warnings must contain RouteContinuityWarning instances"
+            )
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -127,7 +136,8 @@ def _schedule_protection_required(bundle: InventoryBundle) -> bool:
     if any("business" in tag for tag in bundle.tags):
         return True
     if any(
-        lodging.location_summary.business_access_signal and lodging.location_summary.business_access_signal >= 0.8
+        lodging.location_summary.business_access_signal
+        and lodging.location_summary.business_access_signal >= 0.8
         for lodging in bundle.lodging_options
     ):
         return True
@@ -144,7 +154,9 @@ def _arrival_conflicts(bundle: InventoryBundle) -> list[TimingConflict]:
         if arrival is None:
             continue
         matching_lodging = [
-            lodging for lodging in bundle.lodging_options if lodging.destination_id == transport.destination_id
+            lodging
+            for lodging in bundle.lodging_options
+            if lodging.destination_id == transport.destination_id
         ]
         for lodging in matching_lodging:
             window = _parse_window(lodging.booking_terms.checkin_window)
@@ -211,7 +223,10 @@ def _activity_timing_conflicts(
             continue
         available_minutes = max(
             0,
-            (datetime.combine(arrival.date(), end_time, arrival.tzinfo) - arrival).seconds // 60,
+            (
+                datetime.combine(arrival.date(), end_time, arrival.tzinfo) - arrival
+            ).seconds
+            // 60,
         )
         if available_minutes < activity.timing_summary.duration_minutes:
             conflicts.append(
@@ -227,7 +242,10 @@ def _activity_timing_conflicts(
                     related_option_ids=[activity.option_id],
                 )
             )
-        elif schedule_protection_required and available_minutes - activity.timing_summary.duration_minutes < 90:
+        elif (
+            schedule_protection_required
+            and available_minutes - activity.timing_summary.duration_minutes < 90
+        ):
             conflicts.append(
                 TimingConflict(
                     conflict_id=f"timing:{activity.option_id}:buffer",
@@ -244,10 +262,14 @@ def _activity_timing_conflicts(
     return conflicts, sorted(set(missing_data_fields))
 
 
-def _route_warnings(bundle: InventoryBundle, move_costs: list[MoveCostSummary]) -> list[RouteContinuityWarning]:
+def _route_warnings(
+    bundle: InventoryBundle, move_costs: list[MoveCostSummary]
+) -> list[RouteContinuityWarning]:
     warnings: list[RouteContinuityWarning] = []
     destination_sequence = [item.origin_id for item in bundle.transport_options]
-    destination_sequence.extend(item.destination_id for item in bundle.transport_options)
+    destination_sequence.extend(
+        item.destination_id for item in bundle.transport_options
+    )
     backtracking = any(
         destination_sequence[index] == destination_sequence[index + 2]
         for index in range(len(destination_sequence) - 2)
@@ -328,9 +350,7 @@ def evaluate_bundle_feasibility(bundle: InventoryBundle) -> FeasibilityAssessmen
 
     blocking_reasons = list(bundle.feasibility.blocking_reasons)
     blocking_reasons.extend(
-        reason
-        for move_cost in move_costs
-        for reason in move_cost.blocking_reasons
+        reason for move_cost in move_costs for reason in move_cost.blocking_reasons
     )
     blocking_reasons.extend(
         conflict.code for conflict in timing_conflicts if conflict.blocking
@@ -343,10 +363,12 @@ def evaluate_bundle_feasibility(bundle: InventoryBundle) -> FeasibilityAssessmen
 
     route_warnings = _route_warnings(bundle, move_costs)
     friction_penalty_total = round(sum(item.friction_penalty for item in move_costs), 4)
-    total_travel_minutes, total_transfer_count, aggregate_notes = _representative_travel_totals(
-        bundle,
-        travel_estimates,
-        move_costs,
+    total_travel_minutes, total_transfer_count, aggregate_notes = (
+        _representative_travel_totals(
+            bundle,
+            travel_estimates,
+            move_costs,
+        )
     )
     warning_pressure = (
         len([conflict for conflict in timing_conflicts if not conflict.blocking])

--- a/trip_planner/itinerary/move_costs.py
+++ b/trip_planner/itinerary/move_costs.py
@@ -81,7 +81,12 @@ class MoveCostSummary:
     notes: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        for field_name in ("move_id", "origin_id", "destination_id", "transport_option_id"):
+        for field_name in (
+            "move_id",
+            "origin_id",
+            "destination_id",
+            "transport_option_id",
+        ):
             require_non_empty(getattr(self, field_name), field_name)
         require_non_negative(self.travel_minutes, "travel_minutes")
         require_non_negative(self.transfer_count, "transfer_count")
@@ -108,9 +113,11 @@ def _estimate_from_transport(option: TransportOption) -> TravelTimeEstimate:
         [
             option.fit_summary.schedule_fit_signal,
             option.transfer_burden.schedule_protection_signal,
-            1.0 - option.transfer_burden.connection_risk_signal
-            if option.transfer_burden.connection_risk_signal is not None
-            else None,
+            (
+                1.0 - option.transfer_burden.connection_risk_signal
+                if option.transfer_burden.connection_risk_signal is not None
+                else None
+            ),
         ]
     )
     return TravelTimeEstimate(
@@ -130,7 +137,10 @@ def _estimate_from_transport(option: TransportOption) -> TravelTimeEstimate:
 
 def _continuity_signal(bundle: InventoryBundle, option: TransportOption) -> float:
     destination_ids = set(bundle.destination_ids)
-    if option.origin_id not in destination_ids or option.destination_id not in destination_ids:
+    if (
+        option.origin_id not in destination_ids
+        or option.destination_id not in destination_ids
+    ):
         return 0.0
     if option.origin_id == option.destination_id:
         return 0.35
@@ -166,7 +176,10 @@ def build_move_cost_summaries(
             (estimate.duration_minutes / 600.0)
             + (estimate.transfer_count * 0.12)
             + ((burden_signal or 0.0) * 0.45)
-            + ((schedule_pressure or 0.0) * (0.35 if schedule_protection_required else 0.2)),
+            + (
+                (schedule_pressure or 0.0)
+                * (0.35 if schedule_protection_required else 0.2)
+            ),
             4,
         )
 

--- a/trip_planner/itinerary/objective_derivation.py
+++ b/trip_planner/itinerary/objective_derivation.py
@@ -101,7 +101,9 @@ def _move_density(
     interaction_biases: dict[str, float],
 ) -> MoveDensityTarget:
     baseline_moves = max(1, round(duration_days / 7))
-    move_adjustment = round(movement * 2.0) - round(max(0.0, recovery_vs_intensity) * 1.0)
+    move_adjustment = round(movement * 2.0) - round(
+        max(0.0, recovery_vs_intensity) * 1.0
+    )
     if interaction_biases.get("protect_recovery_blocks", 0.0) >= 0.9:
         move_adjustment -= 1
     if interaction_biases.get("alternate_social_and_recovery_days", 0.0) >= 0.9:
@@ -113,10 +115,14 @@ def _move_density(
         f"Recovery adjustment uses recovery_vs_intensity={recovery_vs_intensity:.2f}.",
     ]
     if interaction_biases.get("protect_recovery_blocks", 0.0) >= 0.9:
-        notes.append("Interaction bias keeps recovery blocks intact by lowering move density.")
+        notes.append(
+            "Interaction bias keeps recovery blocks intact by lowering move density."
+        )
     if interaction_biases.get("alternate_social_and_recovery_days", 0.0) >= 0.9:
         notes.append("Interaction bias reserves slower pacing between social peaks.")
-    return MoveDensityTarget(max_moves=max_moves, cadence_days=cadence_days, notes=notes)
+    return MoveDensityTarget(
+        max_moves=max_moves, cadence_days=cadence_days, notes=notes
+    )
 
 
 def _recovery_expectations(
@@ -171,12 +177,17 @@ def _discovery_strategy(
         style = "balanced"
     protect_open_blocks = style == "discovery_forward" or structure_vs_elasticity < 0.0
     notes = [f"Derived from iconic_vs_discovery={iconic_vs_discovery:.2f}."]
-    if interaction_biases.get("favor_wandering_zones", 0.0) >= 0.9 and style == "balanced":
+    if (
+        interaction_biases.get("favor_wandering_zones", 0.0) >= 0.9
+        and style == "balanced"
+    ):
         style = "discovery_forward"
     if interaction_biases.get("keep_daily_skeleton_light", 0.0) >= 0.8:
         protect_open_blocks = True
         notes.append("Interaction bias keeps the daily skeleton intentionally light.")
-    return DiscoveryStrategy(style=style, protect_open_blocks=protect_open_blocks, notes=notes)
+    return DiscoveryStrategy(
+        style=style, protect_open_blocks=protect_open_blocks, notes=notes
+    )
 
 
 def _budget_protection(
@@ -184,7 +195,9 @@ def _budget_protection(
     interaction_biases: dict[str, float],
 ) -> BudgetProtection:
     priorities = resolved.profile.budget_model.spending_priorities
-    protected_categories = sorted(key for key, value in priorities.items() if value >= 0.45)
+    protected_categories = sorted(
+        key for key, value in priorities.items() if value >= 0.45
+    )
     if not protected_categories:
         protected_categories = [
             key
@@ -193,7 +206,9 @@ def _budget_protection(
                 key=lambda item: (-item[1], item[0]),
             )[:2]
         ]
-    sensitivity = _clamp(resolved.profile.budget_model.total_budget_sensitivity, 0.0, 1.0)
+    sensitivity = _clamp(
+        resolved.profile.budget_model.total_budget_sensitivity, 0.0, 1.0
+    )
     notes = [f"Derived from budget sensitivity={sensitivity:.2f}."]
     if resolved.profile.hard_constraints.budget_ceiling is not None:
         notes.append(
@@ -202,7 +217,9 @@ def _budget_protection(
     if interaction_biases.get("protect_quality_floors", 0.0) >= 0.9:
         if not any(category.startswith("lodging") for category in protected_categories):
             protected_categories.append("lodging")
-        notes.append("Interaction bias protects quality floors before relaxing comfort targets.")
+        notes.append(
+            "Interaction bias protects quality floors before relaxing comfort targets."
+        )
     return BudgetProtection(
         protected_categories=protected_categories,
         sensitivity=sensitivity,
@@ -213,7 +230,9 @@ def _budget_protection(
 def _quality_floor(resolved: ResolvedLeisureProfile) -> QualityFloorProtection:
     categories: set[str] = set()
     categories.update(
-        key for key, value in resolved.profile.budget_model.quality_floors.items() if value
+        key
+        for key, value in resolved.profile.budget_model.quality_floors.items()
+        if value
     )
     if resolved.profile.anchors.get("quality_floor_anchors"):
         categories.update(("lodging", "sleep_recovery"))
@@ -244,7 +263,9 @@ def _lodging_strategy(
     if interaction_biases.get("compress_route_before_downgrading_lodging", 0.0) >= 0.9:
         base_style = "few_bases" if base_style == "multi_base" else base_style
         arrival_buffer_priority = _clamp(arrival_buffer_priority + 0.15, 0.0, 1.0)
-        notes.append("Interaction bias contracts route scope before lowering lodging standards.")
+        notes.append(
+            "Interaction bias contracts route scope before lowering lodging standards."
+        )
     return LodgingStrategy(
         base_style=base_style,
         arrival_buffer_priority=arrival_buffer_priority,
@@ -346,11 +367,15 @@ def derive_itinerary_objectives(
     return ItineraryObjectives(
         objective_id=derived_objective_id,
         trip_id=trip_id,
-        route_shape=_route_shape(coherence, breadth_vs_depth, movement, interaction_biases),
+        route_shape=_route_shape(
+            coherence, breadth_vs_depth, movement, interaction_biases
+        ),
         target_base_count=_target_base_count(
             duration_days,
             breadth_vs_depth,
-            must_include_places=len(resolved.profile.hard_constraints.must_include_places),
+            must_include_places=len(
+                resolved.profile.hard_constraints.must_include_places
+            ),
             interaction_biases=interaction_biases,
         ),
         move_density=_move_density(

--- a/trip_planner/options/destinations.py
+++ b/trip_planner/options/destinations.py
@@ -44,8 +44,20 @@ MOBILITY_MODES: tuple[str, ...] = (
     "rideshare",
     "shuttle",
 )
-TAG_SCOPES: tuple[str, ...] = ("identity", "routing", "experience", "seasonal", "operational")
-PROVENANCE_ROLES: tuple[str, ...] = ("identity", "seasonal", "operational", "experience", "routing")
+TAG_SCOPES: tuple[str, ...] = (
+    "identity",
+    "routing",
+    "experience",
+    "seasonal",
+    "operational",
+)
+PROVENANCE_ROLES: tuple[str, ...] = (
+    "identity",
+    "seasonal",
+    "operational",
+    "experience",
+    "routing",
+)
 OPERATIONAL_NOTE_KINDS: tuple[str, ...] = (
     "access",
     "crowding",
@@ -161,7 +173,9 @@ class PlaceHierarchyRef:
     def __post_init__(self) -> None:
         require_non_empty(self.destination_id, "destination_id")
         if self.relationship_kind not in PLACE_RELATIONSHIP_KINDS:
-            raise ValueError(f"relationship_kind must be one of {PLACE_RELATIONSHIP_KINDS}")
+            raise ValueError(
+                f"relationship_kind must be one of {PLACE_RELATIONSHIP_KINDS}"
+            )
         require_optional_non_empty(self.label or None, "label")
         require_strings(self.notes, "notes")
 
@@ -277,17 +291,26 @@ class DestinationSourceRef:
             raise ValueError(f"role must be one of {PROVENANCE_ROLES}")
         require_optional_non_empty(self.source_id or None, "source_id")
         require_optional_non_empty(self.source_category or None, "source_category")
-        if self.source_category and self.source_category not in source_schema.SOURCE_CATEGORIES:
-            raise ValueError(f"source_category must be one of {source_schema.SOURCE_CATEGORIES}")
+        if (
+            self.source_category
+            and self.source_category not in source_schema.SOURCE_CATEGORIES
+        ):
+            raise ValueError(
+                f"source_category must be one of {source_schema.SOURCE_CATEGORIES}"
+            )
         require_optional_non_empty(self.contribution_kind or None, "contribution_kind")
         if (
             self.contribution_kind
             and self.contribution_kind not in source_schema.CONTRIBUTION_KINDS
         ):
-            raise ValueError(f"contribution_kind must be one of {source_schema.CONTRIBUTION_KINDS}")
+            raise ValueError(
+                f"contribution_kind must be one of {source_schema.CONTRIBUTION_KINDS}"
+            )
         require_optional_non_empty(self.summary or None, "summary")
         if self.freshness_days_at_capture is not None:
-            require_non_negative(self.freshness_days_at_capture, "freshness_days_at_capture")
+            require_non_negative(
+                self.freshness_days_at_capture, "freshness_days_at_capture"
+            )
         require_strings(self.notes, "notes")
 
     def to_dict(self) -> dict[str, Any]:
@@ -400,15 +423,30 @@ class Destination:
             raise ValueError("seasonal_signals must contain SeasonalSignal instances")
         if not isinstance(self.mobility_profile, MobilityProfile):
             raise ValueError("mobility_profile must be a MobilityProfile")
-        if any(not isinstance(item, ExperienceSignal) for item in self.experience_signals):
-            raise ValueError("experience_signals must contain ExperienceSignal instances")
-        if any(not isinstance(item, NearbyDestinationRef) for item in self.adjacency_refs):
-            raise ValueError("adjacency_refs must contain NearbyDestinationRef instances")
-        if any(not isinstance(item, RegionExpansionRef) for item in self.region_expansion_refs):
-            raise ValueError("region_expansion_refs must contain RegionExpansionRef instances")
+        if any(
+            not isinstance(item, ExperienceSignal) for item in self.experience_signals
+        ):
+            raise ValueError(
+                "experience_signals must contain ExperienceSignal instances"
+            )
+        if any(
+            not isinstance(item, NearbyDestinationRef) for item in self.adjacency_refs
+        ):
+            raise ValueError(
+                "adjacency_refs must contain NearbyDestinationRef instances"
+            )
+        if any(
+            not isinstance(item, RegionExpansionRef)
+            for item in self.region_expansion_refs
+        ):
+            raise ValueError(
+                "region_expansion_refs must contain RegionExpansionRef instances"
+            )
         if any(not isinstance(item, DestinationSourceRef) for item in self.source_refs):
             raise ValueError("source_refs must contain DestinationSourceRef instances")
-        if any(not isinstance(item, OperationalNote) for item in self.operational_notes):
+        if any(
+            not isinstance(item, OperationalNote) for item in self.operational_notes
+        ):
             raise ValueError("operational_notes must contain OperationalNote instances")
 
     def to_dict(self) -> dict[str, Any]:
@@ -423,11 +461,15 @@ class Destination:
             geo=DestinationGeo(**payload["geo"]),
             summary=payload.get("summary", ""),
             parent_refs=[
-                PlaceHierarchyRef(**item) for item in _optional_list_field(payload, "parent_refs")
+                PlaceHierarchyRef(**item)
+                for item in _optional_list_field(payload, "parent_refs")
             ],
-            tags=[DestinationTag(**item) for item in _optional_list_field(payload, "tags")],
+            tags=[
+                DestinationTag(**item) for item in _optional_list_field(payload, "tags")
+            ],
             seasonal_signals=[
-                SeasonalSignal(**item) for item in _optional_list_field(payload, "seasonal_signals")
+                SeasonalSignal(**item)
+                for item in _optional_list_field(payload, "seasonal_signals")
             ],
             mobility_profile=MobilityProfile(
                 **_optional_mapping_field(payload, "mobility_profile")
@@ -505,7 +547,9 @@ class PlaceContext:
             boundary_mode=payload.get("boundary_mode", "district"),
             summary=payload.get("summary", ""),
             parent_context_ids=_optional_list_field(payload, "parent_context_ids"),
-            supporting_destination_ids=_optional_list_field(payload, "supporting_destination_ids"),
+            supporting_destination_ids=_optional_list_field(
+                payload, "supporting_destination_ids"
+            ),
             tag_keys=_optional_list_field(payload, "tag_keys"),
             source_ref_ids=_optional_list_field(payload, "source_ref_ids"),
             notes=_optional_list_field(payload, "notes"),
@@ -540,7 +584,8 @@ class PlaceContext:
             boundary_mode=boundary_mode,
             summary=summary or destination.summary,
             parent_context_ids=parent_context_ids or [],
-            supporting_destination_ids=supporting_destination_ids or [destination.destination_id],
+            supporting_destination_ids=supporting_destination_ids
+            or [destination.destination_id],
             tag_keys=tag_keys or [tag.key for tag in destination.tags],
             source_ref_ids=source_ref_ids
             or [source.provenance_id for source in destination.source_refs],

--- a/trip_planner/preferences/evidence.py
+++ b/trip_planner/preferences/evidence.py
@@ -63,8 +63,13 @@ class OptionEvidence:
         if self.option_kind not in OPTION_KINDS:
             raise ValueError(f"option_kind must be one of {OPTION_KINDS}")
         _require_strings(self.presented_option_ids, "presented_option_ids")
-        if self.presented_option_ids and self.option_id not in self.presented_option_ids:
-            raise ValueError("presented_option_ids must include option_id when provided")
+        if (
+            self.presented_option_ids
+            and self.option_id not in self.presented_option_ids
+        ):
+            raise ValueError(
+                "presented_option_ids must include option_id when provided"
+            )
         if len(self.presented_option_ids) != len(set(self.presented_option_ids)):
             raise ValueError("presented_option_ids cannot contain duplicates")
 
@@ -124,16 +129,26 @@ class PreferenceEvidence:
         _require_strings(self.affected_dimensions, "affected_dimensions")
         _require_strings(self.affected_hybrid_factors, "affected_hybrid_factors")
         _require_strings(self.anchor_groups, "anchor_groups")
-        invalid_dimensions = set(self.affected_dimensions) - set(schema.TRADEOFF_DIMENSION_KEYS)
+        invalid_dimensions = set(self.affected_dimensions) - set(
+            schema.TRADEOFF_DIMENSION_KEYS
+        )
         if invalid_dimensions:
             raise ValueError(f"unsupported dimensions: {sorted(invalid_dimensions)}")
-        invalid_hybrid = set(self.affected_hybrid_factors) - set(schema.HYBRID_FACTOR_KEYS)
+        invalid_hybrid = set(self.affected_hybrid_factors) - set(
+            schema.HYBRID_FACTOR_KEYS
+        )
         if invalid_hybrid:
             raise ValueError(f"unsupported hybrid factors: {sorted(invalid_hybrid)}")
         invalid_anchor_groups = set(self.anchor_groups) - set(schema.ANCHOR_GROUPS)
         if invalid_anchor_groups:
-            raise ValueError(f"unsupported anchor groups: {sorted(invalid_anchor_groups)}")
-        if not (self.affected_dimensions or self.affected_hybrid_factors or self.anchor_groups):
+            raise ValueError(
+                f"unsupported anchor groups: {sorted(invalid_anchor_groups)}"
+            )
+        if not (
+            self.affected_dimensions
+            or self.affected_hybrid_factors
+            or self.anchor_groups
+        ):
             raise ValueError("PreferenceEvidence must affect at least one target")
         if self.evidence_type in {"option_selection", "option_rejection"}:
             if self.option_evidence is None:
@@ -144,10 +159,19 @@ class PreferenceEvidence:
             raise ValueError(
                 "option_evidence is only allowed for option_selection and option_rejection"
             )
-        if self.evidence_type == "option_rejection" and self.signal_direction == "positive":
-            raise ValueError("option_rejection evidence cannot use a positive signal_direction")
-        if any(not isinstance(item, ContradictionMarker) for item in self.contradictions):
-            raise ValueError("contradictions must contain ContradictionMarker instances")
+        if (
+            self.evidence_type == "option_rejection"
+            and self.signal_direction == "positive"
+        ):
+            raise ValueError(
+                "option_rejection evidence cannot use a positive signal_direction"
+            )
+        if any(
+            not isinstance(item, ContradictionMarker) for item in self.contradictions
+        ):
+            raise ValueError(
+                "contradictions must contain ContradictionMarker instances"
+            )
         from .evidence_catalog import validate_evidence_support
 
         validate_evidence_support(self)

--- a/trip_planner/preferences/evidence_catalog.py
+++ b/trip_planner/preferences/evidence_catalog.py
@@ -183,7 +183,9 @@ def _require_support_level(level: str) -> None:
 
 def support_for_dimension(dimension_key: str, evidence_type: str) -> str | None:
     if dimension_key not in schema.TRADEOFF_DIMENSION_KEYS:
-        raise ValueError(f"dimension_key must be one of {schema.TRADEOFF_DIMENSION_KEYS}")
+        raise ValueError(
+            f"dimension_key must be one of {schema.TRADEOFF_DIMENSION_KEYS}"
+        )
     level = DIMENSION_EVIDENCE_STRENGTH[dimension_key].get(evidence_type)
     if level is not None:
         _require_support_level(level)
@@ -192,7 +194,9 @@ def support_for_dimension(dimension_key: str, evidence_type: str) -> str | None:
 
 def support_for_hybrid_factor(hybrid_factor_key: str, evidence_type: str) -> str | None:
     if hybrid_factor_key not in schema.HYBRID_FACTOR_KEYS:
-        raise ValueError(f"hybrid_factor_key must be one of {schema.HYBRID_FACTOR_KEYS}")
+        raise ValueError(
+            f"hybrid_factor_key must be one of {schema.HYBRID_FACTOR_KEYS}"
+        )
     level = HYBRID_FACTOR_EVIDENCE_STRENGTH[hybrid_factor_key].get(evidence_type)
     if level is not None:
         _require_support_level(level)

--- a/trip_planner/preferences/explanations.py
+++ b/trip_planner/preferences/explanations.py
@@ -61,10 +61,16 @@ class InteractionActivation:
 
 @dataclass(slots=True)
 class ResolutionExplanation:
-    dimension_explanations: dict[str, DimensionResolutionExplanation] = field(default_factory=dict)
-    hybrid_factor_explanations: dict[str, HybridFactorExplanation] = field(default_factory=dict)
+    dimension_explanations: dict[str, DimensionResolutionExplanation] = field(
+        default_factory=dict
+    )
+    hybrid_factor_explanations: dict[str, HybridFactorExplanation] = field(
+        default_factory=dict
+    )
     activated_interactions: list[InteractionActivation] = field(default_factory=list)
-    tension_explanations: dict[str, list[MaterialInfluence]] = field(default_factory=dict)
+    tension_explanations: dict[str, list[MaterialInfluence]] = field(
+        default_factory=dict
+    )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/trip_planner/preferences/interactions.py
+++ b/trip_planner/preferences/interactions.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from dataclasses import replace
 
-from .explanations import InteractionActivation, MaterialInfluence, ResolutionExplanation
+from .explanations import (
+    InteractionActivation,
+    MaterialInfluence,
+    ResolutionExplanation,
+)
 from .models import InteractionRule, LeisurePreferenceProfile, TensionFlag
 
 
@@ -24,7 +28,9 @@ def _upsert_tension(
     description: str,
     influences: list[MaterialInfluence],
 ) -> None:
-    existing = next((flag for flag in profile.tension_flags if flag.id == flag_id), None)
+    existing = next(
+        (flag for flag in profile.tension_flags if flag.id == flag_id), None
+    )
     if existing is None:
         profile.tension_flags.append(
             TensionFlag(
@@ -123,8 +129,13 @@ def apply_interactions(
             ["breadth_vs_depth", "recovery_vs_intensity", "movement_vs_friction"],
         )
         for key in ("breadth_vs_depth", "recovery_vs_intensity"):
-            if tension_id not in explanation.dimension_explanations[key].tension_flag_ids:
-                explanation.dimension_explanations[key].tension_flag_ids.append(tension_id)
+            if (
+                tension_id
+                not in explanation.dimension_explanations[key].tension_flag_ids
+            ):
+                explanation.dimension_explanations[key].tension_flag_ids.append(
+                    tension_id
+                )
         explanation.activated_interactions.append(
             InteractionActivation(
                 rule_id=rule_id,
@@ -144,13 +155,18 @@ def apply_interactions(
         strength = _clamp_probability((abs(movement.value) + abs(scenic.value)) / 2.0)
         hybrids["route_modes"].mode = "both"
         hybrids["route_modes"].salience = max(hybrids["route_modes"].salience, 0.82)
-        hybrids["route_modes"].anchor_strength = max(hybrids["route_modes"].anchor_strength, 0.62)
+        hybrids["route_modes"].anchor_strength = max(
+            hybrids["route_modes"].anchor_strength, 0.62
+        )
         route.salience = max(route.salience, 0.7)
         rule_id = "movement-x-scenic-transit"
         profile.interaction_rules.append(
             InteractionRule(
                 id=rule_id,
-                dimensions=["movement_vs_friction", "scenic_transit_vs_destination_time"],
+                dimensions=[
+                    "movement_vs_friction",
+                    "scenic_transit_vs_destination_time",
+                ],
                 activation={
                     "movement_vs_friction": movement.value,
                     "scenic_transit_vs_destination_time": scenic.value,
@@ -175,12 +191,17 @@ def apply_interactions(
         explanation.activated_interactions.append(
             InteractionActivation(
                 rule_id=rule_id,
-                dimensions=["movement_vs_friction", "scenic_transit_vs_destination_time"],
+                dimensions=[
+                    "movement_vs_friction",
+                    "scenic_transit_vs_destination_time",
+                ],
                 planning_biases={
                     "prefer_overland_modes": 0.93,
                     "treat_transit_as_experience": 0.95,
                 },
-                notes=["The route itself should be treated as part of the trip payoff."],
+                notes=[
+                    "The route itself should be treated as part of the trip payoff."
+                ],
             )
         )
 
@@ -229,8 +250,13 @@ def apply_interactions(
                 influences=influences,
             )
             for key in ("structure_vs_elasticity", "iconic_vs_discovery"):
-                if tension_id not in explanation.dimension_explanations[key].tension_flag_ids:
-                    explanation.dimension_explanations[key].tension_flag_ids.append(tension_id)
+                if (
+                    tension_id
+                    not in explanation.dimension_explanations[key].tension_flag_ids
+                ):
+                    explanation.dimension_explanations[key].tension_flag_ids.append(
+                        tension_id
+                    )
             tension_ids = [tension_id]
         else:
             tension_ids = []
@@ -257,7 +283,9 @@ def apply_interactions(
         or profile.hard_constraints.budget_ceiling is not None
     )
     if has_quality_floor and has_budget_pressure:
-        strength = _clamp_probability(0.5 + (profile.budget_model.total_budget_sensitivity * 0.4))
+        strength = _clamp_probability(
+            0.5 + (profile.budget_model.total_budget_sensitivity * 0.4)
+        )
         self_reliance.value = max(self_reliance.value, 0.45)
         self_reliance.salience = max(self_reliance.salience, 0.7)
         route.salience = max(route.salience, 0.62)
@@ -268,7 +296,9 @@ def apply_interactions(
                 dimensions=["self_reliance_vs_convenience"],
                 activation={
                     "budget_sensitivity": profile.budget_model.total_budget_sensitivity,
-                    "quality_floor_anchor_count": len(profile.anchors["quality_floor_anchors"]),
+                    "quality_floor_anchor_count": len(
+                        profile.anchors["quality_floor_anchors"]
+                    ),
                 },
                 effect={
                     "planning_biases": {
@@ -297,7 +327,9 @@ def apply_interactions(
             description="Budget pressure conflicts with comfort floors unless route scope or timing adjusts.",
             influences=influences,
         )
-        _record_rule_on_dimensions(explanation, rule_id, ["self_reliance_vs_convenience"])
+        _record_rule_on_dimensions(
+            explanation, rule_id, ["self_reliance_vs_convenience"]
+        )
         if (
             tension_id
             not in explanation.dimension_explanations[
@@ -370,8 +402,13 @@ def apply_interactions(
         )
         _record_rule_on_hybrid(explanation, rule_id, "rest")
         for key in ("social_energy_vs_solitude", "recovery_vs_intensity"):
-            if tension_id not in explanation.dimension_explanations[key].tension_flag_ids:
-                explanation.dimension_explanations[key].tension_flag_ids.append(tension_id)
+            if (
+                tension_id
+                not in explanation.dimension_explanations[key].tension_flag_ids
+            ):
+                explanation.dimension_explanations[key].tension_flag_ids.append(
+                    tension_id
+                )
         explanation.activated_interactions.append(
             InteractionActivation(
                 rule_id=rule_id,

--- a/trip_planner/preferences/legacy_request_adapter.py
+++ b/trip_planner/preferences/legacy_request_adapter.py
@@ -61,18 +61,28 @@ def adapt_legacy_request(raw_request: Mapping[str, Any]) -> LeisurePreferencePro
     must_see = [str(place) for place in raw_request.get("must_see", [])]
 
     trip_frame = TripFrame(
-        duration_days=(int(max_weeks * 7) if isinstance(max_weeks, (int, float)) else None),
+        duration_days=(
+            int(max_weeks * 7) if isinstance(max_weeks, (int, float)) else None
+        ),
         season_window=months,
         trip_stage="mixed",
     )
     hard_constraints = HardConstraints(
         date_window=DateWindow(
-            start=(str(raw_request["trip_start"]) if raw_request.get("trip_start") else None),
+            start=(
+                str(raw_request["trip_start"])
+                if raw_request.get("trip_start")
+                else None
+            ),
             end=str(raw_request["trip_end"]) if raw_request.get("trip_end") else None,
         ),
         duration_bounds=DurationBounds(
-            min_days=(int(min_weeks * 7) if isinstance(min_weeks, (int, float)) else None),
-            max_days=(int(max_weeks * 7) if isinstance(max_weeks, (int, float)) else None),
+            min_days=(
+                int(min_weeks * 7) if isinstance(min_weeks, (int, float)) else None
+            ),
+            max_days=(
+                int(max_weeks * 7) if isinstance(max_weeks, (int, float)) else None
+            ),
         ),
         must_include_places=must_see,
     )
@@ -129,7 +139,9 @@ def adapt_legacy_request(raw_request: Mapping[str, Any]) -> LeisurePreferencePro
         )
 
     hybrid_factors = _empty_hybrid_factors()
-    route_preferences = _normalize_route_preferences(raw_request.get("route_passions", {}))
+    route_preferences = _normalize_route_preferences(
+        raw_request.get("route_passions", {})
+    )
     if route_preferences:
         highest_preference = max(route_preferences.values())
         hybrid_factors["route_modes"] = HybridFactor(

--- a/trip_planner/preferences/models.py
+++ b/trip_planner/preferences/models.py
@@ -165,7 +165,9 @@ class TradeoffDimension:
     confidence: float = 0.0
     salience: float = 0.0
     stability: float = 0.0
-    trip_stage_sensitivity: dict[str, float] = field(default_factory=_default_stage_sensitivity)
+    trip_stage_sensitivity: dict[str, float] = field(
+        default_factory=_default_stage_sensitivity
+    )
     scope: str = "global"
     notes: str = ""
 
@@ -203,7 +205,9 @@ class HybridFactor:
         if self.mode not in schema.HYBRID_FACTOR_MODES:
             raise ValueError(f"mode must be one of {schema.HYBRID_FACTOR_MODES}")
         if self.tradeoff_role not in schema.HYBRID_FACTOR_ROLES:
-            raise ValueError(f"tradeoff_role must be one of {schema.HYBRID_FACTOR_ROLES}")
+            raise ValueError(
+                f"tradeoff_role must be one of {schema.HYBRID_FACTOR_ROLES}"
+            )
         _require_probability(self.salience, "salience")
         _require_probability(self.anchor_strength, "anchor_strength")
         _require_string_key_mapping(self.preferences, "preferences")
@@ -297,18 +301,27 @@ class LeisurePreferenceProfile:
                 raise ValueError(f"{group_name} must contain Anchor instances")
         expected_dimensions = set(schema.TRADEOFF_DIMENSION_KEYS)
         if set(self.tradeoff_dimensions) != expected_dimensions:
-            raise ValueError("tradeoff_dimensions must define every first-tier leisure dimension")
+            raise ValueError(
+                "tradeoff_dimensions must define every first-tier leisure dimension"
+            )
         if any(
             not isinstance(dimension, TradeoffDimension)
             for dimension in self.tradeoff_dimensions.values()
         ):
-            raise ValueError("tradeoff_dimensions must contain TradeoffDimension instances")
+            raise ValueError(
+                "tradeoff_dimensions must contain TradeoffDimension instances"
+            )
         expected_hybrid = set(schema.HYBRID_FACTOR_KEYS)
         if set(self.hybrid_factors) != expected_hybrid:
             raise ValueError("hybrid_factors must define every canonical hybrid factor")
-        if any(not isinstance(factor, HybridFactor) for factor in self.hybrid_factors.values()):
+        if any(
+            not isinstance(factor, HybridFactor)
+            for factor in self.hybrid_factors.values()
+        ):
             raise ValueError("hybrid_factors must contain HybridFactor instances")
-        if any(not isinstance(rule, InteractionRule) for rule in self.interaction_rules):
+        if any(
+            not isinstance(rule, InteractionRule) for rule in self.interaction_rules
+        ):
             raise ValueError("interaction_rules must contain InteractionRule instances")
         if any(not isinstance(flag, TensionFlag) for flag in self.tension_flags):
             raise ValueError("tension_flags must contain TensionFlag instances")

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -30,7 +30,10 @@ ANCHOR_GROUP_DIMENSIONS: dict[str, list[str]] = {
     "experience_anchors": ["breadth_vs_depth", "iconic_vs_discovery"],
     "mode_anchors": ["movement_vs_friction", "scenic_transit_vs_destination_time"],
     "rhythm_anchors": ["recovery_vs_intensity", "structure_vs_elasticity"],
-    "calendar_anchors": ["structure_vs_elasticity", "route_coherence_vs_eclectic_contrast"],
+    "calendar_anchors": [
+        "structure_vs_elasticity",
+        "route_coherence_vs_eclectic_contrast",
+    ],
     "quality_floor_anchors": [
         "movement_vs_friction",
         "self_reliance_vs_convenience",
@@ -43,7 +46,10 @@ ANCHOR_GROUP_DIMENSIONS: dict[str, list[str]] = {
 }
 EVIDENCE_STAGE_BOOSTS: dict[str, dict[str, float]] = {
     "direct_statement": {"initial_design": 0.15},
-    "hard_constraint_declaration": {"initial_design": 0.18, "inventory_selection": 0.08},
+    "hard_constraint_declaration": {
+        "initial_design": 0.18,
+        "inventory_selection": 0.08,
+    },
     "anchor_declaration": {"initial_design": 0.18, "daily_activity_design": 0.06},
     "forced_tradeoff_choice": {"initial_design": 0.16},
     "scenario_reaction": {"initial_design": 0.14, "inventory_selection": 0.08},
@@ -61,7 +67,9 @@ def _clamp_axis(value: float) -> float:
     return max(-1.0, min(1.0, value))
 
 
-def _sorted_evidence(evidence_records: list[PreferenceEvidence]) -> list[PreferenceEvidence]:
+def _sorted_evidence(
+    evidence_records: list[PreferenceEvidence],
+) -> list[PreferenceEvidence]:
     return sorted(
         evidence_records,
         key=lambda record: (
@@ -78,7 +86,8 @@ def _influence_weight(record: PreferenceEvidence, support_level: str) -> float:
         sum(marker.weakening_strength for marker in record.contradictions) * 0.12
     )
     return _clamp_probability(
-        support_weight * (0.5 + (record.confidence_hint * 0.3) + (record.salience_hint * 0.2))
+        support_weight
+        * (0.5 + (record.confidence_hint * 0.3) + (record.salience_hint * 0.2))
         - contradiction_penalty
     )
 
@@ -128,10 +137,12 @@ def resolve_leisure_profile(
 
     explanation = ResolutionExplanation(
         dimension_explanations={
-            key: _new_dimension_explanation(key, profile) for key in schema.TRADEOFF_DIMENSION_KEYS
+            key: _new_dimension_explanation(key, profile)
+            for key in schema.TRADEOFF_DIMENSION_KEYS
         },
         hybrid_factor_explanations={
-            key: _new_hybrid_explanation(key, profile) for key in schema.HYBRID_FACTOR_KEYS
+            key: _new_hybrid_explanation(key, profile)
+            for key in schema.HYBRID_FACTOR_KEYS
         },
     )
     ordered_evidence = _sorted_evidence(evidence_records)
@@ -172,22 +183,30 @@ def _apply_dimension_resolution(
                 source_kind="evidence",
                 source_id=record.id,
                 weight=weight,
-                summary=record.note or f"{record.evidence_type} affected {dimension_key}",
+                summary=record.note
+                or f"{record.evidence_type} affected {dimension_key}",
             )
-            explanation.dimension_explanations[dimension_key].influences.append(influence)
-            profile.evidence_summary.sources.setdefault(dimension_key, []).append(record.id)
+            explanation.dimension_explanations[dimension_key].influences.append(
+                influence
+            )
+            profile.evidence_summary.sources.setdefault(dimension_key, []).append(
+                record.id
+            )
             if record.signal_direction == "positive":
                 positive_support += weight
             elif record.signal_direction == "negative":
                 weakening_support += weight
             contradiction_support += sum(
-                marker.weakening_strength * weight * 0.65 for marker in record.contradictions
+                marker.weakening_strength * weight * 0.65
+                for marker in record.contradictions
             )
             if record.signal_direction == "contradiction":
                 contradiction_support += weight * 0.5
             salience_boost += weight * record.salience_hint * 0.45
             stability_bonus += weight * 0.12
-            for stage, boost in EVIDENCE_STAGE_BOOSTS.get(record.evidence_type, {}).items():
+            for stage, boost in EVIDENCE_STAGE_BOOSTS.get(
+                record.evidence_type, {}
+            ).items():
                 stage_boosts[stage] = max(stage_boosts[stage], boost)
 
         if base_direction != 0.0:
@@ -197,11 +216,17 @@ def _apply_dimension_resolution(
             value = _clamp_axis(base_direction * magnitude)
         else:
             value = 0.0
-            if positive_support > 0.0 or weakening_support > 0.0 or contradiction_support > 0.0:
+            if (
+                positive_support > 0.0
+                or weakening_support > 0.0
+                or contradiction_support > 0.0
+            ):
                 tension_id = f"{dimension_key}-needs-directional-seed"
                 flag = TensionFlag(
                     id=tension_id,
-                    severity=_clamp_probability(0.45 + positive_support + contradiction_support),
+                    severity=_clamp_probability(
+                        0.45 + positive_support + contradiction_support
+                    ),
                     description=(
                         f"{dimension_key} has evidence support but still needs directional seeding."
                     ),
@@ -210,9 +235,9 @@ def _apply_dimension_resolution(
                 explanation.tension_explanations[tension_id] = list(
                     explanation.dimension_explanations[dimension_key].influences
                 )
-                explanation.dimension_explanations[dimension_key].tension_flag_ids.append(
-                    tension_id
-                )
+                explanation.dimension_explanations[
+                    dimension_key
+                ].tension_flag_ids.append(tension_id)
                 profile.evidence_summary.confidence_notes.append(
                     f"{dimension_key} received evidence but remained at a zero-direction seed value."
                 )
@@ -226,7 +251,9 @@ def _apply_dimension_resolution(
             max(dimension.salience, 0.22) + salience_boost + (positive_support * 0.12)
         )
         dimension.stability = _clamp_probability(
-            max(dimension.stability, 0.2) + stability_bonus - (contradiction_support * 0.18)
+            max(dimension.stability, 0.2)
+            + stability_bonus
+            - (contradiction_support * 0.18)
         )
         for stage in schema.PLANNING_STAGES:
             dimension.trip_stage_sensitivity[stage] = _clamp_probability(
@@ -237,13 +264,17 @@ def _apply_dimension_resolution(
             flag = TensionFlag(
                 id=tension_id,
                 severity=_clamp_probability(0.45 + contradiction_support),
-                description=(f"Contradictory evidence remains unresolved for {dimension_key}."),
+                description=(
+                    f"Contradictory evidence remains unresolved for {dimension_key}."
+                ),
             )
             profile.tension_flags.append(flag)
             explanation.tension_explanations[tension_id] = list(
                 explanation.dimension_explanations[dimension_key].influences
             )
-            explanation.dimension_explanations[dimension_key].tension_flag_ids.append(tension_id)
+            explanation.dimension_explanations[dimension_key].tension_flag_ids.append(
+                tension_id
+            )
             profile.evidence_summary.confidence_notes.append(
                 f"{dimension_key} includes contradictory evidence that should remain visible downstream."
             )
@@ -270,18 +301,25 @@ def _apply_hybrid_resolution(
                     source_kind="evidence",
                     source_id=record.id,
                     weight=weight,
-                    summary=record.note or f"{record.evidence_type} affected {hybrid_key}",
+                    summary=record.note
+                    or f"{record.evidence_type} affected {hybrid_key}",
                 )
             )
-            profile.evidence_summary.sources.setdefault(hybrid_key, []).append(record.id)
+            profile.evidence_summary.sources.setdefault(hybrid_key, []).append(
+                record.id
+            )
             if record.signal_direction == "positive":
                 salience_boost += weight * 0.42
                 if factor.mode in {"anchor", "both"}:
                     anchor_boost += weight * 0.32
             else:
                 salience_boost -= weight * 0.12
-        factor.salience = _clamp_probability(max(factor.salience, 0.18) + salience_boost)
-        factor.anchor_strength = _clamp_probability(max(factor.anchor_strength, 0.0) + anchor_boost)
+        factor.salience = _clamp_probability(
+            max(factor.salience, 0.18) + salience_boost
+        )
+        factor.anchor_strength = _clamp_probability(
+            max(factor.anchor_strength, 0.0) + anchor_boost
+        )
 
 
 def _apply_anchor_and_constraint_precedence(
@@ -292,7 +330,9 @@ def _apply_anchor_and_constraint_precedence(
         if not anchors:
             continue
         average_strength = sum(anchor.strength for anchor in anchors) / len(anchors)
-        flexibility_discount = sum(anchor.flexibility for anchor in anchors) / len(anchors)
+        flexibility_discount = sum(anchor.flexibility for anchor in anchors) / len(
+            anchors
+        )
         effective_weight = _clamp_probability(
             average_strength * (1.0 - (flexibility_discount * 0.35))
         )
@@ -326,7 +366,9 @@ def _apply_anchor_and_constraint_precedence(
         dimension.value = max(dimension.value, 0.35)
         dimension.salience = max(dimension.salience, 0.66)
         dimension.confidence = max(dimension.confidence, 0.62)
-        explanation.dimension_explanations["self_reliance_vs_convenience"].influences.append(
+        explanation.dimension_explanations[
+            "self_reliance_vs_convenience"
+        ].influences.append(
             MaterialInfluence(
                 source_kind="quality_floor_guardrail",
                 source_id="quality_floor_protection",
@@ -359,7 +401,9 @@ def _finalize_explanations(
                     if tension_id != directional_seed_tension_id
                 ]
             explanation.tension_explanations.pop(directional_seed_tension_id, None)
-            confidence_notes = [note for note in confidence_notes if note != directional_seed_note]
+            confidence_notes = [
+                note for note in confidence_notes if note != directional_seed_note
+            ]
         detail.resolved_value = dimension.value
         detail.confidence = dimension.confidence
         detail.salience = dimension.salience
@@ -377,7 +421,10 @@ def _finalize_explanations(
             key = tension.id[: -len("-needs-directional-seed")]
         else:
             key = ""
-        if tension.id.endswith("-needs-directional-seed") and key in profile.tradeoff_dimensions:
+        if (
+            tension.id.endswith("-needs-directional-seed")
+            and key in profile.tradeoff_dimensions
+        ):
             if profile.tradeoff_dimensions[key].value != 0.0:
                 continue
         filtered_tension_flags.append(tension)

--- a/trip_planner/preferences/revealed_preference.py
+++ b/trip_planner/preferences/revealed_preference.py
@@ -6,7 +6,12 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from . import schema
-from .evidence import ContradictionMarker, OPTION_KINDS, OptionEvidence, PreferenceEvidence
+from .evidence import (
+    ContradictionMarker,
+    OPTION_KINDS,
+    OptionEvidence,
+    PreferenceEvidence,
+)
 from .models import LeisurePreferenceProfile
 
 REACTION_TYPES: tuple[str, ...] = (
@@ -79,12 +84,18 @@ class RevealedPreferenceSignal:
         if self.option_kind not in OPTION_KINDS:
             raise ValueError(f"option_kind must be one of {OPTION_KINDS}")
         _require_probability(self.signal_strength, "signal_strength")
-        invalid_dimensions = set(self.dimension_biases) - set(schema.TRADEOFF_DIMENSION_KEYS)
+        invalid_dimensions = set(self.dimension_biases) - set(
+            schema.TRADEOFF_DIMENSION_KEYS
+        )
         if invalid_dimensions:
-            raise ValueError(f"unsupported dimension_biases keys: {sorted(invalid_dimensions)}")
+            raise ValueError(
+                f"unsupported dimension_biases keys: {sorted(invalid_dimensions)}"
+            )
         invalid_hybrid = set(self.hybrid_biases) - set(schema.HYBRID_FACTOR_KEYS)
         if invalid_hybrid:
-            raise ValueError(f"unsupported hybrid_biases keys: {sorted(invalid_hybrid)}")
+            raise ValueError(
+                f"unsupported hybrid_biases keys: {sorted(invalid_hybrid)}"
+            )
         for key, value in self.dimension_biases.items():
             _require_axis(value, f"dimension_biases[{key}]")
         for key, value in self.hybrid_biases.items():
@@ -104,8 +115,12 @@ class RevealedPreferenceUpdate:
     notes: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        if any(not isinstance(item, PreferenceEvidence) for item in self.emitted_evidence):
-            raise ValueError("emitted_evidence must contain PreferenceEvidence instances")
+        if any(
+            not isinstance(item, PreferenceEvidence) for item in self.emitted_evidence
+        ):
+            raise ValueError(
+                "emitted_evidence must contain PreferenceEvidence instances"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -127,10 +142,15 @@ def build_revealed_preference_update(
         "ignored": "negative",
     }[signal.reaction_type]
     transient = (
-        signal.reaction_type in {"ignored", "saved_for_later"} or signal.signal_strength < 0.45
+        signal.reaction_type in {"ignored", "saved_for_later"}
+        or signal.signal_strength < 0.45
     )
-    confidence_hint = min(1.0, max(0.1, signal.signal_strength * (0.45 if transient else 0.85)))
-    salience_hint = min(1.0, max(0.1, signal.signal_strength * (0.4 if transient else 0.8)))
+    confidence_hint = min(
+        1.0, max(0.1, signal.signal_strength * (0.45 if transient else 0.85))
+    )
+    salience_hint = min(
+        1.0, max(0.1, signal.signal_strength * (0.4 if transient else 0.8))
+    )
 
     contradictions: list[ContradictionMarker] = []
     blocked_overwrites: list[str] = []
@@ -143,7 +163,9 @@ def build_revealed_preference_update(
             current_dimension.salience >= 0.75
             and current_dimension.stability >= 0.75
             and current_dimension.value != 0.0
-            and (current_dimension.value < 0 < bias or current_dimension.value > 0 > bias)
+            and (
+                current_dimension.value < 0 < bias or current_dimension.value > 0 > bias
+            )
         ):
             blocked_overwrites.append(dimension_key)
             contradictions.append(
@@ -168,7 +190,8 @@ def build_revealed_preference_update(
 
     evidence_type = (
         "option_selection"
-        if signal.reaction_type in {"selected", "saved_for_later", "requested_more_like_this"}
+        if signal.reaction_type
+        in {"selected", "saved_for_later", "requested_more_like_this"}
         else "option_rejection"
     )
     emitted = PreferenceEvidence(
@@ -181,7 +204,8 @@ def build_revealed_preference_update(
         confidence_hint=confidence_hint,
         salience_hint=salience_hint,
         sequence=REVEALED_PREFERENCE_FALLBACK_SEQUENCE,
-        note=signal.summary or "Revealed preference update from concrete option feedback.",
+        note=signal.summary
+        or "Revealed preference update from concrete option feedback.",
         option_evidence=OptionEvidence(
             option_set_id=signal.option_set_id,
             option_id=signal.option_id,

--- a/trip_planner/ranking/__init__.py
+++ b/trip_planner/ranking/__init__.py
@@ -5,6 +5,7 @@ from .explanations import (
     EXPLANATION_TARGET_KINDS,
     ExplanationRecord,
 )
+from .leisure import rank_leisure_candidates
 from .models import (
     ADJUSTMENT_KINDS,
     RANK_RESULT_KINDS,
@@ -27,6 +28,7 @@ __all__ = [
     "RISK_SEVERITIES",
     "SCHEMA_VERSION",
     "ExplanationRecord",
+    "rank_leisure_candidates",
     "RankedResult",
     "RankedResultSet",
     "RiskFlag",

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -73,9 +73,9 @@ def rank_leisure_candidates(
 
     scored_results: list[tuple[float, RankedResult]] = []
     for seed in seeds:
-        feasibility = feasibility_index.get(
-            seed.bundle.bundle_id
-        ) or evaluate_bundle_feasibility(seed.bundle)
+        feasibility = feasibility_index.get(seed.bundle.bundle_id) or evaluate_bundle_feasibility(
+            seed.bundle
+        )
         score, result = _build_ranked_result(
             seed=seed,
             resolved_profile=resolved_profile,
@@ -93,19 +93,14 @@ def rank_leisure_candidates(
         ),
         reverse=True,
     )
-    results = [
-        _with_rank(result, rank=index)
-        for index, (_, result) in enumerate(ranked, start=1)
-    ]
+    results = [_with_rank(result, rank=index) for index, (_, result) in enumerate(ranked, start=1)]
     result_set_id = f"ranking:{trip_id}:leisure"
     result_explanations = [
         "Leisure ranking remains downstream from preference resolution, objective derivation, and feasibility evaluation.",
         "Scores keep component breakdowns, confidence penalties, and tension handling explicit for inspection.",
     ]
     source_refs = _dedupe_strings(
-        source_ref
-        for seed in seeds
-        for source_ref in seed.bundle.provenance_summary.source_refs
+        source_ref for seed in seeds for source_ref in seed.bundle.provenance_summary.source_refs
     )
     return RankedResultSet(
         result_set_id=result_set_id,
@@ -217,8 +212,7 @@ def _build_ranked_result(
             label="Quality and value posture",
             axis_key="quality_value",
             normalized_signal=_mean([quality_signal, value_signal]),
-            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5)
-            * 0.12,
+            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5) * 0.12,
             summary="Rewards bundles that preserve quality and value instead of collapsing them into one scalar.",
         ),
         _axis_contribution(
@@ -365,10 +359,7 @@ def _build_ranked_result(
                 amount=round(
                     min(
                         0.12,
-                        sum(
-                            flag.severity
-                            for flag in resolved_profile.profile.tension_flags
-                        )
+                        sum(flag.severity for flag in resolved_profile.profile.tension_flags)
                         * 0.03,
                     ),
                     4,
@@ -384,9 +375,7 @@ def _build_ranked_result(
                 adjustment_id=f"{bundle.bundle_id}:missing",
                 label="Missing feasibility inputs",
                 kind="missing_data",
-                amount=round(
-                    min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4
-                ),
+                amount=round(min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4),
                 reason_code="missing_feasibility_data",
                 summary="Missing feasibility inputs remain visible as ranking discounts.",
                 affected_factor_keys=["missing_data"],
@@ -409,8 +398,7 @@ def _build_ranked_result(
     low_confidence_flags = _low_confidence_flags(resolved_profile)
     coverage = _clamp(1.0 - (0.08 * len(feasibility.missing_data_fields)))
     stability = _mean(
-        dimension.stability
-        for dimension in resolved_profile.profile.tradeoff_dimensions.values()
+        dimension.stability for dimension in resolved_profile.profile.tradeoff_dimensions.values()
     )
     feasibility_confidence = _coalesce_signal(
         feasibility.confidence_signal,
@@ -596,15 +584,11 @@ def _dedupe_strings(values: Iterable[str]) -> list[str]:
 
 
 def _bundle_quality_signal(bundle: InventoryBundle) -> float:
-    lodging_quality = _mean(
-        item.quality_summary.overall_signal for item in bundle.lodging_options
-    )
+    lodging_quality = _mean(item.quality_summary.overall_signal for item in bundle.lodging_options)
     activity_quality = _mean(
         item.quality_summary.overall_signal for item in bundle.activity_options
     )
-    return _mean(
-        [bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality]
-    )
+    return _mean([bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality])
 
 
 def _iconic_signal(bundle: InventoryBundle) -> float:
@@ -614,16 +598,13 @@ def _iconic_signal(bundle: InventoryBundle) -> float:
         if item.significance_summary.local_icon_signal is not None
     ]
     anchor_bonus = [
-        1.0 if item.significance_summary.anchor_worthy else 0.0
-        for item in bundle.activity_options
+        1.0 if item.significance_summary.anchor_worthy else 0.0 for item in bundle.activity_options
     ]
     return _mean(values + anchor_bonus)
 
 
 def _discovery_signal(bundle: InventoryBundle) -> float:
-    open_ended = [
-        1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options
-    ]
+    open_ended = [1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options]
     wander_tags = [
         1.0
         for item in bundle.activity_options
@@ -649,20 +630,14 @@ def _scenic_signal(bundle: InventoryBundle) -> float:
 def _efficiency_signal(feasibility: FeasibilityAssessment) -> float:
     travel_minutes = feasibility.total_travel_minutes
     transfer_count = feasibility.total_transfer_count
-    return _clamp(
-        1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08)
-    )
+    return _clamp(1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08))
 
 
-def _recovery_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _recovery_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     lodging_recovery = _mean(
         item.location_summary.recovery_signal for item in bundle.lodging_options
     )
-    quiet_signal = _mean(
-        item.location_summary.quiet_signal for item in bundle.lodging_options
-    )
+    quiet_signal = _mean(item.location_summary.quiet_signal for item in bundle.lodging_options)
     conflict_penalty = min(
         0.4,
         len([item for item in feasibility.timing_conflicts if item.blocking]) * 0.18,
@@ -686,22 +661,17 @@ def _intensity_signal(bundle: InventoryBundle) -> float:
 
 def _structure_signal(bundle: InventoryBundle) -> float:
     values = [
-        1.0 if item.booking_terms.booking_required else 0.35
-        for item in bundle.activity_options
+        1.0 if item.booking_terms.booking_required else 0.35 for item in bundle.activity_options
     ]
     return _mean(values or [0.45])
 
 
 def _elasticity_signal(bundle: InventoryBundle) -> float:
-    values = [
-        1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options
-    ]
+    values = [1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options]
     return _mean(values or [0.45])
 
 
-def _coherence_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _coherence_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     destination_penalty = max(0, len(bundle.destination_ids) - 1) * 0.14
     route_penalty = len(feasibility.route_warnings) * 0.1
     transfer_penalty = feasibility.total_transfer_count * 0.05
@@ -712,21 +682,15 @@ def _breadth_signal(bundle: InventoryBundle) -> float:
     return _clamp(min(1.0, max(0.0, (len(bundle.destination_ids) - 1) / 2.0)))
 
 
-def _movement_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _movement_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     transport_weight = 0.25 if bundle.transport_options else 0.0
     travel_component = min(0.55, feasibility.total_travel_minutes / 420.0)
     scenic_component = _scenic_signal(bundle) * 0.2
     breadth_component = _breadth_signal(bundle) * 0.25
-    return _clamp(
-        travel_component + scenic_component + breadth_component + transport_weight
-    )
+    return _clamp(travel_component + scenic_component + breadth_component + transport_weight)
 
 
-def _budget_signal(
-    seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile
-) -> float:
+def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile) -> float:
     estimated_total = seed.estimated_total()
     base_signal = _mean(
         [
@@ -740,9 +704,7 @@ def _budget_signal(
         return _clamp((base_signal * (0.65 + (sensitivity * 0.35))))
     if estimated_total.typical_amount is None:
         return base_signal
-    budget_ratio = (
-        estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
-    )
+    budget_ratio = estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
     if budget_ratio <= 0.85:
         return _clamp(max(base_signal, 0.75))
     if budget_ratio <= 1.0:
@@ -762,9 +724,7 @@ def _quality_floor_signal(bundle: InventoryBundle) -> float:
         for item in bundle.lodging_options
         if item.quality_summary.sleep_quality_signal is not None
     ]
-    return _mean(
-        lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal]
-    )
+    return _mean(lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal])
 
 
 def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -> float:
@@ -772,9 +732,7 @@ def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -
     for group_name, anchors in resolved_profile.profile.anchors.items():
         for anchor in anchors:
             label_terms = [
-                term
-                for term in anchor.label.lower().replace("-", " ").split()
-                if len(term) > 2
+                term for term in anchor.label.lower().replace("-", " ").split() if len(term) > 2
             ]
             if any(term in bundle_text for term in label_terms):
                 matches.append(anchor.strength)
@@ -802,15 +760,11 @@ def _hybrid_signal(
         matched = any(keyword in bundle_text for keyword in keywords)
         if key == "rest" and bundle.lodging_options:
             if rest_recovery_signal is None:
-                resolved_feasibility = feasibility or evaluate_bundle_feasibility(
-                    bundle
-                )
+                resolved_feasibility = feasibility or evaluate_bundle_feasibility(bundle)
                 rest_recovery_signal = _recovery_signal(bundle, resolved_feasibility)
             matched = matched or rest_recovery_signal >= 0.7
         if matched:
-            signals.append(
-                _clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3))
-            )
+            signals.append(_clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3)))
     return _mean(signals or [0.45])
 
 
@@ -818,9 +772,7 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
     freshness: list[float] = []
     for destination in bundle.destinations:
         for destination_source in destination.source_refs:
-            freshness_days = getattr(
-                destination_source, "freshness_days_at_capture", None
-            )
+            freshness_days = getattr(destination_source, "freshness_days_at_capture", None)
             if freshness_days is not None:
                 freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     for collection in (
@@ -832,13 +784,9 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
             for option_source in option.source_refs:
                 trust = getattr(option_source, "trust_snapshot", None)
                 if trust and trust.freshness_days is not None:
-                    freshness.append(
-                        _clamp(1.0 - min(1.0, trust.freshness_days / 90.0))
-                    )
+                    freshness.append(_clamp(1.0 - min(1.0, trust.freshness_days / 90.0)))
                 else:
-                    freshness_days = getattr(
-                        option_source, "freshness_days_at_capture", None
-                    )
+                    freshness_days = getattr(option_source, "freshness_days_at_capture", None)
                     if freshness_days is not None:
                         freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     return _mean(freshness or [0.75])
@@ -906,9 +854,7 @@ def _explanations_for_result(
             headline=f"{top_positive.label} promotes this bundle.",
             summary=top_positive.summary,
             factor_keys=[top_positive.axis_key],
-            machine_context={
-                "normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"
-            },
+            machine_context={"normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"},
             human_summary=_non_empty_strings(
                 *bundle.explanation.strengths[:2],
                 bundle.summary or bundle.title,
@@ -930,8 +876,7 @@ def _explanations_for_result(
                 "input_coverage": f"{confidence_summary.input_coverage or 0.0:.2f}",
                 "scoring_stability": f"{confidence_summary.scoring_stability or 0.0:.2f}",
             },
-            human_summary=confidence_summary.notes[:2]
-            or ["Confidence remains inspectable."],
+            human_summary=confidence_summary.notes[:2] or ["Confidence remains inspectable."],
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
     ]

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -73,9 +73,9 @@ def rank_leisure_candidates(
 
     scored_results: list[tuple[float, RankedResult]] = []
     for seed in seeds:
-        feasibility = feasibility_index.get(seed.bundle.bundle_id) or evaluate_bundle_feasibility(
-            seed.bundle
-        )
+        feasibility = feasibility_index.get(
+            seed.bundle.bundle_id
+        ) or evaluate_bundle_feasibility(seed.bundle)
         score, result = _build_ranked_result(
             seed=seed,
             resolved_profile=resolved_profile,
@@ -93,14 +93,19 @@ def rank_leisure_candidates(
         ),
         reverse=True,
     )
-    results = [_with_rank(result, rank=index) for index, (_, result) in enumerate(ranked, start=1)]
+    results = [
+        _with_rank(result, rank=index)
+        for index, (_, result) in enumerate(ranked, start=1)
+    ]
     result_set_id = f"ranking:{trip_id}:leisure"
     result_explanations = [
         "Leisure ranking remains downstream from preference resolution, objective derivation, and feasibility evaluation.",
         "Scores keep component breakdowns, confidence penalties, and tension handling explicit for inspection.",
     ]
     source_refs = _dedupe_strings(
-        source_ref for seed in seeds for source_ref in seed.bundle.provenance_summary.source_refs
+        source_ref
+        for seed in seeds
+        for source_ref in seed.bundle.provenance_summary.source_refs
     )
     return RankedResultSet(
         result_set_id=result_set_id,
@@ -191,7 +196,12 @@ def _build_ranked_result(
     budget_signal = _budget_signal(seed, resolved_profile)
     quality_floor_signal = _quality_floor_signal(bundle)
     anchor_signal = _anchor_signal(resolved_profile, bundle_text)
-    hybrid_signal = _hybrid_signal(resolved_profile, bundle_text, bundle)
+    hybrid_signal = _hybrid_signal(
+        resolved_profile,
+        bundle_text,
+        bundle,
+        feasibility=feasibility,
+    )
 
     contributions = [
         _contribution(
@@ -207,7 +217,8 @@ def _build_ranked_result(
             label="Quality and value posture",
             axis_key="quality_value",
             normalized_signal=_mean([quality_signal, value_signal]),
-            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5) * 0.12,
+            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5)
+            * 0.12,
             summary="Rewards bundles that preserve quality and value instead of collapsing them into one scalar.",
         ),
         _axis_contribution(
@@ -354,7 +365,10 @@ def _build_ranked_result(
                 amount=round(
                     min(
                         0.12,
-                        sum(flag.severity for flag in resolved_profile.profile.tension_flags)
+                        sum(
+                            flag.severity
+                            for flag in resolved_profile.profile.tension_flags
+                        )
                         * 0.03,
                     ),
                     4,
@@ -370,7 +384,9 @@ def _build_ranked_result(
                 adjustment_id=f"{bundle.bundle_id}:missing",
                 label="Missing feasibility inputs",
                 kind="missing_data",
-                amount=round(min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4),
+                amount=round(
+                    min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4
+                ),
                 reason_code="missing_feasibility_data",
                 summary="Missing feasibility inputs remain visible as ranking discounts.",
                 affected_factor_keys=["missing_data"],
@@ -393,7 +409,8 @@ def _build_ranked_result(
     low_confidence_flags = _low_confidence_flags(resolved_profile)
     coverage = _clamp(1.0 - (0.08 * len(feasibility.missing_data_fields)))
     stability = _mean(
-        dimension.stability for dimension in resolved_profile.profile.tradeoff_dimensions.values()
+        dimension.stability
+        for dimension in resolved_profile.profile.tradeoff_dimensions.values()
     )
     feasibility_confidence = _coalesce_signal(
         feasibility.confidence_signal,
@@ -579,11 +596,15 @@ def _dedupe_strings(values: Iterable[str]) -> list[str]:
 
 
 def _bundle_quality_signal(bundle: InventoryBundle) -> float:
-    lodging_quality = _mean(item.quality_summary.overall_signal for item in bundle.lodging_options)
+    lodging_quality = _mean(
+        item.quality_summary.overall_signal for item in bundle.lodging_options
+    )
     activity_quality = _mean(
         item.quality_summary.overall_signal for item in bundle.activity_options
     )
-    return _mean([bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality])
+    return _mean(
+        [bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality]
+    )
 
 
 def _iconic_signal(bundle: InventoryBundle) -> float:
@@ -593,13 +614,16 @@ def _iconic_signal(bundle: InventoryBundle) -> float:
         if item.significance_summary.local_icon_signal is not None
     ]
     anchor_bonus = [
-        1.0 if item.significance_summary.anchor_worthy else 0.0 for item in bundle.activity_options
+        1.0 if item.significance_summary.anchor_worthy else 0.0
+        for item in bundle.activity_options
     ]
     return _mean(values + anchor_bonus)
 
 
 def _discovery_signal(bundle: InventoryBundle) -> float:
-    open_ended = [1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options]
+    open_ended = [
+        1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options
+    ]
     wander_tags = [
         1.0
         for item in bundle.activity_options
@@ -625,14 +649,20 @@ def _scenic_signal(bundle: InventoryBundle) -> float:
 def _efficiency_signal(feasibility: FeasibilityAssessment) -> float:
     travel_minutes = feasibility.total_travel_minutes
     transfer_count = feasibility.total_transfer_count
-    return _clamp(1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08))
+    return _clamp(
+        1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08)
+    )
 
 
-def _recovery_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _recovery_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     lodging_recovery = _mean(
         item.location_summary.recovery_signal for item in bundle.lodging_options
     )
-    quiet_signal = _mean(item.location_summary.quiet_signal for item in bundle.lodging_options)
+    quiet_signal = _mean(
+        item.location_summary.quiet_signal for item in bundle.lodging_options
+    )
     conflict_penalty = min(
         0.4,
         len([item for item in feasibility.timing_conflicts if item.blocking]) * 0.18,
@@ -656,17 +686,22 @@ def _intensity_signal(bundle: InventoryBundle) -> float:
 
 def _structure_signal(bundle: InventoryBundle) -> float:
     values = [
-        1.0 if item.booking_terms.booking_required else 0.35 for item in bundle.activity_options
+        1.0 if item.booking_terms.booking_required else 0.35
+        for item in bundle.activity_options
     ]
     return _mean(values or [0.45])
 
 
 def _elasticity_signal(bundle: InventoryBundle) -> float:
-    values = [1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options]
+    values = [
+        1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options
+    ]
     return _mean(values or [0.45])
 
 
-def _coherence_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _coherence_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     destination_penalty = max(0, len(bundle.destination_ids) - 1) * 0.14
     route_penalty = len(feasibility.route_warnings) * 0.1
     transfer_penalty = feasibility.total_transfer_count * 0.05
@@ -677,15 +712,21 @@ def _breadth_signal(bundle: InventoryBundle) -> float:
     return _clamp(min(1.0, max(0.0, (len(bundle.destination_ids) - 1) / 2.0)))
 
 
-def _movement_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _movement_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     transport_weight = 0.25 if bundle.transport_options else 0.0
     travel_component = min(0.55, feasibility.total_travel_minutes / 420.0)
     scenic_component = _scenic_signal(bundle) * 0.2
     breadth_component = _breadth_signal(bundle) * 0.25
-    return _clamp(travel_component + scenic_component + breadth_component + transport_weight)
+    return _clamp(
+        travel_component + scenic_component + breadth_component + transport_weight
+    )
 
 
-def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile) -> float:
+def _budget_signal(
+    seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile
+) -> float:
     estimated_total = seed.estimated_total()
     base_signal = _mean(
         [
@@ -699,7 +740,9 @@ def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile
         return _clamp((base_signal * (0.65 + (sensitivity * 0.35))))
     if estimated_total.typical_amount is None:
         return base_signal
-    budget_ratio = estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
+    budget_ratio = (
+        estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
+    )
     if budget_ratio <= 0.85:
         return _clamp(max(base_signal, 0.75))
     if budget_ratio <= 1.0:
@@ -719,7 +762,9 @@ def _quality_floor_signal(bundle: InventoryBundle) -> float:
         for item in bundle.lodging_options
         if item.quality_summary.sleep_quality_signal is not None
     ]
-    return _mean(lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal])
+    return _mean(
+        lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal]
+    )
 
 
 def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -> float:
@@ -727,7 +772,9 @@ def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -
     for group_name, anchors in resolved_profile.profile.anchors.items():
         for anchor in anchors:
             label_terms = [
-                term for term in anchor.label.lower().replace("-", " ").split() if len(term) > 2
+                term
+                for term in anchor.label.lower().replace("-", " ").split()
+                if len(term) > 2
             ]
             if any(term in bundle_text for term in label_terms):
                 matches.append(anchor.strength)
@@ -745,17 +792,25 @@ def _hybrid_signal(
     resolved_profile: ResolvedLeisureProfile,
     bundle_text: str,
     bundle: InventoryBundle,
+    *,
+    feasibility: FeasibilityAssessment | None = None,
 ) -> float:
     signals: list[float] = []
+    rest_recovery_signal: float | None = None
     for key, factor in resolved_profile.profile.hybrid_factors.items():
         keywords = _HYBRID_KEYWORDS.get(key, ())
         matched = any(keyword in bundle_text for keyword in keywords)
         if key == "rest" and bundle.lodging_options:
-            matched = (
-                matched or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
-            )
+            if rest_recovery_signal is None:
+                resolved_feasibility = feasibility or evaluate_bundle_feasibility(
+                    bundle
+                )
+                rest_recovery_signal = _recovery_signal(bundle, resolved_feasibility)
+            matched = matched or rest_recovery_signal >= 0.7
         if matched:
-            signals.append(_clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3)))
+            signals.append(
+                _clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3))
+            )
     return _mean(signals or [0.45])
 
 
@@ -763,7 +818,9 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
     freshness: list[float] = []
     for destination in bundle.destinations:
         for destination_source in destination.source_refs:
-            freshness_days = getattr(destination_source, "freshness_days_at_capture", None)
+            freshness_days = getattr(
+                destination_source, "freshness_days_at_capture", None
+            )
             if freshness_days is not None:
                 freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     for collection in (
@@ -775,9 +832,13 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
             for option_source in option.source_refs:
                 trust = getattr(option_source, "trust_snapshot", None)
                 if trust and trust.freshness_days is not None:
-                    freshness.append(_clamp(1.0 - min(1.0, trust.freshness_days / 90.0)))
+                    freshness.append(
+                        _clamp(1.0 - min(1.0, trust.freshness_days / 90.0))
+                    )
                 else:
-                    freshness_days = getattr(option_source, "freshness_days_at_capture", None)
+                    freshness_days = getattr(
+                        option_source, "freshness_days_at_capture", None
+                    )
                     if freshness_days is not None:
                         freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     return _mean(freshness or [0.75])
@@ -845,7 +906,9 @@ def _explanations_for_result(
             headline=f"{top_positive.label} promotes this bundle.",
             summary=top_positive.summary,
             factor_keys=[top_positive.axis_key],
-            machine_context={"normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"},
+            machine_context={
+                "normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"
+            },
             human_summary=_non_empty_strings(
                 *bundle.explanation.strengths[:2],
                 bundle.summary or bundle.title,
@@ -867,7 +930,8 @@ def _explanations_for_result(
                 "input_coverage": f"{confidence_summary.input_coverage or 0.0:.2f}",
                 "scoring_stability": f"{confidence_summary.scoring_stability or 0.0:.2f}",
             },
-            human_summary=confidence_summary.notes[:2] or ["Confidence remains inspectable."],
+            human_summary=confidence_summary.notes[:2]
+            or ["Confidence remains inspectable."],
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
     ]

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -73,9 +73,9 @@ def rank_leisure_candidates(
 
     scored_results: list[tuple[float, RankedResult]] = []
     for seed in seeds:
-        feasibility = feasibility_index.get(
-            seed.bundle.bundle_id
-        ) or evaluate_bundle_feasibility(seed.bundle)
+        feasibility = feasibility_index.get(seed.bundle.bundle_id) or evaluate_bundle_feasibility(
+            seed.bundle
+        )
         score, result = _build_ranked_result(
             seed=seed,
             resolved_profile=resolved_profile,
@@ -93,19 +93,14 @@ def rank_leisure_candidates(
         ),
         reverse=True,
     )
-    results = [
-        _with_rank(result, rank=index)
-        for index, (_, result) in enumerate(ranked, start=1)
-    ]
+    results = [_with_rank(result, rank=index) for index, (_, result) in enumerate(ranked, start=1)]
     result_set_id = f"ranking:{trip_id}:leisure"
     result_explanations = [
         "Leisure ranking remains downstream from preference resolution, objective derivation, and feasibility evaluation.",
         "Scores keep component breakdowns, confidence penalties, and tension handling explicit for inspection.",
     ]
     source_refs = _dedupe_strings(
-        source_ref
-        for seed in seeds
-        for source_ref in seed.bundle.provenance_summary.source_refs
+        source_ref for seed in seeds for source_ref in seed.bundle.provenance_summary.source_refs
     )
     return RankedResultSet(
         result_set_id=result_set_id,
@@ -172,8 +167,14 @@ def _build_ranked_result(
     bundle_text = _bundle_text(bundle)
 
     quality_signal = _bundle_quality_signal(bundle)
-    value_signal = bundle.quality_value_fit.value_signal or quality_signal
-    fit_signal = bundle.quality_value_fit.fit_signal or quality_signal
+    value_signal = _coalesce_signal(
+        bundle.quality_value_fit.value_signal,
+        fallback=quality_signal,
+    )
+    fit_signal = _coalesce_signal(
+        bundle.quality_value_fit.fit_signal,
+        fallback=quality_signal,
+    )
     iconic_signal = _iconic_signal(bundle)
     discovery_signal = _discovery_signal(bundle)
     scenic_signal = _scenic_signal(bundle)
@@ -206,8 +207,7 @@ def _build_ranked_result(
             label="Quality and value posture",
             axis_key="quality_value",
             normalized_signal=_mean([quality_signal, value_signal]),
-            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5)
-            * 0.12,
+            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5) * 0.12,
             summary="Rewards bundles that preserve quality and value instead of collapsing them into one scalar.",
         ),
         _axis_contribution(
@@ -354,10 +354,7 @@ def _build_ranked_result(
                 amount=round(
                     min(
                         0.12,
-                        sum(
-                            flag.severity
-                            for flag in resolved_profile.profile.tension_flags
-                        )
+                        sum(flag.severity for flag in resolved_profile.profile.tension_flags)
                         * 0.03,
                     ),
                     4,
@@ -373,9 +370,7 @@ def _build_ranked_result(
                 adjustment_id=f"{bundle.bundle_id}:missing",
                 label="Missing feasibility inputs",
                 kind="missing_data",
-                amount=round(
-                    min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4
-                ),
+                amount=round(min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4),
                 reason_code="missing_feasibility_data",
                 summary="Missing feasibility inputs remain visible as ranking discounts.",
                 affected_factor_keys=["missing_data"],
@@ -398,13 +393,16 @@ def _build_ranked_result(
     low_confidence_flags = _low_confidence_flags(resolved_profile)
     coverage = _clamp(1.0 - (0.08 * len(feasibility.missing_data_fields)))
     stability = _mean(
-        dimension.stability
-        for dimension in resolved_profile.profile.tradeoff_dimensions.values()
+        dimension.stability for dimension in resolved_profile.profile.tradeoff_dimensions.values()
+    )
+    feasibility_confidence = _coalesce_signal(
+        feasibility.confidence_signal,
+        fallback=0.7,
     )
     overall_confidence = _clamp(
         mean(
             [
-                feasibility.confidence_signal or 0.7,
+                feasibility_confidence,
                 coverage,
                 stability,
                 max(0.0, 1.0 - (0.08 * len(resolved_profile.profile.tension_flags))),
@@ -442,7 +440,7 @@ def _build_ranked_result(
         missing_data_fields=list(feasibility.missing_data_fields),
         notes=[
             f"Derived from {len(resolved_profile.profile.tension_flags)} active tension flags.",
-            f"Feasibility confidence signal={feasibility.confidence_signal or 0.7:.2f}.",
+            f"Feasibility confidence signal={feasibility_confidence:.2f}.",
         ],
     )
     explanation_records = _explanations_for_result(
@@ -474,6 +472,12 @@ def _build_ranked_result(
         ],
     )
     return final_score, result
+
+
+def _coalesce_signal(value: float | None, *, fallback: float) -> float:
+    if value is None:
+        return fallback
+    return value
 
 
 def _with_rank(result: RankedResult, *, rank: int) -> RankedResult:
@@ -575,15 +579,11 @@ def _dedupe_strings(values: Iterable[str]) -> list[str]:
 
 
 def _bundle_quality_signal(bundle: InventoryBundle) -> float:
-    lodging_quality = _mean(
-        item.quality_summary.overall_signal for item in bundle.lodging_options
-    )
+    lodging_quality = _mean(item.quality_summary.overall_signal for item in bundle.lodging_options)
     activity_quality = _mean(
         item.quality_summary.overall_signal for item in bundle.activity_options
     )
-    return _mean(
-        [bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality]
-    )
+    return _mean([bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality])
 
 
 def _iconic_signal(bundle: InventoryBundle) -> float:
@@ -593,16 +593,13 @@ def _iconic_signal(bundle: InventoryBundle) -> float:
         if item.significance_summary.local_icon_signal is not None
     ]
     anchor_bonus = [
-        1.0 if item.significance_summary.anchor_worthy else 0.0
-        for item in bundle.activity_options
+        1.0 if item.significance_summary.anchor_worthy else 0.0 for item in bundle.activity_options
     ]
     return _mean(values + anchor_bonus)
 
 
 def _discovery_signal(bundle: InventoryBundle) -> float:
-    open_ended = [
-        1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options
-    ]
+    open_ended = [1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options]
     wander_tags = [
         1.0
         for item in bundle.activity_options
@@ -628,20 +625,14 @@ def _scenic_signal(bundle: InventoryBundle) -> float:
 def _efficiency_signal(feasibility: FeasibilityAssessment) -> float:
     travel_minutes = feasibility.total_travel_minutes
     transfer_count = feasibility.total_transfer_count
-    return _clamp(
-        1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08)
-    )
+    return _clamp(1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08))
 
 
-def _recovery_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _recovery_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     lodging_recovery = _mean(
         item.location_summary.recovery_signal for item in bundle.lodging_options
     )
-    quiet_signal = _mean(
-        item.location_summary.quiet_signal for item in bundle.lodging_options
-    )
+    quiet_signal = _mean(item.location_summary.quiet_signal for item in bundle.lodging_options)
     conflict_penalty = min(
         0.4,
         len([item for item in feasibility.timing_conflicts if item.blocking]) * 0.18,
@@ -665,22 +656,17 @@ def _intensity_signal(bundle: InventoryBundle) -> float:
 
 def _structure_signal(bundle: InventoryBundle) -> float:
     values = [
-        1.0 if item.booking_terms.booking_required else 0.35
-        for item in bundle.activity_options
+        1.0 if item.booking_terms.booking_required else 0.35 for item in bundle.activity_options
     ]
     return _mean(values or [0.45])
 
 
 def _elasticity_signal(bundle: InventoryBundle) -> float:
-    values = [
-        1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options
-    ]
+    values = [1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options]
     return _mean(values or [0.45])
 
 
-def _coherence_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _coherence_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     destination_penalty = max(0, len(bundle.destination_ids) - 1) * 0.14
     route_penalty = len(feasibility.route_warnings) * 0.1
     transfer_penalty = feasibility.total_transfer_count * 0.05
@@ -691,21 +677,15 @@ def _breadth_signal(bundle: InventoryBundle) -> float:
     return _clamp(min(1.0, max(0.0, (len(bundle.destination_ids) - 1) / 2.0)))
 
 
-def _movement_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _movement_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     transport_weight = 0.25 if bundle.transport_options else 0.0
     travel_component = min(0.55, feasibility.total_travel_minutes / 420.0)
     scenic_component = _scenic_signal(bundle) * 0.2
     breadth_component = _breadth_signal(bundle) * 0.25
-    return _clamp(
-        travel_component + scenic_component + breadth_component + transport_weight
-    )
+    return _clamp(travel_component + scenic_component + breadth_component + transport_weight)
 
 
-def _budget_signal(
-    seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile
-) -> float:
+def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile) -> float:
     estimated_total = seed.estimated_total()
     base_signal = _mean(
         [
@@ -719,9 +699,7 @@ def _budget_signal(
         return _clamp((base_signal * (0.65 + (sensitivity * 0.35))))
     if estimated_total.typical_amount is None:
         return base_signal
-    budget_ratio = (
-        estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
-    )
+    budget_ratio = estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
     if budget_ratio <= 0.85:
         return _clamp(max(base_signal, 0.75))
     if budget_ratio <= 1.0:
@@ -741,9 +719,7 @@ def _quality_floor_signal(bundle: InventoryBundle) -> float:
         for item in bundle.lodging_options
         if item.quality_summary.sleep_quality_signal is not None
     ]
-    return _mean(
-        lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal]
-    )
+    return _mean(lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal])
 
 
 def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -> float:
@@ -751,9 +727,7 @@ def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -
     for group_name, anchors in resolved_profile.profile.anchors.items():
         for anchor in anchors:
             label_terms = [
-                term
-                for term in anchor.label.lower().replace("-", " ").split()
-                if len(term) > 2
+                term for term in anchor.label.lower().replace("-", " ").split() if len(term) > 2
             ]
             if any(term in bundle_text for term in label_terms):
                 matches.append(anchor.strength)
@@ -778,13 +752,10 @@ def _hybrid_signal(
         matched = any(keyword in bundle_text for keyword in keywords)
         if key == "rest" and bundle.lodging_options:
             matched = (
-                matched
-                or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
+                matched or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
             )
         if matched:
-            signals.append(
-                _clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3))
-            )
+            signals.append(_clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3)))
     return _mean(signals or [0.45])
 
 
@@ -792,9 +763,7 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
     freshness: list[float] = []
     for destination in bundle.destinations:
         for destination_source in destination.source_refs:
-            freshness_days = getattr(
-                destination_source, "freshness_days_at_capture", None
-            )
+            freshness_days = getattr(destination_source, "freshness_days_at_capture", None)
             if freshness_days is not None:
                 freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     for collection in (
@@ -806,13 +775,9 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
             for option_source in option.source_refs:
                 trust = getattr(option_source, "trust_snapshot", None)
                 if trust and trust.freshness_days is not None:
-                    freshness.append(
-                        _clamp(1.0 - min(1.0, trust.freshness_days / 90.0))
-                    )
+                    freshness.append(_clamp(1.0 - min(1.0, trust.freshness_days / 90.0)))
                 else:
-                    freshness_days = getattr(
-                        option_source, "freshness_days_at_capture", None
-                    )
+                    freshness_days = getattr(option_source, "freshness_days_at_capture", None)
                     if freshness_days is not None:
                         freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     return _mean(freshness or [0.75])
@@ -880,9 +845,7 @@ def _explanations_for_result(
             headline=f"{top_positive.label} promotes this bundle.",
             summary=top_positive.summary,
             factor_keys=[top_positive.axis_key],
-            machine_context={
-                "normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"
-            },
+            machine_context={"normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"},
             human_summary=_non_empty_strings(
                 *bundle.explanation.strengths[:2],
                 bundle.summary or bundle.title,
@@ -904,8 +867,7 @@ def _explanations_for_result(
                 "input_coverage": f"{confidence_summary.input_coverage or 0.0:.2f}",
                 "scoring_stability": f"{confidence_summary.scoring_stability or 0.0:.2f}",
             },
-            human_summary=confidence_summary.notes[:2]
-            or ["Confidence remains inspectable."],
+            human_summary=confidence_summary.notes[:2] or ["Confidence remains inspectable."],
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
     ]

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -1,0 +1,880 @@
+"""Deterministic leisure candidate ranking built on resolved profiles and bundles."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from statistics import mean
+
+from trip_planner.candidates import CandidateSeed, CandidateSet
+from trip_planner.contracts import ComparisonAxis, ItineraryObjectives
+from trip_planner.itinerary import derive_itinerary_objectives, evaluate_bundle_feasibility
+from trip_planner.itinerary.feasibility import FeasibilityAssessment
+from trip_planner.options import InventoryBundle
+from trip_planner.preferences.explanations import ResolvedLeisureProfile
+
+from .explanations import ExplanationRecord
+from .models import (
+    RankedResult,
+    RankedResultSet,
+    RiskFlag,
+    ScoreAdjustment,
+    ScoreBreakdown,
+    ScoreConfidenceSummary,
+    ScoreContribution,
+)
+
+_DIMENSION_WEIGHTS: dict[str, float] = {
+    "movement_vs_friction": 0.08,
+    "recovery_vs_intensity": 0.09,
+    "structure_vs_elasticity": 0.08,
+    "breadth_vs_depth": 0.08,
+    "iconic_vs_discovery": 0.09,
+    "route_coherence_vs_eclectic_contrast": 0.08,
+    "scenic_transit_vs_destination_time": 0.08,
+}
+_HYBRID_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "food": ("food", "cafe", "market", "restaurant", "dining"),
+    "rest": ("rest", "quiet", "recovery", "sleep", "retreat", "calm"),
+    "music": ("music", "concert", "theater", "performance", "festival"),
+    "route_modes": ("rail", "ferry", "flight", "car", "route", "transit"),
+}
+_ANCHOR_TYPE_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "lodging": ("hotel", "lodging", "retreat", "rental", "sleep"),
+    "museum": ("museum", "gallery", "exhibit"),
+    "food": ("food", "market", "restaurant", "cafe"),
+    "scenic": ("scenic", "view", "hike", "outdoors"),
+    "district": ("district", "wander", "neighborhood"),
+}
+
+
+def rank_leisure_candidates(
+    *,
+    trip_id: str,
+    resolved_profile: ResolvedLeisureProfile,
+    candidate_set: CandidateSet | None = None,
+    bundles: Iterable[InventoryBundle] | None = None,
+    objectives: ItineraryObjectives | None = None,
+    feasibility_by_bundle_id: dict[str, FeasibilityAssessment] | None = None,
+) -> RankedResultSet:
+    """Rank leisure candidates from either a candidate set or raw bundles."""
+    seeds, comparison_axes = _collect_inputs(
+        trip_id=trip_id,
+        candidate_set=candidate_set,
+        bundles=bundles,
+    )
+    derived_objectives = objectives or derive_itinerary_objectives(
+        resolved_profile,
+        trip_id=trip_id,
+    )
+    feasibility_index = dict(feasibility_by_bundle_id or {})
+
+    scored_results: list[tuple[float, RankedResult]] = []
+    for seed in seeds:
+        feasibility = feasibility_index.get(seed.bundle.bundle_id) or evaluate_bundle_feasibility(seed.bundle)
+        score, result = _build_ranked_result(
+            seed=seed,
+            resolved_profile=resolved_profile,
+            objectives=derived_objectives,
+            feasibility=feasibility,
+        )
+        scored_results.append((score, result))
+
+    ranked = sorted(
+        scored_results,
+        key=lambda item: (
+            item[0],
+            item[1].confidence_summary.overall_confidence or 0.0,
+            item[1].target_bundle_id or "",
+        ),
+        reverse=True,
+    )
+    results = [
+        _with_rank(result, rank=index)
+        for index, (_, result) in enumerate(ranked, start=1)
+    ]
+    result_set_id = f"ranking:{trip_id}:leisure"
+    result_explanations = [
+        "Leisure ranking remains downstream from preference resolution, objective derivation, and feasibility evaluation.",
+        "Scores keep component breakdowns, confidence penalties, and tension handling explicit for inspection.",
+    ]
+    source_refs = _dedupe_strings(
+        source_ref
+        for seed in seeds
+        for source_ref in seed.bundle.provenance_summary.source_refs
+    )
+    return RankedResultSet(
+        result_set_id=result_set_id,
+        trip_id=trip_id,
+        purpose="profile_learning",
+        scope="mixed",
+        title="Leisure candidate ranking",
+        results=results,
+        comparison_axes=comparison_axes,
+        explanation=result_explanations,
+        source_refs=source_refs,
+    )
+
+
+def _collect_inputs(
+    *,
+    trip_id: str,
+    candidate_set: CandidateSet | None,
+    bundles: Iterable[InventoryBundle] | None,
+) -> tuple[list[CandidateSeed], list[ComparisonAxis]]:
+    if (candidate_set is None) == (bundles is None):
+        raise ValueError("provide exactly one of candidate_set or bundles")
+    if candidate_set is not None:
+        return list(candidate_set.seeds), list(candidate_set.comparison_axes)
+
+    assert bundles is not None
+    seeds = [
+        CandidateSeed(
+            candidate_id=f"candidate:{bundle.bundle_id}",
+            bundle=bundle,
+            supported_purposes=["profile_learning"],
+            inclusion_reasons=list(bundle.explanation.strengths),
+            unresolved_risks=list(bundle.explanation.tradeoffs),
+        )
+        for bundle in bundles
+    ]
+    if not seeds:
+        raise ValueError("bundles must contain at least one InventoryBundle")
+    axes = [
+        ComparisonAxis(
+            key="leisure_fit",
+            label="Leisure fit",
+            direction="higher_better",
+            notes="Overall alignment with resolved leisure preferences and itinerary objectives.",
+        ),
+        ComparisonAxis(
+            key="ranking_confidence",
+            label="Ranking confidence",
+            direction="higher_better",
+            notes="Coverage and confidence after tension and missing-data penalties.",
+        ),
+    ]
+    return seeds, axes
+
+
+def _build_ranked_result(
+    *,
+    seed: CandidateSeed,
+    resolved_profile: ResolvedLeisureProfile,
+    objectives: ItineraryObjectives,
+    feasibility: FeasibilityAssessment,
+) -> tuple[float, RankedResult]:
+    bundle = seed.bundle
+    bundle_text = _bundle_text(bundle)
+
+    quality_signal = _bundle_quality_signal(bundle)
+    value_signal = bundle.quality_value_fit.value_signal or quality_signal
+    fit_signal = bundle.quality_value_fit.fit_signal or quality_signal
+    iconic_signal = _iconic_signal(bundle)
+    discovery_signal = _discovery_signal(bundle)
+    scenic_signal = _scenic_signal(bundle)
+    efficiency_signal = _efficiency_signal(feasibility)
+    recovery_signal = _recovery_signal(bundle, feasibility)
+    intensity_signal = _intensity_signal(bundle)
+    structure_signal = _structure_signal(bundle)
+    elasticity_signal = _elasticity_signal(bundle)
+    coherence_signal = _coherence_signal(bundle, feasibility)
+    breadth_signal = _breadth_signal(bundle)
+    depth_signal = _clamp(1.0 - breadth_signal)
+    friction_signal = _clamp(1.0 - min(1.0, feasibility.friction_penalty_total))
+    movement_signal = _movement_signal(bundle, feasibility)
+    budget_signal = _budget_signal(seed, resolved_profile)
+    quality_floor_signal = _quality_floor_signal(bundle)
+    anchor_signal = _anchor_signal(resolved_profile, bundle_text)
+    hybrid_signal = _hybrid_signal(resolved_profile, bundle_text, bundle)
+
+    contributions = [
+        _contribution(
+            contribution_id=f"{bundle.bundle_id}:bundle-fit",
+            label="Bundle fit foundation",
+            axis_key="bundle_fit",
+            normalized_signal=fit_signal,
+            weighted_impact=(fit_signal - 0.5) * 0.16,
+            summary="Carries forward the bundle-level fit signal from candidate assembly.",
+        ),
+        _contribution(
+            contribution_id=f"{bundle.bundle_id}:quality-value",
+            label="Quality and value posture",
+            axis_key="quality_value",
+            normalized_signal=_mean([quality_signal, value_signal]),
+            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5) * 0.12,
+            summary="Rewards bundles that preserve quality and value instead of collapsing them into one scalar.",
+        ),
+        _axis_contribution(
+            bundle=bundle,
+            resolved_profile=resolved_profile,
+            dimension_key="iconic_vs_discovery",
+            label="Discovery vs iconic alignment",
+            positive_signal=iconic_signal,
+            negative_signal=discovery_signal,
+            positive_summary="Bundle better fits iconic or anchor-heavy priorities.",
+            negative_summary="Bundle better fits discovery-forward wandering priorities.",
+        ),
+        _axis_contribution(
+            bundle=bundle,
+            resolved_profile=resolved_profile,
+            dimension_key="scenic_transit_vs_destination_time",
+            label="Transit style alignment",
+            positive_signal=scenic_signal,
+            negative_signal=efficiency_signal,
+            positive_summary="Bundle rewards scenic transit as part of the experience.",
+            negative_summary="Bundle protects destination time when scenic transit is not the main goal.",
+        ),
+        _axis_contribution(
+            bundle=bundle,
+            resolved_profile=resolved_profile,
+            dimension_key="recovery_vs_intensity",
+            label="Recovery alignment",
+            positive_signal=recovery_signal,
+            negative_signal=intensity_signal,
+            positive_summary="Bundle protects recovery and schedule buffers.",
+            negative_summary="Bundle tolerates higher activity intensity and movement load.",
+        ),
+        _axis_contribution(
+            bundle=bundle,
+            resolved_profile=resolved_profile,
+            dimension_key="structure_vs_elasticity",
+            label="Structure alignment",
+            positive_signal=structure_signal,
+            negative_signal=elasticity_signal,
+            positive_summary="Bundle offers more structure and timed anchors.",
+            negative_summary="Bundle preserves elastic, open-ended wandering room.",
+        ),
+        _axis_contribution(
+            bundle=bundle,
+            resolved_profile=resolved_profile,
+            dimension_key="breadth_vs_depth",
+            label="Breadth vs depth alignment",
+            positive_signal=depth_signal,
+            negative_signal=breadth_signal,
+            positive_summary="Bundle favors deeper focus and fewer destination pivots.",
+            negative_summary="Bundle supports broader coverage across more places.",
+        ),
+        _axis_contribution(
+            bundle=bundle,
+            resolved_profile=resolved_profile,
+            dimension_key="route_coherence_vs_eclectic_contrast",
+            label="Route shape alignment",
+            positive_signal=coherence_signal,
+            negative_signal=_clamp((breadth_signal * 0.75) + (discovery_signal * 0.25)),
+            positive_summary="Bundle keeps the route coherent and lower-friction.",
+            negative_summary="Bundle tolerates more eclectic contrast across the route.",
+        ),
+        _axis_contribution(
+            bundle=bundle,
+            resolved_profile=resolved_profile,
+            dimension_key="movement_vs_friction",
+            label="Movement vs friction alignment",
+            positive_signal=movement_signal,
+            negative_signal=friction_signal,
+            positive_summary="Bundle keeps movement itself meaningful rather than dead travel.",
+            negative_summary="Bundle limits travel friction when that matters more than movement.",
+        ),
+        _contribution(
+            contribution_id=f"{bundle.bundle_id}:anchors",
+            label="Anchor coverage",
+            axis_key="anchors",
+            normalized_signal=anchor_signal,
+            weighted_impact=(anchor_signal - 0.5) * 0.08,
+            summary="Matches named anchors against bundle tags, names, and summaries.",
+        ),
+        _contribution(
+            contribution_id=f"{bundle.bundle_id}:hybrid-factors",
+            label="Hybrid factor support",
+            axis_key="hybrid_factors",
+            normalized_signal=hybrid_signal,
+            weighted_impact=(hybrid_signal - 0.5) * 0.07,
+            summary="Recognizes salient hybrid factors such as food, rest, music, and route modes.",
+        ),
+        _contribution(
+            contribution_id=f"{bundle.bundle_id}:budget",
+            label="Budget posture",
+            axis_key="budget",
+            normalized_signal=budget_signal,
+            weighted_impact=(budget_signal - 0.5) * 0.08,
+            summary="Keeps budget posture explicit instead of silently assuming the cheapest bundle wins.",
+        ),
+        _contribution(
+            contribution_id=f"{bundle.bundle_id}:quality-floor",
+            label="Quality floors",
+            axis_key="quality_floor",
+            normalized_signal=quality_floor_signal,
+            weighted_impact=(quality_floor_signal - 0.5) * 0.08,
+            summary="Protects quality floors downstream from preference resolution and itinerary objective derivation.",
+        ),
+    ]
+
+    penalties: list[ScoreAdjustment] = []
+    missing_penalties: list[ScoreAdjustment] = []
+    bonuses: list[ScoreAdjustment] = []
+
+    if feasibility.friction_penalty_total > 0.35:
+        penalties.append(
+            ScoreAdjustment(
+                adjustment_id=f"{bundle.bundle_id}:friction",
+                label="Travel friction penalty",
+                kind="penalty",
+                amount=round(min(0.12, feasibility.friction_penalty_total * 0.06), 4),
+                reason_code="travel_friction",
+                summary="Higher transfer or movement friction remains visible in the score.",
+                affected_factor_keys=["movement_vs_friction", "route_coherence_vs_eclectic_contrast"],
+            )
+        )
+    if feasibility.blocking_reasons:
+        penalties.append(
+            ScoreAdjustment(
+                adjustment_id=f"{bundle.bundle_id}:blocking",
+                label="Feasibility blocker penalty",
+                kind="penalty",
+                amount=round(min(0.24, 0.08 * len(feasibility.blocking_reasons)), 4),
+                reason_code="feasibility_blocking",
+                summary="Bundle carries explicit feasibility blockers that should suppress ranking confidence.",
+                affected_factor_keys=["feasibility"],
+            )
+        )
+    if resolved_profile.profile.tension_flags:
+        penalties.append(
+            ScoreAdjustment(
+                adjustment_id=f"{bundle.bundle_id}:tension",
+                label="Preference tension penalty",
+                kind="penalty",
+                amount=round(
+                    min(
+                        0.12,
+                        sum(flag.severity for flag in resolved_profile.profile.tension_flags) * 0.03,
+                    ),
+                    4,
+                ),
+                reason_code="preference_tension",
+                summary="Unresolved preference tensions reduce ranking confidence and score.",
+                affected_factor_keys=["tension_flags"],
+            )
+        )
+    if feasibility.missing_data_fields:
+        missing_penalties.append(
+            ScoreAdjustment(
+                adjustment_id=f"{bundle.bundle_id}:missing",
+                label="Missing feasibility inputs",
+                kind="missing_data",
+                amount=round(min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4),
+                reason_code="missing_feasibility_data",
+                summary="Missing feasibility inputs remain visible as ranking discounts.",
+                affected_factor_keys=["missing_data"],
+                notes=list(feasibility.missing_data_fields),
+            )
+        )
+    if anchor_signal >= 0.75:
+        bonuses.append(
+            ScoreAdjustment(
+                adjustment_id=f"{bundle.bundle_id}:anchor-bonus",
+                label="Anchor match bonus",
+                kind="bonus",
+                amount=round((anchor_signal - 0.5) * 0.06, 4),
+                reason_code="anchor_match",
+                summary="Bundle directly matches one or more explicit anchors.",
+                affected_factor_keys=["anchors"],
+            )
+        )
+
+    low_confidence_flags = _low_confidence_flags(resolved_profile)
+    coverage = _clamp(1.0 - (0.08 * len(feasibility.missing_data_fields)))
+    stability = _mean(
+        dimension.stability
+        for dimension in resolved_profile.profile.tradeoff_dimensions.values()
+    )
+    overall_confidence = _clamp(
+        mean(
+            [
+                feasibility.confidence_signal or 0.7,
+                coverage,
+                stability,
+                max(0.0, 1.0 - (0.08 * len(resolved_profile.profile.tension_flags))),
+            ]
+        )
+    )
+
+    baseline_score = 0.5
+    final_score = round(
+        baseline_score
+        + sum(item.weighted_impact for item in contributions)
+        + sum(item.amount for item in bonuses)
+        - sum(item.amount for item in penalties)
+        - sum(item.amount for item in missing_penalties),
+        4,
+    )
+    breakdown = ScoreBreakdown(
+        baseline_score=baseline_score,
+        component_contributions=contributions,
+        penalties=penalties,
+        bonuses=bonuses,
+        missing_data_penalties=missing_penalties,
+        final_score=final_score,
+        notes=[
+            "Leisure scoring stays deterministic and inspectable.",
+            "Feasibility blockers and missing data remain visible instead of being collapsed into one opaque score.",
+        ],
+    )
+    confidence_summary = ScoreConfidenceSummary(
+        overall_confidence=overall_confidence,
+        input_coverage=coverage,
+        data_freshness=_freshness_signal(bundle),
+        scoring_stability=stability,
+        low_confidence_flags=low_confidence_flags,
+        missing_data_fields=list(feasibility.missing_data_fields),
+        notes=[
+            f"Derived from {len(resolved_profile.profile.tension_flags)} active tension flags.",
+            f"Feasibility confidence signal={feasibility.confidence_signal or 0.7:.2f}.",
+        ],
+    )
+    explanation_records = _explanations_for_result(
+        seed=seed,
+        objectives=objectives,
+        breakdown=breakdown,
+        confidence_summary=confidence_summary,
+    )
+    unresolved_risks = _risks_for_result(
+        resolved_profile=resolved_profile,
+        feasibility=feasibility,
+    )
+    result = RankedResult(
+        result_id=f"ranked:{bundle.bundle_id}",
+        result_kind="bundle",
+        rank=1,
+        score=final_score,
+        target_bundle_id=bundle.bundle_id,
+        supporting_option_ids=bundle.option_ids,
+        supporting_destination_ids=bundle.destination_ids,
+        score_breakdown=breakdown,
+        confidence_summary=confidence_summary,
+        explanation_records=explanation_records,
+        unresolved_risks=unresolved_risks,
+        source_refs=list(bundle.provenance_summary.source_refs),
+        notes=[
+            "Leisure ranking outputs feed downstream explanation and review layers.",
+            f"Objective route shape target: {objectives.route_shape}.",
+        ],
+    )
+    return final_score, result
+
+
+def _with_rank(result: RankedResult, *, rank: int) -> RankedResult:
+    return RankedResult(
+        result_id=result.result_id,
+        result_kind=result.result_kind,
+        rank=rank,
+        score=result.score,
+        target_bundle_id=result.target_bundle_id,
+        supporting_option_ids=list(result.supporting_option_ids),
+        supporting_destination_ids=list(result.supporting_destination_ids),
+        score_breakdown=result.score_breakdown,
+        confidence_summary=result.confidence_summary,
+        explanation_records=list(result.explanation_records),
+        unresolved_risks=list(result.unresolved_risks),
+        source_refs=list(result.source_refs),
+        notes=list(result.notes),
+    )
+
+
+def _contribution(
+    *,
+    contribution_id: str,
+    label: str,
+    axis_key: str,
+    normalized_signal: float,
+    weighted_impact: float,
+    summary: str,
+) -> ScoreContribution:
+    return ScoreContribution(
+        contribution_id=contribution_id,
+        label=label,
+        axis_key=axis_key,
+        direction="higher_better",
+        normalized_signal=_clamp(normalized_signal),
+        weighted_impact=round(weighted_impact, 4),
+        summary=summary,
+    )
+
+
+def _axis_contribution(
+    *,
+    bundle: InventoryBundle,
+    resolved_profile: ResolvedLeisureProfile,
+    dimension_key: str,
+    label: str,
+    positive_signal: float,
+    negative_signal: float,
+    positive_summary: str,
+    negative_summary: str,
+) -> ScoreContribution:
+    dimension = resolved_profile.profile.tradeoff_dimensions[dimension_key]
+    weight = _DIMENSION_WEIGHTS[dimension_key]
+    if dimension.value >= 0:
+        signal = positive_signal
+        summary = positive_summary
+    else:
+        signal = negative_signal
+        summary = negative_summary
+    magnitude = 0.6 + (abs(dimension.value) * 0.4)
+    return _contribution(
+        contribution_id=f"{bundle.bundle_id}:{dimension_key}",
+        label=label,
+        axis_key=dimension_key,
+        normalized_signal=signal,
+        weighted_impact=(signal - 0.5) * weight * magnitude * 2.0,
+        summary=summary,
+    )
+
+
+def _bundle_text(bundle: InventoryBundle) -> str:
+    values = [
+        bundle.title,
+        bundle.summary,
+        *bundle.tags,
+        *bundle.notes,
+        *bundle.explanation.strengths,
+        *bundle.explanation.tradeoffs,
+        *(item.name for item in bundle.lodging_options),
+        *(item.name for item in bundle.activity_options),
+        *(item.name for item in bundle.transport_options),
+    ]
+    return " ".join(values).lower()
+
+
+def _mean(values: Iterable[float | None]) -> float:
+    present = [value for value in values if value is not None]
+    if not present:
+        return 0.5
+    return round(mean(present), 4)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, round(value, 4)))
+
+
+def _dedupe_strings(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(item for item in values if item))
+
+
+def _bundle_quality_signal(bundle: InventoryBundle) -> float:
+    lodging_quality = _mean(item.quality_summary.overall_signal for item in bundle.lodging_options)
+    activity_quality = _mean(item.quality_summary.overall_signal for item in bundle.activity_options)
+    return _mean([bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality])
+
+
+def _iconic_signal(bundle: InventoryBundle) -> float:
+    values = [
+        item.significance_summary.local_icon_signal
+        for item in bundle.activity_options
+        if item.significance_summary.local_icon_signal is not None
+    ]
+    anchor_bonus = [
+        1.0 if item.significance_summary.anchor_worthy else 0.0
+        for item in bundle.activity_options
+    ]
+    return _mean(values + anchor_bonus)
+
+
+def _discovery_signal(bundle: InventoryBundle) -> float:
+    open_ended = [
+        1.0 if item.category.open_ended else 0.0
+        for item in bundle.activity_options
+    ]
+    wander_tags = [
+        1.0
+        for item in bundle.activity_options
+        if {"wander", "open-ended", "district"} & set(item.tags)
+    ]
+    return _mean(open_ended + wander_tags or [0.45])
+
+
+def _scenic_signal(bundle: InventoryBundle) -> float:
+    scenic_values = [
+        item.experience_summary.scenic_value_signal
+        for item in bundle.transport_options
+        if item.experience_summary.scenic_value_signal is not None
+    ]
+    scenic_values.extend(
+        item.significance_summary.scenic_signal
+        for item in bundle.activity_options
+        if item.significance_summary.scenic_signal is not None
+    )
+    return _mean(scenic_values or [0.35])
+
+
+def _efficiency_signal(feasibility: FeasibilityAssessment) -> float:
+    travel_minutes = feasibility.total_travel_minutes
+    transfer_count = feasibility.total_transfer_count
+    return _clamp(1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08))
+
+
+def _recovery_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+    lodging_recovery = _mean(
+        item.location_summary.recovery_signal for item in bundle.lodging_options
+    )
+    quiet_signal = _mean(
+        item.location_summary.quiet_signal for item in bundle.lodging_options
+    )
+    conflict_penalty = min(
+        0.4,
+        len([item for item in feasibility.timing_conflicts if item.blocking]) * 0.18,
+    )
+    return _clamp(_mean([lodging_recovery, quiet_signal]) - conflict_penalty)
+
+
+def _intensity_signal(bundle: InventoryBundle) -> float:
+    values = [
+        item.effort_summary.intensity_signal
+        for item in bundle.activity_options
+        if item.effort_summary.intensity_signal is not None
+    ]
+    values.extend(
+        item.transfer_burden.self_navigation_burden_signal
+        for item in bundle.transport_options
+        if item.transfer_burden.self_navigation_burden_signal is not None
+    )
+    return _mean(values or [0.4])
+
+
+def _structure_signal(bundle: InventoryBundle) -> float:
+    values = [
+        1.0 if item.booking_terms.booking_required else 0.35
+        for item in bundle.activity_options
+    ]
+    return _mean(values or [0.45])
+
+
+def _elasticity_signal(bundle: InventoryBundle) -> float:
+    values = [
+        1.0 if item.category.open_ended else 0.25
+        for item in bundle.activity_options
+    ]
+    return _mean(values or [0.45])
+
+
+def _coherence_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+    destination_penalty = max(0, len(bundle.destination_ids) - 1) * 0.14
+    route_penalty = len(feasibility.route_warnings) * 0.1
+    transfer_penalty = feasibility.total_transfer_count * 0.05
+    return _clamp(1.0 - destination_penalty - route_penalty - transfer_penalty)
+
+
+def _breadth_signal(bundle: InventoryBundle) -> float:
+    return _clamp(min(1.0, max(0.0, (len(bundle.destination_ids) - 1) / 2.0)))
+
+
+def _movement_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+    transport_weight = 0.25 if bundle.transport_options else 0.0
+    travel_component = min(0.55, feasibility.total_travel_minutes / 420.0)
+    scenic_component = _scenic_signal(bundle) * 0.2
+    breadth_component = _breadth_signal(bundle) * 0.25
+    return _clamp(travel_component + scenic_component + breadth_component + transport_weight)
+
+
+def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile) -> float:
+    estimated_total = seed.estimated_total()
+    base_signal = _mean([seed.bundle.quality_value_fit.value_signal, seed.bundle.quality_value_fit.fit_signal])
+    budget_ceiling = resolved_profile.profile.hard_constraints.budget_ceiling
+    sensitivity = resolved_profile.profile.budget_model.total_budget_sensitivity
+    if estimated_total is None or budget_ceiling is None:
+        return _clamp((base_signal * (0.65 + (sensitivity * 0.35))))
+    if estimated_total.typical_amount is None:
+        return base_signal
+    budget_ratio = estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
+    if budget_ratio <= 0.85:
+        return _clamp(max(base_signal, 0.75))
+    if budget_ratio <= 1.0:
+        return _clamp(max(base_signal, 0.6))
+    overspend_penalty = min(0.55, (budget_ratio - 1.0) * (0.7 + sensitivity))
+    return _clamp(base_signal - overspend_penalty)
+
+
+def _quality_floor_signal(bundle: InventoryBundle) -> float:
+    lodging_signals = [
+        item.quality_summary.overall_signal
+        for item in bundle.lodging_options
+        if item.quality_summary.overall_signal is not None
+    ]
+    sleep_signals = [
+        item.quality_summary.sleep_quality_signal
+        for item in bundle.lodging_options
+        if item.quality_summary.sleep_quality_signal is not None
+    ]
+    return _mean(lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal])
+
+
+def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -> float:
+    matches: list[float] = []
+    for group_name, anchors in resolved_profile.profile.anchors.items():
+        for anchor in anchors:
+            label_terms = [term for term in anchor.label.lower().replace("-", " ").split() if len(term) > 2]
+            if any(term in bundle_text for term in label_terms):
+                matches.append(anchor.strength)
+                continue
+            for keyword in _ANCHOR_TYPE_KEYWORDS.get(anchor.type.lower(), ()):
+                if keyword in bundle_text:
+                    matches.append(max(anchor.strength, 0.6))
+                    break
+        if matches and group_name == "quality_floor_anchors":
+            matches.append(0.8)
+    return _mean(matches or [0.45])
+
+
+def _hybrid_signal(
+    resolved_profile: ResolvedLeisureProfile,
+    bundle_text: str,
+    bundle: InventoryBundle,
+) -> float:
+    signals: list[float] = []
+    for key, factor in resolved_profile.profile.hybrid_factors.items():
+        keywords = _HYBRID_KEYWORDS.get(key, ())
+        matched = any(keyword in bundle_text for keyword in keywords)
+        if key == "rest" and bundle.lodging_options:
+            matched = matched or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
+        if matched:
+            signals.append(_clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3)))
+    return _mean(signals or [0.45])
+
+
+def _freshness_signal(bundle: InventoryBundle) -> float:
+    freshness: list[float] = []
+    for destination in bundle.destinations:
+        for source in destination.source_refs:
+            freshness_days = getattr(source, "freshness_days_at_capture", None)
+            if freshness_days is not None:
+                freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
+    for collection in (bundle.lodging_options, bundle.transport_options, bundle.activity_options):
+        for option in collection:
+            for source in option.source_refs:
+                trust = getattr(source, "trust_snapshot", None)
+                if trust and trust.freshness_days is not None:
+                    freshness.append(_clamp(1.0 - min(1.0, trust.freshness_days / 90.0)))
+                else:
+                    freshness_days = getattr(source, "freshness_days_at_capture", None)
+                    if freshness_days is not None:
+                        freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
+    return _mean(freshness or [0.75])
+
+
+def _low_confidence_flags(resolved_profile: ResolvedLeisureProfile) -> list[str]:
+    flags = [
+        key
+        for key, dimension in resolved_profile.profile.tradeoff_dimensions.items()
+        if dimension.confidence < 0.55 and dimension.salience >= 0.35
+    ]
+    flags.extend(flag.id for flag in resolved_profile.profile.tension_flags)
+    return _dedupe_strings(flags)
+
+
+def _explanations_for_result(
+    *,
+    seed: CandidateSeed,
+    objectives: ItineraryObjectives,
+    breakdown: ScoreBreakdown,
+    confidence_summary: ScoreConfidenceSummary,
+) -> list[ExplanationRecord]:
+    top_positive = max(
+        breakdown.component_contributions,
+        key=lambda item: item.weighted_impact,
+    )
+    top_negative = min(
+        breakdown.component_contributions,
+        key=lambda item: item.weighted_impact,
+    )
+    bundle = seed.bundle
+    return [
+        ExplanationRecord(
+            explanation_id=f"{bundle.bundle_id}:summary",
+            record_type="summary",
+            target_kind="bundle",
+            target_id=bundle.bundle_id,
+            headline=f"{bundle.title} ranks through explicit leisure-fit signals.",
+            summary=(
+                f"Top positive driver: {top_positive.label.lower()}; "
+                f"largest drag: {top_negative.label.lower()}."
+            ),
+            factor_keys=[top_positive.axis_key, top_negative.axis_key],
+            machine_context={
+                "route_shape": objectives.route_shape,
+                "top_positive": top_positive.axis_key,
+                "top_negative": top_negative.axis_key,
+            },
+            human_summary=[
+                bundle.summary,
+                top_positive.summary,
+                top_negative.summary,
+            ],
+            source_refs=list(bundle.provenance_summary.source_refs),
+        ),
+        ExplanationRecord(
+            explanation_id=f"{bundle.bundle_id}:promotion",
+            record_type="promotion",
+            target_kind="bundle",
+            target_id=bundle.bundle_id,
+            headline=f"{top_positive.label} promotes this bundle.",
+            summary=top_positive.summary,
+            factor_keys=[top_positive.axis_key],
+            machine_context={"normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"},
+            human_summary=list(bundle.explanation.strengths[:2]) or [bundle.summary],
+            source_refs=list(bundle.provenance_summary.source_refs),
+        ),
+        ExplanationRecord(
+            explanation_id=f"{bundle.bundle_id}:confidence",
+            record_type="confidence",
+            target_kind="bundle",
+            target_id=bundle.bundle_id,
+            headline="Confidence remains explicit downstream.",
+            summary=(
+                f"Overall confidence={confidence_summary.overall_confidence or 0.0:.2f} "
+                "after missing-data and tension handling."
+            ),
+            factor_keys=["ranking_confidence"],
+            machine_context={
+                "input_coverage": f"{confidence_summary.input_coverage or 0.0:.2f}",
+                "scoring_stability": f"{confidence_summary.scoring_stability or 0.0:.2f}",
+            },
+            human_summary=confidence_summary.notes[:2] or ["Confidence remains inspectable."],
+            source_refs=list(bundle.provenance_summary.source_refs),
+        ),
+    ]
+
+
+def _risks_for_result(
+    *,
+    resolved_profile: ResolvedLeisureProfile,
+    feasibility: FeasibilityAssessment,
+) -> list[RiskFlag]:
+    risks: list[RiskFlag] = []
+    for blocking_reason in feasibility.blocking_reasons:
+        risks.append(
+            RiskFlag(
+                risk_id=f"risk:{blocking_reason}",
+                code=blocking_reason,
+                severity="critical",
+                summary=f"Bundle remains blocked by {blocking_reason}.",
+                blocking=True,
+            )
+        )
+    for warning in feasibility.route_warnings:
+        risks.append(
+            RiskFlag(
+                risk_id=warning.warning_id,
+                code=warning.code,
+                severity="warning",
+                summary=warning.summary,
+            )
+        )
+    for flag in resolved_profile.profile.tension_flags:
+        risks.append(
+            RiskFlag(
+                risk_id=f"risk:{flag.id}",
+                code="preference_tension",
+                severity="warning",
+                summary=flag.description,
+                notes=[flag.id],
+            )
+        )
+    return risks

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -828,6 +828,10 @@ def _low_confidence_flags(resolved_profile: ResolvedLeisureProfile) -> list[str]
     return _dedupe_strings(flags)
 
 
+def _non_empty_strings(*values: str) -> list[str]:
+    return [value for value in values if value]
+
+
 def _explanations_for_result(
     *,
     seed: CandidateSeed,
@@ -861,11 +865,11 @@ def _explanations_for_result(
                 "top_positive": top_positive.axis_key,
                 "top_negative": top_negative.axis_key,
             },
-            human_summary=[
-                bundle.summary,
+            human_summary=_non_empty_strings(
+                bundle.summary or bundle.title,
                 top_positive.summary,
                 top_negative.summary,
-            ],
+            ),
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
         ExplanationRecord(
@@ -879,7 +883,10 @@ def _explanations_for_result(
             machine_context={
                 "normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"
             },
-            human_summary=list(bundle.explanation.strengths[:2]) or [bundle.summary],
+            human_summary=_non_empty_strings(
+                *bundle.explanation.strengths[:2],
+                bundle.summary or bundle.title,
+            ),
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
         ExplanationRecord(

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -742,18 +742,18 @@ def _hybrid_signal(
 def _freshness_signal(bundle: InventoryBundle) -> float:
     freshness: list[float] = []
     for destination in bundle.destinations:
-        for source in destination.source_refs:
-            freshness_days = getattr(source, "freshness_days_at_capture", None)
+        for destination_source in destination.source_refs:
+            freshness_days = getattr(destination_source, "freshness_days_at_capture", None)
             if freshness_days is not None:
                 freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     for collection in (bundle.lodging_options, bundle.transport_options, bundle.activity_options):
         for option in collection:
-            for source in option.source_refs:
-                trust = getattr(source, "trust_snapshot", None)
+            for option_source in option.source_refs:
+                trust = getattr(option_source, "trust_snapshot", None)
                 if trust and trust.freshness_days is not None:
                     freshness.append(_clamp(1.0 - min(1.0, trust.freshness_days / 90.0)))
                 else:
-                    freshness_days = getattr(source, "freshness_days_at_capture", None)
+                    freshness_days = getattr(option_source, "freshness_days_at_capture", None)
                     if freshness_days is not None:
                         freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     return _mean(freshness or [0.75])

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -7,7 +7,10 @@ from statistics import mean
 
 from trip_planner.candidates import CandidateSeed, CandidateSet
 from trip_planner.contracts import ComparisonAxis, ItineraryObjectives
-from trip_planner.itinerary import derive_itinerary_objectives, evaluate_bundle_feasibility
+from trip_planner.itinerary import (
+    derive_itinerary_objectives,
+    evaluate_bundle_feasibility,
+)
 from trip_planner.itinerary.feasibility import FeasibilityAssessment
 from trip_planner.options import InventoryBundle
 from trip_planner.preferences.explanations import ResolvedLeisureProfile
@@ -70,7 +73,9 @@ def rank_leisure_candidates(
 
     scored_results: list[tuple[float, RankedResult]] = []
     for seed in seeds:
-        feasibility = feasibility_index.get(seed.bundle.bundle_id) or evaluate_bundle_feasibility(seed.bundle)
+        feasibility = feasibility_index.get(
+            seed.bundle.bundle_id
+        ) or evaluate_bundle_feasibility(seed.bundle)
         score, result = _build_ranked_result(
             seed=seed,
             resolved_profile=resolved_profile,
@@ -201,7 +206,8 @@ def _build_ranked_result(
             label="Quality and value posture",
             axis_key="quality_value",
             normalized_signal=_mean([quality_signal, value_signal]),
-            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5) * 0.12,
+            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5)
+            * 0.12,
             summary="Rewards bundles that preserve quality and value instead of collapsing them into one scalar.",
         ),
         _axis_contribution(
@@ -321,7 +327,10 @@ def _build_ranked_result(
                 amount=round(min(0.12, feasibility.friction_penalty_total * 0.06), 4),
                 reason_code="travel_friction",
                 summary="Higher transfer or movement friction remains visible in the score.",
-                affected_factor_keys=["movement_vs_friction", "route_coherence_vs_eclectic_contrast"],
+                affected_factor_keys=[
+                    "movement_vs_friction",
+                    "route_coherence_vs_eclectic_contrast",
+                ],
             )
         )
     if feasibility.blocking_reasons:
@@ -345,7 +354,11 @@ def _build_ranked_result(
                 amount=round(
                     min(
                         0.12,
-                        sum(flag.severity for flag in resolved_profile.profile.tension_flags) * 0.03,
+                        sum(
+                            flag.severity
+                            for flag in resolved_profile.profile.tension_flags
+                        )
+                        * 0.03,
                     ),
                     4,
                 ),
@@ -360,7 +373,9 @@ def _build_ranked_result(
                 adjustment_id=f"{bundle.bundle_id}:missing",
                 label="Missing feasibility inputs",
                 kind="missing_data",
-                amount=round(min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4),
+                amount=round(
+                    min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4
+                ),
                 reason_code="missing_feasibility_data",
                 summary="Missing feasibility inputs remain visible as ranking discounts.",
                 affected_factor_keys=["missing_data"],
@@ -560,9 +575,15 @@ def _dedupe_strings(values: Iterable[str]) -> list[str]:
 
 
 def _bundle_quality_signal(bundle: InventoryBundle) -> float:
-    lodging_quality = _mean(item.quality_summary.overall_signal for item in bundle.lodging_options)
-    activity_quality = _mean(item.quality_summary.overall_signal for item in bundle.activity_options)
-    return _mean([bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality])
+    lodging_quality = _mean(
+        item.quality_summary.overall_signal for item in bundle.lodging_options
+    )
+    activity_quality = _mean(
+        item.quality_summary.overall_signal for item in bundle.activity_options
+    )
+    return _mean(
+        [bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality]
+    )
 
 
 def _iconic_signal(bundle: InventoryBundle) -> float:
@@ -580,8 +601,7 @@ def _iconic_signal(bundle: InventoryBundle) -> float:
 
 def _discovery_signal(bundle: InventoryBundle) -> float:
     open_ended = [
-        1.0 if item.category.open_ended else 0.0
-        for item in bundle.activity_options
+        1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options
     ]
     wander_tags = [
         1.0
@@ -608,10 +628,14 @@ def _scenic_signal(bundle: InventoryBundle) -> float:
 def _efficiency_signal(feasibility: FeasibilityAssessment) -> float:
     travel_minutes = feasibility.total_travel_minutes
     transfer_count = feasibility.total_transfer_count
-    return _clamp(1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08))
+    return _clamp(
+        1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08)
+    )
 
 
-def _recovery_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _recovery_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     lodging_recovery = _mean(
         item.location_summary.recovery_signal for item in bundle.lodging_options
     )
@@ -649,13 +673,14 @@ def _structure_signal(bundle: InventoryBundle) -> float:
 
 def _elasticity_signal(bundle: InventoryBundle) -> float:
     values = [
-        1.0 if item.category.open_ended else 0.25
-        for item in bundle.activity_options
+        1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options
     ]
     return _mean(values or [0.45])
 
 
-def _coherence_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _coherence_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     destination_penalty = max(0, len(bundle.destination_ids) - 1) * 0.14
     route_penalty = len(feasibility.route_warnings) * 0.1
     transfer_penalty = feasibility.total_transfer_count * 0.05
@@ -666,24 +691,37 @@ def _breadth_signal(bundle: InventoryBundle) -> float:
     return _clamp(min(1.0, max(0.0, (len(bundle.destination_ids) - 1) / 2.0)))
 
 
-def _movement_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _movement_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     transport_weight = 0.25 if bundle.transport_options else 0.0
     travel_component = min(0.55, feasibility.total_travel_minutes / 420.0)
     scenic_component = _scenic_signal(bundle) * 0.2
     breadth_component = _breadth_signal(bundle) * 0.25
-    return _clamp(travel_component + scenic_component + breadth_component + transport_weight)
+    return _clamp(
+        travel_component + scenic_component + breadth_component + transport_weight
+    )
 
 
-def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile) -> float:
+def _budget_signal(
+    seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile
+) -> float:
     estimated_total = seed.estimated_total()
-    base_signal = _mean([seed.bundle.quality_value_fit.value_signal, seed.bundle.quality_value_fit.fit_signal])
+    base_signal = _mean(
+        [
+            seed.bundle.quality_value_fit.value_signal,
+            seed.bundle.quality_value_fit.fit_signal,
+        ]
+    )
     budget_ceiling = resolved_profile.profile.hard_constraints.budget_ceiling
     sensitivity = resolved_profile.profile.budget_model.total_budget_sensitivity
     if estimated_total is None or budget_ceiling is None:
         return _clamp((base_signal * (0.65 + (sensitivity * 0.35))))
     if estimated_total.typical_amount is None:
         return base_signal
-    budget_ratio = estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
+    budget_ratio = (
+        estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
+    )
     if budget_ratio <= 0.85:
         return _clamp(max(base_signal, 0.75))
     if budget_ratio <= 1.0:
@@ -703,14 +741,20 @@ def _quality_floor_signal(bundle: InventoryBundle) -> float:
         for item in bundle.lodging_options
         if item.quality_summary.sleep_quality_signal is not None
     ]
-    return _mean(lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal])
+    return _mean(
+        lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal]
+    )
 
 
 def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -> float:
     matches: list[float] = []
     for group_name, anchors in resolved_profile.profile.anchors.items():
         for anchor in anchors:
-            label_terms = [term for term in anchor.label.lower().replace("-", " ").split() if len(term) > 2]
+            label_terms = [
+                term
+                for term in anchor.label.lower().replace("-", " ").split()
+                if len(term) > 2
+            ]
             if any(term in bundle_text for term in label_terms):
                 matches.append(anchor.strength)
                 continue
@@ -733,9 +777,14 @@ def _hybrid_signal(
         keywords = _HYBRID_KEYWORDS.get(key, ())
         matched = any(keyword in bundle_text for keyword in keywords)
         if key == "rest" and bundle.lodging_options:
-            matched = matched or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
+            matched = (
+                matched
+                or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
+            )
         if matched:
-            signals.append(_clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3)))
+            signals.append(
+                _clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3))
+            )
     return _mean(signals or [0.45])
 
 
@@ -743,17 +792,27 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
     freshness: list[float] = []
     for destination in bundle.destinations:
         for destination_source in destination.source_refs:
-            freshness_days = getattr(destination_source, "freshness_days_at_capture", None)
+            freshness_days = getattr(
+                destination_source, "freshness_days_at_capture", None
+            )
             if freshness_days is not None:
                 freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
-    for collection in (bundle.lodging_options, bundle.transport_options, bundle.activity_options):
+    for collection in (
+        bundle.lodging_options,
+        bundle.transport_options,
+        bundle.activity_options,
+    ):
         for option in collection:
             for option_source in option.source_refs:
                 trust = getattr(option_source, "trust_snapshot", None)
                 if trust and trust.freshness_days is not None:
-                    freshness.append(_clamp(1.0 - min(1.0, trust.freshness_days / 90.0)))
+                    freshness.append(
+                        _clamp(1.0 - min(1.0, trust.freshness_days / 90.0))
+                    )
                 else:
-                    freshness_days = getattr(option_source, "freshness_days_at_capture", None)
+                    freshness_days = getattr(
+                        option_source, "freshness_days_at_capture", None
+                    )
                     if freshness_days is not None:
                         freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     return _mean(freshness or [0.75])
@@ -817,7 +876,9 @@ def _explanations_for_result(
             headline=f"{top_positive.label} promotes this bundle.",
             summary=top_positive.summary,
             factor_keys=[top_positive.axis_key],
-            machine_context={"normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"},
+            machine_context={
+                "normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"
+            },
             human_summary=list(bundle.explanation.strengths[:2]) or [bundle.summary],
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
@@ -836,7 +897,8 @@ def _explanations_for_result(
                 "input_coverage": f"{confidence_summary.input_coverage or 0.0:.2f}",
                 "scoring_stability": f"{confidence_summary.scoring_stability or 0.0:.2f}",
             },
-            human_summary=confidence_summary.notes[:2] or ["Confidence remains inspectable."],
+            human_summary=confidence_summary.notes[:2]
+            or ["Confidence remains inspectable."],
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
     ]

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -73,9 +73,9 @@ def rank_leisure_candidates(
 
     scored_results: list[tuple[float, RankedResult]] = []
     for seed in seeds:
-        feasibility = feasibility_index.get(seed.bundle.bundle_id) or evaluate_bundle_feasibility(
-            seed.bundle
-        )
+        feasibility = feasibility_index.get(
+            seed.bundle.bundle_id
+        ) or evaluate_bundle_feasibility(seed.bundle)
         score, result = _build_ranked_result(
             seed=seed,
             resolved_profile=resolved_profile,
@@ -93,14 +93,19 @@ def rank_leisure_candidates(
         ),
         reverse=True,
     )
-    results = [_with_rank(result, rank=index) for index, (_, result) in enumerate(ranked, start=1)]
+    results = [
+        _with_rank(result, rank=index)
+        for index, (_, result) in enumerate(ranked, start=1)
+    ]
     result_set_id = f"ranking:{trip_id}:leisure"
     result_explanations = [
         "Leisure ranking remains downstream from preference resolution, objective derivation, and feasibility evaluation.",
         "Scores keep component breakdowns, confidence penalties, and tension handling explicit for inspection.",
     ]
     source_refs = _dedupe_strings(
-        source_ref for seed in seeds for source_ref in seed.bundle.provenance_summary.source_refs
+        source_ref
+        for seed in seeds
+        for source_ref in seed.bundle.provenance_summary.source_refs
     )
     return RankedResultSet(
         result_set_id=result_set_id,
@@ -207,7 +212,8 @@ def _build_ranked_result(
             label="Quality and value posture",
             axis_key="quality_value",
             normalized_signal=_mean([quality_signal, value_signal]),
-            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5) * 0.12,
+            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5)
+            * 0.12,
             summary="Rewards bundles that preserve quality and value instead of collapsing them into one scalar.",
         ),
         _axis_contribution(
@@ -354,7 +360,10 @@ def _build_ranked_result(
                 amount=round(
                     min(
                         0.12,
-                        sum(flag.severity for flag in resolved_profile.profile.tension_flags)
+                        sum(
+                            flag.severity
+                            for flag in resolved_profile.profile.tension_flags
+                        )
                         * 0.03,
                     ),
                     4,
@@ -370,7 +379,9 @@ def _build_ranked_result(
                 adjustment_id=f"{bundle.bundle_id}:missing",
                 label="Missing feasibility inputs",
                 kind="missing_data",
-                amount=round(min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4),
+                amount=round(
+                    min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4
+                ),
                 reason_code="missing_feasibility_data",
                 summary="Missing feasibility inputs remain visible as ranking discounts.",
                 affected_factor_keys=["missing_data"],
@@ -393,7 +404,8 @@ def _build_ranked_result(
     low_confidence_flags = _low_confidence_flags(resolved_profile)
     coverage = _clamp(1.0 - (0.08 * len(feasibility.missing_data_fields)))
     stability = _mean(
-        dimension.stability for dimension in resolved_profile.profile.tradeoff_dimensions.values()
+        dimension.stability
+        for dimension in resolved_profile.profile.tradeoff_dimensions.values()
     )
     feasibility_confidence = _coalesce_signal(
         feasibility.confidence_signal,
@@ -579,11 +591,15 @@ def _dedupe_strings(values: Iterable[str]) -> list[str]:
 
 
 def _bundle_quality_signal(bundle: InventoryBundle) -> float:
-    lodging_quality = _mean(item.quality_summary.overall_signal for item in bundle.lodging_options)
+    lodging_quality = _mean(
+        item.quality_summary.overall_signal for item in bundle.lodging_options
+    )
     activity_quality = _mean(
         item.quality_summary.overall_signal for item in bundle.activity_options
     )
-    return _mean([bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality])
+    return _mean(
+        [bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality]
+    )
 
 
 def _iconic_signal(bundle: InventoryBundle) -> float:
@@ -593,13 +609,16 @@ def _iconic_signal(bundle: InventoryBundle) -> float:
         if item.significance_summary.local_icon_signal is not None
     ]
     anchor_bonus = [
-        1.0 if item.significance_summary.anchor_worthy else 0.0 for item in bundle.activity_options
+        1.0 if item.significance_summary.anchor_worthy else 0.0
+        for item in bundle.activity_options
     ]
     return _mean(values + anchor_bonus)
 
 
 def _discovery_signal(bundle: InventoryBundle) -> float:
-    open_ended = [1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options]
+    open_ended = [
+        1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options
+    ]
     wander_tags = [
         1.0
         for item in bundle.activity_options
@@ -625,14 +644,20 @@ def _scenic_signal(bundle: InventoryBundle) -> float:
 def _efficiency_signal(feasibility: FeasibilityAssessment) -> float:
     travel_minutes = feasibility.total_travel_minutes
     transfer_count = feasibility.total_transfer_count
-    return _clamp(1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08))
+    return _clamp(
+        1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08)
+    )
 
 
-def _recovery_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _recovery_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     lodging_recovery = _mean(
         item.location_summary.recovery_signal for item in bundle.lodging_options
     )
-    quiet_signal = _mean(item.location_summary.quiet_signal for item in bundle.lodging_options)
+    quiet_signal = _mean(
+        item.location_summary.quiet_signal for item in bundle.lodging_options
+    )
     conflict_penalty = min(
         0.4,
         len([item for item in feasibility.timing_conflicts if item.blocking]) * 0.18,
@@ -656,17 +681,22 @@ def _intensity_signal(bundle: InventoryBundle) -> float:
 
 def _structure_signal(bundle: InventoryBundle) -> float:
     values = [
-        1.0 if item.booking_terms.booking_required else 0.35 for item in bundle.activity_options
+        1.0 if item.booking_terms.booking_required else 0.35
+        for item in bundle.activity_options
     ]
     return _mean(values or [0.45])
 
 
 def _elasticity_signal(bundle: InventoryBundle) -> float:
-    values = [1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options]
+    values = [
+        1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options
+    ]
     return _mean(values or [0.45])
 
 
-def _coherence_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _coherence_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     destination_penalty = max(0, len(bundle.destination_ids) - 1) * 0.14
     route_penalty = len(feasibility.route_warnings) * 0.1
     transfer_penalty = feasibility.total_transfer_count * 0.05
@@ -677,15 +707,21 @@ def _breadth_signal(bundle: InventoryBundle) -> float:
     return _clamp(min(1.0, max(0.0, (len(bundle.destination_ids) - 1) / 2.0)))
 
 
-def _movement_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
+def _movement_signal(
+    bundle: InventoryBundle, feasibility: FeasibilityAssessment
+) -> float:
     transport_weight = 0.25 if bundle.transport_options else 0.0
     travel_component = min(0.55, feasibility.total_travel_minutes / 420.0)
     scenic_component = _scenic_signal(bundle) * 0.2
     breadth_component = _breadth_signal(bundle) * 0.25
-    return _clamp(travel_component + scenic_component + breadth_component + transport_weight)
+    return _clamp(
+        travel_component + scenic_component + breadth_component + transport_weight
+    )
 
 
-def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile) -> float:
+def _budget_signal(
+    seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile
+) -> float:
     estimated_total = seed.estimated_total()
     base_signal = _mean(
         [
@@ -699,7 +735,9 @@ def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile
         return _clamp((base_signal * (0.65 + (sensitivity * 0.35))))
     if estimated_total.typical_amount is None:
         return base_signal
-    budget_ratio = estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
+    budget_ratio = (
+        estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
+    )
     if budget_ratio <= 0.85:
         return _clamp(max(base_signal, 0.75))
     if budget_ratio <= 1.0:
@@ -719,7 +757,9 @@ def _quality_floor_signal(bundle: InventoryBundle) -> float:
         for item in bundle.lodging_options
         if item.quality_summary.sleep_quality_signal is not None
     ]
-    return _mean(lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal])
+    return _mean(
+        lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal]
+    )
 
 
 def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -> float:
@@ -727,7 +767,9 @@ def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -
     for group_name, anchors in resolved_profile.profile.anchors.items():
         for anchor in anchors:
             label_terms = [
-                term for term in anchor.label.lower().replace("-", " ").split() if len(term) > 2
+                term
+                for term in anchor.label.lower().replace("-", " ").split()
+                if len(term) > 2
             ]
             if any(term in bundle_text for term in label_terms):
                 matches.append(anchor.strength)
@@ -752,10 +794,13 @@ def _hybrid_signal(
         matched = any(keyword in bundle_text for keyword in keywords)
         if key == "rest" and bundle.lodging_options:
             matched = (
-                matched or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
+                matched
+                or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
             )
         if matched:
-            signals.append(_clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3)))
+            signals.append(
+                _clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3))
+            )
     return _mean(signals or [0.45])
 
 
@@ -763,7 +808,9 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
     freshness: list[float] = []
     for destination in bundle.destinations:
         for destination_source in destination.source_refs:
-            freshness_days = getattr(destination_source, "freshness_days_at_capture", None)
+            freshness_days = getattr(
+                destination_source, "freshness_days_at_capture", None
+            )
             if freshness_days is not None:
                 freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     for collection in (
@@ -775,9 +822,13 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
             for option_source in option.source_refs:
                 trust = getattr(option_source, "trust_snapshot", None)
                 if trust and trust.freshness_days is not None:
-                    freshness.append(_clamp(1.0 - min(1.0, trust.freshness_days / 90.0)))
+                    freshness.append(
+                        _clamp(1.0 - min(1.0, trust.freshness_days / 90.0))
+                    )
                 else:
-                    freshness_days = getattr(option_source, "freshness_days_at_capture", None)
+                    freshness_days = getattr(
+                        option_source, "freshness_days_at_capture", None
+                    )
                     if freshness_days is not None:
                         freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     return _mean(freshness or [0.75])
@@ -845,7 +896,9 @@ def _explanations_for_result(
             headline=f"{top_positive.label} promotes this bundle.",
             summary=top_positive.summary,
             factor_keys=[top_positive.axis_key],
-            machine_context={"normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"},
+            machine_context={
+                "normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"
+            },
             human_summary=_non_empty_strings(
                 *bundle.explanation.strengths[:2],
                 bundle.summary or bundle.title,
@@ -867,7 +920,8 @@ def _explanations_for_result(
                 "input_coverage": f"{confidence_summary.input_coverage or 0.0:.2f}",
                 "scoring_stability": f"{confidence_summary.scoring_stability or 0.0:.2f}",
             },
-            human_summary=confidence_summary.notes[:2] or ["Confidence remains inspectable."],
+            human_summary=confidence_summary.notes[:2]
+            or ["Confidence remains inspectable."],
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
     ]

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -73,9 +73,9 @@ def rank_leisure_candidates(
 
     scored_results: list[tuple[float, RankedResult]] = []
     for seed in seeds:
-        feasibility = feasibility_index.get(
-            seed.bundle.bundle_id
-        ) or evaluate_bundle_feasibility(seed.bundle)
+        feasibility = feasibility_index.get(seed.bundle.bundle_id) or evaluate_bundle_feasibility(
+            seed.bundle
+        )
         score, result = _build_ranked_result(
             seed=seed,
             resolved_profile=resolved_profile,
@@ -93,19 +93,14 @@ def rank_leisure_candidates(
         ),
         reverse=True,
     )
-    results = [
-        _with_rank(result, rank=index)
-        for index, (_, result) in enumerate(ranked, start=1)
-    ]
+    results = [_with_rank(result, rank=index) for index, (_, result) in enumerate(ranked, start=1)]
     result_set_id = f"ranking:{trip_id}:leisure"
     result_explanations = [
         "Leisure ranking remains downstream from preference resolution, objective derivation, and feasibility evaluation.",
         "Scores keep component breakdowns, confidence penalties, and tension handling explicit for inspection.",
     ]
     source_refs = _dedupe_strings(
-        source_ref
-        for seed in seeds
-        for source_ref in seed.bundle.provenance_summary.source_refs
+        source_ref for seed in seeds for source_ref in seed.bundle.provenance_summary.source_refs
     )
     return RankedResultSet(
         result_set_id=result_set_id,
@@ -212,8 +207,7 @@ def _build_ranked_result(
             label="Quality and value posture",
             axis_key="quality_value",
             normalized_signal=_mean([quality_signal, value_signal]),
-            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5)
-            * 0.12,
+            weighted_impact=((quality_signal * 0.55) + (value_signal * 0.45) - 0.5) * 0.12,
             summary="Rewards bundles that preserve quality and value instead of collapsing them into one scalar.",
         ),
         _axis_contribution(
@@ -360,10 +354,7 @@ def _build_ranked_result(
                 amount=round(
                     min(
                         0.12,
-                        sum(
-                            flag.severity
-                            for flag in resolved_profile.profile.tension_flags
-                        )
+                        sum(flag.severity for flag in resolved_profile.profile.tension_flags)
                         * 0.03,
                     ),
                     4,
@@ -379,9 +370,7 @@ def _build_ranked_result(
                 adjustment_id=f"{bundle.bundle_id}:missing",
                 label="Missing feasibility inputs",
                 kind="missing_data",
-                amount=round(
-                    min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4
-                ),
+                amount=round(min(0.12, 0.025 * len(feasibility.missing_data_fields)), 4),
                 reason_code="missing_feasibility_data",
                 summary="Missing feasibility inputs remain visible as ranking discounts.",
                 affected_factor_keys=["missing_data"],
@@ -404,8 +393,7 @@ def _build_ranked_result(
     low_confidence_flags = _low_confidence_flags(resolved_profile)
     coverage = _clamp(1.0 - (0.08 * len(feasibility.missing_data_fields)))
     stability = _mean(
-        dimension.stability
-        for dimension in resolved_profile.profile.tradeoff_dimensions.values()
+        dimension.stability for dimension in resolved_profile.profile.tradeoff_dimensions.values()
     )
     feasibility_confidence = _coalesce_signal(
         feasibility.confidence_signal,
@@ -591,15 +579,11 @@ def _dedupe_strings(values: Iterable[str]) -> list[str]:
 
 
 def _bundle_quality_signal(bundle: InventoryBundle) -> float:
-    lodging_quality = _mean(
-        item.quality_summary.overall_signal for item in bundle.lodging_options
-    )
+    lodging_quality = _mean(item.quality_summary.overall_signal for item in bundle.lodging_options)
     activity_quality = _mean(
         item.quality_summary.overall_signal for item in bundle.activity_options
     )
-    return _mean(
-        [bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality]
-    )
+    return _mean([bundle.quality_value_fit.quality_signal, lodging_quality, activity_quality])
 
 
 def _iconic_signal(bundle: InventoryBundle) -> float:
@@ -609,16 +593,13 @@ def _iconic_signal(bundle: InventoryBundle) -> float:
         if item.significance_summary.local_icon_signal is not None
     ]
     anchor_bonus = [
-        1.0 if item.significance_summary.anchor_worthy else 0.0
-        for item in bundle.activity_options
+        1.0 if item.significance_summary.anchor_worthy else 0.0 for item in bundle.activity_options
     ]
     return _mean(values + anchor_bonus)
 
 
 def _discovery_signal(bundle: InventoryBundle) -> float:
-    open_ended = [
-        1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options
-    ]
+    open_ended = [1.0 if item.category.open_ended else 0.0 for item in bundle.activity_options]
     wander_tags = [
         1.0
         for item in bundle.activity_options
@@ -644,20 +625,14 @@ def _scenic_signal(bundle: InventoryBundle) -> float:
 def _efficiency_signal(feasibility: FeasibilityAssessment) -> float:
     travel_minutes = feasibility.total_travel_minutes
     transfer_count = feasibility.total_transfer_count
-    return _clamp(
-        1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08)
-    )
+    return _clamp(1.0 - min(0.7, (travel_minutes / 540.0)) - min(0.3, transfer_count * 0.08))
 
 
-def _recovery_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _recovery_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     lodging_recovery = _mean(
         item.location_summary.recovery_signal for item in bundle.lodging_options
     )
-    quiet_signal = _mean(
-        item.location_summary.quiet_signal for item in bundle.lodging_options
-    )
+    quiet_signal = _mean(item.location_summary.quiet_signal for item in bundle.lodging_options)
     conflict_penalty = min(
         0.4,
         len([item for item in feasibility.timing_conflicts if item.blocking]) * 0.18,
@@ -681,22 +656,17 @@ def _intensity_signal(bundle: InventoryBundle) -> float:
 
 def _structure_signal(bundle: InventoryBundle) -> float:
     values = [
-        1.0 if item.booking_terms.booking_required else 0.35
-        for item in bundle.activity_options
+        1.0 if item.booking_terms.booking_required else 0.35 for item in bundle.activity_options
     ]
     return _mean(values or [0.45])
 
 
 def _elasticity_signal(bundle: InventoryBundle) -> float:
-    values = [
-        1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options
-    ]
+    values = [1.0 if item.category.open_ended else 0.25 for item in bundle.activity_options]
     return _mean(values or [0.45])
 
 
-def _coherence_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _coherence_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     destination_penalty = max(0, len(bundle.destination_ids) - 1) * 0.14
     route_penalty = len(feasibility.route_warnings) * 0.1
     transfer_penalty = feasibility.total_transfer_count * 0.05
@@ -707,21 +677,15 @@ def _breadth_signal(bundle: InventoryBundle) -> float:
     return _clamp(min(1.0, max(0.0, (len(bundle.destination_ids) - 1) / 2.0)))
 
 
-def _movement_signal(
-    bundle: InventoryBundle, feasibility: FeasibilityAssessment
-) -> float:
+def _movement_signal(bundle: InventoryBundle, feasibility: FeasibilityAssessment) -> float:
     transport_weight = 0.25 if bundle.transport_options else 0.0
     travel_component = min(0.55, feasibility.total_travel_minutes / 420.0)
     scenic_component = _scenic_signal(bundle) * 0.2
     breadth_component = _breadth_signal(bundle) * 0.25
-    return _clamp(
-        travel_component + scenic_component + breadth_component + transport_weight
-    )
+    return _clamp(travel_component + scenic_component + breadth_component + transport_weight)
 
 
-def _budget_signal(
-    seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile
-) -> float:
+def _budget_signal(seed: CandidateSeed, resolved_profile: ResolvedLeisureProfile) -> float:
     estimated_total = seed.estimated_total()
     base_signal = _mean(
         [
@@ -735,9 +699,7 @@ def _budget_signal(
         return _clamp((base_signal * (0.65 + (sensitivity * 0.35))))
     if estimated_total.typical_amount is None:
         return base_signal
-    budget_ratio = (
-        estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
-    )
+    budget_ratio = estimated_total.typical_amount / budget_ceiling if budget_ceiling else 1.0
     if budget_ratio <= 0.85:
         return _clamp(max(base_signal, 0.75))
     if budget_ratio <= 1.0:
@@ -757,9 +719,7 @@ def _quality_floor_signal(bundle: InventoryBundle) -> float:
         for item in bundle.lodging_options
         if item.quality_summary.sleep_quality_signal is not None
     ]
-    return _mean(
-        lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal]
-    )
+    return _mean(lodging_signals + sleep_signals or [bundle.quality_value_fit.quality_signal])
 
 
 def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -> float:
@@ -767,9 +727,7 @@ def _anchor_signal(resolved_profile: ResolvedLeisureProfile, bundle_text: str) -
     for group_name, anchors in resolved_profile.profile.anchors.items():
         for anchor in anchors:
             label_terms = [
-                term
-                for term in anchor.label.lower().replace("-", " ").split()
-                if len(term) > 2
+                term for term in anchor.label.lower().replace("-", " ").split() if len(term) > 2
             ]
             if any(term in bundle_text for term in label_terms):
                 matches.append(anchor.strength)
@@ -794,13 +752,10 @@ def _hybrid_signal(
         matched = any(keyword in bundle_text for keyword in keywords)
         if key == "rest" and bundle.lodging_options:
             matched = (
-                matched
-                or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
+                matched or _recovery_signal(bundle, evaluate_bundle_feasibility(bundle)) >= 0.7
             )
         if matched:
-            signals.append(
-                _clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3))
-            )
+            signals.append(_clamp((factor.salience * 0.7) + (factor.anchor_strength * 0.3)))
     return _mean(signals or [0.45])
 
 
@@ -808,9 +763,7 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
     freshness: list[float] = []
     for destination in bundle.destinations:
         for destination_source in destination.source_refs:
-            freshness_days = getattr(
-                destination_source, "freshness_days_at_capture", None
-            )
+            freshness_days = getattr(destination_source, "freshness_days_at_capture", None)
             if freshness_days is not None:
                 freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     for collection in (
@@ -822,13 +775,9 @@ def _freshness_signal(bundle: InventoryBundle) -> float:
             for option_source in option.source_refs:
                 trust = getattr(option_source, "trust_snapshot", None)
                 if trust and trust.freshness_days is not None:
-                    freshness.append(
-                        _clamp(1.0 - min(1.0, trust.freshness_days / 90.0))
-                    )
+                    freshness.append(_clamp(1.0 - min(1.0, trust.freshness_days / 90.0)))
                 else:
-                    freshness_days = getattr(
-                        option_source, "freshness_days_at_capture", None
-                    )
+                    freshness_days = getattr(option_source, "freshness_days_at_capture", None)
                     if freshness_days is not None:
                         freshness.append(_clamp(1.0 - min(1.0, freshness_days / 90.0)))
     return _mean(freshness or [0.75])
@@ -896,9 +845,7 @@ def _explanations_for_result(
             headline=f"{top_positive.label} promotes this bundle.",
             summary=top_positive.summary,
             factor_keys=[top_positive.axis_key],
-            machine_context={
-                "normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"
-            },
+            machine_context={"normalized_signal": f"{top_positive.normalized_signal or 0.0:.2f}"},
             human_summary=_non_empty_strings(
                 *bundle.explanation.strengths[:2],
                 bundle.summary or bundle.title,
@@ -920,8 +867,7 @@ def _explanations_for_result(
                 "input_coverage": f"{confidence_summary.input_coverage or 0.0:.2f}",
                 "scoring_stability": f"{confidence_summary.scoring_stability or 0.0:.2f}",
             },
-            human_summary=confidence_summary.notes[:2]
-            or ["Confidence remains inspectable."],
+            human_summary=confidence_summary.notes[:2] or ["Confidence remains inspectable."],
             source_refs=list(bundle.provenance_summary.source_refs),
         ),
     ]

--- a/trip_planner/sources/adapters/base.py
+++ b/trip_planner/sources/adapters/base.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from trip_planner.sources.models import SourceRecord
-from trip_planner.sources.snapshots import NormalizationHandoff, RawSnapshot, SourceQuery
+from trip_planner.sources.snapshots import (
+    NormalizationHandoff,
+    RawSnapshot,
+    SourceQuery,
+)
 
 
 class SourceAdapter(ABC):

--- a/trip_planner/sources/models.py
+++ b/trip_planner/sources/models.py
@@ -54,7 +54,12 @@ class QualityValueFitSummary:
     notes: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
-        for field_name in ("quality_signal", "value_signal", "fit_signal", "confidence"):
+        for field_name in (
+            "quality_signal",
+            "value_signal",
+            "fit_signal",
+            "confidence",
+        ):
             value = getattr(self, field_name)
             if value is not None:
                 require_probability(value, field_name)
@@ -76,7 +81,9 @@ class SourceRecord:
     base_url: str = ""
     default_locale: str = ""
     trust_signals: SourceTrustSignals = field(default_factory=SourceTrustSignals)
-    quality_summary: QualityValueFitSummary = field(default_factory=QualityValueFitSummary)
+    quality_summary: QualityValueFitSummary = field(
+        default_factory=QualityValueFitSummary
+    )
     business_approval_status: str = "unknown"
     business_approval_notes: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
@@ -109,7 +116,8 @@ class SourceRecord:
             raise ValueError("quality_summary must be a QualityValueFitSummary")
         if self.business_approval_status not in schema.BUSINESS_APPROVAL_STATUSES:
             raise ValueError(
-                "business_approval_status must be one of " f"{schema.BUSINESS_APPROVAL_STATUSES}"
+                "business_approval_status must be one of "
+                f"{schema.BUSINESS_APPROVAL_STATUSES}"
             )
 
     def to_dict(self) -> dict[str, Any]:

--- a/trip_planner/sources/provenance.py
+++ b/trip_planner/sources/provenance.py
@@ -38,23 +38,35 @@ class ProvenanceReference:
         require_non_empty(self.subject_id, "subject_id")
         require_non_empty(self.summary, "summary")
         if self.source_category not in schema.SOURCE_CATEGORIES:
-            raise ValueError(f"source_category must be one of {schema.SOURCE_CATEGORIES}")
+            raise ValueError(
+                f"source_category must be one of {schema.SOURCE_CATEGORIES}"
+            )
         if self.subject_kind not in schema.PROVENANCE_SUBJECT_KINDS:
-            raise ValueError(f"subject_kind must be one of {schema.PROVENANCE_SUBJECT_KINDS}")
+            raise ValueError(
+                f"subject_kind must be one of {schema.PROVENANCE_SUBJECT_KINDS}"
+            )
         if self.contribution_kind not in schema.CONTRIBUTION_KINDS:
-            raise ValueError(f"contribution_kind must be one of {schema.CONTRIBUTION_KINDS}")
+            raise ValueError(
+                f"contribution_kind must be one of {schema.CONTRIBUTION_KINDS}"
+            )
         require_optional_non_empty(self.locator or None, "locator")
         require_optional_non_empty(self.captured_at or None, "captured_at")
         if self.freshness_days_at_capture is not None:
-            require_non_negative(self.freshness_days_at_capture, "freshness_days_at_capture")
+            require_non_negative(
+                self.freshness_days_at_capture, "freshness_days_at_capture"
+            )
         if self.trust_snapshot is not None and not isinstance(
             self.trust_snapshot, SourceTrustSignals
         ):
-            raise ValueError("trust_snapshot must be a SourceTrustSignals when provided")
+            raise ValueError(
+                "trust_snapshot must be a SourceTrustSignals when provided"
+            )
         if self.quality_value_fit is not None and not isinstance(
             self.quality_value_fit, QualityValueFitSummary
         ):
-            raise ValueError("quality_value_fit must be a QualityValueFitSummary when provided")
+            raise ValueError(
+                "quality_value_fit must be a QualityValueFitSummary when provided"
+            )
         require_strings(self.notes, "notes")
 
     def to_dict(self) -> dict[str, Any]:

--- a/trip_planner/sources/snapshots.py
+++ b/trip_planner/sources/snapshots.py
@@ -37,7 +37,9 @@ class SourceQuery:
     def __post_init__(self) -> None:
         require_non_empty(self.query_id, "query_id")
         if self.entity_scope not in schema.SOURCE_ENTITY_SCOPES:
-            raise ValueError(f"entity_scope must be one of {schema.SOURCE_ENTITY_SCOPES}")
+            raise ValueError(
+                f"entity_scope must be one of {schema.SOURCE_ENTITY_SCOPES}"
+            )
         if self.option_kind not in schema.SOURCE_OPTION_KINDS:
             raise ValueError(f"option_kind must be one of {schema.SOURCE_OPTION_KINDS}")
         for field_name in (
@@ -79,7 +81,9 @@ class AdapterIssue:
         if self.stage not in schema.ADAPTER_ISSUE_STAGES:
             raise ValueError(f"stage must be one of {schema.ADAPTER_ISSUE_STAGES}")
         if self.severity not in schema.ADAPTER_ISSUE_SEVERITIES:
-            raise ValueError(f"severity must be one of {schema.ADAPTER_ISSUE_SEVERITIES}")
+            raise ValueError(
+                f"severity must be one of {schema.ADAPTER_ISSUE_SEVERITIES}"
+            )
         require_optional_non_empty(self.observed_at or None, "observed_at")
         require_optional_non_empty(self.provider_status or None, "provider_status")
         require_strings(self.affected_record_ids, "affected_record_ids")
@@ -109,7 +113,9 @@ class RawSourceRecord:
         require_non_empty(self.provider_entity_id, "provider_entity_id")
         require_non_empty(self.payload_type, "payload_type")
         if self.entity_scope not in schema.SOURCE_ENTITY_SCOPES:
-            raise ValueError(f"entity_scope must be one of {schema.SOURCE_ENTITY_SCOPES}")
+            raise ValueError(
+                f"entity_scope must be one of {schema.SOURCE_ENTITY_SCOPES}"
+            )
         if not isinstance(self.payload, dict):
             raise ValueError("payload must be a dict")
         for field_name in (
@@ -155,13 +161,19 @@ class RawSnapshot:
         require_non_empty(self.payload_format, "payload_format")
         require_non_empty(self.transport, "transport")
         if self.source_category not in schema.SOURCE_CATEGORIES:
-            raise ValueError(f"source_category must be one of {schema.SOURCE_CATEGORIES}")
+            raise ValueError(
+                f"source_category must be one of {schema.SOURCE_CATEGORIES}"
+            )
         if self.entity_scope not in schema.SOURCE_ENTITY_SCOPES:
-            raise ValueError(f"entity_scope must be one of {schema.SOURCE_ENTITY_SCOPES}")
+            raise ValueError(
+                f"entity_scope must be one of {schema.SOURCE_ENTITY_SCOPES}"
+            )
         if self.option_kind not in schema.SOURCE_OPTION_KINDS:
             raise ValueError(f"option_kind must be one of {schema.SOURCE_OPTION_KINDS}")
         if self.snapshot_status not in schema.SNAPSHOT_STATUSES:
-            raise ValueError(f"snapshot_status must be one of {schema.SNAPSHOT_STATUSES}")
+            raise ValueError(
+                f"snapshot_status must be one of {schema.SNAPSHOT_STATUSES}"
+            )
         if self.handoff_status not in schema.HANDOFF_STATUSES:
             raise ValueError(f"handoff_status must be one of {schema.HANDOFF_STATUSES}")
         if not isinstance(self.query, SourceQuery):
@@ -173,7 +185,9 @@ class RawSnapshot:
         if any(not isinstance(item, RawSourceRecord) for item in self.records):
             raise ValueError("records must contain RawSourceRecord instances")
         if any(record.entity_scope != self.entity_scope for record in self.records):
-            raise ValueError("all record.entity_scope values must match snapshot entity_scope")
+            raise ValueError(
+                "all record.entity_scope values must match snapshot entity_scope"
+            )
         if any(not isinstance(item, AdapterIssue) for item in self.issues):
             raise ValueError("issues must contain AdapterIssue instances")
         require_optional_non_empty(self.expires_at or None, "expires_at")
@@ -204,13 +218,19 @@ class NormalizationHandoff:
         require_non_empty(self.snapshot_id, "snapshot_id")
         require_non_empty(self.target_contract, "target_contract")
         if self.entity_scope not in schema.SOURCE_ENTITY_SCOPES:
-            raise ValueError(f"entity_scope must be one of {schema.SOURCE_ENTITY_SCOPES}")
+            raise ValueError(
+                f"entity_scope must be one of {schema.SOURCE_ENTITY_SCOPES}"
+            )
         if self.status not in schema.HANDOFF_STATUSES:
             raise ValueError(f"status must be one of {schema.HANDOFF_STATUSES}")
         require_strings(self.input_record_ids, "input_record_ids")
         require_strings(self.blocked_issue_ids, "blocked_issue_ids")
-        if any(not isinstance(item, ProvenanceReference) for item in self.provenance_refs):
-            raise ValueError("provenance_refs must contain ProvenanceReference instances")
+        if any(
+            not isinstance(item, ProvenanceReference) for item in self.provenance_refs
+        ):
+            raise ValueError(
+                "provenance_refs must contain ProvenanceReference instances"
+            )
         if self.record_count is not None:
             require_non_negative(self.record_count, "record_count")
         require_strings(self.notes, "notes")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #534

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Once candidate sets and feasibility outputs exist, the leisure planner needs a real ranking engine that can evaluate options against `LeisurePreferenceProfile`, `ItineraryObjectives`, interaction effects, and revealed-preference signals. This should be the first place where the planner turns the leisure foundation into ordered alternatives.

Parent epic: #531

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#531](https://github.com/stranske/trip-planner/issues/531)
- [#532](https://github.com/stranske/trip-planner/issues/532)
- [#510](https://github.com/stranske/trip-planner/issues/510)
- [#511](https://github.com/stranske/trip-planner/issues/511)
- [#512](https://github.com/stranske/trip-planner/issues/512)
- [#530](https://github.com/stranske/trip-planner/issues/530)
- [#533](https://github.com/stranske/trip-planner/issues/533)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Create `trip_planner/ranking/leisure.py` implementing a deterministic leisure ranking engine that consumes `LeisurePreferenceProfile`, `ItineraryObjectives`, feasibility outputs, and candidate sets/bundles.
  - [ ] Define scope for: Create the `trip_planner/ranking/leisure.py` module with the main LeisureRankingEngine class skeleton (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Create the `trip_planner/ranking/leisure.py` module with the main LeisureRankingEngine class skeleton (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Create the `trip_planner/ranking/leisure.py` module with the main LeisureRankingEngine class skeleton (verify: confirm completion in repo)
  - [ ] Implement methods to consume (verify: confirm completion in repo) validate LeisurePreferenceProfile inputs in the ranking engine (verify: confirm completion in repo) validate ItineraryObjectives inputs in the ranking engine (verify: confirm completion in repo) validate feasibility outputs in the ranking engine (verify: confirm completion in repo) validate candidate sets (verify: confirm completion in repo) bundles in the ranking engine (verify: confirm completion in repo)
  - [ ] Implement the core deterministic scoring algorithm that combines all input sources (verify: confirm completion in repo)
- [ ] Implement scoring components in `trip_planner/ranking/leisure.py` to account for anchors, quality floors, budget posture, route coherence, discovery fit, movement/friction fit, recovery protection, and other first-tier leisure dimensions.
  - [ ] Define scope for: Implement the anchor scoring component that evaluates candidate alignment with user-specified anchors (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement the anchor scoring component that evaluates candidate alignment with user-specified anchors (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement the anchor scoring component that evaluates candidate alignment with user-specified anchors (verify: confirm completion in repo)
  - [ ] Define scope for: Implement the quality floor scoring component that penalizes options below minimum quality thresholds (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement the quality floor scoring component that penalizes options below minimum quality thresholds (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement the quality floor scoring component that penalizes options below minimum quality thresholds (verify: confirm completion in repo)
  - [ ] Define scope for: Implement the budget posture scoring component that evaluates cost alignment with user preferences (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement the budget posture scoring component that evaluates cost alignment with user preferences (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement the budget posture scoring component that evaluates cost alignment with user preferences (verify: confirm completion in repo)
  - [ ] Implement the route coherence scoring component that evaluates geographic (verify: confirm completion in repo) logical flow (verify: confirm completion in repo)
  - [ ] Define scope for: Implement the discovery fit scoring component that matches exploration preferences to candidate characteristics (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement the discovery fit scoring component that matches exploration preferences to candidate characteristics (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement the discovery fit scoring component that matches exploration preferences to candidate characteristics (verify: confirm completion in repo)
  - [ ] Implement the movement (verify: confirm completion in repo) friction fit scoring component that evaluates travel burden (verify: confirm completion in repo)
  - [ ] Implement the recovery protection scoring component that ensures adequate rest periods (verify: confirm completion in repo)
  - [ ] Define scope for: Implement the scoring aggregation logic that combines all component scores into final rankings (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Implement the scoring aggregation logic that combines all component scores into final rankings (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Implement the scoring aggregation logic that combines all component scores into final rankings (verify: confirm completion in repo)
- [ ] Add logic in `trip_planner/ranking/leisure.py` to encode how tension flags and low-confidence profile areas affect ranking confidence and/or penalties.
- [ ] Implement output emission in `trip_planner/ranking/leisure.py` to match the canonical ranking/explanation contracts from issue #532 (ranked results plus component breakdown/explanation records).
- [ ] Add JSON fixtures under `tests/fixtures/ranking/leisure/*.json` representing materially different traveler types (depth-oriented urban trips, scenic-transit routes, discovery-heavy wanderer routes, quality-floor-sensitive trips).
  - [ ] Define scope for: Create JSON fixture for depth-oriented urban trip traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Implement focused slice for: Create JSON fixture for depth-oriented urban trip traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Validate focused slice for: Create JSON fixture for depth-oriented urban trip traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Define scope for: Create JSON fixture for scenic-transit route traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Implement focused slice for: Create JSON fixture for scenic-transit route traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Validate focused slice for: Create JSON fixture for scenic-transit route traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Define scope for: Create JSON fixture for discovery-heavy wanderer route traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Implement focused slice for: Create JSON fixture for discovery-heavy wanderer route traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Validate focused slice for: Create JSON fixture for discovery-heavy wanderer route traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Define scope for: Create JSON fixture for quality-floor-sensitive trip traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Implement focused slice for: Create JSON fixture for quality-floor-sensitive trip traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
  - [ ] Validate focused slice for: Create JSON fixture for quality-floor-sensitive trip traveler profile under tests/fixtures/ranking/leisure/ (verify: tests pass)
- [ ] Write unit tests in `tests/ranking/test_leisure_ranking.py` asserting rank-order differences across traveler types, including at least one case where the same candidates rank differently for different profiles.
  - [ ] Define scope for: Write unit test asserting that depth-oriented urban traveler profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Write unit test asserting that depth-oriented urban traveler profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Write unit test asserting that depth-oriented urban traveler profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Define scope for: Write unit test asserting that scenic-transit route traveler profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Write unit test asserting that scenic-transit route traveler profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Write unit test asserting that scenic-transit route traveler profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Define scope for: Write unit test asserting that discovery-heavy wanderer profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Write unit test asserting that discovery-heavy wanderer profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Write unit test asserting that discovery-heavy wanderer profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Define scope for: Write unit test asserting that quality-floor-sensitive profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Write unit test asserting that quality-floor-sensitive profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Write unit test asserting that quality-floor-sensitive profile produces expected ranking order (verify: confirm completion in repo)
  - [ ] Define scope for: Write unit test demonstrating that identical candidates rank differently for depth-oriented versus discovery-heavy profiles (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Write unit test demonstrating that identical candidates rank differently for depth-oriented versus discovery-heavy profiles (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Write unit test demonstrating that identical candidates rank differently for depth-oriented versus discovery-heavy profiles (verify: confirm completion in repo)
  - [ ] Write unit test validating that tension flags (verify: confirm completion in repo) low-confidence areas affect ranking as expected (verify: confirm completion in repo)
- [ ] Update documentation (file path not provided) describing that leisure ranking remains downstream from preference evaluation and objective derivation.

#### Acceptance criteria
- [ ] `trip_planner/ranking/leisure.py` exists and provides a first-pass leisure ranking engine that consumes `LeisurePreferenceProfile` and `ItineraryObjectives` (and does not bypass them).
- [ ] Ranked outputs produced by the leisure ranking engine include explainable component breakdowns and explanation records per the contracts from issue #532.
- [ ] Running `pytest` includes assertions showing different leisure profiles materially reorder the same candidate set.
- [ ] `tests/ranking/test_leisure_ranking.py` covers multiple traveler-profile cases and includes at least one low-confidence and/or tension-heavy case.
- [ ] Documentation (file path not provided) explicitly states the boundary between leisure preference resolution/objective derivation and leisure ranking.

**Head SHA:** 3dfdf765bed3fb2229ee449e89f7f513de529552
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23856687843) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23856687716) |
<!-- auto-status-summary:end -->