### PR TITLE
Issue #538: add persisted user and traveler profile contracts

### DIFF
--- a/docs/state-account-contracts.md
+++ b/docs/state-account-contracts.md
@@ -1,0 +1,25 @@
+# Account-State Contracts
+
+Issue #538 introduces the first persisted account-state layer for the planner.
+
+## What This Adds
+
+- `trip_planner.state.accounts.User` as the durable account owner for saved trips and planning sessions
+- `trip_planner.state.accounts.TravelerProfile` as the per-context profile record that can point at leisure and business planning profiles without collapsing them together
+- `AccountPreferenceRecord`, `RegionalDefaults`, and `NotificationPreference` for interaction defaults, notification behavior, and locale/origin defaults
+- backend-neutral repository protocols in `trip_planner.state.repositories.accounts` for loading, saving, and versioning account records
+
+## Ownership Boundary
+
+- Account state owns user identity, traveler contexts, defaults, and version metadata.
+- Trip containers in `trip_planner.contracts.trip` should reference persisted account and profile ids instead of copying account preferences inline.
+- Later persistence issues can build on this boundary:
+  - issue `#539` for trip containers and lifecycle storage
+  - issue `#540` for saved scenarios and checkpoints
+  - issue `#542` for mutable planning-session state and activity logs
+
+## Design Notes
+
+- Traveler profiles can support leisure, business, or mixed planning modes through explicit profile references.
+- Regional defaults remain account-level and profile-level so a user can keep one home locale while maintaining specialized traveler contexts.
+- Repository protocols return lightweight `AccountVersion` metadata so implementations can keep audit history without baking in a storage backend.

--- a/tests/fixtures/state/accounts/leisure_user.json
+++ b/tests/fixtures/state/accounts/leisure_user.json
@@ -1,0 +1,50 @@
+{
+  "user_id": "user-leisure-1",
+  "email": "leisure@example.com",
+  "display_name": "Avery Leisure",
+  "traveler_profiles": [
+    {
+      "traveler_profile_id": "traveler-leisure-primary",
+      "display_name": "Primary leisure profile",
+      "profile_kind": "personal",
+      "supported_modes": ["leisure"],
+      "leisure_profile_id": "leisure-profile-paris",
+      "default_origin_airports": ["ORD"],
+      "regional_defaults": {
+        "locale": "en-US",
+        "currency": "USD",
+        "timezone": "America/Chicago",
+        "home_airport": "ORD",
+        "departure_region": "US-MIDWEST"
+      },
+      "traveler_tags": ["art-museums", "rail"],
+      "notes": ["Prefers off-peak leisure travel."]
+    }
+  ],
+  "account_preferences": {
+    "default_traveler_profile_id": "traveler-leisure-primary",
+    "default_interaction_style": "guided",
+    "default_summary_granularity": "balanced",
+    "default_trip_mode": "leisure",
+    "auto_save_checkpoints": true,
+    "regional_defaults": {
+      "locale": "en-US",
+      "currency": "USD",
+      "timezone": "America/Chicago",
+      "home_airport": "ORD",
+      "departure_region": "US-MIDWEST"
+    },
+    "notification_preferences": [
+      {"channel": "email", "cadence": "digest", "enabled": true}
+    ],
+    "preferred_languages": ["en-US"],
+    "planning_tags": ["leisure-defaults"]
+  },
+  "status": "active",
+  "schema_version": "0.1.0",
+  "external_refs": {
+    "crm_contact_id": "crm-1001"
+  },
+  "account_tags": ["beta-user"],
+  "notes": ["Owns leisure trip drafts and saved itineraries."]
+}

--- a/tests/fixtures/state/accounts/mixed_mode_user.json
+++ b/tests/fixtures/state/accounts/mixed_mode_user.json
@@ -1,0 +1,68 @@
+{
+  "user_id": "user-mixed-1",
+  "email": "mixed@example.com",
+  "display_name": "Jordan Hybrid",
+  "traveler_profiles": [
+    {
+      "traveler_profile_id": "traveler-leisure",
+      "display_name": "Personal weekends",
+      "profile_kind": "personal",
+      "supported_modes": ["leisure"],
+      "leisure_profile_id": "leisure-profile-weekend",
+      "default_origin_airports": ["SEA"],
+      "regional_defaults": {
+        "locale": "en-US",
+        "currency": "USD",
+        "timezone": "America/Los_Angeles",
+        "home_airport": "SEA",
+        "departure_region": "US-WEST"
+      },
+      "traveler_tags": ["food", "walkable-city"],
+      "notes": ["Lightweight personal travel defaults."]
+    },
+    {
+      "traveler_profile_id": "traveler-business",
+      "display_name": "Consulting travel",
+      "profile_kind": "business",
+      "supported_modes": ["business"],
+      "business_profile_id": "business-profile-consulting",
+      "default_origin_airports": ["SEA", "SFO"],
+      "regional_defaults": {
+        "locale": "en-US",
+        "currency": "USD",
+        "timezone": "America/Los_Angeles",
+        "home_airport": "SEA",
+        "departure_region": "US-WEST"
+      },
+      "traveler_tags": ["client-facing", "carry-on-only"],
+      "notes": ["Uses stricter notification defaults for work travel."]
+    }
+  ],
+  "account_preferences": {
+    "default_traveler_profile_id": "traveler-business",
+    "default_interaction_style": "concise",
+    "default_summary_granularity": "brief",
+    "default_trip_mode": "business",
+    "auto_save_checkpoints": true,
+    "regional_defaults": {
+      "locale": "en-US",
+      "currency": "USD",
+      "timezone": "America/Los_Angeles",
+      "home_airport": "SEA",
+      "departure_region": "US-WEST"
+    },
+    "notification_preferences": [
+      {"channel": "email", "cadence": "important_only", "enabled": true},
+      {"channel": "push", "cadence": "realtime", "enabled": true}
+    ],
+    "preferred_languages": ["en-US"],
+    "planning_tags": ["mixed-mode"]
+  },
+  "status": "active",
+  "schema_version": "0.1.0",
+  "external_refs": {
+    "account_id": "acct-210"
+  },
+  "account_tags": ["mixed-travel"],
+  "notes": ["Switches between personal and consulting travel."]
+}

--- a/tests/fixtures/state/accounts/multi_profile_user.json
+++ b/tests/fixtures/state/accounts/multi_profile_user.json
@@ -1,0 +1,86 @@
+{
+  "user_id": "user-family-1",
+  "email": "family@example.com",
+  "display_name": "Morgan Planner",
+  "traveler_profiles": [
+    {
+      "traveler_profile_id": "traveler-solo",
+      "display_name": "Solo city breaks",
+      "profile_kind": "personal",
+      "supported_modes": ["leisure"],
+      "leisure_profile_id": "leisure-profile-solo",
+      "default_origin_airports": ["BOS"],
+      "regional_defaults": {
+        "locale": "en-US",
+        "currency": "USD",
+        "timezone": "America/New_York",
+        "home_airport": "BOS",
+        "departure_region": "US-NORTHEAST"
+      },
+      "traveler_tags": ["solo", "museums"],
+      "notes": ["Optimized for short weekend trips."]
+    },
+    {
+      "traveler_profile_id": "traveler-business-lite",
+      "display_name": "Light business travel",
+      "profile_kind": "mixed",
+      "supported_modes": ["leisure", "business"],
+      "leisure_profile_id": "leisure-profile-bleisure",
+      "business_profile_id": "business-profile-bleisure",
+      "default_origin_airports": ["BOS", "JFK"],
+      "regional_defaults": {
+        "locale": "en-US",
+        "currency": "USD",
+        "timezone": "America/New_York",
+        "home_airport": "BOS",
+        "departure_region": "US-NORTHEAST"
+      },
+      "traveler_tags": ["bleisure"],
+      "notes": ["Supports combined personal and client travel."]
+    },
+    {
+      "traveler_profile_id": "traveler-family",
+      "display_name": "Family vacations",
+      "profile_kind": "family",
+      "supported_modes": ["leisure"],
+      "leisure_profile_id": "leisure-profile-family",
+      "default_origin_airports": ["BOS"],
+      "regional_defaults": {
+        "locale": "fr-FR",
+        "currency": "EUR",
+        "timezone": "Europe/Paris",
+        "home_airport": "CDG",
+        "departure_region": "FR-IDF"
+      },
+      "traveler_tags": ["family", "school-breaks"],
+      "notes": ["Carries separate defaults for family holidays in Europe."]
+    }
+  ],
+  "account_preferences": {
+    "default_traveler_profile_id": "traveler-family",
+    "default_interaction_style": "collaborative",
+    "default_summary_granularity": "detailed",
+    "default_trip_mode": "leisure",
+    "auto_save_checkpoints": true,
+    "regional_defaults": {
+      "locale": "en-US",
+      "currency": "USD",
+      "timezone": "America/New_York",
+      "home_airport": "BOS",
+      "departure_region": "US-NORTHEAST"
+    },
+    "notification_preferences": [
+      {"channel": "email", "cadence": "digest", "enabled": true},
+      {"channel": "sms", "cadence": "important_only", "enabled": false}
+    ],
+    "preferred_languages": ["en-US", "fr-FR"],
+    "planning_tags": ["family-priority", "checkpoint-heavy"]
+  },
+  "status": "active",
+  "schema_version": "0.1.0",
+  "external_refs": {
+    "household_id": "home-44"
+  },
+  "account_tags": ["family-planner"],
+  "notes": ["Maintains separate traveler contexts for solo, business, and family travel."]
+}

--- a/tests/state/test_accounts.py
+++ b/tests/state/test_accounts.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from trip_planner.state import (
     AccountPreferenceRecord,
     NotificationPreference,
@@ -84,6 +86,54 @@ def test_user_rejects_missing_default_traveler_profile_reference() -> None:
         assert "default_traveler_profile_id" in str(exc)
     else:
         raise AssertionError("User should reject unknown default traveler profiles")
+
+
+def test_account_preferences_reject_scalar_string_list_fields() -> None:
+    with pytest.raises(ValueError, match="preferred_languages must be a list"):
+        AccountPreferenceRecord.from_dict({"preferred_languages": "en-US"})
+
+
+def test_traveler_profile_rejects_scalar_string_list_fields() -> None:
+    with pytest.raises(ValueError, match="supported_modes must be a list"):
+        TravelerProfile.from_dict(
+            {
+                "traveler_profile_id": "traveler-invalid",
+                "display_name": "Invalid traveler",
+                "supported_modes": "business",
+            }
+        )
+
+
+def test_user_rejects_non_list_traveler_profiles_payload() -> None:
+    with pytest.raises(ValueError, match="traveler_profiles must be a list"):
+        User.from_dict(
+            {
+                "user_id": "user-invalid",
+                "email": "user@example.com",
+                "display_name": "Traveler",
+                "traveler_profiles": "traveler-1",
+            }
+        )
+
+
+def test_user_rejects_scalar_string_account_tags() -> None:
+    with pytest.raises(ValueError, match="account_tags must be a list"):
+        User.from_dict(
+            {
+                "user_id": "user-invalid",
+                "email": "user@example.com",
+                "display_name": "Traveler",
+                "traveler_profiles": [
+                    {
+                        "traveler_profile_id": "traveler-1",
+                        "display_name": "Primary leisure",
+                        "supported_modes": ["leisure"],
+                        "leisure_profile_id": "leisure-1",
+                    }
+                ],
+                "account_tags": "vip",
+            }
+        )
 
 
 def test_account_repository_protocol_can_version_user_state() -> None:

--- a/tests/state/test_accounts.py
+++ b/tests/state/test_accounts.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+
+from trip_planner.state import (
+    AccountPreferenceRecord,
+    NotificationPreference,
+    TravelerProfile,
+    User,
+)
+from trip_planner.state.repositories import AccountRepository, AccountVersion
+
+
+def _fixture_path(name: str) -> Path:
+    fixtures_dir = Path(__file__).resolve().parents[1] / "fixtures" / "state" / "accounts"
+    return fixtures_dir / name
+
+
+def _load_fixture(name: str) -> User:
+    payload = json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+    return User.from_dict(payload)
+
+
+def test_account_loads_leisure_focused_fixture() -> None:
+    account = _load_fixture("leisure_user.json")
+
+    payload = account.to_dict()
+
+    assert payload["user_id"] == "user-leisure-1"
+    assert payload["account_preferences"]["default_trip_mode"] == "leisure"
+    assert payload["traveler_profiles"][0]["leisure_profile_id"] == "leisure-profile-paris"
+
+
+def test_account_loads_mixed_leisure_business_fixture() -> None:
+    account = _load_fixture("mixed_mode_user.json")
+
+    assert len(account.traveler_profiles) == 2
+    assert account.traveler_profiles[1].business_profile_id == "business-profile-consulting"
+    assert account.account_preferences.default_traveler_profile_id == "traveler-business"
+
+
+def test_account_loads_multi_profile_fixture() -> None:
+    account = _load_fixture("multi_profile_user.json")
+
+    payload = account.to_dict()
+
+    assert len(payload["traveler_profiles"]) == 3
+    assert payload["account_preferences"]["preferred_languages"] == ["en-US", "fr-FR"]
+    assert payload["traveler_profiles"][2]["profile_kind"] == "family"
+
+
+def test_traveler_profile_rejects_business_mode_without_business_profile_ref() -> None:
+    try:
+        TravelerProfile(
+            traveler_profile_id="traveler-invalid",
+            display_name="Invalid business profile",
+            profile_kind="business",
+            supported_modes=["business"],
+        )
+    except ValueError as exc:
+        assert "business_profile_id" in str(exc)
+    else:
+        raise AssertionError("Business traveler profiles should require business_profile_id")
+
+
+def test_user_rejects_missing_default_traveler_profile_reference() -> None:
+    try:
+        User(
+            user_id="user-1",
+            email="user@example.com",
+            display_name="Traveler",
+            traveler_profiles=[
+                TravelerProfile(
+                    traveler_profile_id="traveler-1",
+                    display_name="Primary leisure",
+                    supported_modes=["leisure"],
+                    leisure_profile_id="leisure-1",
+                )
+            ],
+            account_preferences=AccountPreferenceRecord(
+                default_traveler_profile_id="missing-profile"
+            ),
+        )
+    except ValueError as exc:
+        assert "default_traveler_profile_id" in str(exc)
+    else:
+        raise AssertionError("User should reject unknown default traveler profiles")
+
+
+def test_account_repository_protocol_can_version_user_state() -> None:
+    class InMemoryAccountRepository(AccountRepository):
+        def __init__(self) -> None:
+            self._users: dict[str, User] = {}
+            self._versions: dict[str, list[AccountVersion]] = {}
+
+        def get_user(self, user_id: str) -> User | None:
+            return self._users.get(user_id)
+
+        def save_user(self, user: User, *, summary: str = "") -> AccountVersion:
+            version = AccountVersion(
+                version_id=f"{user.user_id}-v{len(self._versions.get(user.user_id, [])) + 1}",
+                user_id=user.user_id,
+                recorded_at="2026-04-01T20:00:00Z",
+                summary=summary,
+            )
+            self._users[user.user_id] = user
+            self._versions.setdefault(user.user_id, []).append(version)
+            return version
+
+        def list_users(self) -> list[User]:
+            return list(self._users.values())
+
+        def list_versions(self, user_id: str) -> list[AccountVersion]:
+            return list(self._versions.get(user_id, []))
+
+    repo = InMemoryAccountRepository()
+    account = _load_fixture("multi_profile_user.json")
+    account.account_preferences.notification_preferences.append(
+        NotificationPreference(channel="push", cadence="digest", enabled=True)
+    )
+
+    first = repo.save_user(account, summary="initial import")
+    second = repo.save_user(account, summary="added push digest")
+
+    assert repo.get_user(account.user_id) is account
+    assert [version.version_id for version in repo.list_versions(account.user_id)] == [
+        first.version_id,
+        second.version_id,
+    ]
+    assert repo.list_users()[0].account_preferences.notification_preferences[-1].channel == "push"

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -39,6 +39,7 @@ tests/test_dependency_version_alignment.py
 tests/test_generate_segments.py
 tests/test_penalty.py
 tests/test_render_pr_review_thread_report.py
+tests/state/test_accounts.py
 trip_planner/__init__.py
 trip_planner/_option_contracts.py
 trip_planner/_validators.py
@@ -106,3 +107,7 @@ trip_planner/sources/schema.py
 trip_planner/sources/snapshots.py
 trip_planner/sources/adapters/__init__.py
 trip_planner/sources/adapters/base.py
+trip_planner/state/__init__.py
+trip_planner/state/accounts.py
+trip_planner/state/repositories/__init__.py
+trip_planner/state/repositories/accounts.py

--- a/trip_planner/state/__init__.py
+++ b/trip_planner/state/__init__.py
@@ -1,0 +1,31 @@
+"""Persisted account, trip, and session state contracts."""
+
+from .accounts import (
+    ACCOUNT_SCHEMA_VERSION,
+    ACCOUNT_STATUSES,
+    INTERACTION_STYLES,
+    NOTIFICATION_CADENCES,
+    NOTIFICATION_CHANNELS,
+    SUMMARY_GRANULARITIES,
+    TRAVELER_PROFILE_KINDS,
+    AccountPreferenceRecord,
+    NotificationPreference,
+    RegionalDefaults,
+    TravelerProfile,
+    User,
+)
+
+__all__ = [
+    "ACCOUNT_SCHEMA_VERSION",
+    "ACCOUNT_STATUSES",
+    "AccountPreferenceRecord",
+    "INTERACTION_STYLES",
+    "NOTIFICATION_CADENCES",
+    "NOTIFICATION_CHANNELS",
+    "NotificationPreference",
+    "RegionalDefaults",
+    "SUMMARY_GRANULARITIES",
+    "TRAVELER_PROFILE_KINDS",
+    "TravelerProfile",
+    "User",
+]

--- a/trip_planner/state/accounts.py
+++ b/trip_planner/state/accounts.py
@@ -27,6 +27,13 @@ def _require_unique_strings(values: list[str], field_name: str) -> None:
         raise ValueError(f"{field_name} cannot contain duplicates")
 
 
+def _payload_list(payload: dict[str, Any], field_name: str, default: list[Any]) -> list[Any]:
+    value = payload.get(field_name, default)
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list")
+    return list(value)
+
+
 @dataclass(slots=True)
 class RegionalDefaults:
     locale: str = "en-US"
@@ -135,10 +142,10 @@ class AccountPreferenceRecord:
             ),
             notification_preferences=[
                 NotificationPreference.from_dict(item)
-                for item in payload.get("notification_preferences", [])
+                for item in _payload_list(payload, "notification_preferences", [])
             ],
-            preferred_languages=list(payload.get("preferred_languages", [])),
-            planning_tags=list(payload.get("planning_tags", [])),
+            preferred_languages=_payload_list(payload, "preferred_languages", []),
+            planning_tags=_payload_list(payload, "planning_tags", []),
         )
 
 
@@ -187,19 +194,23 @@ class TravelerProfile:
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "TravelerProfile":
+        supported_modes = _payload_list(payload, "supported_modes", ["leisure"])
+        default_origin_airports = _payload_list(payload, "default_origin_airports", [])
+        traveler_tags = _payload_list(payload, "traveler_tags", [])
+        notes = _payload_list(payload, "notes", [])
         return cls(
             traveler_profile_id=payload["traveler_profile_id"],
             display_name=payload["display_name"],
             profile_kind=payload.get("profile_kind", "personal"),
-            supported_modes=list(payload.get("supported_modes", ["leisure"])),
+            supported_modes=supported_modes,
             leisure_profile_id=payload.get("leisure_profile_id"),
             business_profile_id=payload.get("business_profile_id"),
-            default_origin_airports=list(payload.get("default_origin_airports", [])),
+            default_origin_airports=default_origin_airports,
             regional_defaults=RegionalDefaults.from_dict(
                 payload.get("regional_defaults", {})
             ),
-            traveler_tags=list(payload.get("traveler_tags", [])),
-            notes=list(payload.get("notes", [])),
+            traveler_tags=traveler_tags,
+            notes=notes,
         )
 
 
@@ -252,20 +263,24 @@ class User:
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "User":
+        raw_traveler_profiles = _payload_list(payload, "traveler_profiles", [])
+        traveler_profiles: list[TravelerProfile] = []
+        for index, item in enumerate(raw_traveler_profiles):
+            if not isinstance(item, dict):
+                raise ValueError(f"traveler_profiles[{index}] must be an object")
+            traveler_profiles.append(TravelerProfile.from_dict(item))
+
         return cls(
             user_id=payload["user_id"],
             email=payload["email"],
             display_name=payload["display_name"],
-            traveler_profiles=[
-                TravelerProfile.from_dict(item)
-                for item in payload.get("traveler_profiles", [])
-            ],
+            traveler_profiles=traveler_profiles,
             account_preferences=AccountPreferenceRecord.from_dict(
                 payload.get("account_preferences", {})
             ),
             status=payload.get("status", "active"),
             schema_version=payload.get("schema_version", ACCOUNT_SCHEMA_VERSION),
             external_refs=dict(payload.get("external_refs", {})),
-            account_tags=list(payload.get("account_tags", [])),
-            notes=list(payload.get("notes", [])),
+            account_tags=_payload_list(payload, "account_tags", []),
+            notes=_payload_list(payload, "notes", []),
         )

--- a/trip_planner/state/accounts.py
+++ b/trip_planner/state/accounts.py
@@ -1,0 +1,271 @@
+"""Persisted account-state contracts for users and traveler profiles."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_optional_non_empty,
+    require_strings,
+)
+from trip_planner.contracts.trip import TRIP_MODES
+
+ACCOUNT_SCHEMA_VERSION = "0.1.0"
+ACCOUNT_STATUSES: tuple[str, ...] = ("active", "archived")
+TRAVELER_PROFILE_KINDS: tuple[str, ...] = ("personal", "family", "business", "mixed")
+INTERACTION_STYLES: tuple[str, ...] = ("concise", "guided", "collaborative", "autonomous")
+SUMMARY_GRANULARITIES: tuple[str, ...] = ("brief", "balanced", "detailed")
+NOTIFICATION_CADENCES: tuple[str, ...] = ("off", "important_only", "digest", "realtime")
+NOTIFICATION_CHANNELS: tuple[str, ...] = ("email", "push", "sms")
+
+
+def _require_unique_strings(values: list[str], field_name: str) -> None:
+    require_strings(values, field_name)
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field_name} cannot contain duplicates")
+
+
+@dataclass(slots=True)
+class RegionalDefaults:
+    locale: str = "en-US"
+    currency: str = "USD"
+    timezone: str = "UTC"
+    home_airport: str | None = None
+    departure_region: str | None = None
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.locale, "locale")
+        require_non_empty(self.currency, "currency")
+        require_non_empty(self.timezone, "timezone")
+        require_optional_non_empty(self.home_airport, "home_airport")
+        require_optional_non_empty(self.departure_region, "departure_region")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "RegionalDefaults":
+        return cls(**payload)
+
+
+@dataclass(slots=True)
+class NotificationPreference:
+    channel: str
+    cadence: str = "important_only"
+    enabled: bool = True
+
+    def __post_init__(self) -> None:
+        if self.channel not in NOTIFICATION_CHANNELS:
+            raise ValueError(f"channel must be one of {NOTIFICATION_CHANNELS}")
+        if self.cadence not in NOTIFICATION_CADENCES:
+            raise ValueError(f"cadence must be one of {NOTIFICATION_CADENCES}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "NotificationPreference":
+        return cls(**payload)
+
+
+@dataclass(slots=True)
+class AccountPreferenceRecord:
+    default_traveler_profile_id: str | None = None
+    default_interaction_style: str = "guided"
+    default_summary_granularity: str = "balanced"
+    default_trip_mode: str | None = None
+    auto_save_checkpoints: bool = True
+    regional_defaults: RegionalDefaults = field(default_factory=RegionalDefaults)
+    notification_preferences: list[NotificationPreference] = field(default_factory=list)
+    preferred_languages: list[str] = field(default_factory=list)
+    planning_tags: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_optional_non_empty(
+            self.default_traveler_profile_id,
+            "default_traveler_profile_id",
+        )
+        if self.default_interaction_style not in INTERACTION_STYLES:
+            raise ValueError(
+                f"default_interaction_style must be one of {INTERACTION_STYLES}"
+            )
+        if self.default_summary_granularity not in SUMMARY_GRANULARITIES:
+            raise ValueError(
+                "default_summary_granularity must be one of "
+                f"{SUMMARY_GRANULARITIES}"
+            )
+        if self.default_trip_mode is not None and self.default_trip_mode not in TRIP_MODES:
+            raise ValueError(f"default_trip_mode must be one of {TRIP_MODES}")
+        if not isinstance(self.regional_defaults, RegionalDefaults):
+            raise ValueError("regional_defaults must be a RegionalDefaults")
+        if any(
+            not isinstance(item, NotificationPreference)
+            for item in self.notification_preferences
+        ):
+            raise ValueError(
+                "notification_preferences must contain NotificationPreference instances"
+            )
+        channels = [item.channel for item in self.notification_preferences]
+        if len(set(channels)) != len(channels):
+            raise ValueError("notification_preferences cannot repeat channels")
+        _require_unique_strings(self.preferred_languages, "preferred_languages")
+        _require_unique_strings(self.planning_tags, "planning_tags")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "AccountPreferenceRecord":
+        return cls(
+            default_traveler_profile_id=payload.get("default_traveler_profile_id"),
+            default_interaction_style=payload.get(
+                "default_interaction_style",
+                "guided",
+            ),
+            default_summary_granularity=payload.get(
+                "default_summary_granularity",
+                "balanced",
+            ),
+            default_trip_mode=payload.get("default_trip_mode"),
+            auto_save_checkpoints=payload.get("auto_save_checkpoints", True),
+            regional_defaults=RegionalDefaults.from_dict(
+                payload.get("regional_defaults", {})
+            ),
+            notification_preferences=[
+                NotificationPreference.from_dict(item)
+                for item in payload.get("notification_preferences", [])
+            ],
+            preferred_languages=list(payload.get("preferred_languages", [])),
+            planning_tags=list(payload.get("planning_tags", [])),
+        )
+
+
+@dataclass(slots=True)
+class TravelerProfile:
+    traveler_profile_id: str
+    display_name: str
+    profile_kind: str = "personal"
+    supported_modes: list[str] = field(default_factory=lambda: ["leisure"])
+    leisure_profile_id: str | None = None
+    business_profile_id: str | None = None
+    default_origin_airports: list[str] = field(default_factory=list)
+    regional_defaults: RegionalDefaults = field(default_factory=RegionalDefaults)
+    traveler_tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.traveler_profile_id, "traveler_profile_id")
+        require_non_empty(self.display_name, "display_name")
+        if self.profile_kind not in TRAVELER_PROFILE_KINDS:
+            raise ValueError(f"profile_kind must be one of {TRAVELER_PROFILE_KINDS}")
+        _require_unique_strings(self.supported_modes, "supported_modes")
+        if any(mode not in TRIP_MODES for mode in self.supported_modes):
+            raise ValueError(f"supported_modes must only use {TRIP_MODES}")
+        require_optional_non_empty(self.leisure_profile_id, "leisure_profile_id")
+        require_optional_non_empty(self.business_profile_id, "business_profile_id")
+        if "leisure" in self.supported_modes and self.leisure_profile_id is None:
+            raise ValueError("leisure supported_modes require leisure_profile_id")
+        if "business" in self.supported_modes and self.business_profile_id is None:
+            raise ValueError("business supported_modes require business_profile_id")
+        if "leisure" not in self.supported_modes and self.leisure_profile_id is not None:
+            raise ValueError("leisure_profile_id requires leisure in supported_modes")
+        if "business" not in self.supported_modes and self.business_profile_id is not None:
+            raise ValueError("business_profile_id requires business in supported_modes")
+        _require_unique_strings(
+            self.default_origin_airports,
+            "default_origin_airports",
+        )
+        if not isinstance(self.regional_defaults, RegionalDefaults):
+            raise ValueError("regional_defaults must be a RegionalDefaults")
+        _require_unique_strings(self.traveler_tags, "traveler_tags")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "TravelerProfile":
+        return cls(
+            traveler_profile_id=payload["traveler_profile_id"],
+            display_name=payload["display_name"],
+            profile_kind=payload.get("profile_kind", "personal"),
+            supported_modes=list(payload.get("supported_modes", ["leisure"])),
+            leisure_profile_id=payload.get("leisure_profile_id"),
+            business_profile_id=payload.get("business_profile_id"),
+            default_origin_airports=list(payload.get("default_origin_airports", [])),
+            regional_defaults=RegionalDefaults.from_dict(
+                payload.get("regional_defaults", {})
+            ),
+            traveler_tags=list(payload.get("traveler_tags", [])),
+            notes=list(payload.get("notes", [])),
+        )
+
+
+@dataclass(slots=True)
+class User:
+    user_id: str
+    email: str
+    display_name: str
+    traveler_profiles: list[TravelerProfile]
+    account_preferences: AccountPreferenceRecord = field(
+        default_factory=AccountPreferenceRecord
+    )
+    status: str = "active"
+    schema_version: str = ACCOUNT_SCHEMA_VERSION
+    external_refs: dict[str, str] = field(default_factory=dict)
+    account_tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.user_id, "user_id")
+        require_non_empty(self.email, "email")
+        require_non_empty(self.display_name, "display_name")
+        if not self.traveler_profiles:
+            raise ValueError("traveler_profiles must contain at least one TravelerProfile")
+        if any(not isinstance(item, TravelerProfile) for item in self.traveler_profiles):
+            raise ValueError("traveler_profiles must contain TravelerProfile instances")
+        if not isinstance(self.account_preferences, AccountPreferenceRecord):
+            raise ValueError("account_preferences must be an AccountPreferenceRecord")
+        if self.status not in ACCOUNT_STATUSES:
+            raise ValueError(f"status must be one of {ACCOUNT_STATUSES}")
+        if self.schema_version != ACCOUNT_SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {ACCOUNT_SCHEMA_VERSION!r}")
+        profile_ids = [item.traveler_profile_id for item in self.traveler_profiles]
+        if len(set(profile_ids)) != len(profile_ids):
+            raise ValueError("traveler_profiles cannot repeat traveler_profile_id values")
+        default_id = self.account_preferences.default_traveler_profile_id
+        if default_id is not None and default_id not in profile_ids:
+            raise ValueError(
+                "default_traveler_profile_id must reference a traveler profile in the user record"
+            )
+        if any(not isinstance(key, str) or not key for key in self.external_refs):
+            raise ValueError("external_refs must use non-empty string keys")
+        if any(not isinstance(value, str) or not value for value in self.external_refs.values()):
+            raise ValueError("external_refs must contain non-empty string values")
+        _require_unique_strings(self.account_tags, "account_tags")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "User":
+        return cls(
+            user_id=payload["user_id"],
+            email=payload["email"],
+            display_name=payload["display_name"],
+            traveler_profiles=[
+                TravelerProfile.from_dict(item)
+                for item in payload.get("traveler_profiles", [])
+            ],
+            account_preferences=AccountPreferenceRecord.from_dict(
+                payload.get("account_preferences", {})
+            ),
+            status=payload.get("status", "active"),
+            schema_version=payload.get("schema_version", ACCOUNT_SCHEMA_VERSION),
+            external_refs=dict(payload.get("external_refs", {})),
+            account_tags=list(payload.get("account_tags", [])),
+            notes=list(payload.get("notes", [])),
+        )

--- a/trip_planner/state/repositories/__init__.py
+++ b/trip_planner/state/repositories/__init__.py
@@ -1,0 +1,5 @@
+"""Repository interfaces for persisted planner state."""
+
+from .accounts import AccountRepository, AccountVersion, TravelerProfileRepository
+
+__all__ = ["AccountRepository", "AccountVersion", "TravelerProfileRepository"]

--- a/trip_planner/state/repositories/accounts.py
+++ b/trip_planner/state/repositories/accounts.py
@@ -1,0 +1,53 @@
+"""Backend-neutral repository interfaces for persisted account state."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+from trip_planner.contracts._validators import require_non_empty
+from trip_planner.state.accounts import TravelerProfile, User
+
+
+@dataclass(slots=True)
+class AccountVersion:
+    version_id: str
+    user_id: str
+    recorded_at: str
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.version_id, "version_id")
+        require_non_empty(self.user_id, "user_id")
+        require_non_empty(self.recorded_at, "recorded_at")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class AccountRepository(Protocol):
+    def get_user(self, user_id: str) -> User | None:
+        """Load one persisted user account."""
+
+    def save_user(self, user: User, *, summary: str = "") -> AccountVersion:
+        """Persist a user account snapshot and return its version metadata."""
+
+    def list_users(self) -> list[User]:
+        """List the currently persisted user accounts."""
+
+    def list_versions(self, user_id: str) -> list[AccountVersion]:
+        """List saved versions for one user account."""
+
+
+class TravelerProfileRepository(Protocol):
+    def list_profiles(self, user_id: str) -> list[TravelerProfile]:
+        """List the persisted traveler profiles owned by one user."""
+
+    def save_profile(
+        self,
+        user_id: str,
+        profile: TravelerProfile,
+        *,
+        summary: str = "",
+    ) -> AccountVersion:
+        """Persist a traveler profile update and return version metadata."""


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #538

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The product brief assumes user accounts, traveler context, and saved trip ownership, but the backlog does not yet define canonical persisted account-side objects. Before trips and planning sessions can be stored reliably, the repo needs stable persistence contracts for `User`, traveler profiles, and account-level preferences.

Parent epic: #537

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#537](https://github.com/stranske/trip-planner/issues/537)
- [#505](https://github.com/stranske/trip-planner/issues/505)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement typed persistence contracts for `User`, `TravelerProfile`, and account preference records, including ownership and profile references.
- [x] Ensure the model can represent multiple traveler profiles or contexts for one user, such as personal travel, family travel, and business travel defaults.
- [x] Add fields for saved planning preferences, such as preferred interaction style defaults, notification preferences, and regional defaults where appropriate.
- [x] Define repository or storage interfaces for loading, saving, and versioning account-state records.
- [x] Add representative fixtures or examples for at least: a leisure-focused user, a mixed leisure/business user, and a user with multiple traveler profiles.
- [x] Write unit tests covering serialization, validation failures, and repository-interface behavior.
- [x] Document how account-state contracts relate to trip ownership and later orchestration flows.

#### Acceptance criteria
- [x] The repo contains canonical persisted account-state contracts for users and traveler profiles.
- [x] The contracts can represent multiple traveler contexts for one user without collapsing trip-specific state into the account object.
- [x] Repository or storage interfaces are defined for account-state persistence.
- [x] Tests cover representative account shapes plus malformed-input failures.
- [x] Documentation makes clear how these records anchor saved trips and planning sessions.

**Head SHA:** c963477ecf839adb133d08a9b157bd3c9328d52b
**Latest Runs:** ❔ in progress — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23882194669) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23882194673) |
<!-- auto-status-summary:end -->
