### PR TITLE
Issue #546: add option-presentation feedback loop scaffold

### DIFF
--- a/docs/contracts/orchestration-workflow.md
+++ b/docs/contracts/orchestration-workflow.md
@@ -4,6 +4,7 @@ The canonical orchestration contracts now live in:
 
 - `trip_planner/orchestration/actions.py`
 - `trip_planner/orchestration/in_trip.py`
+- `trip_planner/orchestration/feedback.py`
 - `trip_planner/orchestration/models.py`
 - `trip_planner/orchestration/leisure.py`
 
@@ -27,6 +28,8 @@ These contracts define the shared workflow layer that later leisure, business, a
   - tells later orchestrators which action to continue next and which decision/output references are still blocking
 - `InTripAdjustmentResult`
   - captures one structured in-trip trigger plus the resulting replanning request, planner turn, activity event, and revision output
+- `FeedbackLoopResult`
+  - captures one structured option-feedback event plus the resulting planner turn, session-state delta, activity log event, and optional fallback-save request
 
 ## Design Rules
 
@@ -36,6 +39,7 @@ These contracts define the shared workflow layer that later leisure, business, a
 - Represent decision requests as structured options, not free-form strings.
 - Let later orchestrators compose these contracts instead of inventing mode-specific action containers.
 - Keep in-trip adjustment downstream from saved-scenario, session, ranking, and checkpoint layers instead of bypassing them.
+- Route concrete option reactions through explicit feedback-loop state instead of mutating the session opportunistically.
 
 ## Representative Fixtures
 
@@ -44,6 +48,9 @@ Representative fixtures live in:
 - `tests/fixtures/orchestration/in_trip/budget_drift_replan.json`
 - `tests/fixtures/orchestration/in_trip/closure_driven_replan.json`
 - `tests/fixtures/orchestration/in_trip/travel_delay_emergency.json`
+- `tests/fixtures/orchestration/feedback/accept_option.json`
+- `tests/fixtures/orchestration/feedback/reject_and_rerank.json`
+- `tests/fixtures/orchestration/feedback/save_as_fallback.json`
 - `tests/fixtures/orchestration/turns/leisure_planning_turn.json`
 - `tests/fixtures/orchestration/turns/business_planning_turn.json`
 - `tests/fixtures/orchestration/turns/in_trip_adjustment_turn.json`
@@ -56,6 +63,9 @@ These fixtures show how the same contract layer can express:
 - a budget-drift event that refreshes ranked alternatives without replacing the saved scenario yet
 - a closure-driven in-trip scenario revision that stays anchored to the current checkpoint
 - a travel-delay emergency fallback that escalates without pretending the traveler started a new trip
+- a quick preference-learning acceptance that stays inside a checkpointed leisure workflow
+- a deeper inventory-narrowing rerank request with autonomy feedback
+- a structured "save this as fallback" request that can hand off to scenario persistence
 - a leisure checkpoint with ranked scenario outputs
 - a business planning turn gated by policy posture
 - an in-trip replanning turn triggered by disruption

--- a/tests/fixtures/orchestration/feedback/accept_option.json
+++ b/tests/fixtures/orchestration/feedback/accept_option.json
@@ -1,0 +1,18 @@
+{
+  "event": {
+    "feedback_event_id": "feedback:accept-kyoto-central",
+    "presentation_id": "presentation:kyoto-v3",
+    "feedback_kind": "accept_option",
+    "option_id": "option:kyoto-central",
+    "summary": "Traveler wants to carry the Kyoto central option into the next checkpoint.",
+    "comparison_depth": "quick_preference_check",
+    "signal_strength": 0.82,
+    "dimension_biases": {
+      "route_coherence_vs_eclectic_contrast": -0.55,
+      "self_reliance_vs_convenience": 0.35
+    },
+    "hybrid_biases": {
+      "rest": 0.25
+    }
+  }
+}

--- a/tests/fixtures/orchestration/feedback/reject_and_rerank.json
+++ b/tests/fixtures/orchestration/feedback/reject_and_rerank.json
@@ -1,0 +1,21 @@
+{
+  "event": {
+    "feedback_event_id": "feedback:reject-osaka-rerank",
+    "presentation_id": "presentation:kyoto-v3",
+    "feedback_kind": "request_alternatives",
+    "option_id": "option:osaka-daytrip",
+    "summary": "Traveler wants more alternatives before the next checkpoint and does not want the Osaka-heavy branch.",
+    "comparison_depth": "inventory_narrowing",
+    "signal_strength": 0.88,
+    "dimension_biases": {
+      "movement_vs_friction": -0.65,
+      "self_reliance_vs_convenience": -0.45
+    },
+    "hybrid_biases": {
+      "route_modes": -0.3
+    },
+    "autonomy_feedback_kinds": [
+      "do_more_before_asking"
+    ]
+  }
+}

--- a/tests/fixtures/orchestration/feedback/save_as_fallback.json
+++ b/tests/fixtures/orchestration/feedback/save_as_fallback.json
@@ -1,0 +1,20 @@
+{
+  "event": {
+    "feedback_event_id": "feedback:save-osaka-fallback",
+    "presentation_id": "presentation:kyoto-v3",
+    "feedback_kind": "save_as_fallback",
+    "option_id": "option:osaka-daytrip",
+    "summary": "Traveler does not want Osaka as the default path but wants it preserved as a fallback.",
+    "comparison_depth": "inventory_narrowing",
+    "signal_strength": 0.74,
+    "dimension_biases": {
+      "movement_vs_friction": -0.25,
+      "recovery_vs_intensity": 0.4
+    },
+    "hybrid_biases": {
+      "rest": 0.3
+    },
+    "fallback_saved_scenario_id": "saved-scenario:osaka-weather-fallback",
+    "fallback_title": "Osaka weather fallback"
+  }
+}

--- a/tests/orchestration/test_feedback.py
+++ b/tests/orchestration/test_feedback.py
@@ -1,0 +1,135 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.preferences.fixture_corpus import load_fixture_map
+from trip_planner.orchestration import (
+    FeedbackLoopContext,
+    OptionFeedbackEvent,
+    build_feedback_loop_result,
+)
+from trip_planner.preferences import PlanningAutonomyProfile
+from trip_planner.state import PlanningSessionState
+
+
+def _fixture_path(name: str) -> Path:
+    return (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "orchestration"
+        / "feedback"
+        / name
+    )
+
+
+def _load_event(name: str) -> OptionFeedbackEvent:
+    payload = json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+    return OptionFeedbackEvent(**payload["event"])
+
+
+def _load_session() -> PlanningSessionState:
+    payload = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "fixtures"
+            / "state"
+            / "sessions"
+            / "active_leisure_session.json"
+        ).read_text(encoding="utf-8")
+    )
+    return PlanningSessionState.from_dict(payload["session"])
+
+
+def _context(
+    *,
+    generated_at: str = "2026-04-02T15:00:00Z",
+    session_state: PlanningSessionState | None = None,
+    autonomy_profile: PlanningAutonomyProfile | None = None,
+) -> FeedbackLoopContext:
+    fixture = load_fixture_map()["discovery-wanderer"]
+    return FeedbackLoopContext(
+        preference_profile=fixture.profile,
+        session_state=session_state or _load_session(),
+        autonomy_profile=autonomy_profile or PlanningAutonomyProfile(),
+        generated_at=generated_at,
+    )
+
+
+def test_accept_option_routes_feedback_into_checkpoint_state() -> None:
+    result = build_feedback_loop_result(_context(), _load_event("accept_option.json"))
+
+    presentation = result.updated_session_state.recent_option_presentations[0]
+
+    assert presentation.selected_option_id == "option:kyoto-central"
+    assert result.activity_event.event_kind == "decision_recorded"
+    assert result.planner_turn.workflow_state.current_stage == "decision_checkpoint"
+    assert result.planner_turn.next_step.recommended_action_id == (
+        "action-request-decision"
+    )
+    assert result.revealed_preference_updates[0].signal.reaction_type == "selected"
+
+
+def test_reject_and_rerank_clears_checkpoint_and_updates_autonomy() -> None:
+    result = build_feedback_loop_result(
+        _context(),
+        _load_event("reject_and_rerank.json"),
+    )
+
+    presentation = result.updated_session_state.recent_option_presentations[0]
+
+    assert "option:osaka-daytrip" in presentation.rejected_option_ids
+    assert result.updated_session_state.pending_decisions == []
+    assert result.activity_event.event_kind == "rerank_requested"
+    assert result.planner_turn.next_step.recommended_action_id == "action-rank-options"
+    assert result.updated_session_state.interaction_state.auto_advance_research_passes > 1
+
+
+def test_save_as_fallback_emits_structured_scenario_capture_request() -> None:
+    result = build_feedback_loop_result(
+        _context(),
+        _load_event("save_as_fallback.json"),
+    )
+
+    assert result.scenario_capture_request is not None
+    assert result.scenario_capture_request.label == "fallback"
+    assert result.scenario_capture_request.saved_scenario_id == (
+        "saved-scenario:osaka-weather-fallback"
+    )
+    assert result.activity_event.event_kind == "scenario_saved"
+    assert result.activity_event.saved_scenario_id == (
+        "saved-scenario:osaka-weather-fallback"
+    )
+    assert result.planner_turn.next_step.recommended_action_id == (
+        "action-persist-fallback"
+    )
+
+
+def test_feedback_rejects_unknown_option_id() -> None:
+    event = _load_event("accept_option.json")
+    event.option_id = "option:missing"
+
+    with pytest.raises(ValueError, match="surfaced_option_ids"):
+        build_feedback_loop_result(_context(), event)
+
+
+def test_feedback_loop_supports_reentry_with_updated_session_state() -> None:
+    first = build_feedback_loop_result(_context(), _load_event("accept_option.json"))
+    second = build_feedback_loop_result(
+        _context(
+            generated_at="2026-04-02T15:20:00Z",
+            session_state=first.updated_session_state,
+            autonomy_profile=first.updated_autonomy_profile,
+        ),
+        _load_event("reject_and_rerank.json"),
+    )
+
+    presentation = second.updated_session_state.recent_option_presentations[0]
+
+    assert presentation.selected_option_id == "option:kyoto-central"
+    assert "option:osaka-daytrip" in presentation.rejected_option_ids
+    assert second.updated_session_state.notes[-2:] == [
+        "feedback-loop:accept_option:quick_preference_check:option:kyoto-central",
+        "feedback-loop:request_alternatives:inventory_narrowing:option:osaka-daytrip",
+    ]
+    assert second.planner_turn.transition.to_stage == "ranking"

--- a/tests/orchestration/test_feedback.py
+++ b/tests/orchestration/test_feedback.py
@@ -82,7 +82,10 @@ def test_reject_and_rerank_clears_checkpoint_and_updates_autonomy() -> None:
     assert result.updated_session_state.pending_decisions == []
     assert result.activity_event.event_kind == "rerank_requested"
     assert result.planner_turn.next_step.recommended_action_id == "action-rank-options"
-    assert result.updated_session_state.interaction_state.auto_advance_research_passes > 1
+    assert (
+        result.updated_session_state.interaction_state.auto_advance_research_passes > 1
+    )
+    assert result.planner_turn.workflow_state.pending_decisions == []
 
 
 def test_save_as_fallback_emits_structured_scenario_capture_request() -> None:
@@ -103,6 +106,34 @@ def test_save_as_fallback_emits_structured_scenario_capture_request() -> None:
     assert result.planner_turn.next_step.recommended_action_id == (
         "action-persist-fallback"
     )
+    presentation = result.updated_session_state.recent_option_presentations[0]
+    assert presentation.selected_option_id is None
+    assert presentation.rejected_option_ids == ["option:osaka-daytrip"]
+    assert result.activity_event.actor == "user"
+    assert result.planner_turn.workflow_state.pending_decisions[0].decision_id == (
+        "decision:save-baseline"
+    )
+
+
+def test_feedback_context_rejects_invalid_trip_stage() -> None:
+    fixture = load_fixture_map()["discovery-wanderer"]
+    with pytest.raises(ValueError, match="trip_stage"):
+        FeedbackLoopContext(
+            preference_profile=fixture.profile,
+            session_state=_load_session(),
+            autonomy_profile=PlanningAutonomyProfile(),
+            generated_at="2026-04-02T15:00:00Z",
+            trip_stage="bad-stage",
+        )
+
+
+def test_reject_option_records_option_rejected_activity() -> None:
+    event = _load_event("reject_and_rerank.json")
+    event.feedback_kind = "reject_option"
+    result = build_feedback_loop_result(_context(), event)
+
+    assert result.activity_event.event_kind == "option_rejected"
+    assert result.activity_event.actor == "user"
 
 
 def test_feedback_rejects_unknown_option_id() -> None:

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -92,6 +92,7 @@ trip_planner/orchestration/__init__.py
 trip_planner/orchestration/actions.py
 trip_planner/orchestration/in_trip.py
 trip_planner/orchestration/leisure.py
+trip_planner/orchestration/feedback.py
 trip_planner/orchestration/models.py
 trip_planner/preferences/__init__.py
 trip_planner/preferences/autonomy.py

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -90,8 +90,8 @@ trip_planner/options/lodging.py
 trip_planner/options/transport.py
 trip_planner/orchestration/__init__.py
 trip_planner/orchestration/actions.py
-trip_planner/orchestration/in_trip.py
 trip_planner/orchestration/feedback.py
+trip_planner/orchestration/in_trip.py
 trip_planner/orchestration/leisure.py
 trip_planner/orchestration/models.py
 trip_planner/preferences/__init__.py

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -91,8 +91,8 @@ trip_planner/options/transport.py
 trip_planner/orchestration/__init__.py
 trip_planner/orchestration/actions.py
 trip_planner/orchestration/in_trip.py
-trip_planner/orchestration/leisure.py
 trip_planner/orchestration/feedback.py
+trip_planner/orchestration/leisure.py
 trip_planner/orchestration/models.py
 trip_planner/preferences/__init__.py
 trip_planner/preferences/autonomy.py

--- a/trip_planner/orchestration/__init__.py
+++ b/trip_planner/orchestration/__init__.py
@@ -12,6 +12,15 @@ from .actions import (
     WORKFLOW_STATUSES,
 )
 from .leisure import LeisureWorkflowContext, build_leisure_planner_turn
+from .feedback import (
+    COMPARISON_DEPTHS,
+    FEEDBACK_KINDS,
+    FeedbackLoopContext,
+    FeedbackLoopResult,
+    OptionFeedbackEvent,
+    ScenarioCaptureRequest,
+    build_feedback_loop_result,
+)
 from .models import (
     ORCHESTRATION_SCHEMA_VERSION,
     DecisionOption,
@@ -41,17 +50,23 @@ __all__ = [
     "ACTION_KINDS",
     "ACTION_STATUSES",
     "CHANGE_SCOPES",
+    "COMPARISON_DEPTHS",
     "DecisionOption",
-    "LeisureWorkflowContext",
+    "FEEDBACK_KINDS",
+    "FeedbackLoopContext",
+    "FeedbackLoopResult",
     "InTripAdjustmentContext",
     "InTripAdjustmentResult",
     "InTripRevisionOutput",
     "InTripTriggerEvent",
+    "LeisureWorkflowContext",
     "NextStepSummary",
     "ORCHESTRATION_SCHEMA_VERSION",
+    "OptionFeedbackEvent",
     "OUTPUT_KINDS",
     "OUTPUT_SURFACES",
     "PendingDecision",
+    "ScenarioCaptureRequest",
     "PlannerAction",
     "PlannerOutput",
     "PlannerTurn",
@@ -69,4 +84,5 @@ __all__ = [
     "WorkflowTransition",
     "build_leisure_planner_turn",
     "build_in_trip_adjustment_result",
+    "build_feedback_loop_result",
 ]

--- a/trip_planner/orchestration/feedback.py
+++ b/trip_planner/orchestration/feedback.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import Any
 
 from trip_planner.contracts._validators import (
     require_non_empty,
@@ -15,18 +14,22 @@ from trip_planner.preferences import (
     RevealedPreferenceSignal,
     RevealedPreferenceUpdate,
     build_revealed_preference_update,
+    schema as preference_schema,
 )
 from trip_planner.preferences.autonomy import AUTONOMY_FEEDBACK_KINDS
 from trip_planner.preferences.models import LeisurePreferenceProfile
 from trip_planner.state import (
     ActivityLogEvent,
     OptionPresentationRecord,
+    PendingDecision as SessionPendingDecision,
     PlanningInteractionState,
     PlanningSessionState,
 )
 
 from .models import (
+    DecisionOption,
     NextStepSummary,
+    PendingDecision,
     PlannerAction,
     PlannerOutput,
     PlannerTurn,
@@ -77,6 +80,10 @@ class FeedbackLoopContext:
             raise ValueError("autonomy_profile must be a PlanningAutonomyProfile")
         if self.session_state.mode != "leisure":
             raise ValueError("session_state must represent a leisure session")
+        if self.trip_stage not in preference_schema.PLANNING_STAGES:
+            raise ValueError(
+                f"trip_stage must be one of {preference_schema.PLANNING_STAGES}"
+            )
         require_non_empty(self.generated_at, "generated_at")
 
 
@@ -122,9 +129,7 @@ class OptionFeedbackEvent:
         require_optional_non_empty(self.fallback_title, "fallback_title")
         if self.feedback_kind == "save_as_fallback":
             if self.fallback_saved_scenario_id is None:
-                raise ValueError(
-                    "save_as_fallback requires fallback_saved_scenario_id"
-                )
+                raise ValueError("save_as_fallback requires fallback_saved_scenario_id")
             if self.fallback_title is None:
                 raise ValueError("save_as_fallback requires fallback_title")
 
@@ -255,6 +260,7 @@ def build_feedback_loop_result(
         activity_event,
         scenario_capture_request,
         context.generated_at,
+        context.trip_stage,
     )
 
     return FeedbackLoopResult(
@@ -289,11 +295,15 @@ def _apply_feedback_to_presentation(
             rejected_option_ids.append(event.option_id)
         if selected_option_id == event.option_id:
             selected_option_id = None
-    else:
+    elif event.feedback_kind == "accept_option":
         selected_option_id = event.option_id
         rejected_option_ids = [
-            option_id for option_id in rejected_option_ids if option_id != event.option_id
+            option_id
+            for option_id in rejected_option_ids
+            if option_id != event.option_id
         ]
+    elif event.feedback_kind == "save_as_fallback":
+        pass
 
     notes.append(f"feedback:{event.feedback_kind}:{event.summary}")
 
@@ -360,7 +370,9 @@ def _interaction_state_from_behavior(
         notes.append("feedback-loop updated planner autonomy pacing.")
     return replace(
         previous,
-        initiative_level=_initiative_level_from_preference(preference.system_initiative),
+        initiative_level=_initiative_level_from_preference(
+            preference.system_initiative
+        ),
         checkpoint_frequency=(
             "phase" if behavior.ask_before_next_major_change else "manual"
         ),
@@ -384,7 +396,7 @@ def _initiative_level_from_preference(system_initiative: float) -> str:
 def _updated_pending_decisions(
     session_state: PlanningSessionState,
     event: OptionFeedbackEvent,
-) -> list[Any]:
+) -> list[SessionPendingDecision]:
     if event.feedback_kind in {"reject_option", "request_alternatives"}:
         return []
     return list(session_state.pending_decisions)
@@ -431,7 +443,7 @@ def _build_activity_event(
 ) -> ActivityLogEvent:
     event_kind = {
         "accept_option": "decision_recorded",
-        "reject_option": "rerank_requested",
+        "reject_option": "option_rejected",
         "request_alternatives": "rerank_requested",
         "save_as_fallback": "scenario_saved",
     }[event.feedback_kind]
@@ -442,7 +454,7 @@ def _build_activity_event(
         occurred_at=generated_at,
         event_kind=event_kind,
         summary=event.summary,
-        actor="planner",
+        actor="user",
         related_option_set_id=presentation.option_set_id,
         saved_scenario_id=(
             scenario_capture_request.saved_scenario_id
@@ -466,6 +478,7 @@ def _build_planner_turn(
     activity_event: ActivityLogEvent,
     scenario_capture_request: ScenarioCaptureRequest | None,
     generated_at: str,
+    trip_stage: str,
 ) -> PlannerTurn:
     rerank = event.feedback_kind in {"reject_option", "request_alternatives"}
     current_stage = "ranking" if rerank else "decision_checkpoint"
@@ -501,7 +514,7 @@ def _build_planner_turn(
                 "feedback_kind": event.feedback_kind,
                 "autonomy_feedback_kinds": list(event.autonomy_feedback_kinds),
                 "target_research_passes": autonomy_profile.behavior_for_stage(
-                    "inventory_selection"
+                    trip_stage
                 ).target_research_passes,
             },
         ),
@@ -587,7 +600,8 @@ def _build_planner_turn(
                     payload={
                         "selected_option_id": presentation.selected_option_id or "",
                         "pending_decision_ids": [
-                            decision.decision_id for decision in session_state.pending_decisions
+                            decision.decision_id
+                            for decision in session_state.pending_decisions
                         ],
                     },
                 )
@@ -635,7 +649,7 @@ def _build_planner_turn(
         current_stage=current_stage,
         status=status,
         recorded_at=generated_at,
-        pending_decisions=[],
+        pending_decisions=_map_pending_decisions(session_state.pending_decisions),
         open_action_ids=[
             action.action_id
             for action in actions
@@ -689,6 +703,46 @@ def _build_planner_turn(
             f"presentation:{presentation.presentation_id}",
         ],
     )
+
+
+def _map_pending_decisions(
+    session_decisions: list[SessionPendingDecision],
+) -> list[PendingDecision]:
+    decisions: list[PendingDecision] = []
+    for session_decision in session_decisions:
+        choices = [
+            DecisionOption(
+                choice_id=f"{session_decision.decision_id}:choice:{index + 1}",
+                label=choice,
+                recommended=index == 0,
+            )
+            for index, choice in enumerate(session_decision.choices)
+        ]
+        selected_choice_id = None
+        if session_decision.selected_choice is not None:
+            for choice in choices:
+                if choice.label == session_decision.selected_choice:
+                    selected_choice_id = choice.choice_id
+                    break
+        related_option_ids = []
+        if session_decision.related_option_set_id is not None:
+            related_option_ids.append(session_decision.related_option_set_id)
+        if session_decision.related_saved_scenario_id is not None:
+            related_option_ids.append(session_decision.related_saved_scenario_id)
+        decisions.append(
+            PendingDecision(
+                decision_id=session_decision.decision_id,
+                prompt=session_decision.prompt,
+                requested_at=session_decision.created_at,
+                choices=choices,
+                blocking=session_decision.blocking,
+                selected_choice_id=selected_choice_id,
+                due_by=session_decision.due_by,
+                notes=list(session_decision.notes),
+                related_option_ids=related_option_ids,
+            )
+        )
+    return decisions
 
 
 def _comparison_summary(comparison_depth: str) -> str:

--- a/trip_planner/orchestration/feedback.py
+++ b/trip_planner/orchestration/feedback.py
@@ -1,0 +1,707 @@
+"""Option-presentation feedback loop scaffolds for leisure planning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_optional_non_empty,
+)
+from trip_planner.preferences import (
+    AutonomyFeedback,
+    PlanningAutonomyProfile,
+    RevealedPreferenceSignal,
+    RevealedPreferenceUpdate,
+    build_revealed_preference_update,
+)
+from trip_planner.preferences.autonomy import AUTONOMY_FEEDBACK_KINDS
+from trip_planner.preferences.models import LeisurePreferenceProfile
+from trip_planner.state import (
+    ActivityLogEvent,
+    OptionPresentationRecord,
+    PlanningInteractionState,
+    PlanningSessionState,
+)
+
+from .models import (
+    NextStepSummary,
+    PlannerAction,
+    PlannerOutput,
+    PlannerTurn,
+    WorkflowStateSnapshot,
+    WorkflowTransition,
+)
+
+FEEDBACK_KINDS: tuple[str, ...] = (
+    "accept_option",
+    "reject_option",
+    "request_alternatives",
+    "save_as_fallback",
+)
+COMPARISON_DEPTHS: tuple[str, ...] = (
+    "quick_preference_check",
+    "inventory_narrowing",
+)
+
+
+def _require_axis_mapping(values: dict[str, float], field_name: str) -> None:
+    if not isinstance(values, dict):
+        raise ValueError(f"{field_name} must be a mapping")
+    for key, value in values.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+        if not isinstance(value, int | float):
+            raise ValueError(f"{field_name}[{key}] must be numeric")
+        if not -1.0 <= float(value) <= 1.0:
+            raise ValueError(f"{field_name}[{key}] must be between -1.0 and 1.0")
+
+
+@dataclass(slots=True)
+class FeedbackLoopContext:
+    """Typed inputs required to route one feedback event through orchestration."""
+
+    preference_profile: LeisurePreferenceProfile
+    session_state: PlanningSessionState
+    autonomy_profile: PlanningAutonomyProfile
+    generated_at: str
+    trip_stage: str = "inventory_selection"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.preference_profile, LeisurePreferenceProfile):
+            raise ValueError("preference_profile must be a LeisurePreferenceProfile")
+        if not isinstance(self.session_state, PlanningSessionState):
+            raise ValueError("session_state must be a PlanningSessionState")
+        if not isinstance(self.autonomy_profile, PlanningAutonomyProfile):
+            raise ValueError("autonomy_profile must be a PlanningAutonomyProfile")
+        if self.session_state.mode != "leisure":
+            raise ValueError("session_state must represent a leisure session")
+        require_non_empty(self.generated_at, "generated_at")
+
+
+@dataclass(slots=True)
+class OptionFeedbackEvent:
+    """Structured feedback captured from one option-presentation touchpoint."""
+
+    feedback_event_id: str
+    presentation_id: str
+    feedback_kind: str
+    option_id: str
+    summary: str
+    comparison_depth: str = "quick_preference_check"
+    signal_strength: float = 0.75
+    dimension_biases: dict[str, float] = field(default_factory=dict)
+    hybrid_biases: dict[str, float] = field(default_factory=dict)
+    autonomy_feedback_kinds: list[str] = field(default_factory=list)
+    fallback_saved_scenario_id: str | None = None
+    fallback_title: str | None = None
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.feedback_event_id, "feedback_event_id")
+        require_non_empty(self.presentation_id, "presentation_id")
+        require_non_empty(self.option_id, "option_id")
+        require_non_empty(self.summary, "summary")
+        if self.feedback_kind not in FEEDBACK_KINDS:
+            raise ValueError(f"feedback_kind must be one of {FEEDBACK_KINDS}")
+        if self.comparison_depth not in COMPARISON_DEPTHS:
+            raise ValueError(f"comparison_depth must be one of {COMPARISON_DEPTHS}")
+        if not 0.0 <= self.signal_strength <= 1.0:
+            raise ValueError("signal_strength must be between 0.0 and 1.0")
+        _require_axis_mapping(self.dimension_biases, "dimension_biases")
+        _require_axis_mapping(self.hybrid_biases, "hybrid_biases")
+        for kind in self.autonomy_feedback_kinds:
+            if kind not in AUTONOMY_FEEDBACK_KINDS:
+                raise ValueError(
+                    "autonomy_feedback_kinds must contain supported autonomy feedback"
+                )
+        require_optional_non_empty(
+            self.fallback_saved_scenario_id,
+            "fallback_saved_scenario_id",
+        )
+        require_optional_non_empty(self.fallback_title, "fallback_title")
+        if self.feedback_kind == "save_as_fallback":
+            if self.fallback_saved_scenario_id is None:
+                raise ValueError(
+                    "save_as_fallback requires fallback_saved_scenario_id"
+                )
+            if self.fallback_title is None:
+                raise ValueError("save_as_fallback requires fallback_title")
+
+
+@dataclass(slots=True)
+class ScenarioCaptureRequest:
+    """Structured scenario-persistence request emitted by the feedback loop."""
+
+    saved_scenario_id: str
+    trip_id: str
+    title: str
+    label: str
+    requested_at: str
+    option_id: str
+    option_set_id: str
+    based_on_saved_scenario_id: str | None = None
+    summary: str = ""
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.saved_scenario_id, "saved_scenario_id")
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.title, "title")
+        require_non_empty(self.label, "label")
+        require_non_empty(self.requested_at, "requested_at")
+        require_non_empty(self.option_id, "option_id")
+        require_non_empty(self.option_set_id, "option_set_id")
+        require_optional_non_empty(
+            self.based_on_saved_scenario_id,
+            "based_on_saved_scenario_id",
+        )
+        if self.label != "fallback":
+            raise ValueError("ScenarioCaptureRequest currently supports fallback saves")
+
+
+@dataclass(slots=True)
+class FeedbackLoopResult:
+    """Planner-turn scaffold plus the state updates implied by one feedback event."""
+
+    planner_turn: PlannerTurn
+    updated_session_state: PlanningSessionState
+    activity_event: ActivityLogEvent
+    updated_autonomy_profile: PlanningAutonomyProfile
+    revealed_preference_updates: list[RevealedPreferenceUpdate] = field(
+        default_factory=list
+    )
+    scenario_capture_request: ScenarioCaptureRequest | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.planner_turn, PlannerTurn):
+            raise ValueError("planner_turn must be a PlannerTurn")
+        if not isinstance(self.updated_session_state, PlanningSessionState):
+            raise ValueError("updated_session_state must be a PlanningSessionState")
+        if not isinstance(self.activity_event, ActivityLogEvent):
+            raise ValueError("activity_event must be an ActivityLogEvent")
+        if not isinstance(self.updated_autonomy_profile, PlanningAutonomyProfile):
+            raise ValueError(
+                "updated_autonomy_profile must be a PlanningAutonomyProfile"
+            )
+        if any(
+            not isinstance(item, RevealedPreferenceUpdate)
+            for item in self.revealed_preference_updates
+        ):
+            raise ValueError(
+                "revealed_preference_updates must contain RevealedPreferenceUpdate instances"
+            )
+
+
+def build_feedback_loop_result(
+    context: FeedbackLoopContext,
+    event: OptionFeedbackEvent,
+) -> FeedbackLoopResult:
+    """Build a first-pass feedback routing turn and its implied state deltas."""
+
+    presentation = _select_presentation(context.session_state, event.presentation_id)
+    if event.option_id not in presentation.surfaced_option_ids:
+        raise ValueError("event.option_id must be one of surfaced_option_ids")
+
+    updated_presentation = _apply_feedback_to_presentation(presentation, event)
+    updated_session_state = replace(
+        context.session_state,
+        updated_at=context.generated_at,
+        recent_option_presentations=[
+            updated_presentation
+            if item.presentation_id == presentation.presentation_id
+            else item
+            for item in context.session_state.recent_option_presentations
+        ],
+    )
+
+    revealed_update = build_revealed_preference_update(
+        context.preference_profile,
+        _build_revealed_signal(context, updated_presentation, event),
+    )
+    updated_autonomy = _apply_autonomy_feedback(context, event)
+    updated_session_state = replace(
+        updated_session_state,
+        interaction_state=_interaction_state_from_behavior(
+            updated_session_state.interaction_state,
+            updated_autonomy,
+            context.trip_stage,
+            event.autonomy_feedback_kinds,
+        ),
+    )
+    updated_session_state = replace(
+        updated_session_state,
+        pending_decisions=_updated_pending_decisions(updated_session_state, event),
+        notes=_session_notes(updated_session_state, event),
+    )
+
+    scenario_capture_request = _build_scenario_capture_request(
+        updated_session_state,
+        updated_presentation,
+        event,
+        context.generated_at,
+    )
+    activity_event = _build_activity_event(
+        updated_session_state,
+        updated_presentation,
+        event,
+        scenario_capture_request,
+        context.generated_at,
+    )
+    planner_turn = _build_planner_turn(
+        updated_session_state,
+        updated_presentation,
+        event,
+        updated_autonomy,
+        activity_event,
+        scenario_capture_request,
+        context.generated_at,
+    )
+
+    return FeedbackLoopResult(
+        planner_turn=planner_turn,
+        updated_session_state=updated_session_state,
+        activity_event=activity_event,
+        updated_autonomy_profile=updated_autonomy,
+        revealed_preference_updates=[revealed_update],
+        scenario_capture_request=scenario_capture_request,
+    )
+
+
+def _select_presentation(
+    session_state: PlanningSessionState, presentation_id: str
+) -> OptionPresentationRecord:
+    for presentation in session_state.recent_option_presentations:
+        if presentation.presentation_id == presentation_id:
+            return presentation
+    raise ValueError("presentation_id must match a recent_option_presentations entry")
+
+
+def _apply_feedback_to_presentation(
+    presentation: OptionPresentationRecord,
+    event: OptionFeedbackEvent,
+) -> OptionPresentationRecord:
+    rejected_option_ids = list(presentation.rejected_option_ids)
+    selected_option_id = presentation.selected_option_id
+    notes = list(presentation.notes)
+
+    if event.feedback_kind in {"reject_option", "request_alternatives"}:
+        if event.option_id not in rejected_option_ids:
+            rejected_option_ids.append(event.option_id)
+        if selected_option_id == event.option_id:
+            selected_option_id = None
+    else:
+        selected_option_id = event.option_id
+        rejected_option_ids = [
+            option_id for option_id in rejected_option_ids if option_id != event.option_id
+        ]
+
+    notes.append(f"feedback:{event.feedback_kind}:{event.summary}")
+
+    return replace(
+        presentation,
+        selected_option_id=selected_option_id,
+        rejected_option_ids=rejected_option_ids,
+        notes=notes,
+        summary=event.summary,
+    )
+
+
+def _build_revealed_signal(
+    context: FeedbackLoopContext,
+    presentation: OptionPresentationRecord,
+    event: OptionFeedbackEvent,
+) -> RevealedPreferenceSignal:
+    reaction_type = {
+        "accept_option": "selected",
+        "reject_option": "rejected",
+        "request_alternatives": "requested_less_like_this",
+        "save_as_fallback": "saved_for_later",
+    }[event.feedback_kind]
+    return RevealedPreferenceSignal(
+        signal_id=f"{event.feedback_event_id}:revealed",
+        trip_stage=context.trip_stage,
+        reaction_type=reaction_type,
+        option_set_id=presentation.option_set_id,
+        option_id=event.option_id,
+        option_kind="destination_bundle",
+        signal_strength=event.signal_strength,
+        dimension_biases=event.dimension_biases,
+        hybrid_biases=event.hybrid_biases,
+        summary=event.summary,
+    )
+
+
+def _apply_autonomy_feedback(
+    context: FeedbackLoopContext,
+    event: OptionFeedbackEvent,
+) -> PlanningAutonomyProfile:
+    updated = context.autonomy_profile
+    for feedback_kind in event.autonomy_feedback_kinds:
+        updated = updated.apply_feedback(
+            AutonomyFeedback(
+                feedback_kind=feedback_kind,
+                trip_stage=context.trip_stage,
+                note=event.summary,
+            )
+        )
+    return updated
+
+
+def _interaction_state_from_behavior(
+    previous: PlanningInteractionState,
+    autonomy_profile: PlanningAutonomyProfile,
+    trip_stage: str,
+    autonomy_feedback_kinds: list[str],
+) -> PlanningInteractionState:
+    behavior = autonomy_profile.behavior_for_stage(trip_stage)
+    preference = autonomy_profile.preference_for_stage(trip_stage)
+    notes = list(previous.notes)
+    if autonomy_feedback_kinds:
+        notes.append("feedback-loop updated planner autonomy pacing.")
+    return replace(
+        previous,
+        initiative_level=_initiative_level_from_preference(preference.system_initiative),
+        checkpoint_frequency=(
+            "phase" if behavior.ask_before_next_major_change else "manual"
+        ),
+        option_preview_timing="early" if behavior.surface_options_early else "balanced",
+        auto_advance_research_passes=behavior.target_research_passes,
+        ask_before_major_change=behavior.ask_before_next_major_change,
+        notes=notes,
+    )
+
+
+def _initiative_level_from_preference(system_initiative: float) -> str:
+    if system_initiative >= 0.85:
+        return "planner_first"
+    if system_initiative >= 0.65:
+        return "planner_led"
+    if system_initiative <= 0.25:
+        return "user_led"
+    return "balanced"
+
+
+def _updated_pending_decisions(
+    session_state: PlanningSessionState,
+    event: OptionFeedbackEvent,
+) -> list[Any]:
+    if event.feedback_kind in {"reject_option", "request_alternatives"}:
+        return []
+    return list(session_state.pending_decisions)
+
+
+def _session_notes(
+    session_state: PlanningSessionState,
+    event: OptionFeedbackEvent,
+) -> list[str]:
+    notes = list(session_state.notes)
+    notes.append(
+        f"feedback-loop:{event.feedback_kind}:{event.comparison_depth}:{event.option_id}"
+    )
+    return notes
+
+
+def _build_scenario_capture_request(
+    session_state: PlanningSessionState,
+    presentation: OptionPresentationRecord,
+    event: OptionFeedbackEvent,
+    generated_at: str,
+) -> ScenarioCaptureRequest | None:
+    if event.feedback_kind != "save_as_fallback":
+        return None
+    return ScenarioCaptureRequest(
+        saved_scenario_id=event.fallback_saved_scenario_id or "",
+        trip_id=session_state.trip_id,
+        title=event.fallback_title or "",
+        label="fallback",
+        requested_at=generated_at,
+        option_id=event.option_id,
+        option_set_id=presentation.option_set_id,
+        based_on_saved_scenario_id=session_state.current_saved_scenario_id,
+        summary=event.summary,
+    )
+
+
+def _build_activity_event(
+    session_state: PlanningSessionState,
+    presentation: OptionPresentationRecord,
+    event: OptionFeedbackEvent,
+    scenario_capture_request: ScenarioCaptureRequest | None,
+    generated_at: str,
+) -> ActivityLogEvent:
+    event_kind = {
+        "accept_option": "decision_recorded",
+        "reject_option": "rerank_requested",
+        "request_alternatives": "rerank_requested",
+        "save_as_fallback": "scenario_saved",
+    }[event.feedback_kind]
+    return ActivityLogEvent(
+        activity_event_id=f"{event.feedback_event_id}:activity",
+        trip_id=session_state.trip_id,
+        session_state_id=session_state.session_state_id,
+        occurred_at=generated_at,
+        event_kind=event_kind,
+        summary=event.summary,
+        actor="planner",
+        related_option_set_id=presentation.option_set_id,
+        saved_scenario_id=(
+            scenario_capture_request.saved_scenario_id
+            if scenario_capture_request is not None
+            else None
+        ),
+        metadata={
+            "feedback_kind": event.feedback_kind,
+            "comparison_depth": event.comparison_depth,
+            "option_id": event.option_id,
+        },
+        tags=["feedback-loop", event.feedback_kind],
+    )
+
+
+def _build_planner_turn(
+    session_state: PlanningSessionState,
+    presentation: OptionPresentationRecord,
+    event: OptionFeedbackEvent,
+    autonomy_profile: PlanningAutonomyProfile,
+    activity_event: ActivityLogEvent,
+    scenario_capture_request: ScenarioCaptureRequest | None,
+    generated_at: str,
+) -> PlannerTurn:
+    rerank = event.feedback_kind in {"reject_option", "request_alternatives"}
+    current_stage = "ranking" if rerank else "decision_checkpoint"
+    status = "active" if not session_state.pending_decisions else "waiting_on_user"
+    action_ids = {
+        "collect": "action-collect-feedback-context",
+        "update": "action-refresh-revealed-preferences",
+        "rank": "action-rank-options",
+        "save": "action-persist-fallback",
+        "decision": "action-request-decision",
+    }
+    actions = [
+        PlannerAction(
+            action_id=action_ids["collect"],
+            action_kind="collect_context",
+            title="Capture the latest option-presentation feedback",
+            stage=current_stage,
+            status="completed",
+            payload={
+                "presentation_id": presentation.presentation_id,
+                "option_set_id": presentation.option_set_id,
+                "comparison_depth": event.comparison_depth,
+            },
+        ),
+        PlannerAction(
+            action_id=action_ids["update"],
+            action_kind="refresh_preferences",
+            title="Route revealed-preference and autonomy feedback into planning state",
+            stage="objective_derivation",
+            status="completed",
+            depends_on_action_ids=[action_ids["collect"]],
+            payload={
+                "feedback_kind": event.feedback_kind,
+                "autonomy_feedback_kinds": list(event.autonomy_feedback_kinds),
+                "target_research_passes": autonomy_profile.behavior_for_stage(
+                    "inventory_selection"
+                ).target_research_passes,
+            },
+        ),
+    ]
+    outputs: list[PlannerOutput] = []
+
+    if rerank:
+        actions.append(
+            PlannerAction(
+                action_id=action_ids["rank"],
+                action_kind="rank_options",
+                title="Refresh the ranked option set after explicit traveler feedback",
+                stage="ranking",
+                status="in_progress",
+                depends_on_action_ids=[action_ids["update"]],
+                payload={
+                    "requested_alternatives": event.feedback_kind
+                    == "request_alternatives",
+                    "rejected_option_ids": list(presentation.rejected_option_ids),
+                    "comparison_depth": event.comparison_depth,
+                },
+            )
+        )
+        outputs.extend(
+            [
+                PlannerOutput(
+                    output_id="output-feedback-warning",
+                    output_kind="warning",
+                    title="Feedback loop requested a rerank",
+                    emitted_at=generated_at,
+                    surface="planner_chat",
+                    summary=event.summary,
+                    warnings=["feedback_rerank_requested"],
+                    payload={
+                        "activity_event_id": activity_event.activity_event_id,
+                        "presentation_id": presentation.presentation_id,
+                    },
+                ),
+                PlannerOutput(
+                    output_id="output-feedback-status",
+                    output_kind="status_update",
+                    title="Ranking refresh is queued with explicit feedback context",
+                    emitted_at=generated_at,
+                    surface="side_panel",
+                    summary=_comparison_summary(event.comparison_depth),
+                    payload={
+                        "comparison_depth": event.comparison_depth,
+                        "feedback_kind": event.feedback_kind,
+                    },
+                ),
+            ]
+        )
+        recommended_action_id = action_ids["rank"]
+    else:
+        if scenario_capture_request is not None:
+            actions.append(
+                PlannerAction(
+                    action_id=action_ids["save"],
+                    action_kind="persist_state",
+                    title="Persist the selected option as an explicit fallback scenario",
+                    stage="decision_checkpoint",
+                    status="in_progress",
+                    depends_on_action_ids=[action_ids["update"]],
+                    payload={
+                        "saved_scenario_id": scenario_capture_request.saved_scenario_id,
+                        "label": scenario_capture_request.label,
+                        "based_on_saved_scenario_id": (
+                            scenario_capture_request.based_on_saved_scenario_id or ""
+                        ),
+                    },
+                )
+            )
+            recommended_action_id = action_ids["save"]
+        else:
+            actions.append(
+                PlannerAction(
+                    action_id=action_ids["decision"],
+                    action_kind="request_decision",
+                    title="Carry the accepted option forward into the next checkpoint",
+                    stage="decision_checkpoint",
+                    status="in_progress",
+                    depends_on_action_ids=[action_ids["update"]],
+                    payload={
+                        "selected_option_id": presentation.selected_option_id or "",
+                        "pending_decision_ids": [
+                            decision.decision_id for decision in session_state.pending_decisions
+                        ],
+                    },
+                )
+            )
+            recommended_action_id = action_ids["decision"]
+        outputs.append(
+            PlannerOutput(
+                output_id="output-feedback-status",
+                output_kind="status_update",
+                title="Feedback was captured as structured workflow state",
+                emitted_at=generated_at,
+                surface="planner_chat",
+                summary=event.summary,
+                payload={
+                    "selected_option_id": presentation.selected_option_id or "",
+                    "comparison_depth": event.comparison_depth,
+                },
+            )
+        )
+        if scenario_capture_request is not None:
+            outputs.append(
+                PlannerOutput(
+                    output_id="output-fallback-capture",
+                    output_kind="decision_request",
+                    title="Fallback capture request is ready for persistence",
+                    emitted_at=generated_at,
+                    surface="side_panel",
+                    summary=(
+                        f"{scenario_capture_request.title} stays explicit without"
+                        " replacing the baseline scenario."
+                    ),
+                    ref_ids=[scenario_capture_request.saved_scenario_id],
+                    payload={
+                        "saved_scenario_id": scenario_capture_request.saved_scenario_id,
+                        "label": scenario_capture_request.label,
+                    },
+                )
+            )
+
+    workflow_state = WorkflowStateSnapshot(
+        workflow_state_id=f"workflow-state:{session_state.session_state_id}:feedback-loop",
+        trip_id=session_state.trip_id,
+        mode="leisure",
+        workflow_kind="leisure_planning",
+        current_stage=current_stage,
+        status=status,
+        recorded_at=generated_at,
+        pending_decisions=[],
+        open_action_ids=[
+            action.action_id
+            for action in actions
+            if action.status in {"pending", "in_progress"}
+        ],
+        completed_action_ids=[
+            action.action_id
+            for action in actions
+            if action.status in {"completed", "skipped"}
+        ],
+        recent_output_ids=[output.output_id for output in outputs],
+        notes=[
+            "Feedback loop routes concrete option reactions through explicit workflow state.",
+            f"comparison_depth:{event.comparison_depth}",
+        ],
+        tags=["leisure", "feedback-loop", event.feedback_kind],
+    )
+    next_step = NextStepSummary(
+        headline=_next_step_headline(event),
+        recommended_action_id=recommended_action_id,
+        expected_output_ids=[output.output_id for output in outputs],
+        notes=[
+            _comparison_summary(event.comparison_depth),
+            f"activity_event:{activity_event.activity_event_id}",
+        ],
+    )
+    transition = WorkflowTransition(
+        from_stage="decision_checkpoint" if rerank else "ranking",
+        to_stage=current_stage,
+        trigger="decision_response",
+        changed_at=generated_at,
+        reason=event.summary,
+        changed_by="planner",
+        warning_codes=["feedback_rerank_requested"] if rerank else [],
+    )
+
+    return PlannerTurn(
+        turn_id=f"planner-turn:{session_state.trip_id}:feedback-loop:{generated_at}",
+        trip_id=session_state.trip_id,
+        mode="leisure",
+        workflow_kind="leisure_planning",
+        turn_kind="planning_pass" if rerank else "decision_checkpoint",
+        started_at=generated_at,
+        workflow_state=workflow_state,
+        transition=transition,
+        next_step=next_step,
+        actions=actions,
+        outputs=outputs,
+        notes=[
+            "Planner feedback remains explicit workflow logic instead of loose chat state.",
+            f"presentation:{presentation.presentation_id}",
+        ],
+    )
+
+
+def _comparison_summary(comparison_depth: str) -> str:
+    if comparison_depth == "quick_preference_check":
+        return "Quick preference-learning comparisons should feed the next surfaced options."
+    return "Inventory-narrowing comparisons should refresh the ranked candidate set."
+
+
+def _next_step_headline(event: OptionFeedbackEvent) -> str:
+    if event.feedback_kind == "request_alternatives":
+        return "Refresh the option set with explicit alternatives."
+    if event.feedback_kind == "reject_option":
+        return "Rerank the current option set after a concrete rejection."
+    if event.feedback_kind == "save_as_fallback":
+        return "Persist the selected option as a durable fallback scenario."
+    return "Carry the accepted option into the next structured checkpoint."


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #546

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner is supposed to learn from concrete option choices, not just from abstract answers. Once orchestration exists, the repo still needs a dedicated feedback-loop scaffold that turns option presentations, accept/reject decisions, preference adjustments, and scenario saves into structured updates rather than ad hoc conversation state.

Parent epic: #543

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#543](https://github.com/stranske/trip-planner/issues/543)
- [#508](https://github.com/stranske/trip-planner/issues/508)
- [#511](https://github.com/stranske/trip-planner/issues/511)
- [#530](https://github.com/stranske/trip-planner/issues/530)
- [#542](https://github.com/stranske/trip-planner/issues/542)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement a feedback-loop scaffold that can issue option presentations, capture accept/reject/modify signals, and route those signals into revealed-preference updates, ranking refreshes, or scenario saves.
- [x] Ensure the scaffold can represent both quick preference-learning comparisons and deeper inventory-narrowing comparisons.
- [x] Add support for feedback like “do more before asking again,” “show me alternatives,” and “save this as fallback” as structured orchestration actions.
- [x] Add representative fixtures for at least: a simple option accept, a reject-and-rerank cycle, and a save-as-fallback flow.
- [x] Write unit tests covering feedback capture, state updates, malformed feedback events, and loop re-entry behavior.
- [x] Document how this scaffold connects preference-learning updates, candidate generation, and saved scenarios.

#### Acceptance criteria
- [x] The repo contains a first-pass feedback-loop scaffold for option presentation and revealed-preference updates.
- [x] The scaffold can route structured feedback into profile updates, reranking, or scenario persistence.
- [x] Tests cover representative accept, reject, and revise flows plus malformed feedback cases.
- [x] The resulting state changes are compatible with saved planning-session and scenario layers.
- [x] Documentation makes clear that feedback handling is structured workflow logic, not just loose conversation state.

<!-- auto-status-summary:end -->