### PR TITLE
Issue #540: add saved scenario persistence contracts

### DIFF
--- a/docs/state-scenario-history.md
+++ b/docs/state-scenario-history.md
@@ -1,0 +1,63 @@
+# Saved Scenario And Checkpoint Persistence
+
+Issue `#540` introduces the durable saved-scenario layer that sits above persisted trips and below later session orchestration.
+
+## Intent
+
+`SavedScenarioRecord` keeps scenario history explicit and versioned instead of collapsing route alternatives into one mutable current state.
+
+This layer owns:
+
+- saved scenario versions that reference the planning artifacts captured at save time
+- durable comparison metadata for baseline-versus-fallback or compliant-versus-exception review
+- checkpoints that mark meaningful decision moments or in-trip revisions
+
+## Snapshot Boundary
+
+Saved scenario versions stay reference-oriented. They can point at:
+
+- itinerary objectives
+- ranked result sets
+- scenario-search outputs
+- itinerary scenario ids
+- option sets
+- budget state
+- policy state
+- planning-session state
+- relevant leisure or business profile ids
+
+That keeps persisted trip records small while still making scenario history inspectable and restorable.
+
+## Labels And History
+
+The first-pass label vocabulary is intentionally explicit:
+
+- `baseline`
+- `preferred`
+- `fallback`
+- `compliant_first`
+- `exception_nearest`
+- `in_trip_revision`
+
+Those labels let later UI and verifier flows explain why a scenario exists instead of treating every saved snapshot as just another unnamed revision.
+
+## Checkpoints
+
+`ScenarioCheckpoint` is separate from `SavedScenarioRecord` so the system can mark durable decision moments without mutating the underlying snapshot history.
+
+Typical checkpoint uses include:
+
+- baseline capture before major comparison
+- fallback capture for a retained contingency plan
+- policy review milestones
+- in-trip revisions with pending follow-up decisions
+
+## Repository Expectations
+
+Repository implementations should support:
+
+- saving scenario records and listing version history
+- restoring a prior version as a fresh active snapshot
+- listing scenarios by trip or active label
+- persisting comparison metadata without coupling to a storage backend
+- creating and filtering checkpoints independently of version restore

--- a/tests/fixtures/state/scenarios/business_compliant_vs_exception.json
+++ b/tests/fixtures/state/scenarios/business_compliant_vs_exception.json
@@ -1,0 +1,93 @@
+{
+  "records": [
+    {
+      "saved_scenario_id": "saved-scenario:compliant-first",
+      "trip_id": "trip-business-client-summit",
+      "current_version_id": "saved-scenario:compliant-first-v1",
+      "versions": [
+        {
+          "version_id": "saved-scenario:compliant-first-v1",
+          "saved_scenario_id": "saved-scenario:compliant-first",
+          "trip_id": "trip-business-client-summit",
+          "title": "Compliant-first client summit plan",
+          "label": "compliant_first",
+          "created_at": "2026-04-02T10:00:00Z",
+          "created_by": "policy-planner",
+          "scope": "route",
+          "snapshot_refs": {
+            "objective_id": "objective:client-summit",
+            "scenario_search_id": "scenario-search:client-summit",
+            "source_result_set_id": "ranked-result-set:client-summit",
+            "itinerary_scenario_id": "scenario:trip-business-client-summit:1",
+            "ranked_result_set_id": "ranked-result-set:client-summit",
+            "option_set_ids": [
+              "option-set:air:approved",
+              "option-set:hotel:approved"
+            ],
+            "policy_state_id": "policy-state:q2-client-summit",
+            "business_profile_id": "business-profile-consulting",
+            "notes": [
+              "Primary approval-ready path with compliant booking channels."
+            ]
+          },
+          "summary": "Primary scenario retains approved vendors and schedule protection.",
+          "tags": ["business", "approval-ready"],
+          "notes": ["Used as the baseline for business policy review."]
+        }
+      ],
+      "comparisons": [],
+      "tags": ["business", "policy"],
+      "notes": ["Primary scenario for approval review."]
+    },
+    {
+      "saved_scenario_id": "saved-scenario:exception-nearest",
+      "trip_id": "trip-business-client-summit",
+      "current_version_id": "saved-scenario:exception-nearest-v1",
+      "versions": [
+        {
+          "version_id": "saved-scenario:exception-nearest-v1",
+          "saved_scenario_id": "saved-scenario:exception-nearest",
+          "trip_id": "trip-business-client-summit",
+          "title": "Exception-nearest contingency route",
+          "label": "exception_nearest",
+          "created_at": "2026-04-02T10:10:00Z",
+          "created_by": "policy-planner",
+          "scope": "route",
+          "snapshot_refs": {
+            "objective_id": "objective:client-summit",
+            "scenario_search_id": "scenario-search:client-summit",
+            "source_result_set_id": "ranked-result-set:client-summit",
+            "itinerary_scenario_id": "scenario:trip-business-client-summit:2",
+            "ranked_result_set_id": "ranked-result-set:client-summit",
+            "option_set_ids": [
+              "option-set:air:exception",
+              "option-set:hotel:flex"
+            ],
+            "policy_state_id": "policy-state:q2-client-summit-exception",
+            "business_profile_id": "business-profile-consulting",
+            "notes": [
+              "Fallback path remains inspectable for policy exception review."
+            ]
+          },
+          "summary": "Exception-nearest route stays durable when the compliant path breaks.",
+          "tags": ["business", "exception"],
+          "notes": ["Comparison metadata should explain why the fallback exists."]
+        }
+      ],
+      "comparisons": [],
+      "tags": ["business", "fallback"],
+      "notes": ["Fallback remains explicit for later approval escalation."]
+    }
+  ],
+  "comparison": {
+    "comparison_id": "comparison:compliant-vs-exception",
+    "trip_id": "trip-business-client-summit",
+    "baseline_scenario_id": "saved-scenario:compliant-first",
+    "candidate_scenario_id": "saved-scenario:exception-nearest",
+    "compared_at": "2026-04-02T10:15:00Z",
+    "outcome": "tradeoff",
+    "summary": "Compliant-first stays primary while the exception-nearest path preserves schedule recovery.",
+    "focus_areas": ["policy", "schedule_protection", "exception_handling"],
+    "notes": ["Later review can trace why the exception path was retained."]
+  }
+}

--- a/tests/fixtures/state/scenarios/in_trip_revision_checkpoint.json
+++ b/tests/fixtures/state/scenarios/in_trip_revision_checkpoint.json
@@ -1,0 +1,55 @@
+{
+  "record": {
+    "saved_scenario_id": "saved-scenario:kyoto-rain-revision",
+    "trip_id": "trip-leisure-kyoto-live",
+    "current_version_id": "saved-scenario:kyoto-rain-revision-v1",
+    "versions": [
+      {
+        "version_id": "saved-scenario:kyoto-rain-revision-v1",
+        "saved_scenario_id": "saved-scenario:kyoto-rain-revision",
+        "trip_id": "trip-leisure-kyoto-live",
+        "title": "In-trip rain revision",
+        "label": "in_trip_revision",
+        "created_at": "2026-04-02T11:20:00Z",
+        "created_by": "planner",
+        "scope": "route",
+        "snapshot_refs": {
+          "objective_id": "objective:kyoto-live",
+          "scenario_search_id": "scenario-search:kyoto-live",
+          "source_result_set_id": "ranked-result-set:kyoto-live",
+          "itinerary_scenario_id": "scenario:trip-leisure-kyoto-live:3",
+          "option_set_ids": [
+            "option-set:rainy-day:kyoto"
+          ],
+          "session_state_id": "session-state:kyoto-live",
+          "budget_state_id": "budget-state:kyoto-live",
+          "leisure_profile_id": "leisure-profile-paris",
+          "notes": [
+            "Current in-trip revision captures the weather-disruption alternative."
+          ]
+        },
+        "summary": "Saved a mid-trip rain revision after the traveler chose indoor alternatives.",
+        "tags": ["in-trip", "weather"],
+        "notes": ["Supports later restore if the rain plan becomes the default day."]
+      }
+    ],
+    "comparisons": [],
+    "tags": ["in-trip", "session-aware"],
+    "notes": ["Mutable planning session references stay out-of-line from the trip record."]
+  },
+  "checkpoint": {
+    "checkpoint_id": "checkpoint:kyoto-rain-revision",
+    "trip_id": "trip-leisure-kyoto-live",
+    "saved_scenario_id": "saved-scenario:kyoto-rain-revision",
+    "version_id": "saved-scenario:kyoto-rain-revision-v1",
+    "created_at": "2026-04-02T11:25:00Z",
+    "checkpoint_kind": "in_trip_revision",
+    "title": "Rain revision approved",
+    "summary": "Checkpoint created after the traveler approved the in-trip weather fallback.",
+    "pending_decision_ids": [
+      "decision:move-temple-visit",
+      "decision:confirm-indoor-dinner"
+    ],
+    "notes": ["Checkpoint keeps the pending itinerary swaps visible for the next planner turn."]
+  }
+}

--- a/tests/fixtures/state/scenarios/leisure_baseline_vs_fallback.json
+++ b/tests/fixtures/state/scenarios/leisure_baseline_vs_fallback.json
@@ -1,0 +1,121 @@
+{
+  "records": [
+    {
+      "saved_scenario_id": "saved-scenario:kyoto-baseline",
+      "trip_id": "trip-leisure-kyoto-draft",
+      "current_version_id": "saved-scenario:kyoto-baseline-v2",
+      "versions": [
+        {
+          "version_id": "saved-scenario:kyoto-baseline-v1",
+          "saved_scenario_id": "saved-scenario:kyoto-baseline",
+          "trip_id": "trip-leisure-kyoto-draft",
+          "title": "Kyoto spring baseline",
+          "label": "baseline",
+          "created_at": "2026-04-02T09:00:00Z",
+          "created_by": "planner",
+          "scope": "route",
+          "snapshot_refs": {
+            "objective_id": "objective:kyoto-spring",
+            "scenario_search_id": "scenario-search:kyoto-spring",
+            "source_result_set_id": "ranked-result-set:kyoto-spring",
+            "itinerary_scenario_id": "scenario:trip-leisure-kyoto-draft:1",
+            "ranked_result_set_id": "ranked-result-set:kyoto-spring",
+            "option_set_ids": [
+              "option-set:lodging:kyoto",
+              "option-set:activities:kyoto"
+            ],
+            "leisure_profile_id": "leisure-profile-paris",
+            "notes": [
+              "Baseline route keeps Kyoto as the primary cultural base."
+            ]
+          },
+          "summary": "Initial spring Kyoto baseline saved after route comparison.",
+          "tags": ["baseline", "culture"],
+          "notes": ["Preserves the first coherent route the traveler approved."]
+        },
+        {
+          "version_id": "saved-scenario:kyoto-baseline-v2",
+          "saved_scenario_id": "saved-scenario:kyoto-baseline",
+          "trip_id": "trip-leisure-kyoto-draft",
+          "title": "Kyoto spring preferred refinement",
+          "label": "preferred",
+          "created_at": "2026-04-02T09:30:00Z",
+          "created_by": "planner",
+          "scope": "route",
+          "snapshot_refs": {
+            "objective_id": "objective:kyoto-spring",
+            "scenario_search_id": "scenario-search:kyoto-spring",
+            "source_result_set_id": "ranked-result-set:kyoto-spring",
+            "itinerary_scenario_id": "scenario:trip-leisure-kyoto-draft:1",
+            "ranked_result_set_id": "ranked-result-set:kyoto-spring",
+            "option_set_ids": [
+              "option-set:lodging:kyoto",
+              "option-set:activities:kyoto"
+            ],
+            "budget_state_id": "budget-state:kyoto-spring",
+            "leisure_profile_id": "leisure-profile-paris",
+            "notes": [
+              "Traveler preferred the quieter Kyoto lodging cluster after review."
+            ]
+          },
+          "based_on_version_id": "saved-scenario:kyoto-baseline-v1",
+          "summary": "Promoted the Kyoto baseline to the preferred scenario after refinement.",
+          "tags": ["preferred", "recovery-protected"],
+          "notes": ["Budget reference added once the planner preserved the quieter hotel."]
+        }
+      ],
+      "comparisons": [],
+      "tags": ["leisure", "saved-history"],
+      "notes": ["Trip keeps both the baseline and explicit fallback alternatives."]
+    },
+    {
+      "saved_scenario_id": "saved-scenario:osaka-fallback",
+      "trip_id": "trip-leisure-kyoto-draft",
+      "current_version_id": "saved-scenario:osaka-fallback-v1",
+      "versions": [
+        {
+          "version_id": "saved-scenario:osaka-fallback-v1",
+          "saved_scenario_id": "saved-scenario:osaka-fallback",
+          "trip_id": "trip-leisure-kyoto-draft",
+          "title": "Osaka rainy-day fallback",
+          "label": "fallback",
+          "created_at": "2026-04-02T09:05:00Z",
+          "created_by": "planner",
+          "scope": "route",
+          "snapshot_refs": {
+            "objective_id": "objective:kyoto-spring",
+            "scenario_search_id": "scenario-search:kyoto-spring",
+            "source_result_set_id": "ranked-result-set:kyoto-spring",
+            "itinerary_scenario_id": "scenario:trip-leisure-kyoto-draft:2",
+            "ranked_result_set_id": "ranked-result-set:kyoto-spring",
+            "option_set_ids": [
+              "option-set:lodging:osaka",
+              "option-set:activities:indoor"
+            ],
+            "leisure_profile_id": "leisure-profile-paris",
+            "notes": [
+              "Fallback scenario stays explicit for weather-disrupted days."
+            ]
+          },
+          "summary": "Fallback route retained to preserve lower-friction rainy-day options.",
+          "tags": ["fallback", "weather-safe"],
+          "notes": ["This scenario is durable rather than an ephemeral scratch branch."]
+        }
+      ],
+      "comparisons": [],
+      "tags": ["leisure", "fallback"],
+      "notes": ["Alternative remains available without becoming the default path."]
+    }
+  ],
+  "comparison": {
+    "comparison_id": "comparison:kyoto-vs-osaka",
+    "trip_id": "trip-leisure-kyoto-draft",
+    "baseline_scenario_id": "saved-scenario:kyoto-baseline",
+    "candidate_scenario_id": "saved-scenario:osaka-fallback",
+    "compared_at": "2026-04-02T09:35:00Z",
+    "outcome": "preferred",
+    "summary": "Kyoto remains the preferred baseline while Osaka stays as an explicit fallback.",
+    "focus_areas": ["recovery", "route_coherence", "weather_resilience"],
+    "notes": ["The comparison stays durable for later review and rollback."]
+  }
+}

--- a/tests/itinerary/test_search.py
+++ b/tests/itinerary/test_search.py
@@ -52,7 +52,9 @@ def _fixture_path(*parts: str) -> Path:
 
 
 def _load_json(*parts: str) -> dict[str, Any]:
-    return cast(dict[str, Any], json.loads(_fixture_path(*parts).read_text(encoding="utf-8")))
+    return cast(
+        dict[str, Any], json.loads(_fixture_path(*parts).read_text(encoding="utf-8"))
+    )
 
 
 def _load_destination(name: str) -> Destination:
@@ -121,7 +123,11 @@ def _build_bundle(
         composition_summary=BundleCompositionSummary(
             assembly_role="candidate_seed",
             primary_destination_id=kyoto.destination_id,
-            component_option_ids=[lodging.option_id, transport.option_id, activity.option_id],
+            component_option_ids=[
+                lodging.option_id,
+                transport.option_id,
+                activity.option_id,
+            ],
         ),
         provenance_summary=BundleProvenanceSummary(
             source_refs=[
@@ -196,9 +202,13 @@ def _leisure_candidate_set() -> CandidateSet:
             transport_name="scenic_rail.json",
             activity_name="wandering_district.json",
             summary="Rail-led discovery day with open blocks for wandering.",
-            strengths=["The route keeps wandering and scenic transit as the core experience."],
+            strengths=[
+                "The route keeps wandering and scenic transit as the core experience."
+            ],
             tradeoffs=["The scenic leg is slower than the more direct options."],
-            evidence=["Open-ended exploration is preserved as an explicit alternative."],
+            evidence=[
+                "Open-ended exploration is preserved as an explicit alternative."
+            ],
             tags=["discovery", "rail", "wandering"],
             quality_signal=0.76,
             value_signal=0.78,
@@ -209,7 +219,10 @@ def _leisure_candidate_set() -> CandidateSet:
         candidate_set_id="candidate-set:itinerary:leisure",
         trip_id="trip-itinerary-leisure",
         purpose="final_selection",
-        seeds=[CandidateSeed(candidate_id=f"candidate:{bundle.bundle_id}", bundle=bundle) for bundle in bundles],
+        seeds=[
+            CandidateSeed(candidate_id=f"candidate:{bundle.bundle_id}", bundle=bundle)
+            for bundle in bundles
+        ],
         explanation=["Shared candidate set for itinerary search assembly tests."],
         source_refs=["fixture:itinerary:leisure"],
     )
@@ -241,9 +254,13 @@ def _business_candidate_set() -> CandidateSet:
             transport_name="scenic_rail.json",
             activity_name="wandering_district.json",
             summary="Fallback route retained when the compliant-first path is not viable.",
-            strengths=["Still preserves a coherent trip when strict approval channels fail."],
+            strengths=[
+                "Still preserves a coherent trip when strict approval channels fail."
+            ],
             tradeoffs=["Needs exception handling and weaker schedule protection."],
-            evidence=["Fallback remains explicit instead of disappearing from the route set."],
+            evidence=[
+                "Fallback remains explicit instead of disappearing from the route set."
+            ],
             tags=["business", "fallback", "exception"],
             quality_signal=0.71,
             value_signal=0.74,
@@ -256,8 +273,13 @@ def _business_candidate_set() -> CandidateSet:
         candidate_set_id="candidate-set:itinerary:business",
         trip_id="trip-itinerary-business",
         purpose="policy_comparison",
-        seeds=[CandidateSeed(candidate_id=f"candidate:{bundle.bundle_id}", bundle=bundle) for bundle in bundles],
-        explanation=["Business route alternatives for primary-vs-fallback assembly tests."],
+        seeds=[
+            CandidateSeed(candidate_id=f"candidate:{bundle.bundle_id}", bundle=bundle)
+            for bundle in bundles
+        ],
+        explanation=[
+            "Business route alternatives for primary-vs-fallback assembly tests."
+        ],
         source_refs=["fixture:itinerary:business"],
     )
 
@@ -269,19 +291,27 @@ def _leisure_objectives() -> ItineraryObjectives:
         route_shape="regional_cluster",
         target_base_count=CountRange(min_value=1, max_value=2),
         move_density=MoveDensityTarget(max_moves=3, cadence_days=3),
-        recovery_expectations=RecoveryExpectations(buffer_days=1, recovery_priority=0.62),
+        recovery_expectations=RecoveryExpectations(
+            buffer_days=1, recovery_priority=0.62
+        ),
         day_structure=DayStructureObjectives(
             structure_level="moderate",
             wandering_support_level=0.75,
             reservation_density=0.4,
         ),
-        discovery_strategy=DiscoveryStrategy(style="balanced", protect_open_blocks=True),
+        discovery_strategy=DiscoveryStrategy(
+            style="balanced", protect_open_blocks=True
+        ),
         budget_protection=BudgetProtection(
             protected_categories=["lodging", "food"],
             sensitivity=0.55,
         ),
-        quality_floor_protection=QualityFloorProtection(required_categories=["lodging"]),
-        lodging_strategy=LodgingStrategy(base_style="single_base", arrival_buffer_priority=0.5),
+        quality_floor_protection=QualityFloorProtection(
+            required_categories=["lodging"]
+        ),
+        lodging_strategy=LodgingStrategy(
+            base_style="single_base", arrival_buffer_priority=0.5
+        ),
         transport_strategy=TransportStrategy(preferred_modes=["rail", "local_ground"]),
     )
 
@@ -431,9 +461,15 @@ def test_assemble_itinerary_scenarios_preserves_leisure_alternatives() -> None:
         title=cast(str, fixture["title"]),
     )
 
-    assert [scenario.bundle_id for scenario in result.scenarios] == fixture["expected_bundle_order"]
-    assert [scenario.scenario_summary.scenario_kind for scenario in result.scenarios] == fixture["expected_kinds"]
-    assert all(scenario.scenario_summary.coherence_passed for scenario in result.scenarios)
+    assert [scenario.bundle_id for scenario in result.scenarios] == fixture[
+        "expected_bundle_order"
+    ]
+    assert [
+        scenario.scenario_summary.scenario_kind for scenario in result.scenarios
+    ] == fixture["expected_kinds"]
+    assert all(
+        scenario.scenario_summary.coherence_passed for scenario in result.scenarios
+    )
     assert all(scenario.explanation_records for scenario in result.scenarios)
     assert result.explanation[0] == "objective_mode:leisure"
 
@@ -462,7 +498,9 @@ def test_assemble_itinerary_scenarios_supports_business_primary_and_fallback() -
             total_travel_minutes=95,
             total_transfer_count=2,
             friction_penalty_total=0.21,
-            blocking_reasons=["Manual policy exception review is required before booking."],
+            blocking_reasons=[
+                "Manual policy exception review is required before booking."
+            ],
         ),
     }
 
@@ -474,19 +512,33 @@ def test_assemble_itinerary_scenarios_supports_business_primary_and_fallback() -
         title=cast(str, fixture["title"]),
     )
 
-    assert [scenario.bundle_id for scenario in result.scenarios] == fixture["expected_bundle_order"]
-    assert [scenario.scenario_summary.scenario_kind for scenario in result.scenarios] == fixture["expected_kinds"]
-    fallback_codes = [tradeoff.code for tradeoff in result.scenarios[1].unresolved_tradeoffs]
+    assert [scenario.bundle_id for scenario in result.scenarios] == fixture[
+        "expected_bundle_order"
+    ]
+    assert [
+        scenario.scenario_summary.scenario_kind for scenario in result.scenarios
+    ] == fixture["expected_kinds"]
+    fallback_codes = [
+        tradeoff.code for tradeoff in result.scenarios[1].unresolved_tradeoffs
+    ]
     for code in fixture["expected_fallback_tradeoff_codes"]:
         assert code in fallback_codes
     assert result.explanation[0] == "objective_mode:business"
     assert result.scenarios[0].scenario_summary.recommended_for_selection is True
     assert result.scenarios[1].scenario_summary.recommended_for_selection is False
-    assert result.scenarios[1].unresolved_tradeoffs[0].tradeoff_id == "risk:policy-exception"
-    assert result.scenarios[1].unresolved_tradeoffs[1].tradeoff_id == "blocking:bundle:exception-business:1"
+    assert (
+        result.scenarios[1].unresolved_tradeoffs[0].tradeoff_id
+        == "risk:policy-exception"
+    )
+    assert (
+        result.scenarios[1].unresolved_tradeoffs[1].tradeoff_id
+        == "blocking:bundle:exception-business:1"
+    )
 
 
-def test_assemble_itinerary_scenarios_marks_infeasible_results_as_not_coherent() -> None:
+def test_assemble_itinerary_scenarios_marks_infeasible_results_as_not_coherent() -> (
+    None
+):
     candidate_set = _leisure_candidate_set()
     ranked_results = _leisure_ranked_results(candidate_set)
     lead_bundle = candidate_set.seeds[0].bundle

--- a/tests/state/test_accounts.py
+++ b/tests/state/test_accounts.py
@@ -13,7 +13,9 @@ from trip_planner.state.repositories import AccountRepository, AccountVersion
 
 
 def _fixture_path(name: str) -> Path:
-    fixtures_dir = Path(__file__).resolve().parents[1] / "fixtures" / "state" / "accounts"
+    fixtures_dir = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "state" / "accounts"
+    )
     return fixtures_dir / name
 
 
@@ -29,15 +31,22 @@ def test_account_loads_leisure_focused_fixture() -> None:
 
     assert payload["user_id"] == "user-leisure-1"
     assert payload["account_preferences"]["default_trip_mode"] == "leisure"
-    assert payload["traveler_profiles"][0]["leisure_profile_id"] == "leisure-profile-paris"
+    assert (
+        payload["traveler_profiles"][0]["leisure_profile_id"] == "leisure-profile-paris"
+    )
 
 
 def test_account_loads_mixed_leisure_business_fixture() -> None:
     account = _load_fixture("mixed_mode_user.json")
 
     assert len(account.traveler_profiles) == 2
-    assert account.traveler_profiles[1].business_profile_id == "business-profile-consulting"
-    assert account.account_preferences.default_traveler_profile_id == "traveler-business"
+    assert (
+        account.traveler_profiles[1].business_profile_id
+        == "business-profile-consulting"
+    )
+    assert (
+        account.account_preferences.default_traveler_profile_id == "traveler-business"
+    )
 
 
 def test_account_loads_multi_profile_fixture() -> None:
@@ -61,7 +70,9 @@ def test_traveler_profile_rejects_business_mode_without_business_profile_ref() -
     except ValueError as exc:
         assert "business_profile_id" in str(exc)
     else:
-        raise AssertionError("Business traveler profiles should require business_profile_id")
+        raise AssertionError(
+            "Business traveler profiles should require business_profile_id"
+        )
 
 
 def test_user_rejects_missing_default_traveler_profile_reference() -> None:
@@ -176,4 +187,7 @@ def test_account_repository_protocol_can_version_user_state() -> None:
         first.version_id,
         second.version_id,
     ]
-    assert repo.list_users()[0].account_preferences.notification_preferences[-1].channel == "push"
+    assert (
+        repo.list_users()[0].account_preferences.notification_preferences[-1].channel
+        == "push"
+    )

--- a/tests/state/test_scenarios.py
+++ b/tests/state/test_scenarios.py
@@ -15,7 +15,9 @@ from trip_planner.state.scenarios import (
 
 
 def _fixture_path(name: str) -> Path:
-    fixtures_dir = Path(__file__).resolve().parents[1] / "fixtures" / "state" / "scenarios"
+    fixtures_dir = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "state" / "scenarios"
+    )
     return fixtures_dir / name
 
 
@@ -32,11 +34,16 @@ def test_saved_scenario_record_loads_leisure_pair_fixture() -> None:
     assert baseline.current_version_id == "saved-scenario:kyoto-baseline-v2"
     assert baseline.versions[-1].label == "preferred"
     assert (
-        baseline.versions[-1].snapshot_refs.budget_state_id == "budget-state:kyoto-spring"
+        baseline.versions[-1].snapshot_refs.budget_state_id
+        == "budget-state:kyoto-spring"
     )
     assert fallback.versions[0].label == "fallback"
     assert comparison.outcome == "preferred"
-    assert comparison.focus_areas == ["recovery", "route_coherence", "weather_resilience"]
+    assert comparison.focus_areas == [
+        "recovery",
+        "route_coherence",
+        "weather_resilience",
+    ]
 
 
 def test_saved_scenario_record_loads_business_policy_pair_fixture() -> None:
@@ -45,7 +52,10 @@ def test_saved_scenario_record_loads_business_policy_pair_fixture() -> None:
     exception = SavedScenarioRecord.from_dict(payload["records"][1])
 
     assert compliant.versions[0].label == "compliant_first"
-    assert compliant.versions[0].snapshot_refs.policy_state_id == "policy-state:q2-client-summit"
+    assert (
+        compliant.versions[0].snapshot_refs.policy_state_id
+        == "policy-state:q2-client-summit"
+    )
     assert exception.versions[0].label == "exception_nearest"
     assert (
         exception.versions[0].snapshot_refs.business_profile_id
@@ -59,7 +69,9 @@ def test_scenario_checkpoint_loads_in_trip_revision_fixture() -> None:
     checkpoint = ScenarioCheckpoint.from_dict(payload["checkpoint"])
 
     assert record.versions[0].label == "in_trip_revision"
-    assert record.versions[0].snapshot_refs.session_state_id == "session-state:kyoto-live"
+    assert (
+        record.versions[0].snapshot_refs.session_state_id == "session-state:kyoto-live"
+    )
     assert checkpoint.checkpoint_kind == "in_trip_revision"
     assert checkpoint.pending_decision_ids == [
         "decision:move-temple-visit",
@@ -75,9 +87,82 @@ def test_scenario_artifact_refs_reject_duplicate_option_set_ids() -> None:
         )
 
 
+def test_scenario_artifact_refs_accept_profile_only_reference() -> None:
+    refs = ScenarioArtifactRefs(leisure_profile_id="leisure-profile:kyoto")
+
+    assert refs.leisure_profile_id == "leisure-profile:kyoto"
+
+
+def test_scenario_models_reject_string_notes() -> None:
+    version = ScenarioVersion(
+        version_id="saved-scenario:test-v1",
+        saved_scenario_id="saved-scenario:test",
+        trip_id="trip-1",
+        title="Baseline",
+        label="baseline",
+        created_at="2026-04-02T12:00:00Z",
+        snapshot_refs=ScenarioArtifactRefs(objective_id="objective:1"),
+    )
+
+    with pytest.raises(ValueError, match="notes must be a list of strings"):
+        ScenarioArtifactRefs(objective_id="objective:1", notes="oops")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="notes must be a list of strings"):
+        ScenarioVersion(
+            version_id=version.version_id,
+            saved_scenario_id=version.saved_scenario_id,
+            trip_id=version.trip_id,
+            title=version.title,
+            label=version.label,
+            created_at=version.created_at,
+            snapshot_refs=version.snapshot_refs,
+            notes="oops",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="notes must be a list of strings"):
+        ScenarioComparison(
+            comparison_id="comparison:test",
+            trip_id="trip-1",
+            baseline_scenario_id="saved-scenario:test",
+            candidate_scenario_id="saved-scenario:alt",
+            compared_at="2026-04-02T12:05:00Z",
+            outcome="tradeoff",
+            summary="Compare baseline to fallback.",
+            notes="oops",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="notes must be a list of strings"):
+        SavedScenarioRecord(
+            saved_scenario_id="saved-scenario:test",
+            trip_id="trip-1",
+            current_version_id=version.version_id,
+            versions=[version],
+            notes="oops",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="notes must be a list of strings"):
+        ScenarioCheckpoint(
+            checkpoint_id="checkpoint:test",
+            trip_id="trip-1",
+            saved_scenario_id="saved-scenario:test",
+            version_id=version.version_id,
+            created_at="2026-04-02T12:10:00Z",
+            checkpoint_kind="baseline_capture",
+            title="Checkpoint",
+            notes="oops",  # type: ignore[arg-type]
+        )
+
+
+def test_scenario_version_requires_snapshot_refs_in_payload() -> None:
+    payload = _load_payload("leisure_baseline_vs_fallback.json")["records"][0][
+        "versions"
+    ][0]
+    payload.pop("snapshot_refs")
+
+    with pytest.raises(ValueError, match="snapshot_refs is required"):
+        ScenarioVersion.from_dict(payload)
+
+
 def test_scenario_version_rejects_in_trip_revision_without_session_reference() -> None:
     with pytest.raises(
-        ValueError, match="in_trip_revision versions require snapshot_refs.session_state_id"
+        ValueError,
+        match="in_trip_revision versions require snapshot_refs.session_state_id",
     ):
         ScenarioVersion(
             version_id="saved-scenario:broken-v1",
@@ -94,7 +179,9 @@ def test_saved_scenario_record_rejects_unknown_current_version() -> None:
     payload = _load_payload("leisure_baseline_vs_fallback.json")["records"][0]
     payload["current_version_id"] = "saved-scenario:missing"
 
-    with pytest.raises(ValueError, match="current_version_id must reference a saved version"):
+    with pytest.raises(
+        ValueError, match="current_version_id must reference a saved version"
+    ):
         SavedScenarioRecord.from_dict(payload)
 
 
@@ -133,7 +220,11 @@ def test_scenario_repository_protocol_can_restore_and_compare_versions() -> None
             summary: str = "",
         ) -> ScenarioVersion:
             record = self._records[saved_scenario_id]
-            source = next(version for version in record.versions if version.version_id == version_id)
+            source = next(
+                version
+                for version in record.versions
+                if version.version_id == version_id
+            )
             restored = ScenarioVersion(
                 version_id=f"{saved_scenario_id}-v{len(record.versions) + 1}",
                 saved_scenario_id=saved_scenario_id,
@@ -167,7 +258,8 @@ def test_scenario_repository_protocol_can_restore_and_compare_versions() -> None
                     record
                     for record in results
                     if any(
-                        version.version_id == record.current_version_id and version.label == label
+                        version.version_id == record.current_version_id
+                        and version.label == label
                         for version in record.versions
                     )
                 ]
@@ -230,7 +322,10 @@ def test_scenario_repository_protocol_can_restore_and_compare_versions() -> None
     assert current_record is not None
     assert current_record.current_version_id == restored.version_id
     assert len(repo.list_versions(baseline.saved_scenario_id)) == 3
-    assert repo.list_scenarios(label="fallback")[0].saved_scenario_id == fallback.saved_scenario_id
+    assert (
+        repo.list_scenarios(label="fallback")[0].saved_scenario_id
+        == fallback.saved_scenario_id
+    )
     assert comparison.outcome == "preferred"
     assert comparison.focus_areas == ["route_coherence", "rollback"]
 
@@ -243,7 +338,9 @@ def test_scenario_checkpoint_repository_protocol_can_filter_checkpoints() -> Non
         def get_checkpoint(self, checkpoint_id: str) -> ScenarioCheckpoint | None:
             return self._checkpoints.get(checkpoint_id)
 
-        def create_checkpoint(self, checkpoint: ScenarioCheckpoint) -> ScenarioCheckpoint:
+        def create_checkpoint(
+            self, checkpoint: ScenarioCheckpoint
+        ) -> ScenarioCheckpoint:
             self._checkpoints[checkpoint.checkpoint_id] = checkpoint
             return checkpoint
 
@@ -259,7 +356,9 @@ def test_scenario_checkpoint_repository_protocol_can_filter_checkpoints() -> Non
                 results = [item for item in results if item.trip_id == trip_id]
             if saved_scenario_id is not None:
                 results = [
-                    item for item in results if item.saved_scenario_id == saved_scenario_id
+                    item
+                    for item in results
+                    if item.saved_scenario_id == saved_scenario_id
                 ]
             if checkpoint_kind is not None:
                 results = [

--- a/tests/state/test_scenarios.py
+++ b/tests/state/test_scenarios.py
@@ -224,8 +224,11 @@ def test_scenario_repository_protocol_can_restore_and_compare_versions() -> None
         focus_areas=["route_coherence", "rollback"],
     )
 
+    current_record = repo.get_scenario(baseline.saved_scenario_id)
+
     assert restored.based_on_version_id == "saved-scenario:kyoto-baseline-v1"
-    assert repo.get_scenario(baseline.saved_scenario_id).current_version_id == restored.version_id
+    assert current_record is not None
+    assert current_record.current_version_id == restored.version_id
     assert len(repo.list_versions(baseline.saved_scenario_id)) == 3
     assert repo.list_scenarios(label="fallback")[0].saved_scenario_id == fallback.saved_scenario_id
     assert comparison.outcome == "preferred"

--- a/tests/state/test_scenarios.py
+++ b/tests/state/test_scenarios.py
@@ -1,0 +1,275 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.state import SavedScenarioRecord, ScenarioCheckpoint, ScenarioVersion
+from trip_planner.state.repositories import (
+    ScenarioCheckpointRepository,
+    ScenarioRepository,
+)
+from trip_planner.state.scenarios import (
+    ScenarioArtifactRefs,
+    ScenarioComparison,
+)
+
+
+def _fixture_path(name: str) -> Path:
+    fixtures_dir = Path(__file__).resolve().parents[1] / "fixtures" / "state" / "scenarios"
+    return fixtures_dir / name
+
+
+def _load_payload(name: str) -> dict:
+    return json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+
+
+def test_saved_scenario_record_loads_leisure_pair_fixture() -> None:
+    payload = _load_payload("leisure_baseline_vs_fallback.json")
+    baseline = SavedScenarioRecord.from_dict(payload["records"][0])
+    fallback = SavedScenarioRecord.from_dict(payload["records"][1])
+    comparison = ScenarioComparison.from_dict(payload["comparison"])
+
+    assert baseline.current_version_id == "saved-scenario:kyoto-baseline-v2"
+    assert baseline.versions[-1].label == "preferred"
+    assert (
+        baseline.versions[-1].snapshot_refs.budget_state_id == "budget-state:kyoto-spring"
+    )
+    assert fallback.versions[0].label == "fallback"
+    assert comparison.outcome == "preferred"
+    assert comparison.focus_areas == ["recovery", "route_coherence", "weather_resilience"]
+
+
+def test_saved_scenario_record_loads_business_policy_pair_fixture() -> None:
+    payload = _load_payload("business_compliant_vs_exception.json")
+    compliant = SavedScenarioRecord.from_dict(payload["records"][0])
+    exception = SavedScenarioRecord.from_dict(payload["records"][1])
+
+    assert compliant.versions[0].label == "compliant_first"
+    assert compliant.versions[0].snapshot_refs.policy_state_id == "policy-state:q2-client-summit"
+    assert exception.versions[0].label == "exception_nearest"
+    assert (
+        exception.versions[0].snapshot_refs.business_profile_id
+        == "business-profile-consulting"
+    )
+
+
+def test_scenario_checkpoint_loads_in_trip_revision_fixture() -> None:
+    payload = _load_payload("in_trip_revision_checkpoint.json")
+    record = SavedScenarioRecord.from_dict(payload["record"])
+    checkpoint = ScenarioCheckpoint.from_dict(payload["checkpoint"])
+
+    assert record.versions[0].label == "in_trip_revision"
+    assert record.versions[0].snapshot_refs.session_state_id == "session-state:kyoto-live"
+    assert checkpoint.checkpoint_kind == "in_trip_revision"
+    assert checkpoint.pending_decision_ids == [
+        "decision:move-temple-visit",
+        "decision:confirm-indoor-dinner",
+    ]
+
+
+def test_scenario_artifact_refs_reject_duplicate_option_set_ids() -> None:
+    with pytest.raises(ValueError, match="option_set_ids cannot contain duplicates"):
+        ScenarioArtifactRefs(
+            objective_id="objective:1",
+            option_set_ids=["option-set:1", "option-set:1"],
+        )
+
+
+def test_scenario_version_rejects_in_trip_revision_without_session_reference() -> None:
+    with pytest.raises(
+        ValueError, match="in_trip_revision versions require snapshot_refs.session_state_id"
+    ):
+        ScenarioVersion(
+            version_id="saved-scenario:broken-v1",
+            saved_scenario_id="saved-scenario:broken",
+            trip_id="trip-1",
+            title="Broken in-trip revision",
+            label="in_trip_revision",
+            created_at="2026-04-02T12:00:00Z",
+            snapshot_refs=ScenarioArtifactRefs(objective_id="objective:1"),
+        )
+
+
+def test_saved_scenario_record_rejects_unknown_current_version() -> None:
+    payload = _load_payload("leisure_baseline_vs_fallback.json")["records"][0]
+    payload["current_version_id"] = "saved-scenario:missing"
+
+    with pytest.raises(ValueError, match="current_version_id must reference a saved version"):
+        SavedScenarioRecord.from_dict(payload)
+
+
+def test_scenario_repository_protocol_can_restore_and_compare_versions() -> None:
+    class InMemoryScenarioRepository(ScenarioRepository):
+        def __init__(self) -> None:
+            self._records: dict[str, SavedScenarioRecord] = {}
+            self._comparisons: list[ScenarioComparison] = []
+
+        def get_scenario(self, saved_scenario_id: str) -> SavedScenarioRecord | None:
+            return self._records.get(saved_scenario_id)
+
+        def save_scenario(
+            self,
+            scenario: SavedScenarioRecord,
+            *,
+            summary: str = "",
+        ) -> ScenarioVersion:
+            self._records[scenario.saved_scenario_id] = scenario
+            active = next(
+                version
+                for version in scenario.versions
+                if version.version_id == scenario.current_version_id
+            )
+            if summary:
+                active.summary = summary
+            return active
+
+        def restore_scenario(
+            self,
+            saved_scenario_id: str,
+            version_id: str,
+            *,
+            restored_at: str,
+            actor: str = "system",
+            summary: str = "",
+        ) -> ScenarioVersion:
+            record = self._records[saved_scenario_id]
+            source = next(version for version in record.versions if version.version_id == version_id)
+            restored = ScenarioVersion(
+                version_id=f"{saved_scenario_id}-v{len(record.versions) + 1}",
+                saved_scenario_id=saved_scenario_id,
+                trip_id=record.trip_id,
+                title=f"{source.title} restored",
+                label=source.label,
+                created_at=restored_at,
+                created_by=actor,
+                scope=source.scope,
+                snapshot_refs=source.snapshot_refs,
+                based_on_version_id=source.version_id,
+                summary=summary or f"restored {source.version_id}",
+                tags=list(source.tags),
+                notes=list(source.notes) + [f"Restored from {source.version_id}."],
+            )
+            record.versions.append(restored)
+            record.current_version_id = restored.version_id
+            return restored
+
+        def list_scenarios(
+            self,
+            *,
+            trip_id: str | None = None,
+            label: str | None = None,
+        ) -> list[SavedScenarioRecord]:
+            results = list(self._records.values())
+            if trip_id is not None:
+                results = [record for record in results if record.trip_id == trip_id]
+            if label is not None:
+                results = [
+                    record
+                    for record in results
+                    if any(
+                        version.version_id == record.current_version_id and version.label == label
+                        for version in record.versions
+                    )
+                ]
+            return results
+
+        def list_versions(self, saved_scenario_id: str) -> list[ScenarioVersion]:
+            return list(self._records[saved_scenario_id].versions)
+
+        def compare_scenarios(
+            self,
+            baseline_scenario_id: str,
+            candidate_scenario_id: str,
+            *,
+            compared_at: str,
+            summary: str,
+            outcome: str = "tradeoff",
+            focus_areas: list[str] | None = None,
+        ) -> ScenarioComparison:
+            baseline = self._records[baseline_scenario_id]
+            comparison = ScenarioComparison(
+                comparison_id=f"comparison:{baseline_scenario_id}:{candidate_scenario_id}",
+                trip_id=baseline.trip_id,
+                baseline_scenario_id=baseline_scenario_id,
+                candidate_scenario_id=candidate_scenario_id,
+                compared_at=compared_at,
+                outcome=outcome,
+                summary=summary,
+                focus_areas=list(focus_areas or []),
+            )
+            self._comparisons.append(comparison)
+            return comparison
+
+    payload = _load_payload("leisure_baseline_vs_fallback.json")
+    baseline = SavedScenarioRecord.from_dict(payload["records"][0])
+    fallback = SavedScenarioRecord.from_dict(payload["records"][1])
+
+    repo = InMemoryScenarioRepository()
+    repo.save_scenario(baseline)
+    repo.save_scenario(fallback)
+
+    restored = repo.restore_scenario(
+        baseline.saved_scenario_id,
+        "saved-scenario:kyoto-baseline-v1",
+        restored_at="2026-04-02T10:00:00Z",
+        actor="planner",
+        summary="Restored the original baseline after later edits drifted.",
+    )
+    comparison = repo.compare_scenarios(
+        baseline.saved_scenario_id,
+        fallback.saved_scenario_id,
+        compared_at="2026-04-02T10:05:00Z",
+        summary="Fallback stays available while the restored baseline is active.",
+        outcome="preferred",
+        focus_areas=["route_coherence", "rollback"],
+    )
+
+    assert restored.based_on_version_id == "saved-scenario:kyoto-baseline-v1"
+    assert repo.get_scenario(baseline.saved_scenario_id).current_version_id == restored.version_id
+    assert len(repo.list_versions(baseline.saved_scenario_id)) == 3
+    assert repo.list_scenarios(label="fallback")[0].saved_scenario_id == fallback.saved_scenario_id
+    assert comparison.outcome == "preferred"
+    assert comparison.focus_areas == ["route_coherence", "rollback"]
+
+
+def test_scenario_checkpoint_repository_protocol_can_filter_checkpoints() -> None:
+    class InMemoryCheckpointRepository(ScenarioCheckpointRepository):
+        def __init__(self) -> None:
+            self._checkpoints: dict[str, ScenarioCheckpoint] = {}
+
+        def get_checkpoint(self, checkpoint_id: str) -> ScenarioCheckpoint | None:
+            return self._checkpoints.get(checkpoint_id)
+
+        def create_checkpoint(self, checkpoint: ScenarioCheckpoint) -> ScenarioCheckpoint:
+            self._checkpoints[checkpoint.checkpoint_id] = checkpoint
+            return checkpoint
+
+        def list_checkpoints(
+            self,
+            *,
+            trip_id: str | None = None,
+            saved_scenario_id: str | None = None,
+            checkpoint_kind: str | None = None,
+        ) -> list[ScenarioCheckpoint]:
+            results = list(self._checkpoints.values())
+            if trip_id is not None:
+                results = [item for item in results if item.trip_id == trip_id]
+            if saved_scenario_id is not None:
+                results = [
+                    item for item in results if item.saved_scenario_id == saved_scenario_id
+                ]
+            if checkpoint_kind is not None:
+                results = [
+                    item for item in results if item.checkpoint_kind == checkpoint_kind
+                ]
+            return results
+
+    payload = _load_payload("in_trip_revision_checkpoint.json")
+    checkpoint = ScenarioCheckpoint.from_dict(payload["checkpoint"])
+
+    repo = InMemoryCheckpointRepository()
+    repo.create_checkpoint(checkpoint)
+
+    assert repo.get_checkpoint(checkpoint.checkpoint_id) is checkpoint
+    assert repo.list_checkpoints(trip_id="trip-leisure-kyoto-live")[0] is checkpoint
+    assert repo.list_checkpoints(checkpoint_kind="in_trip_revision")[0] is checkpoint

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -40,6 +40,7 @@ tests/test_generate_segments.py
 tests/test_penalty.py
 tests/test_render_pr_review_thread_report.py
 tests/state/test_accounts.py
+tests/state/test_scenarios.py
 tests/state/test_trips.py
 trip_planner/__init__.py
 trip_planner/_option_contracts.py
@@ -112,7 +113,9 @@ trip_planner/sources/adapters/__init__.py
 trip_planner/sources/adapters/base.py
 trip_planner/state/__init__.py
 trip_planner/state/accounts.py
+trip_planner/state/scenarios.py
 trip_planner/state/trips.py
 trip_planner/state/repositories/__init__.py
 trip_planner/state/repositories/accounts.py
+trip_planner/state/repositories/scenarios.py
 trip_planner/state/repositories/trips.py

--- a/trip_planner/itinerary/scenarios.py
+++ b/trip_planner/itinerary/scenarios.py
@@ -59,7 +59,9 @@ class ScenarioSummary:
         require_non_empty(self.headline, "headline")
         if self.scenario_kind not in SCENARIO_KINDS:
             raise ValueError(f"scenario_kind must be one of {SCENARIO_KINDS}")
-        if self.estimated_total is not None and not isinstance(self.estimated_total, MoneyRange):
+        if self.estimated_total is not None and not isinstance(
+            self.estimated_total, MoneyRange
+        ):
             raise ValueError("estimated_total must be a MoneyRange when provided")
         require_non_negative(self.total_travel_minutes, "total_travel_minutes")
         require_non_negative(self.total_transfer_count, "total_transfer_count")
@@ -94,15 +96,25 @@ class ItineraryScenario:
             raise ValueError("rank must be positive")
         if not isinstance(self.scenario_summary, ScenarioSummary):
             raise ValueError("scenario_summary must be a ScenarioSummary")
-        if any(not isinstance(item, ExplanationRecord) for item in self.explanation_records):
-            raise ValueError("explanation_records must contain ExplanationRecord instances")
-        if any(not isinstance(item, ScenarioTradeoff) for item in self.unresolved_tradeoffs):
-            raise ValueError("unresolved_tradeoffs must contain ScenarioTradeoff instances")
+        if any(
+            not isinstance(item, ExplanationRecord) for item in self.explanation_records
+        ):
+            raise ValueError(
+                "explanation_records must contain ExplanationRecord instances"
+            )
+        if any(
+            not isinstance(item, ScenarioTradeoff) for item in self.unresolved_tradeoffs
+        ):
+            raise ValueError(
+                "unresolved_tradeoffs must contain ScenarioTradeoff instances"
+            )
         require_strings(self.supporting_option_ids, "supporting_option_ids")
         require_strings(self.objective_refs, "objective_refs")
         require_strings(self.notes, "notes")
         if not self.explanation_records:
-            raise ValueError("explanation_records must contain at least one ExplanationRecord")
+            raise ValueError(
+                "explanation_records must contain at least one ExplanationRecord"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/trip_planner/state/__init__.py
+++ b/trip_planner/state/__init__.py
@@ -23,6 +23,17 @@ from .trips import (
     TripStatusChange,
     validate_trip_status_transition,
 )
+from .scenarios import (
+    CHECKPOINT_KINDS,
+    COMPARISON_OUTCOMES,
+    SAVED_SCENARIO_LABELS,
+    SCENARIO_STATE_SCHEMA_VERSION,
+    SavedScenarioRecord,
+    ScenarioArtifactRefs,
+    ScenarioCheckpoint,
+    ScenarioComparison,
+    ScenarioVersion,
+)
 
 __all__ = [
     "ACCOUNT_SCHEMA_VERSION",
@@ -36,6 +47,15 @@ __all__ = [
     "PersistedTripArtifactRefs",
     "PersistedTripRecord",
     "RegionalDefaults",
+    "CHECKPOINT_KINDS",
+    "COMPARISON_OUTCOMES",
+    "SAVED_SCENARIO_LABELS",
+    "SCENARIO_STATE_SCHEMA_VERSION",
+    "SavedScenarioRecord",
+    "ScenarioArtifactRefs",
+    "ScenarioCheckpoint",
+    "ScenarioComparison",
+    "ScenarioVersion",
     "SUMMARY_GRANULARITIES",
     "TRIP_SCHEMA_VERSION",
     "TRAVELER_PROFILE_KINDS",

--- a/trip_planner/state/accounts.py
+++ b/trip_planner/state/accounts.py
@@ -15,7 +15,12 @@ from trip_planner.contracts.trip import TRIP_MODES
 ACCOUNT_SCHEMA_VERSION = "0.1.0"
 ACCOUNT_STATUSES: tuple[str, ...] = ("active", "archived")
 TRAVELER_PROFILE_KINDS: tuple[str, ...] = ("personal", "family", "business", "mixed")
-INTERACTION_STYLES: tuple[str, ...] = ("concise", "guided", "collaborative", "autonomous")
+INTERACTION_STYLES: tuple[str, ...] = (
+    "concise",
+    "guided",
+    "collaborative",
+    "autonomous",
+)
 SUMMARY_GRANULARITIES: tuple[str, ...] = ("brief", "balanced", "detailed")
 NOTIFICATION_CADENCES: tuple[str, ...] = ("off", "important_only", "digest", "realtime")
 NOTIFICATION_CHANNELS: tuple[str, ...] = ("email", "push", "sms")
@@ -27,7 +32,9 @@ def _require_unique_strings(values: list[str], field_name: str) -> None:
         raise ValueError(f"{field_name} cannot contain duplicates")
 
 
-def _payload_list(payload: dict[str, Any], field_name: str, default: list[Any]) -> list[Any]:
+def _payload_list(
+    payload: dict[str, Any], field_name: str, default: list[Any]
+) -> list[Any]:
     value = payload.get(field_name, default)
     if not isinstance(value, list):
         raise ValueError(f"{field_name} must be a list")
@@ -100,10 +107,12 @@ class AccountPreferenceRecord:
             )
         if self.default_summary_granularity not in SUMMARY_GRANULARITIES:
             raise ValueError(
-                "default_summary_granularity must be one of "
-                f"{SUMMARY_GRANULARITIES}"
+                f"default_summary_granularity must be one of {SUMMARY_GRANULARITIES}"
             )
-        if self.default_trip_mode is not None and self.default_trip_mode not in TRIP_MODES:
+        if (
+            self.default_trip_mode is not None
+            and self.default_trip_mode not in TRIP_MODES
+        ):
             raise ValueError(f"default_trip_mode must be one of {TRIP_MODES}")
         if not isinstance(self.regional_defaults, RegionalDefaults):
             raise ValueError("regional_defaults must be a RegionalDefaults")
@@ -176,9 +185,15 @@ class TravelerProfile:
             raise ValueError("leisure supported_modes require leisure_profile_id")
         if "business" in self.supported_modes and self.business_profile_id is None:
             raise ValueError("business supported_modes require business_profile_id")
-        if "leisure" not in self.supported_modes and self.leisure_profile_id is not None:
+        if (
+            "leisure" not in self.supported_modes
+            and self.leisure_profile_id is not None
+        ):
             raise ValueError("leisure_profile_id requires leisure in supported_modes")
-        if "business" not in self.supported_modes and self.business_profile_id is not None:
+        if (
+            "business" not in self.supported_modes
+            and self.business_profile_id is not None
+        ):
             raise ValueError("business_profile_id requires business in supported_modes")
         _require_unique_strings(
             self.default_origin_airports,
@@ -234,8 +249,12 @@ class User:
         require_non_empty(self.email, "email")
         require_non_empty(self.display_name, "display_name")
         if not self.traveler_profiles:
-            raise ValueError("traveler_profiles must contain at least one TravelerProfile")
-        if any(not isinstance(item, TravelerProfile) for item in self.traveler_profiles):
+            raise ValueError(
+                "traveler_profiles must contain at least one TravelerProfile"
+            )
+        if any(
+            not isinstance(item, TravelerProfile) for item in self.traveler_profiles
+        ):
             raise ValueError("traveler_profiles must contain TravelerProfile instances")
         if not isinstance(self.account_preferences, AccountPreferenceRecord):
             raise ValueError("account_preferences must be an AccountPreferenceRecord")
@@ -245,7 +264,9 @@ class User:
             raise ValueError(f"schema_version must be {ACCOUNT_SCHEMA_VERSION!r}")
         profile_ids = [item.traveler_profile_id for item in self.traveler_profiles]
         if len(set(profile_ids)) != len(profile_ids):
-            raise ValueError("traveler_profiles cannot repeat traveler_profile_id values")
+            raise ValueError(
+                "traveler_profiles cannot repeat traveler_profile_id values"
+            )
         default_id = self.account_preferences.default_traveler_profile_id
         if default_id is not None and default_id not in profile_ids:
             raise ValueError(
@@ -253,7 +274,10 @@ class User:
             )
         if any(not isinstance(key, str) or not key for key in self.external_refs):
             raise ValueError("external_refs must use non-empty string keys")
-        if any(not isinstance(value, str) or not value for value in self.external_refs.values()):
+        if any(
+            not isinstance(value, str) or not value
+            for value in self.external_refs.values()
+        ):
             raise ValueError("external_refs must contain non-empty string values")
         _require_unique_strings(self.account_tags, "account_tags")
         require_strings(self.notes, "notes")

--- a/trip_planner/state/repositories/__init__.py
+++ b/trip_planner/state/repositories/__init__.py
@@ -1,11 +1,14 @@
 """Repository interfaces for persisted planner state."""
 
 from .accounts import AccountRepository, AccountVersion, TravelerProfileRepository
+from .scenarios import ScenarioCheckpointRepository, ScenarioRepository
 from .trips import TripRepository, TripVersion
 
 __all__ = [
     "AccountRepository",
     "AccountVersion",
+    "ScenarioCheckpointRepository",
+    "ScenarioRepository",
     "TravelerProfileRepository",
     "TripRepository",
     "TripVersion",

--- a/trip_planner/state/repositories/scenarios.py
+++ b/trip_planner/state/repositories/scenarios.py
@@ -1,0 +1,76 @@
+"""Backend-neutral repository interfaces for saved-scenario state."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from trip_planner.state.scenarios import (
+    SavedScenarioRecord,
+    ScenarioCheckpoint,
+    ScenarioComparison,
+    ScenarioVersion,
+)
+
+
+class ScenarioRepository(Protocol):
+    def get_scenario(self, saved_scenario_id: str) -> SavedScenarioRecord | None:
+        """Load one persisted saved-scenario record."""
+
+    def save_scenario(
+        self,
+        scenario: SavedScenarioRecord,
+        *,
+        summary: str = "",
+    ) -> ScenarioVersion:
+        """Persist one saved-scenario record and return the active version metadata."""
+
+    def restore_scenario(
+        self,
+        saved_scenario_id: str,
+        version_id: str,
+        *,
+        restored_at: str,
+        actor: str = "system",
+        summary: str = "",
+    ) -> ScenarioVersion:
+        """Restore a prior saved-scenario version and return the new active version."""
+
+    def list_scenarios(
+        self,
+        *,
+        trip_id: str | None = None,
+        label: str | None = None,
+    ) -> list[SavedScenarioRecord]:
+        """List persisted saved scenarios, optionally filtered by trip or active label."""
+
+    def list_versions(self, saved_scenario_id: str) -> list[ScenarioVersion]:
+        """List all saved versions for one scenario record."""
+
+    def compare_scenarios(
+        self,
+        baseline_scenario_id: str,
+        candidate_scenario_id: str,
+        *,
+        compared_at: str,
+        summary: str,
+        outcome: str = "tradeoff",
+        focus_areas: list[str] | None = None,
+    ) -> ScenarioComparison:
+        """Persist or return comparison metadata for two saved scenarios."""
+
+
+class ScenarioCheckpointRepository(Protocol):
+    def get_checkpoint(self, checkpoint_id: str) -> ScenarioCheckpoint | None:
+        """Load one saved checkpoint record."""
+
+    def create_checkpoint(self, checkpoint: ScenarioCheckpoint) -> ScenarioCheckpoint:
+        """Persist a new checkpoint tied to a saved scenario version."""
+
+    def list_checkpoints(
+        self,
+        *,
+        trip_id: str | None = None,
+        saved_scenario_id: str | None = None,
+        checkpoint_kind: str | None = None,
+    ) -> list[ScenarioCheckpoint]:
+        """List saved checkpoints using backend-neutral filters."""

--- a/trip_planner/state/scenarios.py
+++ b/trip_planner/state/scenarios.py
@@ -36,10 +36,14 @@ COMPARISON_OUTCOMES: tuple[str, ...] = (
 )
 
 
-def _require_unique_strings(values: list[str], field_name: str) -> None:
+def _require_string_list(values: list[str], field_name: str) -> None:
     if isinstance(values, str) or not isinstance(values, list):
         raise ValueError(f"{field_name} must be a list of strings")
     require_strings(values, field_name)
+
+
+def _require_unique_strings(values: list[str], field_name: str) -> None:
+    _require_string_list(values, field_name)
     if len(set(values)) != len(values):
         raise ValueError(f"{field_name} cannot contain duplicates")
 
@@ -83,7 +87,7 @@ class ScenarioArtifactRefs:
         ):
             require_optional_non_empty(getattr(self, field_name), field_name)
         _require_unique_strings(self.option_set_ids, "option_set_ids")
-        require_strings(self.notes, "notes")
+        _require_string_list(self.notes, "notes")
 
         if not any(
             (
@@ -96,9 +100,13 @@ class ScenarioArtifactRefs:
                 self.budget_state_id,
                 self.policy_state_id,
                 self.session_state_id,
+                self.leisure_profile_id,
+                self.business_profile_id,
             )
         ):
-            raise ValueError("ScenarioArtifactRefs must capture at least one saved reference")
+            raise ValueError(
+                "ScenarioArtifactRefs must capture at least one saved reference"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -129,9 +137,9 @@ class ScenarioVersion:
     title: str
     label: str
     created_at: str
+    snapshot_refs: ScenarioArtifactRefs
     created_by: str = "system"
     scope: str = "route"
-    snapshot_refs: ScenarioArtifactRefs = field(default_factory=ScenarioArtifactRefs)
     based_on_version_id: str | None = None
     summary: str = ""
     tags: list[str] = field(default_factory=list)
@@ -152,7 +160,7 @@ class ScenarioVersion:
             raise ValueError("snapshot_refs must be a ScenarioArtifactRefs")
         require_optional_non_empty(self.based_on_version_id, "based_on_version_id")
         _require_unique_strings(self.tags, "tags")
-        require_strings(self.notes, "notes")
+        _require_string_list(self.notes, "notes")
 
         if self.label in {"compliant_first", "exception_nearest"}:
             if self.snapshot_refs.business_profile_id is None:
@@ -163,14 +171,21 @@ class ScenarioVersion:
                 raise ValueError(
                     f"{self.label} versions require snapshot_refs.policy_state_id"
                 )
-        if self.label == "in_trip_revision" and self.snapshot_refs.session_state_id is None:
-            raise ValueError("in_trip_revision versions require snapshot_refs.session_state_id")
+        if (
+            self.label == "in_trip_revision"
+            and self.snapshot_refs.session_state_id is None
+        ):
+            raise ValueError(
+                "in_trip_revision versions require snapshot_refs.session_state_id"
+            )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "ScenarioVersion":
+        if "snapshot_refs" not in payload:
+            raise ValueError("snapshot_refs is required")
         return cls(
             version_id=payload["version_id"],
             saved_scenario_id=payload["saved_scenario_id"],
@@ -178,11 +193,9 @@ class ScenarioVersion:
             title=payload["title"],
             label=payload["label"],
             created_at=payload["created_at"],
+            snapshot_refs=ScenarioArtifactRefs.from_dict(payload["snapshot_refs"]),
             created_by=payload.get("created_by", "system"),
             scope=payload.get("scope", "route"),
-            snapshot_refs=ScenarioArtifactRefs.from_dict(
-                payload.get("snapshot_refs", {})
-            ),
             based_on_version_id=payload.get("based_on_version_id"),
             summary=payload.get("summary", ""),
             tags=_payload_list(payload, "tags", []),
@@ -212,9 +225,11 @@ class ScenarioComparison:
         if self.outcome not in COMPARISON_OUTCOMES:
             raise ValueError(f"outcome must be one of {COMPARISON_OUTCOMES}")
         if self.baseline_scenario_id == self.candidate_scenario_id:
-            raise ValueError("candidate_scenario_id must differ from baseline_scenario_id")
+            raise ValueError(
+                "candidate_scenario_id must differ from baseline_scenario_id"
+            )
         _require_unique_strings(self.focus_areas, "focus_areas")
-        require_strings(self.notes, "notes")
+        _require_string_list(self.notes, "notes")
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -260,7 +275,7 @@ class SavedScenarioRecord:
                 f"schema_version must be {SCENARIO_STATE_SCHEMA_VERSION!r}"
             )
         _require_unique_strings(self.tags, "tags")
-        require_strings(self.notes, "notes")
+        _require_string_list(self.notes, "notes")
 
         version_ids = [item.version_id for item in self.versions]
         if len(set(version_ids)) != len(version_ids):
@@ -277,7 +292,9 @@ class SavedScenarioRecord:
             if comparison.trip_id != self.trip_id:
                 raise ValueError("comparisons must share the record trip_id")
             if comparison.baseline_scenario_id != self.saved_scenario_id:
-                raise ValueError("comparisons must reference the record scenario as baseline")
+                raise ValueError(
+                    "comparisons must reference the record scenario as baseline"
+                )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -296,9 +313,7 @@ class SavedScenarioRecord:
                 ScenarioComparison.from_dict(item)
                 for item in _payload_list(payload, "comparisons", [])
             ],
-            schema_version=payload.get(
-                "schema_version", SCENARIO_STATE_SCHEMA_VERSION
-            ),
+            schema_version=payload.get("schema_version", SCENARIO_STATE_SCHEMA_VERSION),
             tags=_payload_list(payload, "tags", []),
             notes=_payload_list(payload, "notes", []),
         )
@@ -327,7 +342,7 @@ class ScenarioCheckpoint:
         if self.checkpoint_kind not in CHECKPOINT_KINDS:
             raise ValueError(f"checkpoint_kind must be one of {CHECKPOINT_KINDS}")
         _require_unique_strings(self.pending_decision_ids, "pending_decision_ids")
-        require_strings(self.notes, "notes")
+        _require_string_list(self.notes, "notes")
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/trip_planner/state/scenarios.py
+++ b/trip_planner/state/scenarios.py
@@ -1,0 +1,348 @@
+"""Persisted saved-scenario, checkpoint, and version-history contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner._option_contracts import OPTION_SET_SCOPES
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_optional_non_empty,
+    require_strings,
+)
+
+SCENARIO_STATE_SCHEMA_VERSION = "0.1.0"
+SAVED_SCENARIO_LABELS: tuple[str, ...] = (
+    "baseline",
+    "preferred",
+    "fallback",
+    "compliant_first",
+    "exception_nearest",
+    "in_trip_revision",
+)
+CHECKPOINT_KINDS: tuple[str, ...] = (
+    "baseline_capture",
+    "decision_gate",
+    "fallback_capture",
+    "policy_review",
+    "in_trip_revision",
+)
+COMPARISON_OUTCOMES: tuple[str, ...] = (
+    "preferred",
+    "fallback",
+    "equivalent",
+    "tradeoff",
+)
+
+
+def _require_unique_strings(values: list[str], field_name: str) -> None:
+    if isinstance(values, str) or not isinstance(values, list):
+        raise ValueError(f"{field_name} must be a list of strings")
+    require_strings(values, field_name)
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field_name} cannot contain duplicates")
+
+
+def _payload_list(
+    payload: dict[str, Any], field_name: str, default: list[Any]
+) -> list[Any]:
+    value = payload.get(field_name, default)
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list")
+    return list(value)
+
+
+@dataclass(slots=True)
+class ScenarioArtifactRefs:
+    objective_id: str | None = None
+    scenario_search_id: str | None = None
+    source_result_set_id: str | None = None
+    itinerary_scenario_id: str | None = None
+    ranked_result_set_id: str | None = None
+    option_set_ids: list[str] = field(default_factory=list)
+    budget_state_id: str | None = None
+    policy_state_id: str | None = None
+    session_state_id: str | None = None
+    leisure_profile_id: str | None = None
+    business_profile_id: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "objective_id",
+            "scenario_search_id",
+            "source_result_set_id",
+            "itinerary_scenario_id",
+            "ranked_result_set_id",
+            "budget_state_id",
+            "policy_state_id",
+            "session_state_id",
+            "leisure_profile_id",
+            "business_profile_id",
+        ):
+            require_optional_non_empty(getattr(self, field_name), field_name)
+        _require_unique_strings(self.option_set_ids, "option_set_ids")
+        require_strings(self.notes, "notes")
+
+        if not any(
+            (
+                self.objective_id,
+                self.scenario_search_id,
+                self.source_result_set_id,
+                self.itinerary_scenario_id,
+                self.ranked_result_set_id,
+                self.option_set_ids,
+                self.budget_state_id,
+                self.policy_state_id,
+                self.session_state_id,
+            )
+        ):
+            raise ValueError("ScenarioArtifactRefs must capture at least one saved reference")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ScenarioArtifactRefs":
+        return cls(
+            objective_id=payload.get("objective_id"),
+            scenario_search_id=payload.get("scenario_search_id"),
+            source_result_set_id=payload.get("source_result_set_id"),
+            itinerary_scenario_id=payload.get("itinerary_scenario_id"),
+            ranked_result_set_id=payload.get("ranked_result_set_id"),
+            option_set_ids=_payload_list(payload, "option_set_ids", []),
+            budget_state_id=payload.get("budget_state_id"),
+            policy_state_id=payload.get("policy_state_id"),
+            session_state_id=payload.get("session_state_id"),
+            leisure_profile_id=payload.get("leisure_profile_id"),
+            business_profile_id=payload.get("business_profile_id"),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class ScenarioVersion:
+    version_id: str
+    saved_scenario_id: str
+    trip_id: str
+    title: str
+    label: str
+    created_at: str
+    created_by: str = "system"
+    scope: str = "route"
+    snapshot_refs: ScenarioArtifactRefs = field(default_factory=ScenarioArtifactRefs)
+    based_on_version_id: str | None = None
+    summary: str = ""
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.version_id, "version_id")
+        require_non_empty(self.saved_scenario_id, "saved_scenario_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.title, "title")
+        require_non_empty(self.created_at, "created_at")
+        require_non_empty(self.created_by, "created_by")
+        if self.label not in SAVED_SCENARIO_LABELS:
+            raise ValueError(f"label must be one of {SAVED_SCENARIO_LABELS}")
+        if self.scope not in OPTION_SET_SCOPES:
+            raise ValueError(f"scope must be one of {OPTION_SET_SCOPES}")
+        if not isinstance(self.snapshot_refs, ScenarioArtifactRefs):
+            raise ValueError("snapshot_refs must be a ScenarioArtifactRefs")
+        require_optional_non_empty(self.based_on_version_id, "based_on_version_id")
+        _require_unique_strings(self.tags, "tags")
+        require_strings(self.notes, "notes")
+
+        if self.label in {"compliant_first", "exception_nearest"}:
+            if self.snapshot_refs.business_profile_id is None:
+                raise ValueError(
+                    f"{self.label} versions require snapshot_refs.business_profile_id"
+                )
+            if self.snapshot_refs.policy_state_id is None:
+                raise ValueError(
+                    f"{self.label} versions require snapshot_refs.policy_state_id"
+                )
+        if self.label == "in_trip_revision" and self.snapshot_refs.session_state_id is None:
+            raise ValueError("in_trip_revision versions require snapshot_refs.session_state_id")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ScenarioVersion":
+        return cls(
+            version_id=payload["version_id"],
+            saved_scenario_id=payload["saved_scenario_id"],
+            trip_id=payload["trip_id"],
+            title=payload["title"],
+            label=payload["label"],
+            created_at=payload["created_at"],
+            created_by=payload.get("created_by", "system"),
+            scope=payload.get("scope", "route"),
+            snapshot_refs=ScenarioArtifactRefs.from_dict(
+                payload.get("snapshot_refs", {})
+            ),
+            based_on_version_id=payload.get("based_on_version_id"),
+            summary=payload.get("summary", ""),
+            tags=_payload_list(payload, "tags", []),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class ScenarioComparison:
+    comparison_id: str
+    trip_id: str
+    baseline_scenario_id: str
+    candidate_scenario_id: str
+    compared_at: str
+    outcome: str
+    summary: str
+    focus_areas: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.comparison_id, "comparison_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.baseline_scenario_id, "baseline_scenario_id")
+        require_non_empty(self.candidate_scenario_id, "candidate_scenario_id")
+        require_non_empty(self.compared_at, "compared_at")
+        require_non_empty(self.summary, "summary")
+        if self.outcome not in COMPARISON_OUTCOMES:
+            raise ValueError(f"outcome must be one of {COMPARISON_OUTCOMES}")
+        if self.baseline_scenario_id == self.candidate_scenario_id:
+            raise ValueError("candidate_scenario_id must differ from baseline_scenario_id")
+        _require_unique_strings(self.focus_areas, "focus_areas")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ScenarioComparison":
+        return cls(
+            comparison_id=payload["comparison_id"],
+            trip_id=payload["trip_id"],
+            baseline_scenario_id=payload["baseline_scenario_id"],
+            candidate_scenario_id=payload["candidate_scenario_id"],
+            compared_at=payload["compared_at"],
+            outcome=payload["outcome"],
+            summary=payload["summary"],
+            focus_areas=_payload_list(payload, "focus_areas", []),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class SavedScenarioRecord:
+    saved_scenario_id: str
+    trip_id: str
+    current_version_id: str
+    versions: list[ScenarioVersion]
+    comparisons: list[ScenarioComparison] = field(default_factory=list)
+    schema_version: str = SCENARIO_STATE_SCHEMA_VERSION
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.saved_scenario_id, "saved_scenario_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.current_version_id, "current_version_id")
+        if not self.versions:
+            raise ValueError("versions must contain at least one ScenarioVersion")
+        if any(not isinstance(item, ScenarioVersion) for item in self.versions):
+            raise ValueError("versions must contain ScenarioVersion instances")
+        if any(not isinstance(item, ScenarioComparison) for item in self.comparisons):
+            raise ValueError("comparisons must contain ScenarioComparison instances")
+        if self.schema_version != SCENARIO_STATE_SCHEMA_VERSION:
+            raise ValueError(
+                f"schema_version must be {SCENARIO_STATE_SCHEMA_VERSION!r}"
+            )
+        _require_unique_strings(self.tags, "tags")
+        require_strings(self.notes, "notes")
+
+        version_ids = [item.version_id for item in self.versions]
+        if len(set(version_ids)) != len(version_ids):
+            raise ValueError("versions cannot repeat version_id values")
+        if self.current_version_id not in version_ids:
+            raise ValueError("current_version_id must reference a saved version")
+        for version in self.versions:
+            if version.saved_scenario_id != self.saved_scenario_id:
+                raise ValueError("all versions must share the record saved_scenario_id")
+            if version.trip_id != self.trip_id:
+                raise ValueError("all versions must share the record trip_id")
+
+        for comparison in self.comparisons:
+            if comparison.trip_id != self.trip_id:
+                raise ValueError("comparisons must share the record trip_id")
+            if comparison.baseline_scenario_id != self.saved_scenario_id:
+                raise ValueError("comparisons must reference the record scenario as baseline")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "SavedScenarioRecord":
+        return cls(
+            saved_scenario_id=payload["saved_scenario_id"],
+            trip_id=payload["trip_id"],
+            current_version_id=payload["current_version_id"],
+            versions=[
+                ScenarioVersion.from_dict(item)
+                for item in _payload_list(payload, "versions", [])
+            ],
+            comparisons=[
+                ScenarioComparison.from_dict(item)
+                for item in _payload_list(payload, "comparisons", [])
+            ],
+            schema_version=payload.get(
+                "schema_version", SCENARIO_STATE_SCHEMA_VERSION
+            ),
+            tags=_payload_list(payload, "tags", []),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class ScenarioCheckpoint:
+    checkpoint_id: str
+    trip_id: str
+    saved_scenario_id: str
+    version_id: str
+    created_at: str
+    checkpoint_kind: str
+    title: str
+    summary: str = ""
+    pending_decision_ids: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.checkpoint_id, "checkpoint_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.saved_scenario_id, "saved_scenario_id")
+        require_non_empty(self.version_id, "version_id")
+        require_non_empty(self.created_at, "created_at")
+        require_non_empty(self.title, "title")
+        if self.checkpoint_kind not in CHECKPOINT_KINDS:
+            raise ValueError(f"checkpoint_kind must be one of {CHECKPOINT_KINDS}")
+        _require_unique_strings(self.pending_decision_ids, "pending_decision_ids")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ScenarioCheckpoint":
+        return cls(
+            checkpoint_id=payload["checkpoint_id"],
+            trip_id=payload["trip_id"],
+            saved_scenario_id=payload["saved_scenario_id"],
+            version_id=payload["version_id"],
+            created_at=payload["created_at"],
+            checkpoint_kind=payload["checkpoint_kind"],
+            title=payload["title"],
+            summary=payload.get("summary", ""),
+            pending_decision_ids=_payload_list(payload, "pending_decision_ids", []),
+            notes=_payload_list(payload, "notes", []),
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #540

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
A serious planner needs more than one current state. Users will need saved scenarios, route alternatives, checkpoints, and prior versions to compare decisions over time. Without canonical version-history and checkpoint contracts, later scenario comparison and rollback features will be fragile.

Parent epic: #537

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#537](https://github.com/stranske/trip-planner/issues/537)
- [#514](https://github.com/stranske/trip-planner/issues/514)
- [#536](https://github.com/stranske/trip-planner/issues/536)
- [#505](https://github.com/stranske/trip-planner/issues/505)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement typed contracts for saved scenarios, checkpoints, version snapshots, and comparison metadata tied to trips.
- [x] Ensure snapshots can reference itinerary scenarios, ranked candidate sets, objectives, and relevant preference/business-profile state at save time.
- [x] Add support for labels such as baseline, preferred, fallback, compliant_first, exception_nearest, and in_trip_revision where relevant.
- [x] Define repository interfaces for creating, listing, restoring, and comparing saved scenarios and checkpoints.
- [x] Add representative fixtures or examples for at least: a leisure baseline versus fallback scenario pair, a business compliant-versus-exception pair, and an in-trip revision checkpoint.
- [x] Write unit tests covering save/restore semantics, malformed snapshot references, and comparison metadata behavior.
- [x] Document how versioned scenarios relate to later UI comparison and in-trip replanning flows.

#### Acceptance criteria
- [x] The repo contains canonical contracts for saved scenarios, checkpoints, and version-history metadata.
- [x] The model can represent both leisure and business scenario history without duplicating entire trip storage semantics.
- [x] Repository interfaces exist for saving, restoring, and comparing snapshots.
- [x] Tests cover representative scenario-history cases plus malformed-reference failures.
- [x] Documentation makes clear that saved scenarios are durable comparison objects, not just temporary cache entries.

**Head SHA:** 87a473384c6caff6bf7d363c2d193f99895de17c
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23896007198) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23896007213) |
<!-- auto-status-summary:end -->