### PR TITLE
Issue #542: add planning session persistence contracts

### DIFF
--- a/docs/state-session-persistence.md
+++ b/docs/state-session-persistence.md
@@ -1,0 +1,36 @@
+# Planning Session And Activity-Log Persistence
+
+Issue `#542` adds the mutable session-state layer that sits beside saved scenarios and budgets while keeping a separate append-only activity log.
+
+## Intent
+
+`PlanningSessionState` stores the current interactive planning surface for one trip:
+
+- interaction-style state and initiative settings
+- checkpoint cadence and option-preview timing
+- recent option-presentation history
+- pending decisions that still need user or planner resolution
+
+`ActivityLogEvent` stores the durable event trail for major actions such as scenario saves, rerank requests, option rejections, budget updates, and in-trip change requests.
+
+## Boundary
+
+This layer is intentionally split:
+
+- `PersistedTripRecord` keeps only stable references such as `session_state_id` and `activity_log_id`
+- `SavedScenarioRecord` keeps immutable version history and checkpoints
+- `PlanningSessionState` owns the latest mutable interaction state
+- `ActivityLogEvent` preserves append-only evidence of what happened during planning
+
+That separation lets later orchestration, chat, and in-trip workflow code resume a live session without confusing current planner state with immutable scenario history.
+
+## Repository Expectations
+
+Repository implementations should treat:
+
+- session state as mutable and versioned
+- pending decisions as replaceable current state
+- option-presentation history as a bounded recent-history slice on the session record
+- activity-log events as append-only records that can be filtered by trip, session, decision, or option set
+
+The first pass stays backend-neutral. The goal is to lock the persistence contract before later UI, orchestration, and notification work depends on it.

--- a/tests/fixtures/state/sessions/active_leisure_session.json
+++ b/tests/fixtures/state/sessions/active_leisure_session.json
@@ -1,0 +1,71 @@
+{
+  "session": {
+    "session_state_id": "session-state:kyoto-spring-active",
+    "trip_id": "trip-leisure-kyoto-draft",
+    "user_id": "user:leisure-kyoto",
+    "owner_profile_id": "traveler-profile:kyoto-primary",
+    "mode": "leisure",
+    "started_at": "2026-04-02T08:00:00Z",
+    "updated_at": "2026-04-02T09:15:00Z",
+    "interaction_state": {
+      "interaction_style": "collaborative",
+      "initiative_level": "balanced",
+      "checkpoint_frequency": "milestone",
+      "option_preview_timing": "early",
+      "summary_granularity": "balanced",
+      "auto_advance_research_passes": 1,
+      "ask_before_major_change": true,
+      "notes": [
+        "Traveler wants option previews before the route fully locks."
+      ]
+    },
+    "recent_option_presentations": [
+      {
+        "presentation_id": "presentation:kyoto-v3",
+        "option_set_id": "option-set:kyoto-v3",
+        "shown_at": "2026-04-02T09:10:00Z",
+        "surface_kind": "ranked_results",
+        "surfaced_option_ids": [
+          "option:kyoto-central",
+          "option:osaka-daytrip"
+        ],
+        "highlighted_option_id": "option:kyoto-central",
+        "rejected_option_ids": [
+          "option:osaka-daytrip"
+        ],
+        "summary": "Presented the baseline Kyoto plan with one fallback.",
+        "notes": [
+          "Fallback was rejected due to extra transfer time."
+        ]
+      }
+    ],
+    "pending_decisions": [
+      {
+        "decision_id": "decision:save-baseline",
+        "title": "Save baseline scenario",
+        "prompt": "Should the current Kyoto route become the saved baseline?",
+        "created_at": "2026-04-02T09:12:00Z",
+        "choices": [
+          "save baseline",
+          "keep exploring"
+        ],
+        "blocking": true,
+        "related_option_set_id": "option-set:kyoto-v3",
+        "related_saved_scenario_id": "saved-scenario:kyoto-baseline",
+        "notes": [
+          "Needed before deeper ranking passes."
+        ]
+      }
+    ],
+    "status": "active",
+    "current_saved_scenario_id": "saved-scenario:kyoto-baseline",
+    "activity_log_id": "activity-log:kyoto-spring",
+    "tags": [
+      "leisure",
+      "spring"
+    ],
+    "notes": [
+      "Active planning session before route lock."
+    ]
+  }
+}

--- a/tests/fixtures/state/sessions/business_review_session.json
+++ b/tests/fixtures/state/sessions/business_review_session.json
@@ -1,0 +1,66 @@
+{
+  "session": {
+    "session_state_id": "session-state:client-summit-review",
+    "trip_id": "trip-client-summit-q2",
+    "user_id": "user:consulting-team",
+    "owner_profile_id": "traveler-profile:consulting-lead",
+    "mode": "business",
+    "started_at": "2026-04-02T07:30:00Z",
+    "updated_at": "2026-04-02T10:05:00Z",
+    "interaction_state": {
+      "interaction_style": "guided",
+      "initiative_level": "planner_led",
+      "checkpoint_frequency": "phase",
+      "option_preview_timing": "balanced",
+      "summary_granularity": "detailed",
+      "auto_advance_research_passes": 2,
+      "ask_before_major_change": true,
+      "notes": [
+        "Planner may explore compliant options before the next check-in."
+      ]
+    },
+    "recent_option_presentations": [
+      {
+        "presentation_id": "presentation:client-summit-v2",
+        "option_set_id": "option-set:client-summit-v2",
+        "shown_at": "2026-04-02T09:50:00Z",
+        "surface_kind": "scenario_comparison",
+        "surfaced_option_ids": [
+          "option:compliant-red-eye",
+          "option:exception-direct"
+        ],
+        "highlighted_option_id": "option:exception-direct",
+        "summary": "Compared the compliant and exception-oriented business itineraries."
+      }
+    ],
+    "pending_decisions": [
+      {
+        "decision_id": "decision:policy-path",
+        "title": "Choose policy path",
+        "prompt": "Should the trip stay compliant or request an exception for the direct option?",
+        "created_at": "2026-04-02T09:55:00Z",
+        "choices": [
+          "stay compliant",
+          "request exception"
+        ],
+        "blocking": true,
+        "related_option_set_id": "option-set:client-summit-v2",
+        "notes": [
+          "Finance approval is pending."
+        ]
+      }
+    ],
+    "status": "paused",
+    "current_checkpoint_id": "checkpoint:client-summit-policy-review",
+    "current_saved_scenario_id": "saved-scenario:client-summit-compliant",
+    "active_budget_plan_id": "budget-plan:client-summit",
+    "activity_log_id": "activity-log:client-summit",
+    "tags": [
+      "business",
+      "policy-review"
+    ],
+    "notes": [
+      "Paused pending approval-path choice."
+    ]
+  }
+}

--- a/tests/fixtures/state/sessions/in_trip_revision_session.json
+++ b/tests/fixtures/state/sessions/in_trip_revision_session.json
@@ -1,0 +1,116 @@
+{
+  "session": {
+    "session_state_id": "session-state:kyoto-rainy-day",
+    "trip_id": "trip-leisure-kyoto-live",
+    "user_id": "user:leisure-kyoto",
+    "owner_profile_id": "traveler-profile:kyoto-primary",
+    "mode": "leisure",
+    "started_at": "2026-04-02T06:40:00Z",
+    "updated_at": "2026-04-02T11:20:00Z",
+    "interaction_state": {
+      "interaction_style": "guided",
+      "initiative_level": "planner_first",
+      "checkpoint_frequency": "turn",
+      "option_preview_timing": "immediate",
+      "summary_granularity": "brief",
+      "auto_advance_research_passes": 0,
+      "ask_before_major_change": false,
+      "notes": [
+        "Weather-triggered in-trip replanning should move quickly."
+      ]
+    },
+    "recent_option_presentations": [
+      {
+        "presentation_id": "presentation:rainy-day-v1",
+        "option_set_id": "option-set:rainy-day-v1",
+        "shown_at": "2026-04-02T11:05:00Z",
+        "surface_kind": "in_trip_update",
+        "surfaced_option_ids": [
+          "option:indoor-museum",
+          "option:tea-house"
+        ],
+        "highlighted_option_id": "option:indoor-museum",
+        "selected_option_id": "option:indoor-museum",
+        "summary": "Presented indoor fallback options after weather degraded."
+      }
+    ],
+    "pending_decisions": [
+      {
+        "decision_id": "decision:move-temple-visit",
+        "title": "Reorder afternoon route",
+        "prompt": "Should the temple visit move to tomorrow and the museum happen today?",
+        "created_at": "2026-04-02T11:08:00Z",
+        "choices": [
+          "reorder route",
+          "keep original route"
+        ],
+        "selected_choice": "reorder route",
+        "blocking": false,
+        "related_option_set_id": "option-set:rainy-day-v1",
+        "related_saved_scenario_id": "saved-scenario:kyoto-rainy-day",
+        "notes": [
+          "Recorded after the user accepted the indoor swap."
+        ]
+      }
+    ],
+    "status": "active",
+    "current_checkpoint_id": "checkpoint:rainy-day-1100",
+    "current_saved_scenario_id": "saved-scenario:kyoto-rainy-day",
+    "active_budget_plan_id": "budget-plan:kyoto-spring",
+    "activity_log_id": "activity-log:kyoto-live",
+    "tags": [
+      "in-trip",
+      "weather"
+    ],
+    "notes": [
+      "Live session tracking a weather-driven revision."
+    ]
+  },
+  "events": [
+    {
+      "activity_event_id": "activity:rainy-day-save",
+      "trip_id": "trip-leisure-kyoto-live",
+      "session_state_id": "session-state:kyoto-rainy-day",
+      "occurred_at": "2026-04-02T11:10:00Z",
+      "event_kind": "scenario_saved",
+      "summary": "Saved the rainy-day fallback scenario.",
+      "actor": "planner",
+      "saved_scenario_id": "saved-scenario:kyoto-rainy-day",
+      "checkpoint_id": "checkpoint:rainy-day-1100",
+      "metadata": {
+        "label": "in_trip_revision"
+      },
+      "tags": [
+        "in-trip"
+      ]
+    },
+    {
+      "activity_event_id": "activity:rainy-day-budget",
+      "trip_id": "trip-leisure-kyoto-live",
+      "session_state_id": "session-state:kyoto-rainy-day",
+      "occurred_at": "2026-04-02T11:14:00Z",
+      "event_kind": "budget_updated",
+      "summary": "Shifted activity spend toward indoor alternatives.",
+      "actor": "planner",
+      "budget_plan_id": "budget-plan:kyoto-spring",
+      "scenario_budget_id": "budget-scenario:kyoto-rainy-day",
+      "metadata": {
+        "changed_category": "activities"
+      }
+    },
+    {
+      "activity_event_id": "activity:rainy-day-change-request",
+      "trip_id": "trip-leisure-kyoto-live",
+      "session_state_id": "session-state:kyoto-rainy-day",
+      "occurred_at": "2026-04-02T11:18:00Z",
+      "event_kind": "in_trip_change_requested",
+      "summary": "Recorded the weather-driven change request for the live itinerary.",
+      "actor": "user",
+      "related_decision_id": "decision:move-temple-visit",
+      "related_option_set_id": "option-set:rainy-day-v1",
+      "metadata": {
+        "trigger": "heavy_rain"
+      }
+    }
+  ]
+}

--- a/tests/state/test_budget.py
+++ b/tests/state/test_budget.py
@@ -41,7 +41,7 @@ def test_budget_plan_loads_leisure_fixture_with_scenario_variants() -> None:
     assert record.scenario_budgets[1].allocations[3].category_key == "local_mobility"
 
 
-def test_budget_scenario_to_dict_round_trips_without_derived_fields() -> None:
+def test_budget_plan_to_dict_preserves_scenario_derived_totals() -> None:
     record = _load_plan("leisure_budget_plan.json")
     scenario = record.scenario_budgets[0]
     payload = scenario.to_dict()

--- a/tests/state/test_sessions.py
+++ b/tests/state/test_sessions.py
@@ -111,6 +111,22 @@ def test_activity_log_event_rejects_empty_metadata_value() -> None:
         )
 
 
+def test_activity_log_event_rejects_non_dict_metadata() -> None:
+    with pytest.raises(
+        ValueError,
+        match="metadata must be a dict of string keys to string values",
+    ):
+        ActivityLogEvent(
+            activity_event_id="activity:test",
+            trip_id="trip-1",
+            session_state_id="session-1",
+            occurred_at="2026-04-02T12:00:00Z",
+            event_kind="scenario_saved",
+            summary="Saved scenario.",
+            metadata=["reason"],  # type: ignore[arg-type]
+        )
+
+
 def test_planning_session_rejects_duplicate_pending_decisions() -> None:
     payload = _load_payload("active_leisure_session.json")["session"]
     payload["pending_decisions"].append(payload["pending_decisions"][0])

--- a/tests/state/test_sessions.py
+++ b/tests/state/test_sessions.py
@@ -99,7 +99,9 @@ def test_option_presentation_rejects_rejected_option_outside_surface() -> None:
 
 
 def test_activity_log_event_rejects_empty_metadata_value() -> None:
-    with pytest.raises(ValueError, match="metadata must contain non-empty string values"):
+    with pytest.raises(
+        ValueError, match="metadata must contain non-empty string values"
+    ):
         ActivityLogEvent(
             activity_event_id="activity:test",
             trip_id="trip-1",
@@ -138,7 +140,9 @@ def test_planning_session_rejects_duplicate_pending_decisions() -> None:
         PlanningSessionState.from_dict(payload)
 
 
-def test_planning_session_repository_protocol_can_store_session_state_and_logs() -> None:
+def test_planning_session_repository_protocol_can_store_session_state_and_logs() -> (
+    None
+):
     class InMemoryPlanningSessionRepository(PlanningSessionRepository):
         def __init__(self) -> None:
             self._sessions: dict[str, PlanningSessionState] = {}
@@ -221,9 +225,13 @@ def test_planning_session_repository_protocol_can_store_session_state_and_logs()
         ) -> list[PlanningSessionState]:
             sessions = list(self._sessions.values())
             if trip_id is not None:
-                sessions = [session for session in sessions if session.trip_id == trip_id]
+                sessions = [
+                    session for session in sessions if session.trip_id == trip_id
+                ]
             if user_id is not None:
-                sessions = [session for session in sessions if session.user_id == user_id]
+                sessions = [
+                    session for session in sessions if session.user_id == user_id
+                ]
             if owner_profile_id is not None:
                 sessions = [
                     session
@@ -326,7 +334,8 @@ def test_planning_session_repository_protocol_can_store_session_state_and_logs()
     assert stored.interaction_state.initiative_level == "planner_led"
     assert stored.recent_option_presentations[-1].option_set_id == "option-set:kyoto-v4"
     assert [
-        version.version_id for version in session_repo.list_versions(session.session_state_id)
+        version.version_id
+        for version in session_repo.list_versions(session.session_state_id)
     ] == [first.version_id, second.version_id, third.version_id]
     assert stored_event.event_kind == "scenario_saved"
     assert log_repo.list_events(event_kind="scenario_saved")[0].activity_event_id == (

--- a/tests/state/test_sessions.py
+++ b/tests/state/test_sessions.py
@@ -1,0 +1,318 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.state import (
+    ActivityLogEvent,
+    PendingDecision,
+    PlanningInteractionState,
+    PlanningSessionState,
+)
+from trip_planner.state.repositories import (
+    ActivityLogRepository,
+    PlanningSessionRepository,
+    SessionStateVersion,
+)
+from trip_planner.state.sessions import OptionPresentationRecord
+
+
+def _fixture_path(name: str) -> Path:
+    fixtures_dir = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "state" / "sessions"
+    )
+    return fixtures_dir / name
+
+
+def _load_payload(name: str) -> dict:
+    return json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+
+
+def _load_session(name: str) -> PlanningSessionState:
+    return PlanningSessionState.from_dict(_load_payload(name)["session"])
+
+
+def _load_events(name: str) -> list[ActivityLogEvent]:
+    return [
+        ActivityLogEvent.from_dict(item)
+        for item in _load_payload(name).get("events", [])
+    ]
+
+
+def test_planning_session_loads_active_leisure_fixture() -> None:
+    session = _load_session("active_leisure_session.json")
+
+    assert session.mode == "leisure"
+    assert session.interaction_state.initiative_level == "balanced"
+    assert session.recent_option_presentations[0].option_set_id == "option-set:kyoto-v3"
+    assert session.pending_decisions[0].related_saved_scenario_id == (
+        "saved-scenario:kyoto-baseline"
+    )
+
+
+def test_planning_session_loads_business_fixture_with_policy_review_state() -> None:
+    session = _load_session("business_review_session.json")
+
+    assert session.mode == "business"
+    assert session.status == "paused"
+    assert session.current_checkpoint_id == "checkpoint:client-summit-policy-review"
+    assert session.pending_decisions[0].title == "Choose policy path"
+
+
+def test_planning_session_loads_in_trip_revision_fixture_and_events() -> None:
+    session = _load_session("in_trip_revision_session.json")
+    events = _load_events("in_trip_revision_session.json")
+
+    assert session.status == "active"
+    assert session.current_saved_scenario_id == "saved-scenario:kyoto-rainy-day"
+    assert session.recent_option_presentations[0].surface_kind == "in_trip_update"
+    assert [event.event_kind for event in events] == [
+        "scenario_saved",
+        "budget_updated",
+        "in_trip_change_requested",
+    ]
+
+
+def test_pending_decision_rejects_selected_choice_outside_choices() -> None:
+    with pytest.raises(ValueError, match="selected_choice must be one of choices"):
+        PendingDecision(
+            decision_id="decision:test",
+            prompt="Choose a route.",
+            created_at="2026-04-02T12:00:00Z",
+            choices=["A", "B"],
+            selected_choice="C",
+        )
+
+
+def test_option_presentation_rejects_rejected_option_outside_surface() -> None:
+    with pytest.raises(
+        ValueError,
+        match="rejected_option_ids must be drawn from surfaced options",
+    ):
+        OptionPresentationRecord(
+            presentation_id="presentation:test",
+            option_set_id="option-set:test",
+            shown_at="2026-04-02T12:00:00Z",
+            surfaced_option_ids=["option:1", "option:2"],
+            rejected_option_ids=["option:3"],
+        )
+
+
+def test_activity_log_event_rejects_empty_metadata_value() -> None:
+    with pytest.raises(ValueError, match="metadata must contain non-empty string values"):
+        ActivityLogEvent(
+            activity_event_id="activity:test",
+            trip_id="trip-1",
+            session_state_id="session-1",
+            occurred_at="2026-04-02T12:00:00Z",
+            event_kind="scenario_saved",
+            summary="Saved scenario.",
+            metadata={"reason": ""},
+        )
+
+
+def test_planning_session_rejects_duplicate_pending_decisions() -> None:
+    payload = _load_payload("active_leisure_session.json")["session"]
+    payload["pending_decisions"].append(payload["pending_decisions"][0])
+
+    with pytest.raises(
+        ValueError,
+        match="pending_decisions cannot repeat decision_id values",
+    ):
+        PlanningSessionState.from_dict(payload)
+
+
+def test_planning_session_repository_protocol_can_store_session_state_and_logs() -> None:
+    class InMemoryPlanningSessionRepository(PlanningSessionRepository):
+        def __init__(self) -> None:
+            self._sessions: dict[str, PlanningSessionState] = {}
+            self._versions: dict[str, list[SessionStateVersion]] = {}
+
+        def get_session(self, session_state_id: str) -> PlanningSessionState | None:
+            return self._sessions.get(session_state_id)
+
+        def save_session(
+            self,
+            session_state: PlanningSessionState,
+            *,
+            summary: str = "",
+        ) -> SessionStateVersion:
+            self._sessions[session_state.session_state_id] = session_state
+            version = SessionStateVersion(
+                version_id=(
+                    f"{session_state.session_state_id}-v"
+                    f"{len(self._versions.get(session_state.session_state_id, [])) + 1}"
+                ),
+                session_state_id=session_state.session_state_id,
+                recorded_at=session_state.updated_at,
+                summary=summary,
+            )
+            self._versions.setdefault(session_state.session_state_id, []).append(
+                version
+            )
+            return version
+
+        def update_interaction_state(
+            self,
+            session_state_id: str,
+            interaction_state: PlanningInteractionState,
+            *,
+            updated_at: str,
+            summary: str = "",
+        ) -> SessionStateVersion:
+            session = self._sessions[session_state_id]
+            session.interaction_state = interaction_state
+            session.updated_at = updated_at
+            return self.save_session(session, summary=summary or "interaction update")
+
+        def replace_pending_decisions(
+            self,
+            session_state_id: str,
+            pending_decisions: list[PendingDecision],
+            *,
+            updated_at: str,
+            summary: str = "",
+        ) -> SessionStateVersion:
+            session = self._sessions[session_state_id]
+            session.pending_decisions = pending_decisions
+            session.updated_at = updated_at
+            return self.save_session(session, summary=summary or "decision update")
+
+        def record_option_presentation(
+            self,
+            session_state_id: str,
+            presentation: OptionPresentationRecord,
+            *,
+            updated_at: str,
+            summary: str = "",
+        ) -> SessionStateVersion:
+            session = self._sessions[session_state_id]
+            session.recent_option_presentations.append(presentation)
+            session.updated_at = updated_at
+            return self.save_session(
+                session,
+                summary=summary or "option presentation recorded",
+            )
+
+        def list_sessions(
+            self,
+            *,
+            trip_id: str | None = None,
+            user_id: str | None = None,
+            owner_profile_id: str | None = None,
+            mode: str | None = None,
+            status: str | None = None,
+        ) -> list[PlanningSessionState]:
+            sessions = list(self._sessions.values())
+            if trip_id is not None:
+                sessions = [session for session in sessions if session.trip_id == trip_id]
+            if user_id is not None:
+                sessions = [session for session in sessions if session.user_id == user_id]
+            if owner_profile_id is not None:
+                sessions = [
+                    session
+                    for session in sessions
+                    if session.owner_profile_id == owner_profile_id
+                ]
+            if mode is not None:
+                sessions = [session for session in sessions if session.mode == mode]
+            if status is not None:
+                sessions = [session for session in sessions if session.status == status]
+            return sessions
+
+        def list_versions(self, session_state_id: str) -> list[SessionStateVersion]:
+            return list(self._versions.get(session_state_id, []))
+
+    class InMemoryActivityLogRepository(ActivityLogRepository):
+        def __init__(self) -> None:
+            self._events: dict[str, ActivityLogEvent] = {}
+
+        def get_event(self, activity_event_id: str) -> ActivityLogEvent | None:
+            return self._events.get(activity_event_id)
+
+        def append_event(self, event: ActivityLogEvent) -> ActivityLogEvent:
+            self._events[event.activity_event_id] = event
+            return event
+
+        def list_events(
+            self,
+            *,
+            trip_id: str | None = None,
+            session_state_id: str | None = None,
+            event_kind: str | None = None,
+            related_decision_id: str | None = None,
+            related_option_set_id: str | None = None,
+        ) -> list[ActivityLogEvent]:
+            events = list(self._events.values())
+            if trip_id is not None:
+                events = [event for event in events if event.trip_id == trip_id]
+            if session_state_id is not None:
+                events = [
+                    event
+                    for event in events
+                    if event.session_state_id == session_state_id
+                ]
+            if event_kind is not None:
+                events = [event for event in events if event.event_kind == event_kind]
+            if related_decision_id is not None:
+                events = [
+                    event
+                    for event in events
+                    if event.related_decision_id == related_decision_id
+                ]
+            if related_option_set_id is not None:
+                events = [
+                    event
+                    for event in events
+                    if event.related_option_set_id == related_option_set_id
+                ]
+            return events
+
+    session_repo = InMemoryPlanningSessionRepository()
+    log_repo = InMemoryActivityLogRepository()
+    session = _load_session("active_leisure_session.json")
+    event = _load_events("in_trip_revision_session.json")[0]
+
+    first = session_repo.save_session(session, summary="initial session import")
+    second = session_repo.update_interaction_state(
+        session.session_state_id,
+        PlanningInteractionState(
+            interaction_style="collaborative",
+            initiative_level="planner_led",
+            checkpoint_frequency="phase",
+            option_preview_timing="early",
+            summary_granularity="balanced",
+            auto_advance_research_passes=2,
+            ask_before_major_change=False,
+        ),
+        updated_at="2026-04-02T09:20:00Z",
+        summary="increase planner initiative",
+    )
+    third = session_repo.record_option_presentation(
+        session.session_state_id,
+        OptionPresentationRecord(
+            presentation_id="presentation:extra",
+            option_set_id="option-set:kyoto-v4",
+            shown_at="2026-04-02T09:22:00Z",
+            surfaced_option_ids=["option:3", "option:4"],
+            highlighted_option_id="option:3",
+            selected_option_id="option:3",
+            summary="Presented a narrowed fallback pair.",
+        ),
+        updated_at="2026-04-02T09:22:00Z",
+        summary="recorded narrowed fallback pair",
+    )
+    stored_event = log_repo.append_event(event)
+
+    stored = session_repo.get_session(session.session_state_id)
+
+    assert stored is not None
+    assert stored.interaction_state.initiative_level == "planner_led"
+    assert stored.recent_option_presentations[-1].option_set_id == "option-set:kyoto-v4"
+    assert [
+        version.version_id for version in session_repo.list_versions(session.session_state_id)
+    ] == [first.version_id, second.version_id, third.version_id]
+    assert stored_event.event_kind == "scenario_saved"
+    assert log_repo.list_events(event_kind="scenario_saved")[0].activity_event_id == (
+        stored_event.activity_event_id
+    )

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -42,6 +42,7 @@ tests/test_render_pr_review_thread_report.py
 tests/state/test_accounts.py
 tests/state/test_scenarios.py
 tests/state/test_budget.py
+tests/state/test_sessions.py
 tests/state/test_trips.py
 trip_planner/__init__.py
 trip_planner/_option_contracts.py
@@ -116,9 +117,11 @@ trip_planner/state/__init__.py
 trip_planner/state/accounts.py
 trip_planner/state/budget.py
 trip_planner/state/scenarios.py
+trip_planner/state/sessions.py
 trip_planner/state/trips.py
 trip_planner/state/repositories/__init__.py
 trip_planner/state/repositories/accounts.py
 trip_planner/state/repositories/scenarios.py
 trip_planner/state/repositories/budget.py
 trip_planner/state/repositories/trips.py
+trip_planner/state/repositories/sessions.py

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -40,8 +40,8 @@ tests/test_generate_segments.py
 tests/test_penalty.py
 tests/test_render_pr_review_thread_report.py
 tests/state/test_accounts.py
-tests/state/test_scenarios.py
 tests/state/test_budget.py
+tests/state/test_scenarios.py
 tests/state/test_sessions.py
 tests/state/test_trips.py
 trip_planner/__init__.py
@@ -121,7 +121,7 @@ trip_planner/state/sessions.py
 trip_planner/state/trips.py
 trip_planner/state/repositories/__init__.py
 trip_planner/state/repositories/accounts.py
-trip_planner/state/repositories/scenarios.py
 trip_planner/state/repositories/budget.py
-trip_planner/state/repositories/trips.py
+trip_planner/state/repositories/scenarios.py
 trip_planner/state/repositories/sessions.py
+trip_planner/state/repositories/trips.py

--- a/trip_planner/state/__init__.py
+++ b/trip_planner/state/__init__.py
@@ -1,4 +1,4 @@
-"""Persisted account, budget, trip, and session state contracts."""
+"""Persisted account, budget, trip, scenario, and session state contracts."""
 
 from .accounts import (
     ACCOUNT_SCHEMA_VERSION,
@@ -45,6 +45,20 @@ from .scenarios import (
     ScenarioComparison,
     ScenarioVersion,
 )
+from .sessions import (
+    ACTIVITY_LOG_EVENT_KINDS,
+    CHECKPOINT_FREQUENCIES,
+    INITIATIVE_LEVELS,
+    OPTION_PRESENTATION_KINDS,
+    OPTION_PREVIEW_TIMINGS,
+    PLANNING_SESSION_STATUSES,
+    SESSION_STATE_SCHEMA_VERSION,
+    ActivityLogEvent,
+    OptionPresentationRecord,
+    PendingDecision,
+    PlanningInteractionState,
+    PlanningSessionState,
+)
 
 __all__ = [
     "ACCOUNT_SCHEMA_VERSION",
@@ -68,14 +82,26 @@ __all__ = [
     "PersistedTripRecord",
     "RegionalDefaults",
     "CHECKPOINT_KINDS",
+    "CHECKPOINT_FREQUENCIES",
     "COMPARISON_OUTCOMES",
+    "INITIATIVE_LEVELS",
+    "OPTION_PRESENTATION_KINDS",
+    "OPTION_PREVIEW_TIMINGS",
+    "PLANNING_SESSION_STATUSES",
     "SAVED_SCENARIO_LABELS",
     "SCENARIO_STATE_SCHEMA_VERSION",
+    "SESSION_STATE_SCHEMA_VERSION",
     "SavedScenarioRecord",
     "ScenarioArtifactRefs",
     "ScenarioCheckpoint",
     "ScenarioComparison",
     "ScenarioVersion",
+    "ACTIVITY_LOG_EVENT_KINDS",
+    "ActivityLogEvent",
+    "OptionPresentationRecord",
+    "PendingDecision",
+    "PlanningInteractionState",
+    "PlanningSessionState",
     "SUMMARY_GRANULARITIES",
     "TRIP_SCHEMA_VERSION",
     "TRAVELER_PROFILE_KINDS",

--- a/trip_planner/state/repositories/__init__.py
+++ b/trip_planner/state/repositories/__init__.py
@@ -3,13 +3,21 @@
 from .accounts import AccountRepository, AccountVersion, TravelerProfileRepository
 from .budget import BudgetPlanRepository, BudgetPlanVersion, SpendEventRepository
 from .scenarios import ScenarioCheckpointRepository, ScenarioRepository
+from .sessions import (
+    ActivityLogRepository,
+    PlanningSessionRepository,
+    SessionStateVersion,
+)
 from .trips import TripRepository, TripVersion
 
 __all__ = [
     "AccountRepository",
     "AccountVersion",
+    "ActivityLogRepository",
     "BudgetPlanRepository",
     "BudgetPlanVersion",
+    "PlanningSessionRepository",
+    "SessionStateVersion",
     "SpendEventRepository",
     "ScenarioCheckpointRepository",
     "ScenarioRepository",

--- a/trip_planner/state/repositories/sessions.py
+++ b/trip_planner/state/repositories/sessions.py
@@ -1,0 +1,107 @@
+"""Backend-neutral repository interfaces for planning-session state."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+from trip_planner.contracts._validators import require_non_empty
+from trip_planner.state.sessions import (
+    ActivityLogEvent,
+    OptionPresentationRecord,
+    PendingDecision,
+    PlanningInteractionState,
+    PlanningSessionState,
+)
+
+
+@dataclass(slots=True)
+class SessionStateVersion:
+    version_id: str
+    session_state_id: str
+    recorded_at: str
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.version_id, "version_id")
+        require_non_empty(self.session_state_id, "session_state_id")
+        require_non_empty(self.recorded_at, "recorded_at")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class PlanningSessionRepository(Protocol):
+    def get_session(self, session_state_id: str) -> PlanningSessionState | None:
+        """Load one persisted planning-session state record."""
+
+    def save_session(
+        self,
+        session_state: PlanningSessionState,
+        *,
+        summary: str = "",
+    ) -> SessionStateVersion:
+        """Persist one session-state record and return version metadata."""
+
+    def update_interaction_state(
+        self,
+        session_state_id: str,
+        interaction_state: PlanningInteractionState,
+        *,
+        updated_at: str,
+        summary: str = "",
+    ) -> SessionStateVersion:
+        """Persist an updated interaction-state view for one session."""
+
+    def replace_pending_decisions(
+        self,
+        session_state_id: str,
+        pending_decisions: list[PendingDecision],
+        *,
+        updated_at: str,
+        summary: str = "",
+    ) -> SessionStateVersion:
+        """Persist the current mutable pending-decision set for one session."""
+
+    def record_option_presentation(
+        self,
+        session_state_id: str,
+        presentation: OptionPresentationRecord,
+        *,
+        updated_at: str,
+        summary: str = "",
+    ) -> SessionStateVersion:
+        """Persist the latest option-presentation history for one session."""
+
+    def list_sessions(
+        self,
+        *,
+        trip_id: str | None = None,
+        user_id: str | None = None,
+        owner_profile_id: str | None = None,
+        mode: str | None = None,
+        status: str | None = None,
+    ) -> list[PlanningSessionState]:
+        """List session-state records using backend-neutral filters."""
+
+    def list_versions(self, session_state_id: str) -> list[SessionStateVersion]:
+        """List saved versions for one persisted session-state record."""
+
+
+class ActivityLogRepository(Protocol):
+    def get_event(self, activity_event_id: str) -> ActivityLogEvent | None:
+        """Load one append-only activity-log event."""
+
+    def append_event(self, event: ActivityLogEvent) -> ActivityLogEvent:
+        """Persist one append-only activity-log event."""
+
+    def list_events(
+        self,
+        *,
+        trip_id: str | None = None,
+        session_state_id: str | None = None,
+        event_kind: str | None = None,
+        related_decision_id: str | None = None,
+        related_option_set_id: str | None = None,
+    ) -> list[ActivityLogEvent]:
+        """List append-only activity-log events using backend-neutral filters."""

--- a/trip_planner/state/sessions.py
+++ b/trip_planner/state/sessions.py
@@ -1,0 +1,425 @@
+"""Persisted planning-session and activity-log contracts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_optional_non_empty,
+    require_string_mapping,
+    require_strings,
+)
+from trip_planner.contracts.trip import TRIP_MODES
+from trip_planner.state.accounts import INTERACTION_STYLES, SUMMARY_GRANULARITIES
+
+SESSION_STATE_SCHEMA_VERSION = "0.1.0"
+PLANNING_SESSION_STATUSES: tuple[str, ...] = (
+    "active",
+    "paused",
+    "completed",
+    "archived",
+)
+INITIATIVE_LEVELS: tuple[str, ...] = (
+    "user_led",
+    "balanced",
+    "planner_led",
+    "planner_first",
+)
+CHECKPOINT_FREQUENCIES: tuple[str, ...] = (
+    "manual",
+    "milestone",
+    "phase",
+    "turn",
+)
+OPTION_PREVIEW_TIMINGS: tuple[str, ...] = (
+    "immediate",
+    "early",
+    "balanced",
+    "deferred",
+)
+OPTION_PRESENTATION_KINDS: tuple[str, ...] = (
+    "ranked_results",
+    "scenario_comparison",
+    "budget_review",
+    "in_trip_update",
+)
+ACTIVITY_LOG_EVENT_KINDS: tuple[str, ...] = (
+    "session_started",
+    "checkpoint_created",
+    "scenario_saved",
+    "rerank_requested",
+    "option_rejected",
+    "budget_updated",
+    "decision_recorded",
+    "in_trip_change_requested",
+)
+
+
+def _require_string_list(values: list[str], field_name: str) -> None:
+    if isinstance(values, str) or not isinstance(values, list):
+        raise ValueError(f"{field_name} must be a list of strings")
+    require_strings(values, field_name)
+
+
+def _require_unique_strings(values: list[str], field_name: str) -> None:
+    _require_string_list(values, field_name)
+    if len(set(values)) != len(values):
+        raise ValueError(f"{field_name} cannot contain duplicates")
+
+
+def _payload_list(
+    payload: dict[str, Any], field_name: str, default: list[Any]
+) -> list[Any]:
+    value = payload.get(field_name, default)
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list")
+    return list(value)
+
+
+@dataclass(slots=True)
+class PlanningInteractionState:
+    interaction_style: str = "guided"
+    initiative_level: str = "balanced"
+    checkpoint_frequency: str = "milestone"
+    option_preview_timing: str = "balanced"
+    summary_granularity: str = "balanced"
+    auto_advance_research_passes: int = 1
+    ask_before_major_change: bool = True
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.interaction_style not in INTERACTION_STYLES:
+            raise ValueError(f"interaction_style must be one of {INTERACTION_STYLES}")
+        if self.initiative_level not in INITIATIVE_LEVELS:
+            raise ValueError(f"initiative_level must be one of {INITIATIVE_LEVELS}")
+        if self.checkpoint_frequency not in CHECKPOINT_FREQUENCIES:
+            raise ValueError(
+                f"checkpoint_frequency must be one of {CHECKPOINT_FREQUENCIES}"
+            )
+        if self.option_preview_timing not in OPTION_PREVIEW_TIMINGS:
+            raise ValueError(
+                f"option_preview_timing must be one of {OPTION_PREVIEW_TIMINGS}"
+            )
+        if self.summary_granularity not in SUMMARY_GRANULARITIES:
+            raise ValueError(
+                f"summary_granularity must be one of {SUMMARY_GRANULARITIES}"
+            )
+        if self.auto_advance_research_passes < 0:
+            raise ValueError("auto_advance_research_passes must be non-negative")
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "PlanningInteractionState":
+        return cls(
+            interaction_style=payload.get("interaction_style", "guided"),
+            initiative_level=payload.get("initiative_level", "balanced"),
+            checkpoint_frequency=payload.get("checkpoint_frequency", "milestone"),
+            option_preview_timing=payload.get("option_preview_timing", "balanced"),
+            summary_granularity=payload.get("summary_granularity", "balanced"),
+            auto_advance_research_passes=payload.get(
+                "auto_advance_research_passes",
+                1,
+            ),
+            ask_before_major_change=payload.get("ask_before_major_change", True),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class OptionPresentationRecord:
+    presentation_id: str
+    option_set_id: str
+    shown_at: str
+    surface_kind: str = "ranked_results"
+    surfaced_option_ids: list[str] = field(default_factory=list)
+    highlighted_option_id: str | None = None
+    selected_option_id: str | None = None
+    rejected_option_ids: list[str] = field(default_factory=list)
+    summary: str = ""
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.presentation_id, "presentation_id")
+        require_non_empty(self.option_set_id, "option_set_id")
+        require_non_empty(self.shown_at, "shown_at")
+        if self.surface_kind not in OPTION_PRESENTATION_KINDS:
+            raise ValueError(
+                f"surface_kind must be one of {OPTION_PRESENTATION_KINDS}"
+            )
+        if not self.surfaced_option_ids:
+            raise ValueError("surfaced_option_ids must contain at least one option id")
+        _require_unique_strings(self.surfaced_option_ids, "surfaced_option_ids")
+        require_optional_non_empty(self.highlighted_option_id, "highlighted_option_id")
+        require_optional_non_empty(self.selected_option_id, "selected_option_id")
+        _require_unique_strings(self.rejected_option_ids, "rejected_option_ids")
+        _require_string_list(self.notes, "notes")
+        if (
+            self.highlighted_option_id is not None
+            and self.highlighted_option_id not in self.surfaced_option_ids
+        ):
+            raise ValueError("highlighted_option_id must be one of surfaced_option_ids")
+        if (
+            self.selected_option_id is not None
+            and self.selected_option_id not in self.surfaced_option_ids
+        ):
+            raise ValueError("selected_option_id must be one of surfaced_option_ids")
+        if any(
+            option_id not in self.surfaced_option_ids
+            for option_id in self.rejected_option_ids
+        ):
+            raise ValueError("rejected_option_ids must be drawn from surfaced options")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "OptionPresentationRecord":
+        return cls(
+            presentation_id=payload["presentation_id"],
+            option_set_id=payload["option_set_id"],
+            shown_at=payload["shown_at"],
+            surface_kind=payload.get("surface_kind", "ranked_results"),
+            surfaced_option_ids=_payload_list(payload, "surfaced_option_ids", []),
+            highlighted_option_id=payload.get("highlighted_option_id"),
+            selected_option_id=payload.get("selected_option_id"),
+            rejected_option_ids=_payload_list(payload, "rejected_option_ids", []),
+            summary=payload.get("summary", ""),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class PendingDecision:
+    decision_id: str
+    prompt: str
+    created_at: str
+    title: str = ""
+    choices: list[str] = field(default_factory=list)
+    selected_choice: str | None = None
+    blocking: bool = True
+    due_by: str | None = None
+    related_option_set_id: str | None = None
+    related_saved_scenario_id: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.decision_id, "decision_id")
+        require_non_empty(self.prompt, "prompt")
+        require_non_empty(self.created_at, "created_at")
+        if not self.choices:
+            raise ValueError("choices must contain at least one option")
+        _require_unique_strings(self.choices, "choices")
+        require_optional_non_empty(self.selected_choice, "selected_choice")
+        require_optional_non_empty(self.due_by, "due_by")
+        require_optional_non_empty(self.related_option_set_id, "related_option_set_id")
+        require_optional_non_empty(
+            self.related_saved_scenario_id,
+            "related_saved_scenario_id",
+        )
+        _require_string_list(self.notes, "notes")
+        if self.selected_choice is not None and self.selected_choice not in self.choices:
+            raise ValueError("selected_choice must be one of choices")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "PendingDecision":
+        return cls(
+            decision_id=payload["decision_id"],
+            prompt=payload["prompt"],
+            created_at=payload["created_at"],
+            title=payload.get("title", ""),
+            choices=_payload_list(payload, "choices", []),
+            selected_choice=payload.get("selected_choice"),
+            blocking=payload.get("blocking", True),
+            due_by=payload.get("due_by"),
+            related_option_set_id=payload.get("related_option_set_id"),
+            related_saved_scenario_id=payload.get("related_saved_scenario_id"),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class PlanningSessionState:
+    session_state_id: str
+    trip_id: str
+    user_id: str
+    owner_profile_id: str
+    mode: str
+    started_at: str
+    updated_at: str
+    interaction_state: PlanningInteractionState = field(
+        default_factory=PlanningInteractionState
+    )
+    recent_option_presentations: list[OptionPresentationRecord] = field(
+        default_factory=list
+    )
+    pending_decisions: list[PendingDecision] = field(default_factory=list)
+    status: str = "active"
+    current_checkpoint_id: str | None = None
+    current_saved_scenario_id: str | None = None
+    active_budget_plan_id: str | None = None
+    activity_log_id: str | None = None
+    schema_version: str = SESSION_STATE_SCHEMA_VERSION
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.session_state_id, "session_state_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.user_id, "user_id")
+        require_non_empty(self.owner_profile_id, "owner_profile_id")
+        require_non_empty(self.started_at, "started_at")
+        require_non_empty(self.updated_at, "updated_at")
+        if self.mode not in TRIP_MODES:
+            raise ValueError(f"mode must be one of {TRIP_MODES}")
+        if self.status not in PLANNING_SESSION_STATUSES:
+            raise ValueError(
+                f"status must be one of {PLANNING_SESSION_STATUSES}"
+            )
+        if not isinstance(self.interaction_state, PlanningInteractionState):
+            raise ValueError("interaction_state must be a PlanningInteractionState")
+        if any(
+            not isinstance(item, OptionPresentationRecord)
+            for item in self.recent_option_presentations
+        ):
+            raise ValueError(
+                "recent_option_presentations must contain OptionPresentationRecord instances"
+            )
+        if any(not isinstance(item, PendingDecision) for item in self.pending_decisions):
+            raise ValueError("pending_decisions must contain PendingDecision instances")
+        presentation_ids = [
+            presentation.presentation_id
+            for presentation in self.recent_option_presentations
+        ]
+        if len(set(presentation_ids)) != len(presentation_ids):
+            raise ValueError(
+                "recent_option_presentations cannot repeat presentation_id values"
+            )
+        decision_ids = [decision.decision_id for decision in self.pending_decisions]
+        if len(set(decision_ids)) != len(decision_ids):
+            raise ValueError("pending_decisions cannot repeat decision_id values")
+        for field_name in (
+            "current_checkpoint_id",
+            "current_saved_scenario_id",
+            "active_budget_plan_id",
+            "activity_log_id",
+        ):
+            require_optional_non_empty(getattr(self, field_name), field_name)
+        if self.schema_version != SESSION_STATE_SCHEMA_VERSION:
+            raise ValueError(f"schema_version must be {SESSION_STATE_SCHEMA_VERSION!r}")
+        _require_unique_strings(self.tags, "tags")
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "PlanningSessionState":
+        return cls(
+            session_state_id=payload["session_state_id"],
+            trip_id=payload["trip_id"],
+            user_id=payload["user_id"],
+            owner_profile_id=payload["owner_profile_id"],
+            mode=payload["mode"],
+            started_at=payload["started_at"],
+            updated_at=payload["updated_at"],
+            interaction_state=PlanningInteractionState.from_dict(
+                payload.get("interaction_state", {})
+            ),
+            recent_option_presentations=[
+                OptionPresentationRecord.from_dict(item)
+                for item in _payload_list(payload, "recent_option_presentations", [])
+            ],
+            pending_decisions=[
+                PendingDecision.from_dict(item)
+                for item in _payload_list(payload, "pending_decisions", [])
+            ],
+            status=payload.get("status", "active"),
+            current_checkpoint_id=payload.get("current_checkpoint_id"),
+            current_saved_scenario_id=payload.get("current_saved_scenario_id"),
+            active_budget_plan_id=payload.get("active_budget_plan_id"),
+            activity_log_id=payload.get("activity_log_id"),
+            schema_version=payload.get(
+                "schema_version",
+                SESSION_STATE_SCHEMA_VERSION,
+            ),
+            tags=_payload_list(payload, "tags", []),
+            notes=_payload_list(payload, "notes", []),
+        )
+
+
+@dataclass(slots=True)
+class ActivityLogEvent:
+    activity_event_id: str
+    trip_id: str
+    session_state_id: str
+    occurred_at: str
+    event_kind: str
+    summary: str
+    actor: str = "system"
+    related_decision_id: str | None = None
+    related_option_set_id: str | None = None
+    saved_scenario_id: str | None = None
+    budget_plan_id: str | None = None
+    scenario_budget_id: str | None = None
+    checkpoint_id: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.activity_event_id, "activity_event_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.session_state_id, "session_state_id")
+        require_non_empty(self.occurred_at, "occurred_at")
+        require_non_empty(self.summary, "summary")
+        require_non_empty(self.actor, "actor")
+        if self.event_kind not in ACTIVITY_LOG_EVENT_KINDS:
+            raise ValueError(
+                f"event_kind must be one of {ACTIVITY_LOG_EVENT_KINDS}"
+            )
+        for field_name in (
+            "related_decision_id",
+            "related_option_set_id",
+            "saved_scenario_id",
+            "budget_plan_id",
+            "scenario_budget_id",
+            "checkpoint_id",
+        ):
+            require_optional_non_empty(getattr(self, field_name), field_name)
+        require_string_mapping(self.metadata, "metadata")
+        if any(not isinstance(value, str) or not value for value in self.metadata.values()):
+            raise ValueError("metadata must contain non-empty string values")
+        _require_unique_strings(self.tags, "tags")
+        _require_string_list(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ActivityLogEvent":
+        return cls(
+            activity_event_id=payload["activity_event_id"],
+            trip_id=payload["trip_id"],
+            session_state_id=payload["session_state_id"],
+            occurred_at=payload["occurred_at"],
+            event_kind=payload["event_kind"],
+            summary=payload["summary"],
+            actor=payload.get("actor", "system"),
+            related_decision_id=payload.get("related_decision_id"),
+            related_option_set_id=payload.get("related_option_set_id"),
+            saved_scenario_id=payload.get("saved_scenario_id"),
+            budget_plan_id=payload.get("budget_plan_id"),
+            scenario_budget_id=payload.get("scenario_budget_id"),
+            checkpoint_id=payload.get("checkpoint_id"),
+            metadata=payload.get("metadata", {}),
+            tags=_payload_list(payload, "tags", []),
+            notes=_payload_list(payload, "notes", []),
+        )

--- a/trip_planner/state/sessions.py
+++ b/trip_planner/state/sessions.py
@@ -148,9 +148,7 @@ class OptionPresentationRecord:
         require_non_empty(self.option_set_id, "option_set_id")
         require_non_empty(self.shown_at, "shown_at")
         if self.surface_kind not in OPTION_PRESENTATION_KINDS:
-            raise ValueError(
-                f"surface_kind must be one of {OPTION_PRESENTATION_KINDS}"
-            )
+            raise ValueError(f"surface_kind must be one of {OPTION_PRESENTATION_KINDS}")
         if not self.surfaced_option_ids:
             raise ValueError("surfaced_option_ids must contain at least one option id")
         _require_unique_strings(self.surfaced_option_ids, "surfaced_option_ids")
@@ -222,7 +220,10 @@ class PendingDecision:
             "related_saved_scenario_id",
         )
         _require_string_list(self.notes, "notes")
-        if self.selected_choice is not None and self.selected_choice not in self.choices:
+        if (
+            self.selected_choice is not None
+            and self.selected_choice not in self.choices
+        ):
             raise ValueError("selected_choice must be one of choices")
 
     def to_dict(self) -> dict[str, Any]:
@@ -280,9 +281,7 @@ class PlanningSessionState:
         if self.mode not in TRIP_MODES:
             raise ValueError(f"mode must be one of {TRIP_MODES}")
         if self.status not in PLANNING_SESSION_STATUSES:
-            raise ValueError(
-                f"status must be one of {PLANNING_SESSION_STATUSES}"
-            )
+            raise ValueError(f"status must be one of {PLANNING_SESSION_STATUSES}")
         if not isinstance(self.interaction_state, PlanningInteractionState):
             raise ValueError("interaction_state must be a PlanningInteractionState")
         if any(
@@ -292,7 +291,9 @@ class PlanningSessionState:
             raise ValueError(
                 "recent_option_presentations must contain OptionPresentationRecord instances"
             )
-        if any(not isinstance(item, PendingDecision) for item in self.pending_decisions):
+        if any(
+            not isinstance(item, PendingDecision) for item in self.pending_decisions
+        ):
             raise ValueError("pending_decisions must contain PendingDecision instances")
         presentation_ids = [
             presentation.presentation_id
@@ -382,9 +383,7 @@ class ActivityLogEvent:
         require_non_empty(self.summary, "summary")
         require_non_empty(self.actor, "actor")
         if self.event_kind not in ACTIVITY_LOG_EVENT_KINDS:
-            raise ValueError(
-                f"event_kind must be one of {ACTIVITY_LOG_EVENT_KINDS}"
-            )
+            raise ValueError(f"event_kind must be one of {ACTIVITY_LOG_EVENT_KINDS}")
         for field_name in (
             "related_decision_id",
             "related_option_set_id",
@@ -397,7 +396,9 @@ class ActivityLogEvent:
         if not isinstance(self.metadata, dict):
             raise ValueError("metadata must be a dict of string keys to string values")
         require_string_mapping(self.metadata, "metadata")
-        if any(not isinstance(value, str) or not value for value in self.metadata.values()):
+        if any(
+            not isinstance(value, str) or not value for value in self.metadata.values()
+        ):
             raise ValueError("metadata must contain non-empty string values")
         _require_unique_strings(self.tags, "tags")
         _require_string_list(self.notes, "notes")

--- a/trip_planner/state/sessions.py
+++ b/trip_planner/state/sessions.py
@@ -394,6 +394,8 @@ class ActivityLogEvent:
             "checkpoint_id",
         ):
             require_optional_non_empty(getattr(self, field_name), field_name)
+        if not isinstance(self.metadata, dict):
+            raise ValueError("metadata must be a dict of string keys to string values")
         require_string_mapping(self.metadata, "metadata")
         if any(not isinstance(value, str) or not value for value in self.metadata.values()):
             raise ValueError("metadata must contain non-empty string values")


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #542

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner is intended to be interactive and iterative, which means it needs durable planning-session state beyond saved scenarios alone. The system should be able to remember checkpoints, interaction-style settings, recent option presentations, and an activity log of major planning actions so later orchestration and in-trip revision work has stable state to build on.

Parent epic: #537

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#537](https://github.com/stranske/trip-planner/issues/537)
- [#511](https://github.com/stranske/trip-planner/issues/511)
- [#505](https://github.com/stranske/trip-planner/issues/505)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement typed contracts for planning-session state, interaction-style state, recent option-presentation history, and activity-log events tied to a trip.
- [x] Ensure the model can capture interaction defaults and current state such as initiative level, checkpoint frequency, last shown option sets, and pending decisions.
- [x] Add activity-log records for major planning actions such as scenario save, re-rank, option rejection, budget update, and in-trip change request.
- [x] Define repository interfaces for loading and updating current planning-session state separately from immutable activity-log history.
- [x] Add representative fixtures or examples for at least: an active leisure planning session, an in-progress business session, and an in-trip revision session.
- [x] Write unit tests covering serialization, repository behavior, and malformed-state transitions.
- [x] Document how this layer should support later orchestration, chat, and in-trip adjustment flows.

#### Acceptance criteria
- [x] The repo contains canonical persisted planning-session and activity-log contracts.
- [x] Interaction-style and pending-decision state can be stored without being confused with immutable trip or scenario history.
- [x] Repository interfaces distinguish mutable session state from append-only activity logs.
- [x] Tests cover representative planning-session states and malformed-input failures.
- [x] Documentation makes clear how this layer supports later orchestration and in-trip workflows.

<!-- auto-status-summary:end -->