### PR TITLE
Issue #545: build the leisure planning workflow scaffold

### DIFF
--- a/docs/contracts/orchestration-workflow.md
+++ b/docs/contracts/orchestration-workflow.md
@@ -4,6 +4,7 @@ The canonical orchestration contracts now live in:
 
 - `trip_planner/orchestration/actions.py`
 - `trip_planner/orchestration/models.py`
+- `trip_planner/orchestration/leisure.py`
 
 These contracts define the shared workflow layer that later leisure, business, and in-trip orchestrators should build on.
 
@@ -39,9 +40,15 @@ Representative fixtures live in:
 - `tests/fixtures/orchestration/turns/leisure_planning_turn.json`
 - `tests/fixtures/orchestration/turns/business_planning_turn.json`
 - `tests/fixtures/orchestration/turns/in_trip_adjustment_turn.json`
+- `tests/fixtures/orchestration/leisure/delegated_planning_flow.json`
+- `tests/fixtures/orchestration/leisure/collaborative_iterative_flow.json`
+- `tests/fixtures/orchestration/leisure/revised_after_feedback_flow.json`
 
 These fixtures show how the same contract layer can express:
 
 - a leisure checkpoint with ranked scenario outputs
 - a business planning turn gated by policy posture
 - an in-trip replanning turn triggered by disruption
+- a delegated leisure scaffold that can auto-advance to a save-ready checkpoint
+- a collaborative leisure flow that waits on a structured traveler decision
+- a revision flow that returns to explicit reranking after surfaced-option feedback

--- a/tests/fixtures/orchestration/leisure/collaborative_iterative_flow.json
+++ b/tests/fixtures/orchestration/leisure/collaborative_iterative_flow.json
@@ -1,0 +1,66 @@
+{
+  "session": {
+    "session_state_id": "session-state:kyoto-collaborative",
+    "trip_id": "trip-leisure-kyoto-draft",
+    "user_id": "user:leisure-kyoto",
+    "owner_profile_id": "traveler-leisure",
+    "mode": "leisure",
+    "started_at": "2026-04-02T08:00:00Z",
+    "updated_at": "2026-04-02T09:15:00Z",
+    "interaction_state": {
+      "interaction_style": "collaborative",
+      "initiative_level": "balanced",
+      "checkpoint_frequency": "milestone",
+      "option_preview_timing": "early",
+      "summary_granularity": "balanced",
+      "auto_advance_research_passes": 1,
+      "ask_before_major_change": true,
+      "notes": [
+        "Traveler wants to approve the next save/revise step."
+      ]
+    },
+    "recent_option_presentations": [
+      {
+        "presentation_id": "presentation:kyoto-v3",
+        "option_set_id": "option-set:kyoto-v3",
+        "shown_at": "2026-04-02T09:10:00Z",
+        "surface_kind": "scenario_comparison",
+        "surfaced_option_ids": [
+          "option:kyoto-central",
+          "option:osaka-daytrip"
+        ],
+        "highlighted_option_id": "option:kyoto-central",
+        "rejected_option_ids": [],
+        "summary": "Presented the baseline Kyoto plan with one fallback."
+      }
+    ],
+    "pending_decisions": [
+      {
+        "decision_id": "decision:save-baseline",
+        "title": "Save baseline scenario",
+        "prompt": "Should the current Kyoto route become the saved baseline?",
+        "created_at": "2026-04-02T09:12:00Z",
+        "choices": [
+          "save baseline",
+          "keep exploring"
+        ],
+        "blocking": true,
+        "related_option_set_id": "option-set:kyoto-v3",
+        "related_saved_scenario_id": "saved-scenario:baseline-kyoto",
+        "notes": [
+          "Needed before the next revision cycle."
+        ]
+      }
+    ],
+    "status": "active",
+    "current_saved_scenario_id": "saved-scenario:baseline-kyoto",
+    "activity_log_id": "activity-log:kyoto-spring",
+    "tags": [
+      "collaborative",
+      "leisure"
+    ],
+    "notes": [
+      "The leisure workflow pauses at explicit collaborative checkpoints."
+    ]
+  }
+}

--- a/tests/fixtures/orchestration/leisure/delegated_planning_flow.json
+++ b/tests/fixtures/orchestration/leisure/delegated_planning_flow.json
@@ -1,0 +1,35 @@
+{
+  "session": {
+    "session_state_id": "session-state:kyoto-delegated",
+    "trip_id": "trip-leisure-kyoto-draft",
+    "user_id": "user:leisure-kyoto",
+    "owner_profile_id": "traveler-leisure",
+    "mode": "leisure",
+    "started_at": "2026-04-02T08:00:00Z",
+    "updated_at": "2026-04-02T09:20:00Z",
+    "interaction_state": {
+      "interaction_style": "guided",
+      "initiative_level": "planner_first",
+      "checkpoint_frequency": "phase",
+      "option_preview_timing": "deferred",
+      "summary_granularity": "balanced",
+      "auto_advance_research_passes": 2,
+      "ask_before_major_change": false,
+      "notes": [
+        "Planner may carry the leisure flow through scenario review before the next checkpoint."
+      ]
+    },
+    "recent_option_presentations": [],
+    "pending_decisions": [],
+    "status": "active",
+    "current_saved_scenario_id": "saved-scenario:baseline-kyoto",
+    "activity_log_id": "activity-log:kyoto-spring",
+    "tags": [
+      "delegated",
+      "leisure"
+    ],
+    "notes": [
+      "Delegated planning prefers a save-ready checkpoint over an immediate traveler interrupt."
+    ]
+  }
+}

--- a/tests/fixtures/orchestration/leisure/revised_after_feedback_flow.json
+++ b/tests/fixtures/orchestration/leisure/revised_after_feedback_flow.json
@@ -1,0 +1,51 @@
+{
+  "session": {
+    "session_state_id": "session-state:kyoto-revision",
+    "trip_id": "trip-leisure-kyoto-draft",
+    "user_id": "user:leisure-kyoto",
+    "owner_profile_id": "traveler-leisure",
+    "mode": "leisure",
+    "started_at": "2026-04-02T08:00:00Z",
+    "updated_at": "2026-04-02T09:35:00Z",
+    "interaction_state": {
+      "interaction_style": "collaborative",
+      "initiative_level": "balanced",
+      "checkpoint_frequency": "milestone",
+      "option_preview_timing": "early",
+      "summary_granularity": "detailed",
+      "auto_advance_research_passes": 1,
+      "ask_before_major_change": true,
+      "notes": [
+        "Traveler rejected the surfaced fallback and asked for a calmer route."
+      ]
+    },
+    "recent_option_presentations": [
+      {
+        "presentation_id": "presentation:kyoto-v3",
+        "option_set_id": "option-set:kyoto-v3",
+        "shown_at": "2026-04-02T09:30:00Z",
+        "surface_kind": "scenario_comparison",
+        "surfaced_option_ids": [
+          "option:kyoto-central",
+          "option:osaka-daytrip"
+        ],
+        "highlighted_option_id": "option:osaka-daytrip",
+        "rejected_option_ids": [
+          "option:osaka-daytrip"
+        ],
+        "summary": "Traveler rejected the higher-movement fallback."
+      }
+    ],
+    "pending_decisions": [],
+    "status": "active",
+    "current_saved_scenario_id": "saved-scenario:baseline-kyoto",
+    "activity_log_id": "activity-log:kyoto-spring",
+    "tags": [
+      "revision",
+      "leisure"
+    ],
+    "notes": [
+      "Revision should trigger an explicit reranking pass."
+    ]
+  }
+}

--- a/tests/orchestration/test_leisure_flow.py
+++ b/tests/orchestration/test_leisure_flow.py
@@ -161,6 +161,13 @@ def test_delegated_leisure_flow_auto_advances_to_save_ready_checkpoint() -> None
     assert turn.outputs[0].output_kind == "ranked_scenarios"
     assert turn.outputs[1].output_kind == "status_update"
     assert turn.workflow_state.open_action_ids == ["action-persist-state"]
+    assert turn.actions[0].payload["activity_log_id"] == "activity-log:kyoto-spring"
+    assert turn.actions[1].payload["ask_before_major_change"] is False
+    assert turn.actions[3].payload["scenario_count"] == 2
+    assert turn.actions[4].payload["source_refs"] == [
+        "ranked-results:kyoto-spring",
+        "objective:kyoto-spring",
+    ]
 
 
 def test_collaborative_leisure_flow_waits_on_structured_checkpoint() -> None:
@@ -172,6 +179,8 @@ def test_collaborative_leisure_flow_waits_on_structured_checkpoint() -> None:
     assert turn.next_step.blocking_decision_ids == ["decision:save-baseline"]
     assert turn.outputs[1].output_kind == "decision_request"
     assert "action-request-decision" in turn.workflow_state.open_action_ids
+    assert turn.actions[5].payload["decision_ids"] == ["decision:save-baseline"]
+    assert turn.actions[6].payload["decision_ids"] == ["decision:save-baseline"]
 
 
 def test_revised_leisure_flow_returns_to_ranking_after_feedback() -> None:
@@ -185,6 +194,26 @@ def test_revised_leisure_flow_returns_to_ranking_after_feedback() -> None:
     assert turn.outputs[1].output_kind == "status_update"
     assert turn.workflow_state.open_action_ids == ["action-rank-options"]
     assert turn.transition.warning_codes == ["feedback_rejected_option_set"]
+    assert turn.actions[-1].payload["rejected_option_ids"] == [
+        "option:osaka-daytrip"
+    ]
+
+
+def test_collect_context_omits_missing_activity_log_id() -> None:
+    trip = _trip_record()
+    session = _session_state("delegated_planning_flow.json")
+    session.activity_log_id = None
+
+    turn = build_leisure_planner_turn(
+        LeisureWorkflowContext(
+            trip_record=trip,
+            session_state=session,
+            scenario_search=_scenario_search(),
+            generated_at="2026-04-02T15:00:00Z",
+        )
+    )
+
+    assert "activity_log_id" not in turn.actions[0].payload
 
 
 def test_builder_rejects_trip_and_session_mismatch() -> None:

--- a/tests/orchestration/test_leisure_flow.py
+++ b/tests/orchestration/test_leisure_flow.py
@@ -10,7 +10,10 @@ from trip_planner.itinerary import (
     ScenarioSummary,
     ScenarioTradeoff,
 )
-from trip_planner.orchestration import LeisureWorkflowContext, build_leisure_planner_turn
+from trip_planner.orchestration import (
+    LeisureWorkflowContext,
+    build_leisure_planner_turn,
+)
 from trip_planner.ranking import ExplanationRecord
 from trip_planner.state import PersistedTripRecord, PlanningSessionState
 
@@ -77,7 +80,9 @@ def _scenario_search(trip_id: str = "trip-leisure-kyoto-draft") -> ScenarioSearc
                     summary="The baseline scenario preserves depth in Kyoto with one light excursion.",
                     factor_keys=["cultural_depth", "moderate_pace"],
                     machine_context={"planner_mode": "leisure"},
-                    human_summary=["Keeps travel friction moderate while preserving variety."],
+                    human_summary=[
+                        "Keeps travel friction moderate while preserving variety."
+                    ],
                     source_refs=["ranked-results:kyoto-spring"],
                 )
             ],
@@ -120,7 +125,9 @@ def _scenario_search(trip_id: str = "trip-leisure-kyoto-draft") -> ScenarioSearc
                     summary="The alternative opens more nightlife at the cost of extra transfers.",
                     factor_keys=["breadth", "transfer_cost"],
                     machine_context={"planner_mode": "leisure"},
-                    human_summary=["Broader exploration, slightly more travel fatigue."],
+                    human_summary=[
+                        "Broader exploration, slightly more travel fatigue."
+                    ],
                     source_refs=["ranked-results:kyoto-spring"],
                 )
             ],
@@ -194,9 +201,7 @@ def test_revised_leisure_flow_returns_to_ranking_after_feedback() -> None:
     assert turn.outputs[1].output_kind == "status_update"
     assert turn.workflow_state.open_action_ids == ["action-rank-options"]
     assert turn.transition.warning_codes == ["feedback_rejected_option_set"]
-    assert turn.actions[-1].payload["rejected_option_ids"] == [
-        "option:osaka-daytrip"
-    ]
+    assert turn.actions[-1].payload["rejected_option_ids"] == ["option:osaka-daytrip"]
 
 
 def test_collect_context_omits_missing_activity_log_id() -> None:

--- a/tests/orchestration/test_leisure_flow.py
+++ b/tests/orchestration/test_leisure_flow.py
@@ -218,3 +218,19 @@ def test_builder_rejects_non_final_selection_scenario_search() -> None:
                 generated_at="2026-04-02T15:00:00Z",
             )
         )
+
+
+@pytest.mark.parametrize("generated_at", ["", "not-a-timestamp"])
+def test_builder_rejects_invalid_generated_at(generated_at: str) -> None:
+    trip = _trip_record()
+    session = _session_state("delegated_planning_flow.json")
+
+    with pytest.raises(ValueError, match="generated_at"):
+        build_leisure_planner_turn(
+            LeisureWorkflowContext(
+                trip_record=trip,
+                session_state=session,
+                scenario_search=_scenario_search(),
+                generated_at=generated_at,
+            )
+        )

--- a/tests/orchestration/test_leisure_flow.py
+++ b/tests/orchestration/test_leisure_flow.py
@@ -1,0 +1,220 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.contracts import MoneyRange
+from trip_planner.itinerary import (
+    ItineraryScenario,
+    ScenarioSearchResult,
+    ScenarioSummary,
+    ScenarioTradeoff,
+)
+from trip_planner.orchestration import LeisureWorkflowContext, build_leisure_planner_turn
+from trip_planner.ranking import ExplanationRecord
+from trip_planner.state import PersistedTripRecord, PlanningSessionState
+
+
+def _fixture_path(name: str) -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "orchestration"
+        / "leisure"
+        / name
+    )
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _trip_record() -> PersistedTripRecord:
+    payload = _load_json(
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "state"
+        / "trips"
+        / "leisure_draft_trip.json"
+    )
+    return PersistedTripRecord.from_dict(payload)
+
+
+def _session_state(name: str) -> PlanningSessionState:
+    payload = _load_json(_fixture_path(name))
+    return PlanningSessionState.from_dict(payload["session"])
+
+
+def _scenario_search(trip_id: str = "trip-leisure-kyoto-draft") -> ScenarioSearchResult:
+    scenarios = [
+        ItineraryScenario(
+            scenario_id=f"scenario:{trip_id}:1",
+            title="Kyoto base with Uji day trip",
+            rank=1,
+            bundle_id="bundle:urban-culture",
+            source_result_id=f"ranked-result:{trip_id}:1",
+            score=0.93,
+            scenario_summary=ScenarioSummary(
+                headline="Balanced Kyoto culture baseline",
+                scenario_kind="primary",
+                feasible=True,
+                recommended_for_selection=True,
+                coherence_passed=True,
+                estimated_total=MoneyRange(currency="USD", typical_amount=3400.0),
+                total_travel_minutes=265,
+                total_transfer_count=4,
+                route_sequence=["kyoto", "uji", "kyoto"],
+                notes=["baseline"],
+            ),
+            supporting_option_ids=["option:kyoto-central", "option:uji-daytrip"],
+            objective_refs=["objective:kyoto-spring"],
+            explanation_records=[
+                ExplanationRecord(
+                    explanation_id=f"explanation:{trip_id}:1",
+                    target_kind="route",
+                    target_id=f"scenario:{trip_id}:1",
+                    headline="Best overall cultural balance",
+                    summary="The baseline scenario preserves depth in Kyoto with one light excursion.",
+                    factor_keys=["cultural_depth", "moderate_pace"],
+                    machine_context={"planner_mode": "leisure"},
+                    human_summary=["Keeps travel friction moderate while preserving variety."],
+                    source_refs=["ranked-results:kyoto-spring"],
+                )
+            ],
+            unresolved_tradeoffs=[
+                ScenarioTradeoff(
+                    tradeoff_id=f"tradeoff:{trip_id}:1",
+                    code="limited_nightlife",
+                    summary="Evening variety is lower than the fallback Osaka-heavy path.",
+                    severity="info",
+                )
+            ],
+        ),
+        ItineraryScenario(
+            scenario_id=f"scenario:{trip_id}:2",
+            title="Kyoto plus Osaka fallback",
+            rank=2,
+            bundle_id="bundle:scenic-wanderer",
+            source_result_id=f"ranked-result:{trip_id}:2",
+            score=0.88,
+            scenario_summary=ScenarioSummary(
+                headline="Higher-energy fallback with extra transfers",
+                scenario_kind="alternative",
+                feasible=True,
+                recommended_for_selection=False,
+                coherence_passed=True,
+                estimated_total=MoneyRange(currency="USD", typical_amount=3250.0),
+                total_travel_minutes=360,
+                total_transfer_count=7,
+                route_sequence=["kyoto", "osaka", "kyoto"],
+                notes=["higher movement"],
+            ),
+            supporting_option_ids=["option:kyoto-central", "option:osaka-daytrip"],
+            objective_refs=["objective:kyoto-spring"],
+            explanation_records=[
+                ExplanationRecord(
+                    explanation_id=f"explanation:{trip_id}:2",
+                    target_kind="route",
+                    target_id=f"scenario:{trip_id}:2",
+                    headline="Fallback with broader city coverage",
+                    summary="The alternative opens more nightlife at the cost of extra transfers.",
+                    factor_keys=["breadth", "transfer_cost"],
+                    machine_context={"planner_mode": "leisure"},
+                    human_summary=["Broader exploration, slightly more travel fatigue."],
+                    source_refs=["ranked-results:kyoto-spring"],
+                )
+            ],
+        ),
+    ]
+    return ScenarioSearchResult(
+        search_id="scenario-search:kyoto-spring",
+        trip_id=trip_id,
+        purpose="final_selection",
+        title="Kyoto leisure scenario comparison",
+        source_result_set_id="ranked-results:kyoto-spring",
+        scenarios=scenarios,
+        explanation=[
+            "Leisure orchestration should consume ranked scenarios rather than replace ranking."
+        ],
+        source_refs=["ranked-results:kyoto-spring", "objective:kyoto-spring"],
+    )
+
+
+def _build_turn(name: str):
+    return build_leisure_planner_turn(
+        LeisureWorkflowContext(
+            trip_record=_trip_record(),
+            session_state=_session_state(name),
+            scenario_search=_scenario_search(),
+            generated_at="2026-04-02T15:00:00Z",
+        )
+    )
+
+
+def test_delegated_leisure_flow_auto_advances_to_save_ready_checkpoint() -> None:
+    turn = _build_turn("delegated_planning_flow.json")
+
+    assert turn.turn_kind == "planning_pass"
+    assert turn.workflow_state.current_stage == "decision_checkpoint"
+    assert turn.workflow_state.status == "active"
+    assert turn.next_step.recommended_action_id == "action-persist-state"
+    assert turn.outputs[0].output_kind == "ranked_scenarios"
+    assert turn.outputs[1].output_kind == "status_update"
+    assert turn.workflow_state.open_action_ids == ["action-persist-state"]
+
+
+def test_collaborative_leisure_flow_waits_on_structured_checkpoint() -> None:
+    turn = _build_turn("collaborative_iterative_flow.json")
+
+    assert turn.turn_kind == "decision_checkpoint"
+    assert turn.workflow_state.status == "waiting_on_user"
+    assert turn.next_step.recommended_action_id == "action-request-decision"
+    assert turn.next_step.blocking_decision_ids == ["decision:save-baseline"]
+    assert turn.outputs[1].output_kind == "decision_request"
+    assert "action-request-decision" in turn.workflow_state.open_action_ids
+
+
+def test_revised_leisure_flow_returns_to_ranking_after_feedback() -> None:
+    turn = _build_turn("revised_after_feedback_flow.json")
+
+    assert turn.turn_kind == "planning_pass"
+    assert turn.workflow_state.current_stage == "ranking"
+    assert turn.workflow_state.status == "active"
+    assert turn.next_step.recommended_action_id == "action-rank-options"
+    assert turn.outputs[0].output_kind == "warning"
+    assert turn.outputs[1].output_kind == "status_update"
+    assert turn.workflow_state.open_action_ids == ["action-rank-options"]
+    assert turn.transition.warning_codes == ["feedback_rejected_option_set"]
+
+
+def test_builder_rejects_trip_and_session_mismatch() -> None:
+    trip = _trip_record()
+    session = _session_state("delegated_planning_flow.json")
+    session.trip_id = "trip-leisure-other"
+
+    with pytest.raises(ValueError, match="session_state.trip_id"):
+        build_leisure_planner_turn(
+            LeisureWorkflowContext(
+                trip_record=trip,
+                session_state=session,
+                scenario_search=_scenario_search(),
+                generated_at="2026-04-02T15:00:00Z",
+            )
+        )
+
+
+def test_builder_rejects_non_final_selection_scenario_search() -> None:
+    trip = _trip_record()
+    session = _session_state("delegated_planning_flow.json")
+    scenario_search = _scenario_search()
+    scenario_search.purpose = "inventory_narrowing"
+
+    with pytest.raises(ValueError, match="final_selection"):
+        build_leisure_planner_turn(
+            LeisureWorkflowContext(
+                trip_record=trip,
+                session_state=session,
+                scenario_search=scenario_search,
+                generated_at="2026-04-02T15:00:00Z",
+            )
+        )

--- a/tests/state/test_budget.py
+++ b/tests/state/test_budget.py
@@ -41,7 +41,7 @@ def test_budget_plan_loads_leisure_fixture_with_scenario_variants() -> None:
     assert record.scenario_budgets[1].allocations[3].category_key == "local_mobility"
 
 
-def test_budget_plan_to_dict_preserves_scenario_derived_totals() -> None:
+def test_budget_plan_round_trip_preserves_scenario_derived_totals() -> None:
     record = _load_plan("leisure_budget_plan.json")
     scenario = record.scenario_budgets[0]
     payload = scenario.to_dict()

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -90,6 +90,7 @@ trip_planner/options/lodging.py
 trip_planner/options/transport.py
 trip_planner/orchestration/__init__.py
 trip_planner/orchestration/actions.py
+trip_planner/orchestration/leisure.py
 trip_planner/orchestration/models.py
 trip_planner/preferences/__init__.py
 trip_planner/preferences/autonomy.py

--- a/trip_planner/orchestration/__init__.py
+++ b/trip_planner/orchestration/__init__.py
@@ -11,6 +11,7 @@ from .actions import (
     WORKFLOW_STAGES,
     WORKFLOW_STATUSES,
 )
+from .leisure import LeisureWorkflowContext, build_leisure_planner_turn
 from .models import (
     ORCHESTRATION_SCHEMA_VERSION,
     DecisionOption,
@@ -27,6 +28,7 @@ __all__ = [
     "ACTION_KINDS",
     "ACTION_STATUSES",
     "DecisionOption",
+    "LeisureWorkflowContext",
     "NextStepSummary",
     "ORCHESTRATION_SCHEMA_VERSION",
     "OUTPUT_KINDS",
@@ -42,4 +44,5 @@ __all__ = [
     "WORKFLOW_STATUSES",
     "WorkflowStateSnapshot",
     "WorkflowTransition",
+    "build_leisure_planner_turn",
 ]

--- a/trip_planner/orchestration/leisure.py
+++ b/trip_planner/orchestration/leisure.py
@@ -235,11 +235,7 @@ def _build_actions(
             title="Load persisted leisure session context",
             stage="intake",
             status="completed",
-            payload={
-                "trip_id": trip_id,
-                "session_state_id": session.session_state_id,
-                "activity_log_id": session.activity_log_id or "",
-            },
+            payload=_collect_context_payload(trip_id, session),
         ),
         PlannerAction(
             action_id="action-refresh-preferences",
@@ -250,9 +246,7 @@ def _build_actions(
             payload={
                 "interaction_style": session.interaction_state.interaction_style,
                 "initiative_level": session.interaction_state.initiative_level,
-                "ask_before_major_change": str(
-                    session.interaction_state.ask_before_major_change
-                ).lower(),
+                "ask_before_major_change": session.interaction_state.ask_before_major_change,
             },
         ),
         PlannerAction(
@@ -273,7 +267,7 @@ def _build_actions(
             stage="candidate_generation",
             status="completed",
             payload={
-                "scenario_count": str(len(scenario_search.scenarios)),
+                "scenario_count": len(scenario_search.scenarios),
                 "source_result_set_id": scenario_search.source_result_set_id,
             },
         ),
@@ -299,7 +293,7 @@ def _build_actions(
             payload={
                 "search_id": scenario_search.search_id,
                 "top_scenario_id": scenario_search.scenarios[0].scenario_id,
-                "source_refs": ",".join(scenario_search.source_refs),
+                "source_refs": list(scenario_search.source_refs),
             },
         )
     )
@@ -334,7 +328,7 @@ def _build_actions(
                     status="in_progress",
                     depends_on_action_ids=["action-rank-options"],
                     payload={
-                        "decision_ids": ",".join(decision_ids),
+                        "decision_ids": decision_ids,
                         "latest_option_set_id": (
                             latest_presentation.option_set_id
                             if latest_presentation is not None
@@ -350,7 +344,7 @@ def _build_actions(
                     status="pending",
                     depends_on_action_ids=["action-request-decision"],
                     payload={
-                        "decision_ids": ",".join(decision_ids),
+                        "decision_ids": decision_ids,
                         "current_saved_scenario_id": session.current_saved_scenario_id
                         or "",
                     },
@@ -367,7 +361,7 @@ def _build_actions(
                 status="completed",
                 depends_on_action_ids=["action-collect-context"],
                 payload={
-                    "rejected_option_ids": ",".join(feedback_option_ids),
+                    "rejected_option_ids": feedback_option_ids,
                     "presentation_id": (
                         latest_presentation.presentation_id
                         if latest_presentation is not None
@@ -388,6 +382,9 @@ def _build_outputs(
     scenario_search = context.scenario_search
     session = context.session_state
     latest_presentation = _latest_presentation(session)
+    latest_presentation_id = (
+        latest_presentation.presentation_id if latest_presentation is not None else ""
+    )
     outputs: list[PlannerOutput] = []
 
     if variant != "revised_after_feedback":
@@ -472,11 +469,7 @@ def _build_outputs(
                     warnings=["feedback_rejected_option_set"],
                     payload={
                         "rejected_option_ids": _feedback_option_ids(session),
-                        "presentation_id": (
-                            latest_presentation.presentation_id
-                            if latest_presentation is not None
-                            else ""
-                        ),
+                        "presentation_id": latest_presentation_id,
                     },
                 ),
                 PlannerOutput(
@@ -576,6 +569,18 @@ def _validate_generated_at(value: str) -> None:
         datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
         raise ValueError("generated_at must be a valid ISO 8601 timestamp") from exc
+
+
+def _collect_context_payload(
+    trip_id: str, session: PlanningSessionState
+) -> dict[str, str]:
+    payload = {
+        "trip_id": trip_id,
+        "session_state_id": session.session_state_id,
+    }
+    if session.activity_log_id is not None:
+        payload["activity_log_id"] = session.activity_log_id
+    return payload
 
 
 def _latest_presentation(session: PlanningSessionState):

--- a/trip_planner/orchestration/leisure.py
+++ b/trip_planner/orchestration/leisure.py
@@ -36,21 +36,32 @@ class LeisureWorkflowContext:
             raise ValueError("session_state must represent a leisure session")
         _validate_generated_at(self.generated_at)
         if self.scenario_search.trip_id != self.trip_record.trip.trip_id:
-            raise ValueError("scenario_search.trip_id must match trip_record.trip.trip_id")
+            raise ValueError(
+                "scenario_search.trip_id must match trip_record.trip.trip_id"
+            )
         if self.session_state.trip_id != self.trip_record.trip.trip_id:
-            raise ValueError("session_state.trip_id must match trip_record.trip.trip_id")
+            raise ValueError(
+                "session_state.trip_id must match trip_record.trip.trip_id"
+            )
         if self.scenario_search.purpose != "final_selection":
             raise ValueError("scenario_search.purpose must be final_selection")
         if not self.scenario_search.scenarios:
             raise ValueError("scenario_search.scenarios must not be empty")
         current_saved = self.session_state.current_saved_scenario_id
         known_saved = set(self.trip_record.artifact_refs.saved_scenario_ids)
-        if current_saved is not None and known_saved and current_saved not in known_saved:
+        if (
+            current_saved is not None
+            and known_saved
+            and current_saved not in known_saved
+        ):
             raise ValueError(
                 "session_state.current_saved_scenario_id must be present in trip_record artifact_refs"
             )
         scenario_search_id = self.trip_record.artifact_refs.scenario_search_id
-        if scenario_search_id is not None and scenario_search_id != self.scenario_search.search_id:
+        if (
+            scenario_search_id is not None
+            and scenario_search_id != self.scenario_search.search_id
+        ):
             raise ValueError(
                 "trip_record artifact_refs.scenario_search_id must match scenario_search.search_id"
             )
@@ -161,7 +172,9 @@ def _workflow_notes(context: LeisureWorkflowContext, variant: str) -> list[str]:
         ),
     ]
     if variant == "revised_after_feedback":
-        notes.append("Feedback-triggered revision keeps the workflow stateful and explicit.")
+        notes.append(
+            "Feedback-triggered revision keeps the workflow stateful and explicit."
+        )
     return notes
 
 
@@ -311,7 +324,8 @@ def _build_actions(
                     "Delegated planning can auto-advance to a save-ready checkpoint without forcing an immediate user stop."
                 ],
                 payload={
-                    "current_saved_scenario_id": session.current_saved_scenario_id or "",
+                    "current_saved_scenario_id": session.current_saved_scenario_id
+                    or "",
                     "scenario_search_id": scenario_search.search_id,
                 },
             )

--- a/trip_planner/orchestration/leisure.py
+++ b/trip_planner/orchestration/leisure.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 
 from trip_planner.itinerary import ScenarioSearchResult
 from trip_planner.state import PlanningSessionState, PersistedTripRecord
@@ -33,6 +34,7 @@ class LeisureWorkflowContext:
             raise ValueError("trip_record must represent a leisure trip")
         if self.session_state.mode != "leisure":
             raise ValueError("session_state must represent a leisure session")
+        _validate_generated_at(self.generated_at)
         if self.scenario_search.trip_id != self.trip_record.trip.trip_id:
             raise ValueError("scenario_search.trip_id must match trip_record.trip.trip_id")
         if self.session_state.trip_id != self.trip_record.trip.trip_id:
@@ -385,6 +387,7 @@ def _build_outputs(
 ) -> list[PlannerOutput]:
     scenario_search = context.scenario_search
     session = context.session_state
+    latest_presentation = _latest_presentation(session)
     outputs: list[PlannerOutput] = []
 
     if variant != "revised_after_feedback":
@@ -470,8 +473,8 @@ def _build_outputs(
                     payload={
                         "rejected_option_ids": _feedback_option_ids(session),
                         "presentation_id": (
-                            _latest_presentation(session).presentation_id
-                            if _latest_presentation(session) is not None
+                            latest_presentation.presentation_id
+                            if latest_presentation is not None
                             else ""
                         ),
                     },
@@ -564,6 +567,15 @@ def _build_transition(
         changed_by="planner",
         warning_codes=["feedback_rejected_option_set"],
     )
+
+
+def _validate_generated_at(value: str) -> None:
+    if not value.strip():
+        raise ValueError("generated_at must be a non-empty ISO 8601 timestamp")
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("generated_at must be a valid ISO 8601 timestamp") from exc
 
 
 def _latest_presentation(session: PlanningSessionState):

--- a/trip_planner/orchestration/leisure.py
+++ b/trip_planner/orchestration/leisure.py
@@ -1,0 +1,579 @@
+"""Leisure-planning workflow scaffolds built on shared orchestration contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from trip_planner.itinerary import ScenarioSearchResult
+from trip_planner.state import PlanningSessionState, PersistedTripRecord
+
+from .models import (
+    DecisionOption,
+    NextStepSummary,
+    PendingDecision,
+    PlannerAction,
+    PlannerOutput,
+    PlannerTurn,
+    WorkflowStateSnapshot,
+    WorkflowTransition,
+)
+
+
+@dataclass(slots=True)
+class LeisureWorkflowContext:
+    """Typed inputs required to build one leisure planner turn."""
+
+    trip_record: PersistedTripRecord
+    session_state: PlanningSessionState
+    scenario_search: ScenarioSearchResult
+    generated_at: str
+
+    def __post_init__(self) -> None:
+        if self.trip_record.trip.mode != "leisure":
+            raise ValueError("trip_record must represent a leisure trip")
+        if self.session_state.mode != "leisure":
+            raise ValueError("session_state must represent a leisure session")
+        if self.scenario_search.trip_id != self.trip_record.trip.trip_id:
+            raise ValueError("scenario_search.trip_id must match trip_record.trip.trip_id")
+        if self.session_state.trip_id != self.trip_record.trip.trip_id:
+            raise ValueError("session_state.trip_id must match trip_record.trip.trip_id")
+        if self.scenario_search.purpose != "final_selection":
+            raise ValueError("scenario_search.purpose must be final_selection")
+        if not self.scenario_search.scenarios:
+            raise ValueError("scenario_search.scenarios must not be empty")
+        current_saved = self.session_state.current_saved_scenario_id
+        known_saved = set(self.trip_record.artifact_refs.saved_scenario_ids)
+        if current_saved is not None and known_saved and current_saved not in known_saved:
+            raise ValueError(
+                "session_state.current_saved_scenario_id must be present in trip_record artifact_refs"
+            )
+        scenario_search_id = self.trip_record.artifact_refs.scenario_search_id
+        if scenario_search_id is not None and scenario_search_id != self.scenario_search.search_id:
+            raise ValueError(
+                "trip_record artifact_refs.scenario_search_id must match scenario_search.search_id"
+            )
+
+
+def build_leisure_planner_turn(context: LeisureWorkflowContext) -> PlannerTurn:
+    """Build a first-pass leisure orchestration turn from persisted state."""
+
+    trip_id = context.trip_record.trip.trip_id
+    session = context.session_state
+    variant = _resolve_variant(session)
+    decisions = _map_pending_decisions(session)
+    actions = _build_actions(context, variant, decisions)
+    outputs = _build_outputs(context, variant, decisions)
+    open_action_ids = [
+        action.action_id
+        for action in actions
+        if action.status in {"pending", "in_progress"}
+    ]
+    completed_action_ids = [
+        action.action_id
+        for action in actions
+        if action.status in {"completed", "skipped"}
+    ]
+    recent_output_ids = [output.output_id for output in outputs]
+
+    workflow_state = WorkflowStateSnapshot(
+        workflow_state_id=f"workflow-state:{session.session_state_id}:leisure",
+        trip_id=trip_id,
+        mode="leisure",
+        workflow_kind="leisure_planning",
+        current_stage=_current_stage(variant),
+        status=_workflow_status(variant),
+        recorded_at=context.generated_at,
+        pending_decisions=decisions,
+        open_action_ids=open_action_ids,
+        completed_action_ids=completed_action_ids,
+        recent_output_ids=recent_output_ids,
+        notes=_workflow_notes(context, variant),
+        tags=_workflow_tags(session, variant),
+    )
+    next_step = _build_next_step(variant, decisions, outputs)
+    transition = _build_transition(context, variant)
+
+    return PlannerTurn(
+        turn_id=f"planner-turn:{trip_id}:{variant}:{context.generated_at}",
+        trip_id=trip_id,
+        mode="leisure",
+        workflow_kind="leisure_planning",
+        turn_kind=_turn_kind(variant),
+        started_at=context.generated_at,
+        workflow_state=workflow_state,
+        transition=transition,
+        next_step=next_step,
+        actions=actions,
+        outputs=outputs,
+        notes=_turn_notes(context, variant),
+    )
+
+
+def _resolve_variant(session: PlanningSessionState) -> str:
+    if session.pending_decisions:
+        return "collaborative_iterative"
+    if any(item.rejected_option_ids for item in session.recent_option_presentations):
+        return "revised_after_feedback"
+    return "delegated_planning"
+
+
+def _current_stage(variant: str) -> str:
+    if variant in {"delegated_planning", "collaborative_iterative"}:
+        return "decision_checkpoint"
+    return "ranking"
+
+
+def _workflow_status(variant: str) -> str:
+    if variant == "collaborative_iterative":
+        return "waiting_on_user"
+    return "active"
+
+
+def _turn_kind(variant: str) -> str:
+    if variant == "collaborative_iterative":
+        return "decision_checkpoint"
+    return "planning_pass"
+
+
+def _workflow_tags(session: PlanningSessionState, variant: str) -> list[str]:
+    tags = ["leisure", "orchestration", variant]
+    tags.extend(session.tags)
+    return list(dict.fromkeys(tags))
+
+
+def _workflow_notes(context: LeisureWorkflowContext, variant: str) -> list[str]:
+    interaction = context.session_state.interaction_state
+    notes = [
+        (
+            "Leisure orchestration stays downstream from preference resolution, "
+            "candidate generation, and scenario ranking."
+        ),
+        (
+            f"interaction_style:{interaction.interaction_style};"
+            f"initiative_level:{interaction.initiative_level};"
+            f"checkpoint_frequency:{interaction.checkpoint_frequency}"
+        ),
+        (
+            f"scenario_search:{context.scenario_search.search_id};"
+            f"scenario_count:{len(context.scenario_search.scenarios)}"
+        ),
+    ]
+    if variant == "revised_after_feedback":
+        notes.append("Feedback-triggered revision keeps the workflow stateful and explicit.")
+    return notes
+
+
+def _turn_notes(context: LeisureWorkflowContext, variant: str) -> list[str]:
+    latest_presentation = _latest_presentation(context.session_state)
+    notes = [
+        (
+            "This leisure scaffold converts persisted trip/session/scenario artifacts "
+            "into an explicit planner turn."
+        ),
+        f"variant:{variant}",
+    ]
+    if latest_presentation is not None:
+        notes.append(f"latest_presentation:{latest_presentation.presentation_id}")
+    return notes
+
+
+def _map_pending_decisions(session: PlanningSessionState) -> list[PendingDecision]:
+    decisions: list[PendingDecision] = []
+    for session_decision in session.pending_decisions:
+        choices = [
+            DecisionOption(
+                choice_id=f"{session_decision.decision_id}:choice:{index + 1}",
+                label=choice,
+                recommended=index == 0,
+            )
+            for index, choice in enumerate(session_decision.choices)
+        ]
+        selected_choice_id = None
+        if session_decision.selected_choice is not None:
+            for choice in choices:
+                if choice.label == session_decision.selected_choice:
+                    selected_choice_id = choice.choice_id
+                    break
+        related_option_ids = []
+        if session_decision.related_option_set_id is not None:
+            related_option_ids.append(session_decision.related_option_set_id)
+        if session_decision.related_saved_scenario_id is not None:
+            related_option_ids.append(session_decision.related_saved_scenario_id)
+        decisions.append(
+            PendingDecision(
+                decision_id=session_decision.decision_id,
+                prompt=session_decision.prompt,
+                requested_at=session_decision.created_at,
+                choices=choices,
+                blocking=session_decision.blocking,
+                selected_choice_id=selected_choice_id,
+                due_by=session_decision.due_by,
+                notes=list(session_decision.notes),
+                related_option_ids=related_option_ids,
+            )
+        )
+    return decisions
+
+
+def _build_actions(
+    context: LeisureWorkflowContext,
+    variant: str,
+    decisions: list[PendingDecision],
+) -> list[PlannerAction]:
+    trip_id = context.trip_record.trip.trip_id
+    scenario_search = context.scenario_search
+    session = context.session_state
+    latest_presentation = _latest_presentation(session)
+    feedback_option_ids = _feedback_option_ids(session)
+
+    actions = [
+        PlannerAction(
+            action_id="action-collect-context",
+            action_kind="collect_context",
+            title="Load persisted leisure session context",
+            stage="intake",
+            status="completed",
+            payload={
+                "trip_id": trip_id,
+                "session_state_id": session.session_state_id,
+                "activity_log_id": session.activity_log_id or "",
+            },
+        ),
+        PlannerAction(
+            action_id="action-refresh-preferences",
+            action_kind="refresh_preferences",
+            title="Refresh leisure interaction and preference posture",
+            stage="objective_derivation",
+            status="completed",
+            payload={
+                "interaction_style": session.interaction_state.interaction_style,
+                "initiative_level": session.interaction_state.initiative_level,
+                "ask_before_major_change": str(
+                    session.interaction_state.ask_before_major_change
+                ).lower(),
+            },
+        ),
+        PlannerAction(
+            action_id="action-derive-objectives",
+            action_kind="derive_objectives",
+            title="Confirm downstream objectives before scenario review",
+            stage="objective_derivation",
+            status="completed",
+            payload={
+                "objective_id": context.trip_record.artifact_refs.objective_id or "",
+                "scenario_search_id": scenario_search.search_id,
+            },
+        ),
+        PlannerAction(
+            action_id="action-assemble-candidates",
+            action_kind="assemble_candidates",
+            title="Carry forward ranked leisure scenario candidates",
+            stage="candidate_generation",
+            status="completed",
+            payload={
+                "scenario_count": str(len(scenario_search.scenarios)),
+                "source_result_set_id": scenario_search.source_result_set_id,
+            },
+        ),
+    ]
+
+    rank_status = "completed"
+    rank_notes = [
+        "Ranking remains the upstream source of scenario order for the leisure scaffold."
+    ]
+    if variant == "revised_after_feedback":
+        rank_status = "in_progress"
+        rank_notes.append(
+            "Rejected surfaced options force an explicit reranking pass instead of implicit chat-state mutation."
+        )
+    actions.append(
+        PlannerAction(
+            action_id="action-rank-options",
+            action_kind="rank_options",
+            title="Rank leisure scenarios for the next planner turn",
+            stage="ranking",
+            status=rank_status,
+            notes=rank_notes,
+            payload={
+                "search_id": scenario_search.search_id,
+                "top_scenario_id": scenario_search.scenarios[0].scenario_id,
+                "source_refs": ",".join(scenario_search.source_refs),
+            },
+        )
+    )
+
+    if variant == "delegated_planning":
+        actions.append(
+            PlannerAction(
+                action_id="action-persist-state",
+                action_kind="persist_state",
+                title="Persist a save-ready baseline scenario checkpoint",
+                stage="decision_checkpoint",
+                status="in_progress",
+                depends_on_action_ids=["action-rank-options"],
+                notes=[
+                    "Delegated planning can auto-advance to a save-ready checkpoint without forcing an immediate user stop."
+                ],
+                payload={
+                    "current_saved_scenario_id": session.current_saved_scenario_id or "",
+                    "scenario_search_id": scenario_search.search_id,
+                },
+            )
+        )
+    elif variant == "collaborative_iterative":
+        decision_ids = [decision.decision_id for decision in decisions]
+        actions.extend(
+            [
+                PlannerAction(
+                    action_id="action-request-decision",
+                    action_kind="request_decision",
+                    title="Request a collaborative checkpoint before scenario save",
+                    stage="decision_checkpoint",
+                    status="in_progress",
+                    depends_on_action_ids=["action-rank-options"],
+                    payload={
+                        "decision_ids": ",".join(decision_ids),
+                        "latest_option_set_id": (
+                            latest_presentation.option_set_id
+                            if latest_presentation is not None
+                            else ""
+                        ),
+                    },
+                ),
+                PlannerAction(
+                    action_id="action-persist-state",
+                    action_kind="persist_state",
+                    title="Persist the chosen collaborative scenario after approval",
+                    stage="decision_checkpoint",
+                    status="pending",
+                    depends_on_action_ids=["action-request-decision"],
+                    payload={
+                        "decision_ids": ",".join(decision_ids),
+                        "current_saved_scenario_id": session.current_saved_scenario_id
+                        or "",
+                    },
+                ),
+            ]
+        )
+    else:
+        actions.append(
+            PlannerAction(
+                action_id="action-record-warning",
+                action_kind="record_warning",
+                title="Record revision-driving leisure feedback",
+                stage="ranking",
+                status="completed",
+                depends_on_action_ids=["action-collect-context"],
+                payload={
+                    "rejected_option_ids": ",".join(feedback_option_ids),
+                    "presentation_id": (
+                        latest_presentation.presentation_id
+                        if latest_presentation is not None
+                        else ""
+                    ),
+                },
+            )
+        )
+
+    return actions
+
+
+def _build_outputs(
+    context: LeisureWorkflowContext,
+    variant: str,
+    decisions: list[PendingDecision],
+) -> list[PlannerOutput]:
+    scenario_search = context.scenario_search
+    session = context.session_state
+    outputs: list[PlannerOutput] = []
+
+    if variant != "revised_after_feedback":
+        outputs.append(
+            PlannerOutput(
+                output_id="output-ranked-scenarios",
+                output_kind="ranked_scenarios",
+                title="Ranked leisure scenarios ready for orchestration",
+                emitted_at=context.generated_at,
+                surface="side_panel",
+                summary=(
+                    f"{len(scenario_search.scenarios)} ranked leisure scenarios remain "
+                    "downstream from preference learning and route ranking."
+                ),
+                ref_ids=[
+                    scenario_search.search_id,
+                    scenario_search.source_result_set_id,
+                ],
+                payload={
+                    "search_id": scenario_search.search_id,
+                    "scenario_ids": [
+                        scenario.scenario_id for scenario in scenario_search.scenarios
+                    ],
+                    "recommended_scenario_id": scenario_search.scenarios[0].scenario_id,
+                    "saved_scenario_id": session.current_saved_scenario_id or "",
+                },
+            )
+        )
+
+    if variant == "delegated_planning":
+        outputs.append(
+            PlannerOutput(
+                output_id="output-delegated-status",
+                output_kind="status_update",
+                title="Delegated leisure flow is ready to save a baseline",
+                emitted_at=context.generated_at,
+                surface="planner_chat",
+                summary=(
+                    "Planner-first leisure mode can advance from ranked scenarios to "
+                    "a save-ready checkpoint without inventing extra chat state."
+                ),
+                ref_ids=["action-persist-state", scenario_search.search_id],
+                payload={
+                    "auto_advance_research_passes": session.interaction_state.auto_advance_research_passes,
+                    "checkpoint_frequency": session.interaction_state.checkpoint_frequency,
+                },
+            )
+        )
+    elif variant == "collaborative_iterative":
+        outputs.append(
+            PlannerOutput(
+                output_id="output-decision-request",
+                output_kind="decision_request",
+                title="Collaborative checkpoint requested before scenario save",
+                emitted_at=context.generated_at,
+                surface="planner_chat",
+                summary="The planner pauses at a structured checkpoint so the traveler can steer the next save/revise step.",
+                ref_ids=[decision.decision_id for decision in decisions],
+                payload={
+                    "decision_ids": [decision.decision_id for decision in decisions],
+                    "blocking_decision_ids": [
+                        decision.decision_id
+                        for decision in decisions
+                        if decision.blocking
+                    ],
+                },
+            )
+        )
+    else:
+        outputs.extend(
+            [
+                PlannerOutput(
+                    output_id="output-feedback-warning",
+                    output_kind="warning",
+                    title="Feedback-triggered reranking remains unresolved",
+                    emitted_at=context.generated_at,
+                    surface="planner_chat",
+                    summary=(
+                        "Rejected surfaced options triggered a new ranking pass instead "
+                        "of silently mutating the prior scenario choice."
+                    ),
+                    warnings=["feedback_rejected_option_set"],
+                    payload={
+                        "rejected_option_ids": _feedback_option_ids(session),
+                        "presentation_id": (
+                            _latest_presentation(session).presentation_id
+                            if _latest_presentation(session) is not None
+                            else ""
+                        ),
+                    },
+                ),
+                PlannerOutput(
+                    output_id="output-revision-status",
+                    output_kind="status_update",
+                    title="Leisure workflow is recomputing ranked scenarios",
+                    emitted_at=context.generated_at,
+                    surface="timeline",
+                    summary=(
+                        "Preference feedback, saved state, and scenario history stay "
+                        "separate while the workflow recomputes the next ranked pass."
+                    ),
+                    ref_ids=["action-rank-options", scenario_search.search_id],
+                    payload={
+                        "search_id": scenario_search.search_id,
+                        "current_saved_scenario_id": session.current_saved_scenario_id
+                        or "",
+                    },
+                ),
+            ]
+        )
+
+    return outputs
+
+
+def _build_next_step(
+    variant: str,
+    decisions: list[PendingDecision],
+    outputs: list[PlannerOutput],
+) -> NextStepSummary:
+    if variant == "delegated_planning":
+        return NextStepSummary(
+            headline="Persist the current save-ready leisure baseline.",
+            recommended_action_id="action-persist-state",
+            expected_output_ids=[output.output_id for output in outputs],
+            notes=[
+                "Delegated leisure planning can continue to checkpoint persistence without an immediate user stop."
+            ],
+        )
+    if variant == "collaborative_iterative":
+        return NextStepSummary(
+            headline="Resolve the active traveler checkpoint before saving the scenario.",
+            recommended_action_id="action-request-decision",
+            blocking_decision_ids=[decision.decision_id for decision in decisions],
+            expected_output_ids=[output.output_id for output in outputs],
+            notes=[
+                "Collaborative mode surfaces a structured choice set before advancing the session."
+            ],
+        )
+    return NextStepSummary(
+        headline="Re-rank leisure scenarios after the latest traveler feedback.",
+        recommended_action_id="action-rank-options",
+        expected_output_ids=[output.output_id for output in outputs],
+        notes=[
+            "Revision remains explicit: feedback changes ranking inputs instead of mutating the saved scenario in place."
+        ],
+    )
+
+
+def _build_transition(
+    context: LeisureWorkflowContext,
+    variant: str,
+) -> WorkflowTransition:
+    if variant == "delegated_planning":
+        return WorkflowTransition(
+            from_stage="ranking",
+            to_stage="decision_checkpoint",
+            trigger="planner_recommendation",
+            changed_at=context.generated_at,
+            reason="Ranked leisure scenarios are ready for a delegated save-ready checkpoint.",
+            changed_by="planner",
+        )
+    if variant == "collaborative_iterative":
+        return WorkflowTransition(
+            from_stage="ranking",
+            to_stage="decision_checkpoint",
+            trigger="checkpoint_due",
+            changed_at=context.generated_at,
+            reason="Checkpoint-heavy collaboration pauses the leisure flow for a structured traveler decision.",
+            changed_by="planner",
+        )
+    return WorkflowTransition(
+        from_stage="decision_checkpoint",
+        to_stage="ranking",
+        trigger="decision_response",
+        changed_at=context.generated_at,
+        reason="Traveler feedback rejected surfaced options, so the planner is recomputing ranked leisure scenarios.",
+        changed_by="planner",
+        warning_codes=["feedback_rejected_option_set"],
+    )
+
+
+def _latest_presentation(session: PlanningSessionState):
+    if not session.recent_option_presentations:
+        return None
+    return max(session.recent_option_presentations, key=lambda item: item.shown_at)
+
+
+def _feedback_option_ids(session: PlanningSessionState) -> list[str]:
+    option_ids: list[str] = []
+    for presentation in session.recent_option_presentations:
+        option_ids.extend(presentation.rejected_option_ids)
+    return list(dict.fromkeys(option_ids))


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #545

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The leisure side needs a concrete orchestration flow that can move from profile state to option presentation, ranking, scenario saving, and revision without collapsing the planner into a generic conversation loop. Once the contracts exist, the repo needs a first-pass leisure workflow scaffold that can drive iterative planning.

Parent epic: #543

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#543](https://github.com/stranske/trip-planner/issues/543)
- [#510](https://github.com/stranske/trip-planner/issues/510)
- [#511](https://github.com/stranske/trip-planner/issues/511)
- [#530](https://github.com/stranske/trip-planner/issues/530)
- [#534](https://github.com/stranske/trip-planner/issues/534)
- [#537](https://github.com/stranske/trip-planner/issues/537)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement a leisure orchestration scaffold that can progress through major phases such as profile confirmation, option presentation, scenario review, scenario save, and revision.
- [x] Ensure the scaffold can consume preference-profile updates, candidate outputs, ranked scenarios, and saved checkpoints from earlier layers.
- [x] Add support for both more autonomous and more checkpoint-heavy planning styles using the interaction-state model from the preference work.
- [x] Add representative fixtures for at least: a delegated-planning flow, a collaborative iterative flow, and a revised-after-feedback flow.
- [x] Write unit tests covering state progression, planner-output generation, and malformed or incomplete workflow states.
- [x] Document how this orchestration flow remains downstream from preference learning and ranking rather than replacing them.

#### Acceptance criteria
- [x] The repo contains a first-pass leisure orchestration scaffold built on explicit planner-turn contracts.
- [x] The scaffold can represent materially different interaction styles without changing the underlying domain contracts.
- [x] Tests cover representative leisure flow progressions and malformed-state failures.
- [x] The orchestration output is compatible with saved scenarios and later UI layers.
- [x] Documentation preserves the boundary between leisure workflow orchestration and underlying planning engines.

<!-- auto-status-summary:end -->