### PR TITLE
Issue #536: add itinerary scenario assembly scaffold

### DIFF
--- a/docs/itinerary-scenario-assembly-boundary.md
+++ b/docs/itinerary-scenario-assembly-boundary.md
@@ -1,0 +1,23 @@
+# Itinerary Scenario Assembly Boundary
+
+Issue #536 adds a first-pass route-search scaffold that turns ranked bundle candidates into multiple explainable itinerary scenarios.
+
+## In Scope
+
+- Define canonical scenario and route-search result contracts.
+- Assemble multiple itinerary scenarios from ranked bundle candidates plus feasibility signals.
+- Preserve explanation records, unresolved tradeoffs, and primary-vs-fallback distinctions.
+
+## Out of Scope
+
+- Exhaustive global route optimization.
+- Final booking, approval submission, or policy adjudication.
+- Interactive planner UX, map rendering, or live search orchestration.
+
+## Contract Position
+
+`CandidateSet` -> `RankedResultSet` + `FeasibilityAssessment` -> `ScenarioSearchResult`
+
+Scenario assembly stays downstream from candidate generation, ranking, and feasibility evaluation.
+It should package coherent alternatives for later planner orchestration, not replace component scoring
+with one opaque route-level heuristic.

--- a/tests/fixtures/itinerary/scenarios/business_primary_vs_fallback.json
+++ b/tests/fixtures/itinerary/scenarios/business_primary_vs_fallback.json
@@ -1,0 +1,15 @@
+{
+  "title": "Business primary versus fallback route set",
+  "expected_bundle_order": [
+    "bundle:approved-business",
+    "bundle:exception-business"
+  ],
+  "expected_kinds": [
+    "primary",
+    "fallback"
+  ],
+  "expected_fallback_tradeoff_codes": [
+    "policy_exception_path",
+    "ranking_not_recommended"
+  ]
+}

--- a/tests/fixtures/itinerary/scenarios/leisure_multi_scenario.json
+++ b/tests/fixtures/itinerary/scenarios/leisure_multi_scenario.json
@@ -1,0 +1,13 @@
+{
+  "title": "Leisure multi-scenario route set",
+  "expected_bundle_order": [
+    "bundle:urban-culture",
+    "bundle:quiet-recovery",
+    "bundle:scenic-wanderer"
+  ],
+  "expected_kinds": [
+    "primary",
+    "alternative",
+    "alternative"
+  ]
+}

--- a/tests/itinerary/test_search.py
+++ b/tests/itinerary/test_search.py
@@ -1,0 +1,481 @@
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from trip_planner.business import (
+    BusinessPlanningObjectives,
+    BusinessTravelProfile,
+    PolicyConstraintSet,
+    derive_business_planning_objectives,
+)
+from trip_planner.candidates import CandidateSeed, CandidateSet
+from trip_planner.contracts import (
+    BudgetProtection,
+    CountRange,
+    DayStructureObjectives,
+    DiscoveryStrategy,
+    ItineraryObjectives,
+    LodgingStrategy,
+    MoveDensityTarget,
+    QualityFloorProtection,
+    RecoveryExpectations,
+    TransportStrategy,
+)
+from trip_planner.itinerary import assemble_itinerary_scenarios
+from trip_planner.itinerary.feasibility import FeasibilityAssessment
+from trip_planner.options import (
+    ActivityOption,
+    BundleCompositionSummary,
+    BundleExplanation,
+    BundleProvenanceSummary,
+    BundleQualityValueFitSummary,
+    Destination,
+    InventoryBundle,
+    LodgingOption,
+    TransportOption,
+)
+from trip_planner.ranking import (
+    ExplanationRecord,
+    RankedResult,
+    RankedResultSet,
+    RiskFlag,
+    ScoreBreakdown,
+    ScoreConfidenceSummary,
+)
+
+
+def _fixture_path(*parts: str) -> Path:
+    return Path(__file__).resolve().parents[1] / "fixtures" / Path(*parts)
+
+
+def _load_json(*parts: str) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(_fixture_path(*parts).read_text(encoding="utf-8")))
+
+
+def _load_destination(name: str) -> Destination:
+    return Destination.from_dict(_load_json("options", "destinations", name))
+
+
+def _load_lodging(name: str) -> LodgingOption:
+    return LodgingOption.from_dict(_load_json("options", "lodging", name))
+
+
+def _load_transport(name: str) -> TransportOption:
+    return TransportOption.from_dict(_load_json("options", "transport", name))
+
+
+def _load_activity(name: str) -> ActivityOption:
+    return ActivityOption.from_dict(_load_json("options", "activities", name))
+
+
+def _load_business_profile(name: str) -> BusinessTravelProfile:
+    return BusinessTravelProfile.from_dict(_load_json("business", name))
+
+
+def _load_constraint_set(name: str) -> PolicyConstraintSet:
+    payload = _load_json("business", name)
+    return PolicyConstraintSet(**payload["constraint_set"])
+
+
+def _build_bundle(
+    *,
+    bundle_id: str,
+    title: str,
+    lodging_name: str,
+    transport_name: str,
+    activity_name: str,
+    summary: str,
+    strengths: list[str],
+    tradeoffs: list[str],
+    evidence: list[str],
+    tags: list[str],
+    quality_signal: float,
+    value_signal: float,
+    fit_signal: float,
+    transport_status: str = "approved",
+    business_access_signal: float = 0.0,
+) -> InventoryBundle:
+    kyoto = _load_destination("kyoto_city.json")
+    gion = _load_destination("gion_neighborhood.json")
+    lodging = _load_lodging(lodging_name)
+    transport = _load_transport(transport_name)
+    activity = _load_activity(activity_name)
+
+    transport.origin_id = gion.destination_id
+    transport.destination_id = kyoto.destination_id
+    transport.policy_summary.business_approval_status = transport_status
+    lodging.location_summary.business_access_signal = business_access_signal
+    activity.destination_id = kyoto.destination_id
+
+    return InventoryBundle(
+        bundle_id=bundle_id,
+        title=title,
+        bundle_context="mixed",
+        destinations=[gion, kyoto],
+        lodging_options=[lodging],
+        transport_options=[transport],
+        activity_options=[activity],
+        composition_summary=BundleCompositionSummary(
+            assembly_role="candidate_seed",
+            primary_destination_id=kyoto.destination_id,
+            component_option_ids=[lodging.option_id, transport.option_id, activity.option_id],
+        ),
+        provenance_summary=BundleProvenanceSummary(
+            source_refs=[
+                kyoto.source_refs[0].provenance_id,
+                gion.source_refs[0].provenance_id,
+                lodging.source_refs[0].provenance_id,
+                transport.source_refs[0].provenance_id,
+                activity.source_refs[0].provenance_id,
+            ],
+            booking_links=[
+                link
+                for link in [
+                    lodging.booking_links[0] if lodging.booking_links else "",
+                    transport.booking_links[0] if transport.booking_links else "",
+                    activity.booking_links[0] if activity.booking_links else "",
+                ]
+                if link
+            ],
+        ),
+        quality_value_fit=BundleQualityValueFitSummary(
+            quality_signal=quality_signal,
+            value_signal=value_signal,
+            fit_signal=fit_signal,
+        ),
+        explanation=BundleExplanation(
+            headline=title,
+            strengths=strengths,
+            tradeoffs=tradeoffs,
+            evidence=evidence,
+        ),
+        summary=summary,
+        tags=tags,
+    )
+
+
+def _leisure_candidate_set() -> CandidateSet:
+    bundles = [
+        _build_bundle(
+            bundle_id="bundle:urban-culture",
+            title="Urban culture base",
+            lodging_name="central_urban_hotel.json",
+            transport_name="downtown_local_ground.json",
+            activity_name="major_museum.json",
+            summary="Walkable, museum-forward Kyoto base with direct local movement.",
+            strengths=["Direct access to dense cultural inventory."],
+            tradeoffs=["High-energy core can feel crowded late in the day."],
+            evidence=["Museum density and walkability drive the primary route."],
+            tags=["urban", "museum", "iconic"],
+            quality_signal=0.84,
+            value_signal=0.72,
+            fit_signal=0.86,
+        ),
+        _build_bundle(
+            bundle_id="bundle:quiet-recovery",
+            title="Quiet recovery-first base",
+            lodging_name="quiet_outer_area_hotel.json",
+            transport_name="downtown_local_ground.json",
+            activity_name="major_museum.json",
+            summary="Comfort-protective Kyoto stay with lower noise and deeper recovery.",
+            strengths=["Sleep quality and recovery windows stay protected."],
+            tradeoffs=["Outer-neighborhood location adds more transit overhead."],
+            evidence=["Recovery matters more than immediate density for this route."],
+            tags=["quiet", "recovery", "quality-floor"],
+            quality_signal=0.88,
+            value_signal=0.66,
+            fit_signal=0.8,
+        ),
+        _build_bundle(
+            bundle_id="bundle:scenic-wanderer",
+            title="Scenic wanderer route",
+            lodging_name="vacation_rental.json",
+            transport_name="scenic_rail.json",
+            activity_name="wandering_district.json",
+            summary="Rail-led discovery day with open blocks for wandering.",
+            strengths=["The route keeps wandering and scenic transit as the core experience."],
+            tradeoffs=["The scenic leg is slower than the more direct options."],
+            evidence=["Open-ended exploration is preserved as an explicit alternative."],
+            tags=["discovery", "rail", "wandering"],
+            quality_signal=0.76,
+            value_signal=0.78,
+            fit_signal=0.82,
+        ),
+    ]
+    return CandidateSet(
+        candidate_set_id="candidate-set:itinerary:leisure",
+        trip_id="trip-itinerary-leisure",
+        purpose="final_selection",
+        seeds=[CandidateSeed(candidate_id=f"candidate:{bundle.bundle_id}", bundle=bundle) for bundle in bundles],
+        explanation=["Shared candidate set for itinerary search assembly tests."],
+        source_refs=["fixture:itinerary:leisure"],
+    )
+
+
+def _business_candidate_set() -> CandidateSet:
+    bundles = [
+        _build_bundle(
+            bundle_id="bundle:approved-business",
+            title="Approved channel primary route",
+            lodging_name="central_urban_hotel.json",
+            transport_name="downtown_local_ground.json",
+            activity_name="major_museum.json",
+            summary="Approved-channel itinerary that preserves arrival buffers and central access.",
+            strengths=["Channels and schedule protection remain policy aligned."],
+            tradeoffs=["Costs run slightly above the leanest alternative."],
+            evidence=["Approval-ready route is preserved as the primary scenario."],
+            tags=["business", "approved", "primary"],
+            quality_signal=0.83,
+            value_signal=0.69,
+            fit_signal=0.85,
+            transport_status="approved",
+            business_access_signal=0.9,
+        ),
+        _build_bundle(
+            bundle_id="bundle:exception-business",
+            title="Exception-nearest fallback route",
+            lodging_name="vacation_rental.json",
+            transport_name="scenic_rail.json",
+            activity_name="wandering_district.json",
+            summary="Fallback route retained when the compliant-first path is not viable.",
+            strengths=["Still preserves a coherent trip when strict approval channels fail."],
+            tradeoffs=["Needs exception handling and weaker schedule protection."],
+            evidence=["Fallback remains explicit instead of disappearing from the route set."],
+            tags=["business", "fallback", "exception"],
+            quality_signal=0.71,
+            value_signal=0.74,
+            fit_signal=0.67,
+            transport_status="restricted",
+            business_access_signal=0.55,
+        ),
+    ]
+    return CandidateSet(
+        candidate_set_id="candidate-set:itinerary:business",
+        trip_id="trip-itinerary-business",
+        purpose="policy_comparison",
+        seeds=[CandidateSeed(candidate_id=f"candidate:{bundle.bundle_id}", bundle=bundle) for bundle in bundles],
+        explanation=["Business route alternatives for primary-vs-fallback assembly tests."],
+        source_refs=["fixture:itinerary:business"],
+    )
+
+
+def _leisure_objectives() -> ItineraryObjectives:
+    return ItineraryObjectives(
+        objective_id="obj:itinerary:leisure",
+        trip_id="trip-itinerary-leisure",
+        route_shape="regional_cluster",
+        target_base_count=CountRange(min_value=1, max_value=2),
+        move_density=MoveDensityTarget(max_moves=3, cadence_days=3),
+        recovery_expectations=RecoveryExpectations(buffer_days=1, recovery_priority=0.62),
+        day_structure=DayStructureObjectives(
+            structure_level="moderate",
+            wandering_support_level=0.75,
+            reservation_density=0.4,
+        ),
+        discovery_strategy=DiscoveryStrategy(style="balanced", protect_open_blocks=True),
+        budget_protection=BudgetProtection(
+            protected_categories=["lodging", "food"],
+            sensitivity=0.55,
+        ),
+        quality_floor_protection=QualityFloorProtection(required_categories=["lodging"]),
+        lodging_strategy=LodgingStrategy(base_style="single_base", arrival_buffer_priority=0.5),
+        transport_strategy=TransportStrategy(preferred_modes=["rail", "local_ground"]),
+    )
+
+
+def _business_objectives() -> BusinessPlanningObjectives:
+    profile = _load_business_profile("client_meeting_profile.json")
+    constraint_set = _load_constraint_set("policy_round_trip_exception.json")
+    return derive_business_planning_objectives(
+        profile,
+        trip_id="trip-itinerary-business",
+        constraint_set=constraint_set,
+    )
+
+
+def _ranked_result(
+    *,
+    bundle: InventoryBundle,
+    result_id: str,
+    rank: int,
+    score: float,
+    note: str,
+    risk: RiskFlag | None = None,
+) -> RankedResult:
+    return RankedResult(
+        result_id=result_id,
+        result_kind="bundle",
+        rank=rank,
+        score=score,
+        target_bundle_id=bundle.bundle_id,
+        supporting_option_ids=bundle.option_ids,
+        supporting_destination_ids=bundle.destination_ids,
+        route_sequence=bundle.destination_ids,
+        score_breakdown=ScoreBreakdown(baseline_score=score, final_score=score),
+        confidence_summary=ScoreConfidenceSummary(overall_confidence=0.81),
+        explanation_records=[
+            ExplanationRecord(
+                explanation_id=f"exp:{result_id}",
+                target_kind="bundle",
+                target_id=bundle.bundle_id,
+                headline=bundle.title,
+                summary=note,
+                factor_keys=["scenario_assembly"],
+                machine_context={"bundle_id": bundle.bundle_id},
+                human_summary=[note],
+                source_refs=[bundle.bundle_id],
+            )
+        ],
+        unresolved_risks=[risk] if risk is not None else [],
+        source_refs=[bundle.bundle_id],
+    )
+
+
+def _leisure_ranked_results(candidate_set: CandidateSet) -> RankedResultSet:
+    by_id = {seed.bundle.bundle_id: seed.bundle for seed in candidate_set.seeds}
+    return RankedResultSet(
+        result_set_id="result-set:itinerary:leisure",
+        trip_id=candidate_set.trip_id,
+        purpose=candidate_set.purpose,
+        scope="mixed",
+        title="Leisure route ranking",
+        results=[
+            _ranked_result(
+                bundle=by_id["bundle:urban-culture"],
+                result_id="result:urban-culture",
+                rank=1,
+                score=0.91,
+                note="Dense cultural coverage and easy movement make this the lead route.",
+            ),
+            _ranked_result(
+                bundle=by_id["bundle:quiet-recovery"],
+                result_id="result:quiet-recovery",
+                rank=2,
+                score=0.86,
+                note="Recovery-first route remains a coherent alternative.",
+            ),
+            _ranked_result(
+                bundle=by_id["bundle:scenic-wanderer"],
+                result_id="result:scenic-wanderer",
+                rank=3,
+                score=0.8,
+                note="Scenic wandering route stays available as an explainable option.",
+            ),
+        ],
+        explanation=["Rank leisure bundles before assembling route scenarios."],
+        source_refs=["fixture:itinerary:leisure:results"],
+    )
+
+
+def _business_ranked_results(candidate_set: CandidateSet) -> RankedResultSet:
+    by_id = {seed.bundle.bundle_id: seed.bundle for seed in candidate_set.seeds}
+    return RankedResultSet(
+        result_set_id="result-set:itinerary:business",
+        trip_id=candidate_set.trip_id,
+        purpose=candidate_set.purpose,
+        scope="mixed",
+        title="Business route ranking",
+        results=[
+            _ranked_result(
+                bundle=by_id["bundle:approved-business"],
+                result_id="result:approved-business",
+                rank=1,
+                score=0.94,
+                note="Approved channel and buffer protection make this the primary business route.",
+            ),
+            _ranked_result(
+                bundle=by_id["bundle:exception-business"],
+                result_id="result:exception-business",
+                rank=2,
+                score=0.73,
+                note="Fallback route remains visible when the compliant-first option is unavailable.",
+                risk=RiskFlag(
+                    risk_id="risk:policy-exception",
+                    code="policy_exception_path",
+                    severity="warning",
+                    summary="Requires explicit exception handling before booking.",
+                ),
+            ),
+        ],
+        explanation=["Rank business bundles before assembling route scenarios."],
+        source_refs=["fixture:itinerary:business:results"],
+    )
+
+
+def test_assemble_itinerary_scenarios_preserves_leisure_alternatives() -> None:
+    fixture = _load_json("itinerary", "scenarios", "leisure_multi_scenario.json")
+    candidate_set = _leisure_candidate_set()
+    ranked_results = _leisure_ranked_results(candidate_set)
+    feasibility = [
+        FeasibilityAssessment(
+            assessment_id=f"assessment:{seed.bundle.bundle_id}",
+            bundle_id=seed.bundle.bundle_id,
+            feasible=True,
+            recommended_for_ranking=True,
+            schedule_protection_required=False,
+            total_travel_minutes=50 + index * 15,
+            total_transfer_count=index,
+            friction_penalty_total=0.05 * index,
+        )
+        for index, seed in enumerate(candidate_set.seeds)
+    ]
+
+    result = assemble_itinerary_scenarios(
+        ranked_results,
+        candidate_set=candidate_set,
+        objectives=_leisure_objectives(),
+        feasibility_outputs=feasibility,
+        title=cast(str, fixture["title"]),
+    )
+
+    assert [scenario.bundle_id for scenario in result.scenarios] == fixture["expected_bundle_order"]
+    assert [scenario.scenario_summary.scenario_kind for scenario in result.scenarios] == fixture["expected_kinds"]
+    assert all(scenario.scenario_summary.coherence_passed for scenario in result.scenarios)
+    assert all(scenario.explanation_records for scenario in result.scenarios)
+    assert result.explanation[0] == "objective_mode:leisure"
+
+
+def test_assemble_itinerary_scenarios_supports_business_primary_and_fallback() -> None:
+    fixture = _load_json("itinerary", "scenarios", "business_primary_vs_fallback.json")
+    candidate_set = _business_candidate_set()
+    ranked_results = _business_ranked_results(candidate_set)
+    feasibility = {
+        "bundle:approved-business": FeasibilityAssessment(
+            assessment_id="assessment:approved-business",
+            bundle_id="bundle:approved-business",
+            feasible=True,
+            recommended_for_ranking=True,
+            schedule_protection_required=True,
+            total_travel_minutes=55,
+            total_transfer_count=1,
+            friction_penalty_total=0.08,
+        ),
+        "bundle:exception-business": FeasibilityAssessment(
+            assessment_id="assessment:exception-business",
+            bundle_id="bundle:exception-business",
+            feasible=True,
+            recommended_for_ranking=False,
+            schedule_protection_required=True,
+            total_travel_minutes=95,
+            total_transfer_count=2,
+            friction_penalty_total=0.21,
+            blocking_reasons=["Manual policy exception review is required before booking."],
+        ),
+    }
+
+    result = assemble_itinerary_scenarios(
+        ranked_results,
+        candidate_set=candidate_set,
+        objectives=_business_objectives(),
+        feasibility_outputs=feasibility,
+        title=cast(str, fixture["title"]),
+    )
+
+    assert [scenario.bundle_id for scenario in result.scenarios] == fixture["expected_bundle_order"]
+    assert [scenario.scenario_summary.scenario_kind for scenario in result.scenarios] == fixture["expected_kinds"]
+    fallback_codes = [tradeoff.code for tradeoff in result.scenarios[1].unresolved_tradeoffs]
+    for code in fixture["expected_fallback_tradeoff_codes"]:
+        assert code in fallback_codes
+    assert result.explanation[0] == "objective_mode:business"
+    assert result.scenarios[0].scenario_summary.recommended_for_selection is True
+    assert result.scenarios[1].scenario_summary.recommended_for_selection is False

--- a/tests/itinerary/test_search.py
+++ b/tests/itinerary/test_search.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
+
 from trip_planner.business import (
     BusinessPlanningObjectives,
     BusinessTravelProfile,
@@ -23,6 +25,7 @@ from trip_planner.contracts import (
 )
 from trip_planner.itinerary import assemble_itinerary_scenarios
 from trip_planner.itinerary.feasibility import FeasibilityAssessment
+from trip_planner.itinerary.scenarios import ScenarioSearchResult
 from trip_planner.options import (
     ActivityOption,
     BundleCompositionSummary,
@@ -479,3 +482,57 @@ def test_assemble_itinerary_scenarios_supports_business_primary_and_fallback() -
     assert result.explanation[0] == "objective_mode:business"
     assert result.scenarios[0].scenario_summary.recommended_for_selection is True
     assert result.scenarios[1].scenario_summary.recommended_for_selection is False
+    assert result.scenarios[1].unresolved_tradeoffs[0].tradeoff_id == "risk:policy-exception"
+    assert result.scenarios[1].unresolved_tradeoffs[1].tradeoff_id == "blocking:bundle:exception-business:1"
+
+
+def test_assemble_itinerary_scenarios_marks_infeasible_results_as_not_coherent() -> None:
+    candidate_set = _leisure_candidate_set()
+    ranked_results = _leisure_ranked_results(candidate_set)
+    lead_bundle = candidate_set.seeds[0].bundle
+
+    result = assemble_itinerary_scenarios(
+        ranked_results,
+        candidate_set=candidate_set,
+        objectives=_leisure_objectives(),
+        feasibility_outputs={
+            lead_bundle.bundle_id: FeasibilityAssessment(
+                assessment_id=f"assessment:{lead_bundle.bundle_id}",
+                bundle_id=lead_bundle.bundle_id,
+                feasible=False,
+                recommended_for_ranking=True,
+                schedule_protection_required=False,
+                total_travel_minutes=65,
+                total_transfer_count=1,
+                friction_penalty_total=0.12,
+            )
+        },
+        max_scenarios=1,
+    )
+
+    assert result.scenarios[0].scenario_summary.feasible is False
+    assert result.scenarios[0].scenario_summary.coherence_passed is False
+
+
+def test_scenario_search_result_validates_purpose_against_shared_vocab() -> None:
+    candidate_set = _leisure_candidate_set()
+    ranked_results = _leisure_ranked_results(candidate_set)
+    result = assemble_itinerary_scenarios(
+        ranked_results,
+        candidate_set=candidate_set,
+        objectives=_leisure_objectives(),
+        max_scenarios=1,
+    )
+
+    scenario = result.scenarios[0]
+    with pytest.raises(ValueError, match="purpose must be one of"):
+        ScenarioSearchResult(
+            search_id=result.search_id,
+            trip_id=result.trip_id,
+            purpose="ad_hoc",
+            title=result.title,
+            source_result_set_id=result.source_result_set_id,
+            scenarios=[scenario],
+            explanation=list(result.explanation),
+            source_refs=list(result.source_refs),
+        )

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -75,6 +75,8 @@ trip_planner/itinerary/__init__.py
 trip_planner/itinerary/feasibility.py
 trip_planner/itinerary/move_costs.py
 trip_planner/itinerary/objective_derivation.py
+trip_planner/itinerary/scenarios.py
+trip_planner/itinerary/search.py
 trip_planner/options/__init__.py
 trip_planner/options/activities.py
 trip_planner/options/bundles.py

--- a/trip_planner/itinerary/__init__.py
+++ b/trip_planner/itinerary/__init__.py
@@ -3,10 +3,26 @@
 from .feasibility import evaluate_bundle_feasibility
 from .objective_derivation import derive_itinerary_objectives
 from .move_costs import MoveCostSummary, TravelTimeEstimate, build_move_cost_summaries
+from .scenarios import (
+    SCENARIO_KINDS,
+    TRADEOFF_SEVERITIES,
+    ItineraryScenario,
+    ScenarioSearchResult,
+    ScenarioSummary,
+    ScenarioTradeoff,
+)
+from .search import assemble_itinerary_scenarios
 
 __all__ = [
     "MoveCostSummary",
     "TravelTimeEstimate",
+    "SCENARIO_KINDS",
+    "TRADEOFF_SEVERITIES",
+    "ItineraryScenario",
+    "ScenarioSearchResult",
+    "ScenarioSummary",
+    "ScenarioTradeoff",
+    "assemble_itinerary_scenarios",
     "build_move_cost_summaries",
     "derive_itinerary_objectives",
     "evaluate_bundle_feasibility",

--- a/trip_planner/itinerary/scenarios.py
+++ b/trip_planner/itinerary/scenarios.py
@@ -1,0 +1,145 @@
+"""Route-search and scenario-output contracts for itinerary assembly."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_strings,
+)
+from trip_planner.contracts import MoneyRange
+from trip_planner.ranking import ExplanationRecord
+
+SCHEMA_VERSION = "0.1.0"
+SCENARIO_KINDS: tuple[str, ...] = ("primary", "alternative", "fallback")
+TRADEOFF_SEVERITIES: tuple[str, ...] = ("info", "warning", "critical")
+
+
+@dataclass(slots=True)
+class ScenarioTradeoff:
+    tradeoff_id: str
+    code: str
+    summary: str
+    severity: str = "warning"
+    blocking: bool = False
+    related_ids: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.tradeoff_id, "tradeoff_id")
+        require_non_empty(self.code, "code")
+        require_non_empty(self.summary, "summary")
+        if self.severity not in TRADEOFF_SEVERITIES:
+            raise ValueError(f"severity must be one of {TRADEOFF_SEVERITIES}")
+        require_strings(self.related_ids, "related_ids")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ScenarioSummary:
+    headline: str
+    scenario_kind: str
+    feasible: bool
+    recommended_for_selection: bool
+    coherence_passed: bool
+    estimated_total: MoneyRange | None = None
+    total_travel_minutes: int = 0
+    total_transfer_count: int = 0
+    route_sequence: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.headline, "headline")
+        if self.scenario_kind not in SCENARIO_KINDS:
+            raise ValueError(f"scenario_kind must be one of {SCENARIO_KINDS}")
+        if self.estimated_total is not None and not isinstance(self.estimated_total, MoneyRange):
+            raise ValueError("estimated_total must be a MoneyRange when provided")
+        require_non_negative(self.total_travel_minutes, "total_travel_minutes")
+        require_non_negative(self.total_transfer_count, "total_transfer_count")
+        require_strings(self.route_sequence, "route_sequence")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ItineraryScenario:
+    scenario_id: str
+    title: str
+    rank: int
+    bundle_id: str
+    source_result_id: str
+    score: float
+    scenario_summary: ScenarioSummary
+    supporting_option_ids: list[str] = field(default_factory=list)
+    objective_refs: list[str] = field(default_factory=list)
+    explanation_records: list[ExplanationRecord] = field(default_factory=list)
+    unresolved_tradeoffs: list[ScenarioTradeoff] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.scenario_id, "scenario_id")
+        require_non_empty(self.title, "title")
+        require_non_empty(self.bundle_id, "bundle_id")
+        require_non_empty(self.source_result_id, "source_result_id")
+        if self.rank <= 0:
+            raise ValueError("rank must be positive")
+        if not isinstance(self.scenario_summary, ScenarioSummary):
+            raise ValueError("scenario_summary must be a ScenarioSummary")
+        if any(not isinstance(item, ExplanationRecord) for item in self.explanation_records):
+            raise ValueError("explanation_records must contain ExplanationRecord instances")
+        if any(not isinstance(item, ScenarioTradeoff) for item in self.unresolved_tradeoffs):
+            raise ValueError("unresolved_tradeoffs must contain ScenarioTradeoff instances")
+        require_strings(self.supporting_option_ids, "supporting_option_ids")
+        require_strings(self.objective_refs, "objective_refs")
+        require_strings(self.notes, "notes")
+        if not self.explanation_records:
+            raise ValueError("explanation_records must contain at least one ExplanationRecord")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ScenarioSearchResult:
+    search_id: str
+    trip_id: str
+    purpose: str
+    title: str
+    source_result_set_id: str
+    scenarios: list[ItineraryScenario]
+    scope: str = "route"
+    explanation: list[str] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.search_id, "search_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.purpose, "purpose")
+        require_non_empty(self.title, "title")
+        require_non_empty(self.source_result_set_id, "source_result_set_id")
+        if self.scope != "route":
+            raise ValueError("scope must be 'route'")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+        if not self.scenarios:
+            raise ValueError("scenarios must contain at least one ItineraryScenario")
+        if any(not isinstance(item, ItineraryScenario) for item in self.scenarios):
+            raise ValueError("scenarios must contain ItineraryScenario instances")
+        require_strings(self.explanation, "explanation")
+        require_strings(self.source_refs, "source_refs")
+
+        ranks = [item.rank for item in self.scenarios]
+        if len(set(ranks)) != len(ranks):
+            raise ValueError("scenarios must use unique ranks")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/trip_planner/itinerary/scenarios.py
+++ b/trip_planner/itinerary/scenarios.py
@@ -10,6 +10,7 @@ from trip_planner._validators import (
     require_non_negative,
     require_strings,
 )
+from trip_planner._option_contracts import OPTION_SET_PURPOSES
 from trip_planner.contracts import MoneyRange
 from trip_planner.ranking import ExplanationRecord
 
@@ -123,7 +124,8 @@ class ScenarioSearchResult:
     def __post_init__(self) -> None:
         require_non_empty(self.search_id, "search_id")
         require_non_empty(self.trip_id, "trip_id")
-        require_non_empty(self.purpose, "purpose")
+        if self.purpose not in OPTION_SET_PURPOSES:
+            raise ValueError(f"purpose must be one of {OPTION_SET_PURPOSES}")
         require_non_empty(self.title, "title")
         require_non_empty(self.source_result_set_id, "source_result_set_id")
         if self.scope != "route":

--- a/trip_planner/itinerary/search.py
+++ b/trip_planner/itinerary/search.py
@@ -123,7 +123,7 @@ def _route_sequence(result: RankedResult, bundle: InventoryBundle) -> list[str]:
 
 def _tradeoff_from_risk_flag(risk: RiskFlag) -> ScenarioTradeoff:
     return ScenarioTradeoff(
-        tradeoff_id=f"risk:{risk.risk_id}",
+        tradeoff_id=risk.risk_id,
         code=risk.code,
         summary=risk.summary,
         severity=risk.severity,
@@ -138,10 +138,10 @@ def _build_tradeoffs(
 ) -> list[ScenarioTradeoff]:
     tradeoffs = [_tradeoff_from_risk_flag(risk) for risk in result.unresolved_risks]
 
-    for reason in assessment.blocking_reasons:
+    for index, reason in enumerate(assessment.blocking_reasons, start=1):
         tradeoffs.append(
             ScenarioTradeoff(
-                tradeoff_id=f"blocking:{assessment.bundle_id}:{reason}",
+                tradeoff_id=f"blocking:{assessment.bundle_id}:{index}",
                 code="blocking_reason",
                 summary=reason,
                 severity="critical",
@@ -251,8 +251,10 @@ def assemble_itinerary_scenarios(
             tradeoffs=tradeoffs,
         )
         route_sequence = _route_sequence(result, bundle)
-        coherence_passed = bundle.feasibility.internally_consistent and not any(
-            item.blocking for item in tradeoffs
+        coherence_passed = (
+            assessment.feasible
+            and bundle.feasibility.internally_consistent
+            and not any(item.blocking for item in tradeoffs)
         )
 
         summary_notes = list(bundle.explanation.tradeoffs)

--- a/trip_planner/itinerary/search.py
+++ b/trip_planner/itinerary/search.py
@@ -1,0 +1,329 @@
+"""Deterministic first-pass route assembly over ranked itinerary candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from trip_planner.business import BusinessPlanningObjectives
+from trip_planner.candidates import CandidateSet
+from trip_planner.contracts import ItineraryObjectives, MoneyRange
+from trip_planner.itinerary.feasibility import FeasibilityAssessment, evaluate_bundle_feasibility
+from trip_planner.options import InventoryBundle
+from trip_planner.ranking import RankedResult, RankedResultSet, RiskFlag
+
+from .scenarios import (
+    ItineraryScenario,
+    ScenarioSearchResult,
+    ScenarioSummary,
+    ScenarioTradeoff,
+)
+
+
+def _bundle_total(bundle: InventoryBundle) -> MoneyRange | None:
+    currency: str | None = None
+    total = 0.0
+    seen = False
+
+    for option in bundle.lodging_options:
+        amount = option.cost_summary.total or option.cost_summary.nightly
+        if amount is None or amount.typical_amount is None:
+            continue
+        currency = currency or amount.currency
+        if amount.currency != currency:
+            return None
+        total += amount.typical_amount
+        seen = True
+
+    for option in bundle.transport_options:
+        amount = option.cost_summary.total
+        if amount is None or amount.typical_amount is None:
+            continue
+        currency = currency or amount.currency
+        if amount.currency != currency:
+            return None
+        total += amount.typical_amount
+        seen = True
+
+    for option in bundle.activity_options:
+        amount = option.cost_summary.total or option.cost_summary.per_person
+        if amount is None or amount.typical_amount is None:
+            continue
+        currency = currency or amount.currency
+        if amount.currency != currency:
+            return None
+        total += amount.typical_amount
+        seen = True
+
+    if not seen:
+        return None
+
+    return MoneyRange(currency=currency or "USD", typical_amount=round(total, 2))
+
+
+def _bundle_map(
+    candidate_set: CandidateSet | None,
+    bundles: Sequence[InventoryBundle] | None,
+) -> dict[str, InventoryBundle]:
+    mapped: dict[str, InventoryBundle] = {}
+    if candidate_set is not None:
+        mapped.update({seed.bundle.bundle_id: seed.bundle for seed in candidate_set.seeds})
+    if bundles is not None:
+        mapped.update({bundle.bundle_id: bundle for bundle in bundles})
+    if not mapped:
+        raise ValueError("candidate_set or bundles must provide at least one InventoryBundle")
+    return mapped
+
+
+def _normalize_feasibility_outputs(
+    feasibility_outputs: Mapping[str, FeasibilityAssessment] | Sequence[FeasibilityAssessment] | None,
+) -> dict[str, FeasibilityAssessment]:
+    if feasibility_outputs is None:
+        return {}
+    if isinstance(feasibility_outputs, Mapping):
+        values = dict(feasibility_outputs)
+    elif isinstance(feasibility_outputs, Sequence):
+        values = {item.bundle_id: item for item in feasibility_outputs}
+    else:
+        raise ValueError(
+            "feasibility_outputs must be a mapping, sequence of FeasibilityAssessment values, or None"
+        )
+    if any(not isinstance(item, FeasibilityAssessment) for item in values.values()):
+        raise ValueError("feasibility_outputs must contain FeasibilityAssessment instances")
+    return values
+
+
+def _objective_mode(objectives: object | None) -> str:
+    if isinstance(objectives, BusinessPlanningObjectives):
+        return "business"
+    if isinstance(objectives, ItineraryObjectives):
+        return "leisure"
+    return "generic"
+
+
+def _objective_refs(objectives: object | None) -> list[str]:
+    if objectives is None:
+        return []
+    objective_id = getattr(objectives, "objective_id", None)
+    trip_id = getattr(objectives, "trip_id", None)
+    refs: list[str] = []
+    if isinstance(objective_id, str) and objective_id:
+        refs.append(objective_id)
+    if isinstance(trip_id, str) and trip_id:
+        refs.append(trip_id)
+    return refs
+
+
+def _route_sequence(result: RankedResult, bundle: InventoryBundle) -> list[str]:
+    if result.route_sequence:
+        return list(result.route_sequence)
+    if result.supporting_destination_ids:
+        return list(result.supporting_destination_ids)
+    return bundle.destination_ids
+
+
+def _tradeoff_from_risk_flag(risk: RiskFlag) -> ScenarioTradeoff:
+    return ScenarioTradeoff(
+        tradeoff_id=f"risk:{risk.risk_id}",
+        code=risk.code,
+        summary=risk.summary,
+        severity=risk.severity,
+        blocking=risk.blocking,
+        notes=list(risk.notes),
+    )
+
+
+def _build_tradeoffs(
+    result: RankedResult,
+    assessment: FeasibilityAssessment,
+) -> list[ScenarioTradeoff]:
+    tradeoffs = [_tradeoff_from_risk_flag(risk) for risk in result.unresolved_risks]
+
+    for reason in assessment.blocking_reasons:
+        tradeoffs.append(
+            ScenarioTradeoff(
+                tradeoff_id=f"blocking:{assessment.bundle_id}:{reason}",
+                code="blocking_reason",
+                summary=reason,
+                severity="critical",
+                blocking=True,
+                related_ids=[assessment.bundle_id],
+            )
+        )
+
+    for conflict in assessment.timing_conflicts:
+        tradeoffs.append(
+            ScenarioTradeoff(
+                tradeoff_id=conflict.conflict_id,
+                code=conflict.code,
+                summary=conflict.summary,
+                severity=conflict.severity,
+                blocking=conflict.blocking,
+                related_ids=list(conflict.related_option_ids),
+                notes=list(conflict.notes),
+            )
+        )
+
+    for warning in assessment.route_warnings:
+        tradeoffs.append(
+            ScenarioTradeoff(
+                tradeoff_id=warning.warning_id,
+                code=warning.code,
+                summary=warning.summary,
+                severity=warning.severity,
+                related_ids=list(warning.related_option_ids) + list(warning.destination_ids),
+                notes=list(warning.notes),
+            )
+        )
+
+    if not assessment.recommended_for_ranking and not any(
+        item.code == "ranking_not_recommended" for item in tradeoffs
+    ):
+        tradeoffs.append(
+            ScenarioTradeoff(
+                tradeoff_id=f"ranking:{assessment.bundle_id}:not-recommended",
+                code="ranking_not_recommended",
+                summary="Scenario is retained as a fallback even though it is not recommended for ranking.",
+                severity="warning",
+                related_ids=[assessment.bundle_id],
+            )
+        )
+
+    return tradeoffs
+
+
+def _scenario_kind(
+    *,
+    rank: int,
+    objective_mode: str,
+    assessment: FeasibilityAssessment,
+    tradeoffs: Sequence[ScenarioTradeoff],
+) -> str:
+    has_blocking_tradeoff = any(item.blocking for item in tradeoffs)
+
+    if rank == 1 and assessment.recommended_for_ranking and not has_blocking_tradeoff:
+        return "primary"
+
+    if objective_mode == "business" and (
+        not assessment.recommended_for_ranking or has_blocking_tradeoff
+    ):
+        return "fallback"
+
+    if not assessment.feasible or has_blocking_tradeoff:
+        return "fallback"
+
+    return "alternative"
+
+
+def assemble_itinerary_scenarios(
+    ranked_results: RankedResultSet,
+    *,
+    candidate_set: CandidateSet | None = None,
+    bundles: Sequence[InventoryBundle] | None = None,
+    objectives: object | None = None,
+    feasibility_outputs: Mapping[str, FeasibilityAssessment] | Sequence[FeasibilityAssessment] | None = None,
+    max_scenarios: int = 3,
+    title: str | None = None,
+) -> ScenarioSearchResult:
+    """Assemble explainable itinerary scenarios from ranked bundle candidates."""
+
+    if max_scenarios <= 0:
+        raise ValueError("max_scenarios must be positive")
+
+    bundle_map = _bundle_map(candidate_set, bundles)
+    assessments = _normalize_feasibility_outputs(feasibility_outputs)
+    objective_mode = _objective_mode(objectives)
+    objective_refs = _objective_refs(objectives)
+
+    scenarios: list[ItineraryScenario] = []
+    for result in sorted(ranked_results.results, key=lambda item: item.rank)[:max_scenarios]:
+        if not result.target_bundle_id:
+            raise ValueError("route assembly requires ranked results with target_bundle_id values")
+        bundle = bundle_map.get(result.target_bundle_id)
+        if bundle is None:
+            raise ValueError(f"missing bundle for ranked result target {result.target_bundle_id!r}")
+
+        assessment = assessments.get(bundle.bundle_id) or evaluate_bundle_feasibility(bundle)
+        tradeoffs = _build_tradeoffs(result, assessment)
+        scenario_kind = _scenario_kind(
+            rank=result.rank,
+            objective_mode=objective_mode,
+            assessment=assessment,
+            tradeoffs=tradeoffs,
+        )
+        route_sequence = _route_sequence(result, bundle)
+        coherence_passed = bundle.feasibility.internally_consistent and not any(
+            item.blocking for item in tradeoffs
+        )
+
+        summary_notes = list(bundle.explanation.tradeoffs)
+        if assessment.schedule_protection_required:
+            summary_notes.append("schedule_protection_required")
+        if assessment.missing_data_fields:
+            summary_notes.append(
+                f"missing_data:{','.join(sorted(set(assessment.missing_data_fields)))}"
+            )
+
+        scenario_summary = ScenarioSummary(
+            headline=bundle.explanation.headline or result.explanation_records[0].headline,
+            scenario_kind=scenario_kind,
+            feasible=assessment.feasible,
+            recommended_for_selection=assessment.recommended_for_ranking,
+            coherence_passed=coherence_passed,
+            estimated_total=_bundle_total(bundle),
+            total_travel_minutes=assessment.total_travel_minutes,
+            total_transfer_count=assessment.total_transfer_count,
+            route_sequence=route_sequence,
+            notes=summary_notes,
+        )
+
+        scenarios.append(
+            ItineraryScenario(
+                scenario_id=f"scenario:{ranked_results.trip_id}:{result.rank}",
+                title=bundle.title,
+                rank=result.rank,
+                bundle_id=bundle.bundle_id,
+                source_result_id=result.result_id,
+                score=result.score,
+                scenario_summary=scenario_summary,
+                supporting_option_ids=(
+                    list(result.supporting_option_ids) if result.supporting_option_ids else bundle.option_ids
+                ),
+                objective_refs=objective_refs,
+                explanation_records=list(result.explanation_records),
+                unresolved_tradeoffs=tradeoffs,
+                notes=list(bundle.notes) + list(result.notes),
+            )
+        )
+
+    if not scenarios:
+        raise ValueError("ranked_results must contain at least one scenario-ready result")
+
+    explanation = [
+        f"objective_mode:{objective_mode}",
+        f"scenario_count:{len(scenarios)}",
+        f"assembled_from:{ranked_results.result_set_id}",
+    ]
+    if objective_mode == "business":
+        explanation.append(
+            "Business scenario assembly preserves a compliant-first primary path and explicit fallback routes."
+        )
+    elif objective_mode == "leisure":
+        explanation.append(
+            "Leisure scenario assembly keeps multiple route alternatives instead of collapsing to one opaque plan."
+        )
+    else:
+        explanation.append("Scenario assembly preserves ranking explanations and feasibility tradeoffs.")
+
+    search_title = title or f"{objective_mode.title()} itinerary scenarios"
+    source_refs = list(dict.fromkeys([*ranked_results.source_refs, ranked_results.result_set_id]))
+
+    return ScenarioSearchResult(
+        search_id=f"scenario-search:{ranked_results.trip_id}:{objective_mode}",
+        trip_id=ranked_results.trip_id,
+        purpose=ranked_results.purpose,
+        title=search_title,
+        source_result_set_id=ranked_results.result_set_id,
+        scenarios=scenarios,
+        explanation=explanation,
+        source_refs=source_refs,
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #536

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Item-level or bundle-level ranking alone is not enough for a trip planner. The system eventually needs route-level alternatives and scenario outputs that combine ranked components into coherent trip proposals. Before any polished planner UI, the repo needs a first route-search and itinerary-assembly scaffold that can produce multiple explainable scenarios instead of one opaque “best trip.”

Parent epic: #531

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#531](https://github.com/stranske/trip-planner/issues/531)
- [#532](https://github.com/stranske/trip-planner/issues/532)
- [#533](https://github.com/stranske/trip-planner/issues/533)
- [#534](https://github.com/stranske/trip-planner/issues/534)
- [#535](https://github.com/stranske/trip-planner/issues/535)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define route-search result and scenario contracts that can represent multiple itinerary candidates, scenario summaries, explanation metadata, and unresolved tradeoffs.
- [x] Implement a first-pass route-assembly scaffold that consumes ranked candidates, objectives, and feasibility outputs and emits multiple coherent itinerary scenarios rather than a single opaque answer.
- [x] Ensure the scaffold can support both leisure multi-scenario planning and business fallback scenarios, such as compliant-first and exception-nearest options.
- [x] Add representative fixtures for at least: a leisure multi-scenario route set and a business primary-versus-fallback set.
- [x] Write unit tests covering scenario generation, internal coherence checks, and preservation of explanation metadata.
- [x] Document the boundary between route assembly, final ranking, and later interactive planner behavior.

#### Acceptance criteria
- [x] The repo contains canonical route-search and scenario-output contracts plus a first-pass assembly scaffold.
- [x] The scaffold can emit multiple coherent scenarios with explanations rather than one opaque result.
- [x] Leisure and business scenario generation can share the same high-level result structure while relying on different objective inputs.
- [x] Tests cover representative leisure and business scenario cases.
- [x] Documentation makes clear that route assembly is downstream from candidate ranking and feasibility.

**Head SHA:** 139db32e9f2b27538b97db55ced74778aa26f5f3
**Latest Runs:** ❔ in progress — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23882259734) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23882259740) |
<!-- auto-status-summary:end -->
