### PR TITLE
Issue #541: add budget and actual spend state contracts

### DIFF
--- a/docs/state-budget-persistence.md
+++ b/docs/state-budget-persistence.md
@@ -1,0 +1,39 @@
+# Budget Persistence Boundary
+
+Issue `#541` adds the durable budget slice that hangs off the persisted trip container from issue `#539`.
+
+## Intent
+
+`BudgetPlan` stores the canonical pre-trip budget baseline and any scenario-specific variants without embedding the entire trip record.
+
+`ActualSpendEvent` stores in-trip or post-trip spend observations with:
+
+- budget category
+- timestamp
+- amount and currency
+- source kind and freeform source context
+- optional links back to saved-scenario ids and scenario-budget variants
+
+## Relationship To Trips And Scenarios
+
+The persisted trip record should keep only `budget_state_id` references. The budget state owns:
+
+- per-category planned allocations
+- multiple scenario-linked budget variants for the same trip
+- actual spend events that can be filtered by trip, budget plan, scenario, or category
+
+This keeps the boundary clean:
+
+- trip identity and lifecycle stay in `PersistedTripRecord`
+- saved-scenario history can evolve independently in issue `#540`
+- budget replanning can switch `current_scenario_budget_id` without mutating trip identity
+- later comparison and in-trip adjustment flows can reconcile planned-vs-actual spend from stable records
+
+## Mode Distinction
+
+Budget persistence keeps leisure and business plans distinct:
+
+- leisure plans can use traveler-facing categories such as lodging, food, activities, and contingency
+- business plans can additionally carry policy-sensitive categories such as workspace and client hospitality
+
+That separation prevents later reimbursement or policy logic from flattening all spend into one undifferentiated cost blob.

--- a/tests/fixtures/state/budget/actual_spend_events.json
+++ b/tests/fixtures/state/budget/actual_spend_events.json
@@ -1,0 +1,34 @@
+{
+  "events": [
+    {
+      "spend_event_id": "spend:kyoto-rail-pass",
+      "trip_id": "trip-leisure-kyoto-draft",
+      "budget_plan_id": "budget-plan:kyoto-spring",
+      "scenario_budget_id": "budget-scenario:kyoto-baseline",
+      "saved_scenario_id": "saved-scenario:baseline-kyoto",
+      "category_key": "transport",
+      "amount": 182.5,
+      "currency": "USD",
+      "occurred_at": "2026-04-06T08:15:00Z",
+      "source_kind": "receipt",
+      "source_context": "JR pass purchase after dates were finalized",
+      "merchant_name": "JR Central",
+      "source_ref": "receipt:jr-pass-0001"
+    },
+    {
+      "spend_event_id": "spend:client-summit-dinner",
+      "trip_id": "trip-business-client-summit",
+      "budget_plan_id": "budget-plan:client-summit",
+      "scenario_budget_id": "budget-scenario:client-summit-compliant",
+      "saved_scenario_id": "saved-scenario:client-summit-compliant",
+      "category_key": "client_hospitality",
+      "amount": 194.2,
+      "currency": "USD",
+      "occurred_at": "2026-04-09T20:10:00Z",
+      "source_kind": "manual",
+      "source_context": "Client dinner logged ahead of reimbursement export",
+      "merchant_name": "The Delegate Room",
+      "notes": ["Awaiting final attendee roster"]
+    }
+  ]
+}

--- a/tests/fixtures/state/budget/business_budget_plan.json
+++ b/tests/fixtures/state/budget/business_budget_plan.json
@@ -1,0 +1,62 @@
+{
+  "budget_plan_id": "budget-plan:client-summit",
+  "trip_id": "trip-business-client-summit",
+  "owner_profile_id": "traveler-profile:consulting-team",
+  "title": "Client summit policy-aware budget",
+  "mode": "business",
+  "created_at": "2026-04-02T06:00:00Z",
+  "updated_at": "2026-04-02T06:20:00Z",
+  "current_scenario_budget_id": "budget-scenario:client-summit-compliant",
+  "currency": "USD",
+  "tags": ["business", "policy"],
+  "notes": ["Protected workspace and client meal categories align with reimbursement review."],
+  "scenario_budgets": [
+    {
+      "scenario_budget_id": "budget-scenario:client-summit-compliant",
+      "trip_id": "trip-business-client-summit",
+      "title": "Compliant booking budget",
+      "created_at": "2026-04-02T06:00:00Z",
+      "saved_scenario_id": "saved-scenario:client-summit-compliant",
+      "currency": "USD",
+      "summary": "Preferred suppliers and policy-safe meal posture.",
+      "tags": ["compliant_first"],
+      "allocations": [
+        {
+          "category_key": "lodging",
+          "label": "Preferred hotel block",
+          "planned_amount": 940.0,
+          "currency": "USD",
+          "flexibility": "protected"
+        },
+        {
+          "category_key": "transport",
+          "label": "Preferred carrier airfare and airport transfers",
+          "planned_amount": 690.0,
+          "currency": "USD",
+          "flexibility": "fixed"
+        },
+        {
+          "category_key": "food",
+          "label": "Daily meals within policy caps",
+          "planned_amount": 260.0,
+          "currency": "USD",
+          "flexibility": "flexible"
+        },
+        {
+          "category_key": "workspace",
+          "label": "Coworking meeting room buffer",
+          "planned_amount": 180.0,
+          "currency": "USD",
+          "flexibility": "protected"
+        },
+        {
+          "category_key": "client_hospitality",
+          "label": "Hosted client dinner",
+          "planned_amount": 220.0,
+          "currency": "USD",
+          "flexibility": "protected"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/state/budget/leisure_budget_plan.json
+++ b/tests/fixtures/state/budget/leisure_budget_plan.json
@@ -1,0 +1,109 @@
+{
+  "budget_plan_id": "budget-plan:kyoto-spring",
+  "trip_id": "trip-leisure-kyoto-draft",
+  "owner_profile_id": "traveler-profile:kyoto-leisure",
+  "title": "Kyoto spring budget guardrails",
+  "mode": "leisure",
+  "created_at": "2026-04-02T05:00:00Z",
+  "updated_at": "2026-04-02T05:30:00Z",
+  "current_scenario_budget_id": "budget-scenario:kyoto-baseline",
+  "currency": "USD",
+  "tags": ["spring", "leisure"],
+  "notes": ["Baseline budget keeps one splurge dinner while protecting transit."],
+  "scenario_budgets": [
+    {
+      "scenario_budget_id": "budget-scenario:kyoto-baseline",
+      "trip_id": "trip-leisure-kyoto-draft",
+      "title": "Kyoto baseline",
+      "created_at": "2026-04-02T05:00:00Z",
+      "saved_scenario_id": "saved-scenario:baseline-kyoto",
+      "currency": "USD",
+      "summary": "Baseline leisure plan with food and activity headroom.",
+      "tags": ["baseline"],
+      "allocations": [
+        {
+          "category_key": "lodging",
+          "label": "Ryokan + hotel split",
+          "planned_amount": 780.0,
+          "currency": "USD",
+          "flexibility": "protected"
+        },
+        {
+          "category_key": "transport",
+          "label": "Rail passes and airport transfer",
+          "planned_amount": 260.0,
+          "currency": "USD",
+          "flexibility": "fixed"
+        },
+        {
+          "category_key": "food",
+          "label": "Daily meals plus one splurge dinner",
+          "planned_amount": 340.0,
+          "currency": "USD",
+          "flexibility": "flexible"
+        },
+        {
+          "category_key": "activities",
+          "label": "Temples, museum tickets, and tea ceremony",
+          "planned_amount": 220.0,
+          "currency": "USD",
+          "flexibility": "flexible"
+        },
+        {
+          "category_key": "contingency",
+          "label": "Weather reroute reserve",
+          "planned_amount": 120.0,
+          "currency": "USD",
+          "flexibility": "stretch"
+        }
+      ]
+    },
+    {
+      "scenario_budget_id": "budget-scenario:kyoto-rainy-day",
+      "trip_id": "trip-leisure-kyoto-draft",
+      "title": "Kyoto rainy-day fallback",
+      "created_at": "2026-04-02T05:12:00Z",
+      "saved_scenario_id": "saved-scenario:fallback-osaka",
+      "currency": "USD",
+      "summary": "Fallback shifts more spend into lodging and local mobility.",
+      "tags": ["fallback"],
+      "allocations": [
+        {
+          "category_key": "lodging",
+          "label": "Central hotel upgrade",
+          "planned_amount": 860.0,
+          "currency": "USD",
+          "flexibility": "protected"
+        },
+        {
+          "category_key": "transport",
+          "label": "Rail passes and fallback intercity segment",
+          "planned_amount": 280.0,
+          "currency": "USD",
+          "flexibility": "fixed"
+        },
+        {
+          "category_key": "food",
+          "label": "Indoor dining reserve",
+          "planned_amount": 300.0,
+          "currency": "USD",
+          "flexibility": "flexible"
+        },
+        {
+          "category_key": "local_mobility",
+          "label": "Taxi buffer for rain days",
+          "planned_amount": 120.0,
+          "currency": "USD",
+          "flexibility": "stretch"
+        },
+        {
+          "category_key": "contingency",
+          "label": "Late-booking reserve",
+          "planned_amount": 150.0,
+          "currency": "USD",
+          "flexibility": "stretch"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/state/test_budget.py
+++ b/tests/state/test_budget.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from trip_planner.state import ActualSpendEvent, BudgetPlan, BudgetScenario
+from trip_planner.state import ActualSpendEvent, BudgetPlan
 from trip_planner.state.budget import BudgetCategoryAllocation
 from trip_planner.state.repositories import (
     BudgetPlanRepository,
@@ -23,7 +23,9 @@ def _load_plan(name: str) -> BudgetPlan:
 
 
 def _load_events() -> list[ActualSpendEvent]:
-    payload = json.loads(_fixture_path("actual_spend_events.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        _fixture_path("actual_spend_events.json").read_text(encoding="utf-8")
+    )
     return [ActualSpendEvent.from_dict(item) for item in payload["events"]]
 
 
@@ -32,7 +34,9 @@ def test_budget_plan_loads_leisure_fixture_with_scenario_variants() -> None:
 
     assert record.mode == "leisure"
     assert record.current_scenario_budget_id == "budget-scenario:kyoto-baseline"
-    assert record.scenario_budgets[0].saved_scenario_id == "saved-scenario:baseline-kyoto"
+    assert (
+        record.scenario_budgets[0].saved_scenario_id == "saved-scenario:baseline-kyoto"
+    )
     assert record.scenario_budgets[0].total_planned_amount == 1720.0
     assert record.scenario_budgets[1].allocations[3].category_key == "local_mobility"
 
@@ -216,7 +220,9 @@ def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
                     if event.saved_scenario_id == saved_scenario_id
                 ]
             if category_key is not None:
-                events = [event for event in events if event.category_key == category_key]
+                events = [
+                    event for event in events if event.category_key == category_key
+                ]
             if source_kind is not None:
                 events = [event for event in events if event.source_kind == source_kind]
             return events
@@ -239,16 +245,21 @@ def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
 
     assert stored is not None
     assert stored.current_scenario_budget_id == "budget-scenario:kyoto-rainy-day"
-    assert [version.version_id for version in plan_repo.list_versions(plan.budget_plan_id)] == [
+    assert [
+        version.version_id for version in plan_repo.list_versions(plan.budget_plan_id)
+    ] == [
         first.version_id,
         second.version_id,
     ]
-    assert len(
-        spend_repo.list_spend_events(
-            trip_id="trip-leisure-kyoto-draft",
-            saved_scenario_id="saved-scenario:baseline-kyoto",
+    assert (
+        len(
+            spend_repo.list_spend_events(
+                trip_id="trip-leisure-kyoto-draft",
+                saved_scenario_id="saved-scenario:baseline-kyoto",
+            )
         )
-    ) == 1
-    assert spend_repo.list_spend_events(category_key="client_hospitality")[0].trip_id == (
-        "trip-business-client-summit"
+        == 1
     )
+    assert spend_repo.list_spend_events(category_key="client_hospitality")[
+        0
+    ].trip_id == ("trip-business-client-summit")

--- a/tests/state/test_budget.py
+++ b/tests/state/test_budget.py
@@ -1,0 +1,254 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.state import ActualSpendEvent, BudgetPlan, BudgetScenario
+from trip_planner.state.budget import BudgetCategoryAllocation
+from trip_planner.state.repositories import (
+    BudgetPlanRepository,
+    BudgetPlanVersion,
+    SpendEventRepository,
+)
+
+
+def _fixture_path(name: str) -> Path:
+    fixtures_dir = Path(__file__).resolve().parents[1] / "fixtures" / "state" / "budget"
+    return fixtures_dir / name
+
+
+def _load_plan(name: str) -> BudgetPlan:
+    payload = json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+    return BudgetPlan.from_dict(payload)
+
+
+def _load_events() -> list[ActualSpendEvent]:
+    payload = json.loads(_fixture_path("actual_spend_events.json").read_text(encoding="utf-8"))
+    return [ActualSpendEvent.from_dict(item) for item in payload["events"]]
+
+
+def test_budget_plan_loads_leisure_fixture_with_scenario_variants() -> None:
+    record = _load_plan("leisure_budget_plan.json")
+
+    assert record.mode == "leisure"
+    assert record.current_scenario_budget_id == "budget-scenario:kyoto-baseline"
+    assert record.scenario_budgets[0].saved_scenario_id == "saved-scenario:baseline-kyoto"
+    assert record.scenario_budgets[0].total_planned_amount == 1720.0
+    assert record.scenario_budgets[1].allocations[3].category_key == "local_mobility"
+
+
+def test_budget_plan_loads_business_fixture_with_policy_sensitive_categories() -> None:
+    record = _load_plan("business_budget_plan.json")
+    categories = {
+        allocation.category_key
+        for scenario in record.scenario_budgets
+        for allocation in scenario.allocations
+    }
+
+    assert record.mode == "business"
+    assert "workspace" in categories
+    assert "client_hospitality" in categories
+
+
+def test_actual_spend_event_fixture_captures_source_context() -> None:
+    events = _load_events()
+
+    assert events[0].source_kind == "receipt"
+    assert "JR pass" in events[0].source_context
+    assert events[1].category_key == "client_hospitality"
+    assert events[1].merchant_name == "The Delegate Room"
+
+
+def test_budget_plan_rejects_leisure_business_only_category() -> None:
+    payload = json.loads(
+        _fixture_path("leisure_budget_plan.json").read_text(encoding="utf-8")
+    )
+    payload["scenario_budgets"][0]["allocations"].append(
+        {
+            "category_key": "workspace",
+            "label": "Should not exist",
+            "planned_amount": 40.0,
+            "currency": "USD",
+        }
+    )
+
+    with pytest.raises(
+        ValueError, match="leisure budget plans cannot use business-only categories"
+    ):
+        BudgetPlan.from_dict(payload)
+
+
+def test_budget_category_allocation_rejects_invalid_currency_and_category() -> None:
+    with pytest.raises(
+        ValueError, match="currency must be a 3-letter uppercase currency code"
+    ):
+        BudgetCategoryAllocation(
+            category_key="lodging",
+            label="Hotel",
+            planned_amount=100.0,
+            currency="usd",
+        )
+    with pytest.raises(ValueError, match="category_key must be one of"):
+        BudgetCategoryAllocation(
+            category_key="souvenirs",
+            label="Shops",
+            planned_amount=50.0,
+            currency="USD",
+        )
+
+
+def test_actual_spend_event_rejects_invalid_source_or_amount() -> None:
+    with pytest.raises(ValueError, match="amount must be positive"):
+        ActualSpendEvent(
+            spend_event_id="spend:bad",
+            trip_id="trip-1",
+            budget_plan_id="budget-plan:1",
+            category_key="food",
+            amount=0,
+            currency="USD",
+            occurred_at="2026-04-02T07:00:00Z",
+            source_kind="manual",
+            source_context="Bad test",
+        )
+    with pytest.raises(ValueError, match="source_kind must be one of"):
+        ActualSpendEvent(
+            spend_event_id="spend:bad-source",
+            trip_id="trip-1",
+            budget_plan_id="budget-plan:1",
+            category_key="food",
+            amount=10.0,
+            currency="USD",
+            occurred_at="2026-04-02T07:00:00Z",
+            source_kind="bank_feed",
+            source_context="Bad test",
+        )
+
+
+def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
+    class InMemoryBudgetPlanRepository(BudgetPlanRepository):
+        def __init__(self) -> None:
+            self._plans: dict[str, BudgetPlan] = {}
+            self._versions: dict[str, list[BudgetPlanVersion]] = {}
+
+        def get_budget_plan(self, budget_plan_id: str) -> BudgetPlan | None:
+            return self._plans.get(budget_plan_id)
+
+        def save_budget_plan(
+            self,
+            budget_plan: BudgetPlan,
+            *,
+            summary: str = "",
+        ) -> BudgetPlanVersion:
+            self._plans[budget_plan.budget_plan_id] = budget_plan
+            version = BudgetPlanVersion(
+                version_id=(
+                    f"{budget_plan.budget_plan_id}-v"
+                    f"{len(self._versions.get(budget_plan.budget_plan_id, [])) + 1}"
+                ),
+                budget_plan_id=budget_plan.budget_plan_id,
+                recorded_at=budget_plan.updated_at,
+                summary=summary,
+            )
+            self._versions.setdefault(budget_plan.budget_plan_id, []).append(version)
+            return version
+
+        def list_budget_plans(
+            self,
+            *,
+            trip_id: str | None = None,
+            mode: str | None = None,
+            saved_scenario_id: str | None = None,
+        ) -> list[BudgetPlan]:
+            plans = list(self._plans.values())
+            if trip_id is not None:
+                plans = [plan for plan in plans if plan.trip_id == trip_id]
+            if mode is not None:
+                plans = [plan for plan in plans if plan.mode == mode]
+            if saved_scenario_id is not None:
+                plans = [
+                    plan
+                    for plan in plans
+                    if any(
+                        scenario.saved_scenario_id == saved_scenario_id
+                        for scenario in plan.scenario_budgets
+                    )
+                ]
+            return plans
+
+        def list_versions(self, budget_plan_id: str) -> list[BudgetPlanVersion]:
+            return list(self._versions.get(budget_plan_id, []))
+
+    class InMemorySpendEventRepository(SpendEventRepository):
+        def __init__(self) -> None:
+            self._events: dict[str, ActualSpendEvent] = {}
+
+        def get_spend_event(self, spend_event_id: str) -> ActualSpendEvent | None:
+            return self._events.get(spend_event_id)
+
+        def record_spend_event(self, spend_event: ActualSpendEvent) -> ActualSpendEvent:
+            self._events[spend_event.spend_event_id] = spend_event
+            return spend_event
+
+        def update_spend_event(self, spend_event: ActualSpendEvent) -> ActualSpendEvent:
+            self._events[spend_event.spend_event_id] = spend_event
+            return spend_event
+
+        def list_spend_events(
+            self,
+            *,
+            trip_id: str | None = None,
+            budget_plan_id: str | None = None,
+            saved_scenario_id: str | None = None,
+            category_key: str | None = None,
+            source_kind: str | None = None,
+        ) -> list[ActualSpendEvent]:
+            events = list(self._events.values())
+            if trip_id is not None:
+                events = [event for event in events if event.trip_id == trip_id]
+            if budget_plan_id is not None:
+                events = [
+                    event for event in events if event.budget_plan_id == budget_plan_id
+                ]
+            if saved_scenario_id is not None:
+                events = [
+                    event
+                    for event in events
+                    if event.saved_scenario_id == saved_scenario_id
+                ]
+            if category_key is not None:
+                events = [event for event in events if event.category_key == category_key]
+            if source_kind is not None:
+                events = [event for event in events if event.source_kind == source_kind]
+            return events
+
+    plan_repo = InMemoryBudgetPlanRepository()
+    spend_repo = InMemorySpendEventRepository()
+    plan = _load_plan("leisure_budget_plan.json")
+    events = _load_events()
+
+    first = plan_repo.save_budget_plan(plan, summary="initial baseline import")
+    updated_plan = BudgetPlan.from_dict(plan.to_dict())
+    updated_plan.current_scenario_budget_id = "budget-scenario:kyoto-rainy-day"
+    updated_plan.updated_at = "2026-04-02T06:10:00Z"
+    second = plan_repo.save_budget_plan(updated_plan, summary="switch to fallback")
+
+    for event in events:
+        spend_repo.record_spend_event(event)
+
+    stored = plan_repo.get_budget_plan(plan.budget_plan_id)
+
+    assert stored is not None
+    assert stored.current_scenario_budget_id == "budget-scenario:kyoto-rainy-day"
+    assert [version.version_id for version in plan_repo.list_versions(plan.budget_plan_id)] == [
+        first.version_id,
+        second.version_id,
+    ]
+    assert len(
+        spend_repo.list_spend_events(
+            trip_id="trip-leisure-kyoto-draft",
+            saved_scenario_id="saved-scenario:baseline-kyoto",
+        )
+    ) == 1
+    assert spend_repo.list_spend_events(category_key="client_hospitality")[0].trip_id == (
+        "trip-business-client-summit"
+    )

--- a/tests/state/test_budget.py
+++ b/tests/state/test_budget.py
@@ -137,6 +137,16 @@ def test_actual_spend_event_rejects_invalid_source_or_amount() -> None:
         )
 
 
+def test_budget_scenario_to_dict_round_trips_without_derived_fields() -> None:
+    record = _load_plan("leisure_budget_plan.json")
+    scenario_payload = record.scenario_budgets[0].to_dict()
+
+    assert "total_planned_amount" not in scenario_payload
+    assert BudgetPlan.from_dict(record.to_dict()).scenario_budgets[
+        0
+    ].total_planned_amount == record.scenario_budgets[0].total_planned_amount
+
+
 def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
     class InMemoryBudgetPlanRepository(BudgetPlanRepository):
         def __init__(self) -> None:
@@ -285,3 +295,6 @@ def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
     assert spend_repo.list_spend_events(category_key="client_hospitality")[
         0
     ].trip_id == ("trip-business-client-summit")
+    assert spend_repo.list_spend_events(
+        scenario_budget_id="budget-scenario:client-summit-compliant"
+    )[0].category_key == "client_hospitality"

--- a/tests/state/test_budget.py
+++ b/tests/state/test_budget.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from trip_planner.state import ActualSpendEvent, BudgetPlan
+from trip_planner.state import ActualSpendEvent, BudgetPlan, BudgetScenario
 from trip_planner.state.budget import BudgetCategoryAllocation
 from trip_planner.state.repositories import (
     BudgetPlanRepository,
@@ -39,6 +39,15 @@ def test_budget_plan_loads_leisure_fixture_with_scenario_variants() -> None:
     )
     assert record.scenario_budgets[0].total_planned_amount == 1720.0
     assert record.scenario_budgets[1].allocations[3].category_key == "local_mobility"
+
+
+def test_budget_scenario_to_dict_round_trips_without_derived_fields() -> None:
+    record = _load_plan("leisure_budget_plan.json")
+    scenario = record.scenario_budgets[0]
+    payload = scenario.to_dict()
+
+    assert "total_planned_amount" not in payload
+    assert BudgetScenario.from_dict(payload) == scenario
 
 
 def test_budget_plan_loads_business_fixture_with_policy_sensitive_categories() -> None:
@@ -203,6 +212,7 @@ def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
             trip_id: str | None = None,
             budget_plan_id: str | None = None,
             saved_scenario_id: str | None = None,
+            scenario_budget_id: str | None = None,
             category_key: str | None = None,
             source_kind: str | None = None,
         ) -> list[ActualSpendEvent]:
@@ -218,6 +228,12 @@ def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
                     event
                     for event in events
                     if event.saved_scenario_id == saved_scenario_id
+                ]
+            if scenario_budget_id is not None:
+                events = [
+                    event
+                    for event in events
+                    if event.scenario_budget_id == scenario_budget_id
                 ]
             if category_key is not None:
                 events = [
@@ -259,6 +275,12 @@ def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
             )
         )
         == 1
+    )
+    assert (
+        spend_repo.list_spend_events(
+            scenario_budget_id="budget-scenario:client-summit-compliant"
+        )[0].saved_scenario_id
+        == "saved-scenario:client-summit-compliant"
     )
     assert spend_repo.list_spend_events(category_key="client_hospitality")[
         0

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -41,6 +41,7 @@ tests/test_penalty.py
 tests/test_render_pr_review_thread_report.py
 tests/state/test_accounts.py
 tests/state/test_scenarios.py
+tests/state/test_budget.py
 tests/state/test_trips.py
 trip_planner/__init__.py
 trip_planner/_option_contracts.py
@@ -113,9 +114,11 @@ trip_planner/sources/adapters/__init__.py
 trip_planner/sources/adapters/base.py
 trip_planner/state/__init__.py
 trip_planner/state/accounts.py
+trip_planner/state/budget.py
 trip_planner/state/scenarios.py
 trip_planner/state/trips.py
 trip_planner/state/repositories/__init__.py
 trip_planner/state/repositories/accounts.py
 trip_planner/state/repositories/scenarios.py
+trip_planner/state/repositories/budget.py
 trip_planner/state/repositories/trips.py

--- a/trip_planner/state/__init__.py
+++ b/trip_planner/state/__init__.py
@@ -1,4 +1,4 @@
-"""Persisted account, trip, and session state contracts."""
+"""Persisted account, budget, trip, and session state contracts."""
 
 from .accounts import (
     ACCOUNT_SCHEMA_VERSION,
@@ -13,6 +13,17 @@ from .accounts import (
     RegionalDefaults,
     TravelerProfile,
     User,
+)
+from .budget import (
+    ACTUAL_SPEND_SOURCE_KINDS,
+    BUDGET_CATEGORY_KEYS,
+    BUDGET_FLEXIBILITY_LEVELS,
+    BUDGET_SCHEMA_VERSION,
+    BUSINESS_ONLY_BUDGET_CATEGORIES,
+    ActualSpendEvent,
+    BudgetCategoryAllocation,
+    BudgetPlan,
+    BudgetScenario,
 )
 from .trips import (
     ALLOWED_TRIP_STATUS_TRANSITIONS,
@@ -37,9 +48,18 @@ from .scenarios import (
 
 __all__ = [
     "ACCOUNT_SCHEMA_VERSION",
+    "ACTUAL_SPEND_SOURCE_KINDS",
     "ACCOUNT_STATUSES",
     "ALLOWED_TRIP_STATUS_TRANSITIONS",
     "AccountPreferenceRecord",
+    "ActualSpendEvent",
+    "BUDGET_CATEGORY_KEYS",
+    "BUDGET_FLEXIBILITY_LEVELS",
+    "BUDGET_SCHEMA_VERSION",
+    "BUSINESS_ONLY_BUDGET_CATEGORIES",
+    "BudgetCategoryAllocation",
+    "BudgetPlan",
+    "BudgetScenario",
     "INTERACTION_STYLES",
     "NOTIFICATION_CADENCES",
     "NOTIFICATION_CHANNELS",

--- a/trip_planner/state/budget.py
+++ b/trip_planner/state/budget.py
@@ -148,9 +148,7 @@ class BudgetScenario:
         return round(sum(item.planned_amount for item in self.allocations), 2)
 
     def to_dict(self) -> dict[str, Any]:
-        payload = asdict(self)
-        payload["total_planned_amount"] = self.total_planned_amount
-        return payload
+        return asdict(self)
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "BudgetScenario":

--- a/trip_planner/state/budget.py
+++ b/trip_planner/state/budget.py
@@ -87,9 +87,7 @@ class BudgetCategoryAllocation:
         if self.planned_amount <= 0:
             raise ValueError("planned_amount must be positive")
         if self.flexibility not in BUDGET_FLEXIBILITY_LEVELS:
-            raise ValueError(
-                f"flexibility must be one of {BUDGET_FLEXIBILITY_LEVELS}"
-            )
+            raise ValueError(f"flexibility must be one of {BUDGET_FLEXIBILITY_LEVELS}")
         _require_string_list(self.notes, "notes")
 
     def to_dict(self) -> dict[str, Any]:
@@ -200,14 +198,14 @@ class BudgetPlan:
             raise ValueError(f"mode must be one of {TRIP_MODES}")
         _require_currency(self.currency, "currency")
         if not self.scenario_budgets:
-            raise ValueError("scenario_budgets must contain at least one BudgetScenario")
+            raise ValueError(
+                "scenario_budgets must contain at least one BudgetScenario"
+            )
         if any(not isinstance(item, BudgetScenario) for item in self.scenario_budgets):
             raise ValueError("scenario_budgets must contain BudgetScenario instances")
         scenario_ids = [item.scenario_budget_id for item in self.scenario_budgets]
         if len(set(scenario_ids)) != len(scenario_ids):
-            raise ValueError(
-                "scenario_budgets cannot repeat scenario_budget_id values"
-            )
+            raise ValueError("scenario_budgets cannot repeat scenario_budget_id values")
         if self.current_scenario_budget_id not in scenario_ids:
             raise ValueError(
                 "current_scenario_budget_id must reference a scenario budget"
@@ -285,9 +283,7 @@ class ActualSpendEvent:
         _require_currency(self.currency, "currency")
         require_non_empty(self.occurred_at, "occurred_at")
         if self.source_kind not in ACTUAL_SPEND_SOURCE_KINDS:
-            raise ValueError(
-                f"source_kind must be one of {ACTUAL_SPEND_SOURCE_KINDS}"
-            )
+            raise ValueError(f"source_kind must be one of {ACTUAL_SPEND_SOURCE_KINDS}")
         require_non_empty(self.source_context, "source_context")
         require_optional_non_empty(self.scenario_budget_id, "scenario_budget_id")
         require_optional_non_empty(self.saved_scenario_id, "saved_scenario_id")

--- a/trip_planner/state/budget.py
+++ b/trip_planner/state/budget.py
@@ -1,0 +1,317 @@
+"""Persisted budget-plan and actual-spend contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_optional_non_empty,
+    require_strings,
+)
+from trip_planner.contracts.trip import TRIP_MODES
+
+BUDGET_SCHEMA_VERSION = "0.1.0"
+BUDGET_CATEGORY_KEYS: tuple[str, ...] = (
+    "lodging",
+    "transport",
+    "food",
+    "activities",
+    "local_mobility",
+    "fees",
+    "contingency",
+    "workspace",
+    "client_hospitality",
+)
+BUSINESS_ONLY_BUDGET_CATEGORIES: tuple[str, ...] = (
+    "workspace",
+    "client_hospitality",
+)
+BUDGET_FLEXIBILITY_LEVELS: tuple[str, ...] = (
+    "fixed",
+    "protected",
+    "flexible",
+    "stretch",
+)
+ACTUAL_SPEND_SOURCE_KINDS: tuple[str, ...] = (
+    "manual",
+    "receipt",
+    "card_import",
+    "policy_export",
+    "replan_adjustment",
+)
+
+
+def _require_currency(value: str, field_name: str) -> None:
+    require_non_empty(value, field_name)
+    if len(value) != 3 or not value.isalpha() or value.upper() != value:
+        raise ValueError(f"{field_name} must be a 3-letter uppercase currency code")
+
+
+def _require_string_list(values: list[str], field_name: str) -> None:
+    if isinstance(values, str) or not isinstance(values, list):
+        raise ValueError(f"{field_name} must be a list of strings")
+    require_strings(values, field_name)
+
+
+def _require_unique_strings(values: list[str], field_name: str) -> None:
+    _require_string_list(values, field_name)
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field_name} cannot contain duplicates")
+
+
+def _payload_list(
+    payload: dict[str, Any], field_name: str, default: list[Any]
+) -> list[Any]:
+    value = payload.get(field_name, default)
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list")
+    return list(value)
+
+
+@dataclass(slots=True)
+class BudgetCategoryAllocation:
+    category_key: str
+    label: str
+    planned_amount: float
+    currency: str = "USD"
+    flexibility: str = "flexible"
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.category_key not in BUDGET_CATEGORY_KEYS:
+            raise ValueError(f"category_key must be one of {BUDGET_CATEGORY_KEYS}")
+        require_non_empty(self.label, "label")
+        _require_currency(self.currency, "currency")
+        if self.planned_amount <= 0:
+            raise ValueError("planned_amount must be positive")
+        if self.flexibility not in BUDGET_FLEXIBILITY_LEVELS:
+            raise ValueError(
+                f"flexibility must be one of {BUDGET_FLEXIBILITY_LEVELS}"
+            )
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "BudgetCategoryAllocation":
+        return cls(
+            category_key=payload["category_key"],
+            label=payload["label"],
+            planned_amount=payload["planned_amount"],
+            currency=payload.get("currency", "USD"),
+            flexibility=payload.get("flexibility", "flexible"),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class BudgetScenario:
+    scenario_budget_id: str
+    trip_id: str
+    title: str
+    created_at: str
+    allocations: list[BudgetCategoryAllocation]
+    currency: str = "USD"
+    saved_scenario_id: str | None = None
+    summary: str = ""
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.scenario_budget_id, "scenario_budget_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.title, "title")
+        require_non_empty(self.created_at, "created_at")
+        _require_currency(self.currency, "currency")
+        require_optional_non_empty(self.saved_scenario_id, "saved_scenario_id")
+        if not self.allocations:
+            raise ValueError(
+                "allocations must contain at least one BudgetCategoryAllocation"
+            )
+        if any(
+            not isinstance(item, BudgetCategoryAllocation) for item in self.allocations
+        ):
+            raise ValueError(
+                "allocations must contain BudgetCategoryAllocation instances"
+            )
+        category_keys = [item.category_key for item in self.allocations]
+        if len(set(category_keys)) != len(category_keys):
+            raise ValueError("allocations cannot repeat category_key values")
+        if any(item.currency != self.currency for item in self.allocations):
+            raise ValueError("allocations must use the scenario currency")
+        _require_unique_strings(self.tags, "tags")
+        _require_string_list(self.notes, "notes")
+
+    @property
+    def total_planned_amount(self) -> float:
+        return round(sum(item.planned_amount for item in self.allocations), 2)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["total_planned_amount"] = self.total_planned_amount
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "BudgetScenario":
+        return cls(
+            scenario_budget_id=payload["scenario_budget_id"],
+            trip_id=payload["trip_id"],
+            title=payload["title"],
+            created_at=payload["created_at"],
+            allocations=[
+                BudgetCategoryAllocation.from_dict(item)
+                for item in _payload_list(payload, "allocations", [])
+            ],
+            currency=payload.get("currency", "USD"),
+            saved_scenario_id=payload.get("saved_scenario_id"),
+            summary=payload.get("summary", ""),
+            tags=_payload_list(payload, "tags", []),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class BudgetPlan:
+    budget_plan_id: str
+    trip_id: str
+    owner_profile_id: str
+    title: str
+    mode: str
+    created_at: str
+    updated_at: str
+    scenario_budgets: list[BudgetScenario]
+    current_scenario_budget_id: str
+    currency: str = "USD"
+    schema_version: str = BUDGET_SCHEMA_VERSION
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.budget_plan_id, "budget_plan_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.owner_profile_id, "owner_profile_id")
+        require_non_empty(self.title, "title")
+        require_non_empty(self.created_at, "created_at")
+        require_non_empty(self.updated_at, "updated_at")
+        if self.mode not in TRIP_MODES:
+            raise ValueError(f"mode must be one of {TRIP_MODES}")
+        _require_currency(self.currency, "currency")
+        if not self.scenario_budgets:
+            raise ValueError("scenario_budgets must contain at least one BudgetScenario")
+        if any(not isinstance(item, BudgetScenario) for item in self.scenario_budgets):
+            raise ValueError("scenario_budgets must contain BudgetScenario instances")
+        scenario_ids = [item.scenario_budget_id for item in self.scenario_budgets]
+        if len(set(scenario_ids)) != len(scenario_ids):
+            raise ValueError(
+                "scenario_budgets cannot repeat scenario_budget_id values"
+            )
+        if self.current_scenario_budget_id not in scenario_ids:
+            raise ValueError(
+                "current_scenario_budget_id must reference a scenario budget"
+            )
+        if any(item.trip_id != self.trip_id for item in self.scenario_budgets):
+            raise ValueError("scenario_budgets must share the budget plan trip_id")
+        if any(item.currency != self.currency for item in self.scenario_budgets):
+            raise ValueError("scenario_budgets must use the budget plan currency")
+        if self.schema_version != BUDGET_SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {BUDGET_SCHEMA_VERSION!r}")
+        if self.mode == "leisure":
+            business_categories = {
+                allocation.category_key
+                for scenario in self.scenario_budgets
+                for allocation in scenario.allocations
+                if allocation.category_key in BUSINESS_ONLY_BUDGET_CATEGORIES
+            }
+            if business_categories:
+                raise ValueError(
+                    "leisure budget plans cannot use business-only categories"
+                )
+        _require_unique_strings(self.tags, "tags")
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "BudgetPlan":
+        return cls(
+            budget_plan_id=payload["budget_plan_id"],
+            trip_id=payload["trip_id"],
+            owner_profile_id=payload["owner_profile_id"],
+            title=payload["title"],
+            mode=payload["mode"],
+            created_at=payload["created_at"],
+            updated_at=payload["updated_at"],
+            scenario_budgets=[
+                BudgetScenario.from_dict(item)
+                for item in _payload_list(payload, "scenario_budgets", [])
+            ],
+            current_scenario_budget_id=payload["current_scenario_budget_id"],
+            currency=payload.get("currency", "USD"),
+            schema_version=payload.get("schema_version", BUDGET_SCHEMA_VERSION),
+            tags=_payload_list(payload, "tags", []),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class ActualSpendEvent:
+    spend_event_id: str
+    trip_id: str
+    budget_plan_id: str
+    category_key: str
+    amount: float
+    currency: str
+    occurred_at: str
+    source_kind: str
+    source_context: str
+    scenario_budget_id: str | None = None
+    saved_scenario_id: str | None = None
+    merchant_name: str = ""
+    source_ref: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.spend_event_id, "spend_event_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.budget_plan_id, "budget_plan_id")
+        if self.category_key not in BUDGET_CATEGORY_KEYS:
+            raise ValueError(f"category_key must be one of {BUDGET_CATEGORY_KEYS}")
+        if self.amount <= 0:
+            raise ValueError("amount must be positive")
+        _require_currency(self.currency, "currency")
+        require_non_empty(self.occurred_at, "occurred_at")
+        if self.source_kind not in ACTUAL_SPEND_SOURCE_KINDS:
+            raise ValueError(
+                f"source_kind must be one of {ACTUAL_SPEND_SOURCE_KINDS}"
+            )
+        require_non_empty(self.source_context, "source_context")
+        require_optional_non_empty(self.scenario_budget_id, "scenario_budget_id")
+        require_optional_non_empty(self.saved_scenario_id, "saved_scenario_id")
+        require_optional_non_empty(self.source_ref, "source_ref")
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ActualSpendEvent":
+        return cls(
+            spend_event_id=payload["spend_event_id"],
+            trip_id=payload["trip_id"],
+            budget_plan_id=payload["budget_plan_id"],
+            category_key=payload["category_key"],
+            amount=payload["amount"],
+            currency=payload["currency"],
+            occurred_at=payload["occurred_at"],
+            source_kind=payload["source_kind"],
+            source_context=payload["source_context"],
+            scenario_budget_id=payload.get("scenario_budget_id"),
+            saved_scenario_id=payload.get("saved_scenario_id"),
+            merchant_name=payload.get("merchant_name", ""),
+            source_ref=payload.get("source_ref"),
+            notes=_payload_list(payload, "notes", []),
+        )

--- a/trip_planner/state/repositories/__init__.py
+++ b/trip_planner/state/repositories/__init__.py
@@ -1,12 +1,16 @@
 """Repository interfaces for persisted planner state."""
 
 from .accounts import AccountRepository, AccountVersion, TravelerProfileRepository
+from .budget import BudgetPlanRepository, BudgetPlanVersion, SpendEventRepository
 from .scenarios import ScenarioCheckpointRepository, ScenarioRepository
 from .trips import TripRepository, TripVersion
 
 __all__ = [
     "AccountRepository",
     "AccountVersion",
+    "BudgetPlanRepository",
+    "BudgetPlanVersion",
+    "SpendEventRepository",
     "ScenarioCheckpointRepository",
     "ScenarioRepository",
     "TravelerProfileRepository",

--- a/trip_planner/state/repositories/budget.py
+++ b/trip_planner/state/repositories/budget.py
@@ -66,6 +66,7 @@ class SpendEventRepository(Protocol):
         trip_id: str | None = None,
         budget_plan_id: str | None = None,
         saved_scenario_id: str | None = None,
+        scenario_budget_id: str | None = None,
         category_key: str | None = None,
         source_kind: str | None = None,
     ) -> list[ActualSpendEvent]:

--- a/trip_planner/state/repositories/budget.py
+++ b/trip_planner/state/repositories/budget.py
@@ -70,4 +70,8 @@ class SpendEventRepository(Protocol):
         category_key: str | None = None,
         source_kind: str | None = None,
     ) -> list[ActualSpendEvent]:
-        """List actual-spend events using backend-neutral filters."""
+        """List actual-spend events using backend-neutral filters.
+
+        Use ``saved_scenario_id`` to filter by the logical saved scenario and
+        ``scenario_budget_id`` to target a specific scenario-budget variant.
+        """

--- a/trip_planner/state/repositories/budget.py
+++ b/trip_planner/state/repositories/budget.py
@@ -1,0 +1,72 @@
+"""Backend-neutral repository interfaces for persisted budget state."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+from trip_planner.contracts._validators import require_non_empty
+from trip_planner.state.budget import ActualSpendEvent, BudgetPlan
+
+
+@dataclass(slots=True)
+class BudgetPlanVersion:
+    version_id: str
+    budget_plan_id: str
+    recorded_at: str
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.version_id, "version_id")
+        require_non_empty(self.budget_plan_id, "budget_plan_id")
+        require_non_empty(self.recorded_at, "recorded_at")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class BudgetPlanRepository(Protocol):
+    def get_budget_plan(self, budget_plan_id: str) -> BudgetPlan | None:
+        """Load one persisted budget plan."""
+
+    def save_budget_plan(
+        self,
+        budget_plan: BudgetPlan,
+        *,
+        summary: str = "",
+    ) -> BudgetPlanVersion:
+        """Persist one budget plan and return version metadata."""
+
+    def list_budget_plans(
+        self,
+        *,
+        trip_id: str | None = None,
+        mode: str | None = None,
+        saved_scenario_id: str | None = None,
+    ) -> list[BudgetPlan]:
+        """List budget plans using backend-neutral filters."""
+
+    def list_versions(self, budget_plan_id: str) -> list[BudgetPlanVersion]:
+        """List saved versions for one persisted budget plan."""
+
+
+class SpendEventRepository(Protocol):
+    def get_spend_event(self, spend_event_id: str) -> ActualSpendEvent | None:
+        """Load one persisted spend event."""
+
+    def record_spend_event(self, spend_event: ActualSpendEvent) -> ActualSpendEvent:
+        """Persist a new actual-spend event."""
+
+    def update_spend_event(self, spend_event: ActualSpendEvent) -> ActualSpendEvent:
+        """Persist an updated actual-spend event."""
+
+    def list_spend_events(
+        self,
+        *,
+        trip_id: str | None = None,
+        budget_plan_id: str | None = None,
+        saved_scenario_id: str | None = None,
+        category_key: str | None = None,
+        source_kind: str | None = None,
+    ) -> list[ActualSpendEvent]:
+        """List actual-spend events using backend-neutral filters."""


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #541

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The product brief explicitly calls for planned versus actual cost tracking and tradeoff analysis, but the backlog does not yet define persisted budget and spend records. Before in-trip adjustment and post-trip analysis can work, the repo needs canonical stored budget state.

Parent epic: #537

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#537](https://github.com/stranske/trip-planner/issues/537)
- [#505](https://github.com/stranske/trip-planner/issues/505)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement typed persisted contracts for `BudgetPlan`, category allocations, scenario-specific budget variants, and `ActualSpendEvent`.
- [x] Ensure the model can represent both pre-trip planned budgets and in-trip or post-trip actual spend events with category, timestamp, amount, currency, and source context.
- [x] Add support for linking budget plans to trip scenarios so alternative plans can carry different budget expectations.
- [x] Define repository interfaces for saving, updating, and querying budget plans and actual-spend records.
- [x] Add representative fixtures or examples for at least: a leisure multi-category budget plan, a business trip budget with policy-sensitive categories, and a set of actual spend events.
- [x] Write unit tests covering serialization, repository-interface behavior, and malformed category or currency cases.
- [x] Document how budget persistence should be used later by in-trip adjustment and comparison flows.

#### Acceptance criteria
- [x] The repo contains canonical persisted contracts for planned budgets and actual spend events.
- [x] The model supports both leisure and business budget needs without flattening them into one undifferentiated cost record.
- [x] Repository interfaces exist for budget and spend persistence.
- [x] Tests cover representative budget plans, spend-event histories, and malformed-input failures.
- [x] Documentation makes clear how budget state connects to scenarios and later replanning.

**Head SHA:** 79abe75d5c42687e945090120055ee7b1ae7fbc2
**Latest Runs:** ❌ failure — Gate
**Required:** gate: ❌ failure

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/23895976133) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23896024293) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23896024279) |
| CI | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/23895979465) |
| Claude Code Review | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23895978767) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23895978782) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23895977690) |
| Gate | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/23895979085) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/23895978798) |
<!-- auto-status-summary:end -->