### PR TITLE
Issue #548: build business orchestration scaffold

### DIFF
--- a/docs/business-orchestration-boundary.md
+++ b/docs/business-orchestration-boundary.md
@@ -1,0 +1,34 @@
+# Business Orchestration Boundary
+
+Issue #548 introduces the business-planning orchestration scaffold that sits between deterministic business objectives and the external policy-evaluation system.
+
+## In Scope
+
+- Convert persisted trip state, business profiles, planning objectives, comparable coverage, and optional proposal packets into an explicit business planner turn.
+- Represent the major business phases directly:
+  - profile confirmation
+  - policy-input assembly
+  - comparable collection
+  - ranked-option review
+  - proposal preparation
+  - fallback or exception preparation
+- Keep compliant-first and exception-nearest paths inspectable instead of collapsing them into generic planner notes.
+- Surface missing policy-ready inputs and comparable shortfalls as structured pending decisions so later runs and UIs can track them deterministically.
+- Emit policy-packet outputs that point back to saved-state layers such as `policy_state_id`, `saved_scenario_ids`, and ranked option-set references.
+
+## Out Of Scope
+
+- Final policy evaluation or approval execution.
+- Live booking, ERP, or travel-management integrations.
+- Replacing the business objective derivation layer, ranking engines, or the separate policy system.
+
+## Contract Position
+
+`PersistedTripRecord` + `BusinessTravelProfile` + `BusinessPlanningObjectives`
+-> `BusinessWorkflowContext`
+-> `PlannerTurn`
+-> proposal-preparation / saved-state persistence / external policy evaluation
+
+The orchestration layer owns progression and packaging. It decides what stage the business workflow is in, what information is still missing, whether the run is staying compliant-first or carrying an explicit exception-nearest branch, and what packet should be prepared next.
+
+The orchestration layer does not decide whether a proposal is finally approved. It prepares policy-ready state and then hands that packet to the external policy-evaluation system.

--- a/scripts/langchain/capability_check.py
+++ b/scripts/langchain/capability_check.py
@@ -139,9 +139,7 @@ def _build_llm_config(
     issue_or_pr = (
         str(issue_number)
         if issue_number is not None
-        else env_issue
-        if env_issue.isdigit()
-        else "unknown"
+        else env_issue if env_issue.isdigit() else "unknown"
     )
     metadata = {
         "repo": repo,

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -931,9 +931,7 @@ def _build_llm_config(
         issue_or_pr = (
             env_pr
             if env_pr.isdigit()
-            else env_issue
-            if env_issue.isdigit()
-            else "unknown"
+            else env_issue if env_issue.isdigit() else "unknown"
         )
     metadata = {
         "repo": repo,

--- a/scripts/langchain/issue_optimizer.py
+++ b/scripts/langchain/issue_optimizer.py
@@ -329,9 +329,7 @@ def _build_llm_config(
     issue_or_pr = (
         str(issue_number)
         if issue_number is not None
-        else env_issue
-        if env_issue.isdigit()
-        else "unknown"
+        else env_issue if env_issue.isdigit() else "unknown"
     )
     metadata = {
         "repo": repo,

--- a/scripts/langchain/pr_verifier.py
+++ b/scripts/langchain/pr_verifier.py
@@ -499,9 +499,7 @@ def _build_llm_config(
         issue_or_pr = (
             env_pr
             if env_pr.isdigit()
-            else env_issue
-            if env_issue.isdigit()
-            else "unknown"
+            else env_issue if env_issue.isdigit() else "unknown"
         )
     metadata = {
         "repo": repo,

--- a/tests/fixtures/orchestration/business/compliant_flow.json
+++ b/tests/fixtures/orchestration/business/compliant_flow.json
@@ -1,0 +1,46 @@
+{
+  "generated_at": "2026-04-02T18:00:00Z",
+  "trip_fixture": "business_active_trip.json",
+  "profile_fixture": "conference_profile.json",
+  "policy_fixture": "policy_round_trip_compliant.json",
+  "proposal_policy_fixture": "policy_round_trip_compliant.json",
+  "selected_path": "compliant_first",
+  "collected_policy_inputs": {
+    "conference relevance": "Conference sessions support FY26 partner roadmap priorities.",
+    "expected partner meetings": "Three partner meetings and one sponsor briefing are scheduled onsite."
+  },
+  "comparable_inventory": {
+    "airfare": 2,
+    "lodging": 2
+  },
+  "trip_overrides": {
+    "trip": {
+      "trip_id": "trip-business-conference-001",
+      "title": "Conference partner summit",
+      "summary": "Conference travel packet under active review.",
+      "artifacts": {
+        "objective_id": "objective:conference-001",
+        "option_set_ids": [
+          "option-set:conference-airfare",
+          "option-set:conference-lodging"
+        ],
+        "policy_state_id": "policy-state:conference-001"
+      }
+    },
+    "artifact_refs": {
+      "objective_id": "objective:conference-001",
+      "option_set_ids": [
+        "option-set:conference-airfare",
+        "option-set:conference-lodging"
+      ],
+      "ranked_result_set_id": "ranked-results:conference-001",
+      "scenario_search_id": "scenario-search:conference-001",
+      "saved_scenario_ids": [
+        "saved-scenario:conference-compliant"
+      ],
+      "policy_state_id": "policy-state:conference-001",
+      "session_state_id": "session-state:conference-001",
+      "activity_log_id": "activity-log:conference-001"
+    }
+  }
+}

--- a/tests/fixtures/orchestration/business/exception_prep_flow.json
+++ b/tests/fixtures/orchestration/business/exception_prep_flow.json
@@ -1,0 +1,51 @@
+{
+  "generated_at": "2026-04-02T18:40:00Z",
+  "trip_fixture": "business_active_trip.json",
+  "profile_fixture": "site_visit_profile.json",
+  "policy_fixture": "policy_round_trip_exception.json",
+  "proposal_policy_fixture": "policy_round_trip_exception.json",
+  "selected_path": "exception_nearest",
+  "collected_policy_inputs": {
+    "site access necessity": "The audit requires on-site inspection across two facilities.",
+    "inspection schedule rigidity": "Primary access begins at 07:30 and cannot move.",
+    "exception rationale": "An extra lodging night prevents unsafe overnight driving before the audit."
+  },
+  "comparable_inventory": {
+    "airfare": 2,
+    "lodging": 2,
+    "car_rental": 2
+  },
+  "trip_overrides": {
+    "trip": {
+      "trip_id": "trip-business-site-visit-001",
+      "title": "Operational audit site visit",
+      "summary": "Exception-nearest planning packet for fatigue-safe routing.",
+      "artifacts": {
+        "objective_id": "objective:site-visit-001",
+        "option_set_ids": [
+          "option-set:site-visit-airfare",
+          "option-set:site-visit-lodging",
+          "option-set:site-visit-car"
+        ],
+        "policy_state_id": "policy-state:site-visit-001"
+      }
+    },
+    "artifact_refs": {
+      "objective_id": "objective:site-visit-001",
+      "option_set_ids": [
+        "option-set:site-visit-airfare",
+        "option-set:site-visit-lodging",
+        "option-set:site-visit-car"
+      ],
+      "ranked_result_set_id": "ranked-results:site-visit-001",
+      "scenario_search_id": "scenario-search:site-visit-001",
+      "saved_scenario_ids": [
+        "saved-scenario:site-visit-compliant",
+        "saved-scenario:site-visit-exception"
+      ],
+      "policy_state_id": "policy-state:site-visit-001",
+      "session_state_id": "session-state:site-visit-001",
+      "activity_log_id": "activity-log:site-visit-001"
+    }
+  }
+}

--- a/tests/fixtures/orchestration/business/missing_comparables_flow.json
+++ b/tests/fixtures/orchestration/business/missing_comparables_flow.json
@@ -1,0 +1,47 @@
+{
+  "generated_at": "2026-04-02T18:20:00Z",
+  "trip_fixture": "business_active_trip.json",
+  "profile_fixture": "client_meeting_profile.json",
+  "policy_fixture": "policy_round_trip_exception.json",
+  "selected_path": "compliant_first",
+  "collected_policy_inputs": {
+    "client importance": "Renewal meeting controls the account expansion decision."
+  },
+  "comparable_inventory": {
+    "airfare": 1,
+    "lodging": 1,
+    "ground_transport": 0
+  },
+  "trip_overrides": {
+    "trip": {
+      "trip_id": "trip-business-client-renewal-001",
+      "title": "Client renewal negotiation",
+      "summary": "Business planning is still collecting compliant comparables.",
+      "artifacts": {
+        "objective_id": "objective:client-renewal-001",
+        "option_set_ids": [
+          "option-set:client-renewal-air",
+          "option-set:client-renewal-lodging",
+          "option-set:client-renewal-ground"
+        ],
+        "policy_state_id": "policy-state:client-renewal-001"
+      }
+    },
+    "artifact_refs": {
+      "objective_id": "objective:client-renewal-001",
+      "option_set_ids": [
+        "option-set:client-renewal-air",
+        "option-set:client-renewal-lodging",
+        "option-set:client-renewal-ground"
+      ],
+      "ranked_result_set_id": "ranked-results:client-renewal-001",
+      "scenario_search_id": "scenario-search:client-renewal-001",
+      "saved_scenario_ids": [
+        "saved-scenario:client-renewal-compliant"
+      ],
+      "policy_state_id": "policy-state:client-renewal-001",
+      "session_state_id": "session-state:client-renewal-001",
+      "activity_log_id": "activity-log:client-renewal-001"
+    }
+  }
+}

--- a/tests/itinerary/test_feasibility.py
+++ b/tests/itinerary/test_feasibility.py
@@ -90,9 +90,9 @@ def test_malformed_times_do_not_crash_feasibility_evaluation() -> None:
     payload = json.loads(
         _fixture_path("coherent_low_friction_route.json").read_text(encoding="utf-8")
     )
-    payload["transport_options"][0]["timing_summary"]["arrival_local"] = (
-        "not-a-timestamp"
-    )
+    payload["transport_options"][0]["timing_summary"][
+        "arrival_local"
+    ] = "not-a-timestamp"
     payload["lodging_options"][0]["booking_terms"]["checkin_window"] = "not-a-window"
 
     assessment = evaluate_bundle_feasibility(InventoryBundle.from_dict(payload))
@@ -112,9 +112,9 @@ def test_candidate_seed_uses_representative_travel_totals() -> None:
     alternate_transport["option_id"] = "transport-kyoto-osaka-slow"
     alternate_transport["name"] = "Slow regional detour"
     alternate_transport["timing_summary"]["duration_minutes"] = 480
-    alternate_transport["timing_summary"]["departure_local"] = (
-        "2026-04-10T06:00:00+09:00"
-    )
+    alternate_transport["timing_summary"][
+        "departure_local"
+    ] = "2026-04-10T06:00:00+09:00"
     alternate_transport["timing_summary"]["arrival_local"] = "2026-04-10T14:00:00+09:00"
     alternate_transport["transfer_burden"]["transfer_count"] = 3
     alternate_transport["transfer_burden"]["self_navigation_burden_signal"] = 0.8

--- a/tests/orchestration/test_business_flow.py
+++ b/tests/orchestration/test_business_flow.py
@@ -1,0 +1,179 @@
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from trip_planner.business import (
+    BusinessTravelProfile,
+    PolicyConstraintSet,
+    TripPlanProposal,
+    derive_business_planning_objectives,
+)
+from trip_planner.orchestration import (
+    BUSINESS_PATHS,
+    BusinessWorkflowContext,
+    build_business_planner_turn,
+)
+from trip_planner.state import PersistedTripRecord
+
+
+def _fixture_root() -> Path:
+    return Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _deep_merge(base: dict, overrides: dict) -> dict:
+    merged = deepcopy(base)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def _load_scenario(name: str) -> dict:
+    return _load_json(_fixture_root() / "orchestration" / "business" / name)
+
+
+def _build_context(name: str) -> BusinessWorkflowContext:
+    scenario = _load_scenario(name)
+    trip_payload = _load_json(
+        _fixture_root() / "state" / "trips" / scenario["trip_fixture"]
+    )
+    if "trip_overrides" in scenario:
+        trip_payload = _deep_merge(trip_payload, scenario["trip_overrides"])
+    trip_record = PersistedTripRecord.from_dict(trip_payload)
+
+    profile_payload = _load_json(
+        _fixture_root() / "business" / scenario["profile_fixture"]
+    )
+    profile = BusinessTravelProfile.from_dict(profile_payload)
+
+    policy_payload = _load_json(
+        _fixture_root() / "business" / scenario["policy_fixture"]
+    )
+    constraint_set = PolicyConstraintSet(**policy_payload["constraint_set"])
+    objectives = derive_business_planning_objectives(
+        profile,
+        trip_id=trip_record.trip.trip_id,
+        constraint_set=constraint_set,
+    )
+
+    proposal = None
+    proposal_fixture = scenario.get("proposal_policy_fixture")
+    if proposal_fixture is not None:
+        proposal_payload = _load_json(_fixture_root() / "business" / proposal_fixture)
+        proposal_dict = deepcopy(proposal_payload["proposal"])
+        proposal_dict["trip_id"] = trip_record.trip.trip_id
+        proposal_dict["constraint_set_id"] = constraint_set.policy_id
+        proposal = TripPlanProposal.from_dict(proposal_dict)
+
+    return BusinessWorkflowContext(
+        trip_record=trip_record,
+        business_profile=profile,
+        objectives=objectives,
+        generated_at=scenario["generated_at"],
+        constraint_set=constraint_set,
+        proposal=proposal,
+        comparable_inventory=scenario["comparable_inventory"],
+        collected_policy_inputs=scenario["collected_policy_inputs"],
+        selected_path=scenario["selected_path"],
+    )
+
+
+def test_business_paths_export_expected_values() -> None:
+    assert BUSINESS_PATHS == ("compliant_first", "exception_nearest")
+
+
+def test_compliant_business_flow_transitions_to_policy_ready_booking_prep() -> None:
+    turn = build_business_planner_turn(_build_context("compliant_flow.json"))
+
+    assert turn.turn_kind == "planning_pass"
+    assert turn.workflow_state.current_stage == "booking_prep"
+    assert turn.workflow_state.status == "active"
+    assert turn.next_step.recommended_action_id == "action-persist-business-state"
+    assert turn.outputs[0].output_kind == "policy_summary"
+    assert turn.outputs[0].payload["policy_state_id"] == "policy-state:conference-001"
+    assert turn.outputs[0].payload["saved_scenario_ids"] == [
+        "saved-scenario:conference-compliant"
+    ]
+    assert turn.actions[4].status == "completed"
+    assert turn.actions[6].status == "pending"
+
+
+def test_missing_comparable_flow_surfaces_structured_pending_decisions() -> None:
+    turn = build_business_planner_turn(_build_context("missing_comparables_flow.json"))
+
+    assert turn.turn_kind == "decision_checkpoint"
+    assert turn.workflow_state.current_stage == "objective_derivation"
+    assert turn.workflow_state.status == "waiting_on_user"
+    assert turn.next_step.recommended_action_id == "action-assemble-policy-inputs"
+    assert len(turn.workflow_state.pending_decisions) == 5
+    assert turn.outputs[1].output_kind == "decision_request"
+    assert turn.outputs[2].output_kind == "warning"
+    input_fields = {
+        decision.choices[0].metadata["field"]
+        for decision in turn.workflow_state.pending_decisions
+        if decision.decision_id.startswith("decision:policy-input:")
+    }
+    assert input_fields == {"need for in-person presence", "exception rationale"}
+    comparable_decision = next(
+        decision
+        for decision in turn.workflow_state.pending_decisions
+        if decision.decision_id == "decision:comparables:ground-transport"
+    )
+    assert comparable_decision.choices[0].metadata["required_total"] == 1
+    assert comparable_decision.choices[1].metadata["shortfall"] == 1
+
+
+def test_exception_prep_flow_keeps_exception_nearest_path_explicit() -> None:
+    turn = build_business_planner_turn(_build_context("exception_prep_flow.json"))
+
+    assert turn.workflow_state.current_stage == "policy_alignment"
+    assert turn.workflow_state.status == "active"
+    assert turn.next_step.recommended_action_id == "action-prepare-policy-packet"
+    assert turn.outputs[0].payload["requested_exception_type"] == "fatigue_management"
+    assert turn.outputs[0].payload["required_approval_roles"] == ["finance", "manager"]
+    assert turn.outputs[-1].warnings == ["exception-path-active"]
+    assert "exception_nearest" in turn.workflow_state.tags
+
+
+def test_business_builder_rejects_mismatched_proposal_trip() -> None:
+    context = _build_context("compliant_flow.json")
+    proposal_payload = deepcopy(context.proposal.to_dict()) if context.proposal else {}
+    proposal_payload["trip_id"] = "trip-business-other"
+
+    with pytest.raises(ValueError, match="proposal.trip_id"):
+        BusinessWorkflowContext(
+            trip_record=context.trip_record,
+            business_profile=context.business_profile,
+            objectives=context.objectives,
+            generated_at=context.generated_at,
+            constraint_set=context.constraint_set,
+            proposal=TripPlanProposal.from_dict(proposal_payload),
+            comparable_inventory=context.comparable_inventory,
+            collected_policy_inputs=context.collected_policy_inputs,
+            selected_path=context.selected_path,
+        )
+
+
+def test_business_builder_rejects_unknown_generated_at() -> None:
+    context = _build_context("compliant_flow.json")
+
+    with pytest.raises(ValueError, match="generated_at"):
+        BusinessWorkflowContext(
+            trip_record=context.trip_record,
+            business_profile=context.business_profile,
+            objectives=context.objectives,
+            generated_at="not-a-timestamp",
+            constraint_set=context.constraint_set,
+            proposal=context.proposal,
+            comparable_inventory=context.comparable_inventory,
+            collected_policy_inputs=context.collected_policy_inputs,
+            selected_path=context.selected_path,
+        )

--- a/tests/orchestration/test_business_flow.py
+++ b/tests/orchestration/test_business_flow.py
@@ -129,6 +129,63 @@ def test_missing_comparable_flow_surfaces_structured_pending_decisions() -> None
     )
     assert comparable_decision.choices[0].metadata["required_total"] == 1
     assert comparable_decision.choices[1].metadata["shortfall"] == 1
+    assert turn.actions[5].title == (
+        "Confirm the remaining policy-input and comparable checkpoints"
+    )
+
+
+def test_comparable_only_gap_uses_structured_decision_ids_in_transition_and_warnings() -> None:
+    context = _build_context("missing_comparables_flow.json")
+    context.collected_policy_inputs["need for in-person presence"] = (
+        "Lead negotiator must be physically present for renewal terms."
+    )
+    context.collected_policy_inputs["exception rationale"] = (
+        "Ground transport shortfall is the only remaining exception candidate."
+    )
+
+    turn = build_business_planner_turn(context)
+
+    assert turn.workflow_state.current_stage == "candidate_generation"
+    assert turn.transition.blocker_ids == [
+        "decision:comparables:airfare",
+        "decision:comparables:ground-transport",
+        "decision:comparables:lodging",
+    ]
+    assert turn.transition.warning_codes == [
+        "missing-comparable:airfare",
+        "missing-comparable:ground_transport",
+        "missing-comparable:lodging",
+    ]
+    warning_output = next(
+        output for output in turn.outputs if output.output_kind == "warning"
+    )
+    assert warning_output.warnings == [
+        "missing-comparable:airfare",
+        "missing-comparable:ground_transport",
+        "missing-comparable:lodging",
+    ]
+
+
+def test_exception_path_without_proposal_stays_active_when_fallback_is_available() -> None:
+    context = _build_context("exception_prep_flow.json")
+
+    turn = build_business_planner_turn(
+        BusinessWorkflowContext(
+            trip_record=context.trip_record,
+            business_profile=context.business_profile,
+            objectives=context.objectives,
+            generated_at=context.generated_at,
+            constraint_set=context.constraint_set,
+            proposal=None,
+            comparable_inventory=context.comparable_inventory,
+            collected_policy_inputs=context.collected_policy_inputs,
+            selected_path=context.selected_path,
+        )
+    )
+
+    assert turn.workflow_state.current_stage == "policy_alignment"
+    assert turn.workflow_state.status == "active"
+    assert turn.next_step.recommended_action_id == "action-prepare-policy-packet"
 
 
 def test_exception_prep_flow_keeps_exception_nearest_path_explicit() -> None:

--- a/tests/orchestration/test_business_flow.py
+++ b/tests/orchestration/test_business_flow.py
@@ -134,7 +134,9 @@ def test_missing_comparable_flow_surfaces_structured_pending_decisions() -> None
     )
 
 
-def test_comparable_only_gap_uses_structured_decision_ids_in_transition_and_warnings() -> None:
+def test_comparable_only_gap_uses_structured_decision_ids_in_transition_and_warnings() -> (
+    None
+):
     context = _build_context("missing_comparables_flow.json")
     context.collected_policy_inputs["need for in-person presence"] = (
         "Lead negotiator must be physically present for renewal terms."
@@ -166,7 +168,9 @@ def test_comparable_only_gap_uses_structured_decision_ids_in_transition_and_warn
     ]
 
 
-def test_exception_path_without_proposal_stays_active_when_fallback_is_available() -> None:
+def test_exception_path_without_proposal_stays_active_when_fallback_is_available() -> (
+    None
+):
     context = _build_context("exception_prep_flow.json")
 
     turn = build_business_planner_turn(

--- a/tests/state/test_budget.py
+++ b/tests/state/test_budget.py
@@ -142,9 +142,10 @@ def test_budget_plan_to_dict_preserves_scenario_derived_totals() -> None:
     scenario_payload = record.scenario_budgets[0].to_dict()
 
     assert "total_planned_amount" not in scenario_payload
-    assert BudgetPlan.from_dict(record.to_dict()).scenario_budgets[
-        0
-    ].total_planned_amount == record.scenario_budgets[0].total_planned_amount
+    assert (
+        BudgetPlan.from_dict(record.to_dict()).scenario_budgets[0].total_planned_amount
+        == record.scenario_budgets[0].total_planned_amount
+    )
 
 
 def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
@@ -295,6 +296,9 @@ def test_budget_repository_protocol_can_store_plans_and_spend_events() -> None:
     assert spend_repo.list_spend_events(category_key="client_hospitality")[
         0
     ].trip_id == ("trip-business-client-summit")
-    assert spend_repo.list_spend_events(
-        scenario_budget_id="budget-scenario:client-summit-compliant"
-    )[0].category_key == "client_hospitality"
+    assert (
+        spend_repo.list_spend_events(
+            scenario_budget_id="budget-scenario:client-summit-compliant"
+        )[0].category_key
+        == "client_hospitality"
+    )

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -54,6 +54,6 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
         if dependency not in lock_versions and normalised not in lock_versions:
             missing.append(dependency)
 
-    assert not missing, (
-        "requirements.lock is missing pinned versions for: " + ", ".join(missing)
-    )
+    assert (
+        not missing
+    ), "requirements.lock is missing pinned versions for: " + ", ".join(missing)

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -120,9 +120,7 @@ def build_langsmith_metadata(
             issue_or_pr_number = (
                 env_pr
                 if env_pr.isdigit()
-                else env_issue
-                if env_issue.isdigit()
-                else "unknown"
+                else env_issue if env_issue.isdigit() else "unknown"
             )
 
     _ensure_langsmith_enabled()

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -90,6 +90,7 @@ trip_planner/options/lodging.py
 trip_planner/options/transport.py
 trip_planner/orchestration/__init__.py
 trip_planner/orchestration/actions.py
+trip_planner/orchestration/business.py
 trip_planner/orchestration/feedback.py
 trip_planner/orchestration/in_trip.py
 trip_planner/orchestration/leisure.py

--- a/trip_planner/itinerary/search.py
+++ b/trip_planner/itinerary/search.py
@@ -87,9 +87,9 @@ def _bundle_map(
 
 
 def _normalize_feasibility_outputs(
-    feasibility_outputs: Mapping[str, FeasibilityAssessment]
-    | Sequence[FeasibilityAssessment]
-    | None,
+    feasibility_outputs: (
+        Mapping[str, FeasibilityAssessment] | Sequence[FeasibilityAssessment] | None
+    ),
 ) -> dict[str, FeasibilityAssessment]:
     if feasibility_outputs is None:
         return {}
@@ -237,9 +237,9 @@ def assemble_itinerary_scenarios(
     candidate_set: CandidateSet | None = None,
     bundles: Sequence[InventoryBundle] | None = None,
     objectives: object | None = None,
-    feasibility_outputs: Mapping[str, FeasibilityAssessment]
-    | Sequence[FeasibilityAssessment]
-    | None = None,
+    feasibility_outputs: (
+        Mapping[str, FeasibilityAssessment] | Sequence[FeasibilityAssessment] | None
+    ) = None,
     max_scenarios: int = 3,
     title: str | None = None,
 ) -> ScenarioSearchResult:

--- a/trip_planner/orchestration/__init__.py
+++ b/trip_planner/orchestration/__init__.py
@@ -11,6 +11,12 @@ from .actions import (
     WORKFLOW_STAGES,
     WORKFLOW_STATUSES,
 )
+from .business import (
+    BUSINESS_PATHS,
+    BUSINESS_WORKFLOW_PHASES,
+    BusinessWorkflowContext,
+    build_business_planner_turn,
+)
 from .leisure import LeisureWorkflowContext, build_leisure_planner_turn
 from .feedback import (
     COMPARISON_DEPTHS,
@@ -49,12 +55,15 @@ from .in_trip import (
 __all__ = [
     "ACTION_KINDS",
     "ACTION_STATUSES",
+    "BUSINESS_PATHS",
+    "BUSINESS_WORKFLOW_PHASES",
     "CHANGE_SCOPES",
     "COMPARISON_DEPTHS",
     "DecisionOption",
     "FEEDBACK_KINDS",
     "FeedbackLoopContext",
     "FeedbackLoopResult",
+    "BusinessWorkflowContext",
     "InTripAdjustmentContext",
     "InTripAdjustmentResult",
     "InTripRevisionOutput",
@@ -82,6 +91,7 @@ __all__ = [
     "WORKFLOW_STATUSES",
     "WorkflowStateSnapshot",
     "WorkflowTransition",
+    "build_business_planner_turn",
     "build_leisure_planner_turn",
     "build_in_trip_adjustment_result",
     "build_feedback_loop_result",

--- a/trip_planner/orchestration/business.py
+++ b/trip_planner/orchestration/business.py
@@ -211,6 +211,18 @@ def _slug(value: str) -> str:
     return "".join(char.lower() if char.isalnum() else "-" for char in value).strip("-")
 
 
+def _policy_input_decision_id(field_name: str) -> str:
+    return f"decision:policy-input:{_slug(field_name)}"
+
+
+def _comparable_decision_id(category: str) -> str:
+    return f"decision:comparables:{_slug(category)}"
+
+
+def _missing_comparable_warning_code(category: str) -> str:
+    return f"missing-comparable:{category}"
+
+
 def _missing_policy_inputs(context: BusinessWorkflowContext) -> list[str]:
     required_fields = context.objectives.justification_readiness.required_fields
     return [
@@ -292,7 +304,11 @@ def _workflow_status(
 ) -> str:
     if pending_decisions:
         return "waiting_on_user"
-    if _needs_exception_path(context) and context.proposal is None:
+    if (
+        _needs_exception_path(context)
+        and context.proposal is None
+        and not context.objectives.policy_nearest_fallback.active
+    ):
         return "blocked"
     return "active"
 
@@ -384,7 +400,7 @@ def _build_pending_decisions(
         decision_slug = _slug(field_name)
         decisions.append(
             PendingDecision(
-                decision_id=f"decision:policy-input:{decision_slug}",
+                decision_id=_policy_input_decision_id(field_name),
                 prompt=f"Provide the policy-ready detail for {field_name}.",
                 requested_at=context.generated_at,
                 choices=[
@@ -416,7 +432,7 @@ def _build_pending_decisions(
         ]
         decisions.append(
             PendingDecision(
-                decision_id=f"decision:comparables:{decision_slug}",
+                decision_id=_comparable_decision_id(category),
                 prompt=(
                     f"Collect {shortfall} more {category} comparable"
                     f"{'s' if shortfall != 1 else ''} before proposal prep?"
@@ -553,7 +569,7 @@ def _build_actions(
         PlannerAction(
             action_id="action-request-path-decision",
             action_kind="request_decision",
-            title="Confirm the compliant-first or exception-nearest business path",
+            title="Confirm the remaining policy-input and comparable checkpoints",
             stage="decision_checkpoint",
             status="pending" if pending_decisions else "skipped",
             depends_on_action_ids=["action-prepare-policy-packet"],
@@ -640,7 +656,10 @@ def _build_outputs(
                     "without performing the external policy evaluation."
                 ),
                 ref_ids=packet_ref_ids,
-                warnings=list(comparable_gaps),
+                warnings=[
+                    _missing_comparable_warning_code(category)
+                    for category in sorted(comparable_gaps)
+                ],
                 payload={
                     "selected_path": context.selected_path,
                     "proposal_id": (
@@ -712,7 +731,7 @@ def _build_outputs(
                 ref_ids=packet_ref_ids,
                 warnings=[
                     *(
-                        f"missing-comparable:{category}"
+                        _missing_comparable_warning_code(category)
                         for category in sorted(comparable_gaps)
                     ),
                     *(
@@ -793,9 +812,7 @@ def _build_transition(
             trigger="policy_constraint",
             changed_at=context.generated_at,
             reason="Business planning cannot prepare a packet until required policy inputs are captured.",
-            blocker_ids=[
-                f"policy-input:{_slug(name)}" for name in missing_policy_inputs
-            ],
+            blocker_ids=[_policy_input_decision_id(name) for name in missing_policy_inputs],
         )
     if comparable_gaps:
         return WorkflowTransition(
@@ -805,10 +822,11 @@ def _build_transition(
             changed_at=context.generated_at,
             reason="Comparable collection remains incomplete for the active business path.",
             blocker_ids=[
-                f"comparable:{category}" for category in sorted(comparable_gaps)
+                _comparable_decision_id(category) for category in sorted(comparable_gaps)
             ],
             warning_codes=[
-                f"missing-comparable:{category}" for category in sorted(comparable_gaps)
+                _missing_comparable_warning_code(category)
+                for category in sorted(comparable_gaps)
             ],
         )
     if current_stage == "policy_alignment":

--- a/trip_planner/orchestration/business.py
+++ b/trip_planner/orchestration/business.py
@@ -812,7 +812,9 @@ def _build_transition(
             trigger="policy_constraint",
             changed_at=context.generated_at,
             reason="Business planning cannot prepare a packet until required policy inputs are captured.",
-            blocker_ids=[_policy_input_decision_id(name) for name in missing_policy_inputs],
+            blocker_ids=[
+                _policy_input_decision_id(name) for name in missing_policy_inputs
+            ],
         )
     if comparable_gaps:
         return WorkflowTransition(
@@ -822,7 +824,8 @@ def _build_transition(
             changed_at=context.generated_at,
             reason="Comparable collection remains incomplete for the active business path.",
             blocker_ids=[
-                _comparable_decision_id(category) for category in sorted(comparable_gaps)
+                _comparable_decision_id(category)
+                for category in sorted(comparable_gaps)
             ],
             warning_codes=[
                 _missing_comparable_warning_code(category)

--- a/trip_planner/orchestration/business.py
+++ b/trip_planner/orchestration/business.py
@@ -97,11 +97,11 @@ class BusinessWorkflowContext:
             require_non_empty(str(value), f"collected_policy_inputs[{key}]")
         if not isinstance(self.comparable_inventory, dict):
             raise ValueError("comparable_inventory must be a mapping")
-        for key, value in self.comparable_inventory.items():
+        for key, count in self.comparable_inventory.items():
             require_non_empty(key, "comparable_inventory key")
-            if isinstance(value, bool) or not isinstance(value, int):
+            if isinstance(count, bool) or not isinstance(count, int):
                 raise ValueError(f"comparable_inventory[{key}] must be an int")
-            if value < 0:
+            if count < 0:
                 raise ValueError(f"comparable_inventory[{key}] must be non-negative")
 
 

--- a/trip_planner/orchestration/business.py
+++ b/trip_planner/orchestration/business.py
@@ -1,0 +1,829 @@
+"""Business-planning workflow scaffolds built on shared orchestration contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from trip_planner.business import (
+    BusinessPlanningObjectives,
+    BusinessTravelProfile,
+    PolicyConstraintSet,
+    TripPlanProposal,
+)
+from trip_planner.contracts._validators import (
+    require_non_empty,
+    require_string_mapping,
+)
+from trip_planner.state import PersistedTripRecord
+
+from .models import (
+    DecisionOption,
+    NextStepSummary,
+    PendingDecision,
+    PlannerAction,
+    PlannerOutput,
+    PlannerTurn,
+    WorkflowStateSnapshot,
+    WorkflowTransition,
+)
+
+BUSINESS_PATHS: tuple[str, ...] = ("compliant_first", "exception_nearest")
+BUSINESS_WORKFLOW_PHASES: tuple[str, ...] = (
+    "profile_confirmation",
+    "policy_input_assembly",
+    "comparable_collection",
+    "ranked_option_review",
+    "proposal_preparation",
+    "fallback_or_exception_preparation",
+)
+
+
+@dataclass(slots=True)
+class BusinessWorkflowContext:
+    """Typed inputs required to build one business planner turn."""
+
+    trip_record: PersistedTripRecord
+    business_profile: BusinessTravelProfile
+    objectives: BusinessPlanningObjectives
+    generated_at: str
+    constraint_set: PolicyConstraintSet | None = None
+    proposal: TripPlanProposal | None = None
+    comparable_inventory: dict[str, int] = field(default_factory=dict)
+    collected_policy_inputs: dict[str, str] = field(default_factory=dict)
+    selected_path: str = "compliant_first"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.trip_record, PersistedTripRecord):
+            raise ValueError("trip_record must be a PersistedTripRecord")
+        if self.trip_record.trip.mode != "business":
+            raise ValueError("trip_record must represent a business trip")
+        if not isinstance(self.business_profile, BusinessTravelProfile):
+            raise ValueError("business_profile must be a BusinessTravelProfile")
+        if not isinstance(self.objectives, BusinessPlanningObjectives):
+            raise ValueError("objectives must be a BusinessPlanningObjectives")
+        _validate_generated_at(self.generated_at)
+        if self.objectives.trip_id != self.trip_record.trip.trip_id:
+            raise ValueError("objectives.trip_id must match trip_record.trip.trip_id")
+        if self.constraint_set is not None and not isinstance(
+            self.constraint_set, PolicyConstraintSet
+        ):
+            raise ValueError(
+                "constraint_set must be a PolicyConstraintSet when provided"
+            )
+        if self.proposal is not None:
+            if not isinstance(self.proposal, TripPlanProposal):
+                raise ValueError("proposal must be a TripPlanProposal when provided")
+            if self.proposal.trip_id != self.trip_record.trip.trip_id:
+                raise ValueError("proposal.trip_id must match trip_record.trip.trip_id")
+            if self.constraint_set is not None:
+                if self.proposal.constraint_set_id != self.constraint_set.policy_id:
+                    raise ValueError(
+                        "proposal.constraint_set_id must match constraint_set.policy_id"
+                    )
+        if self.selected_path not in BUSINESS_PATHS:
+            raise ValueError(f"selected_path must be one of {BUSINESS_PATHS}")
+        if (
+            self.selected_path == "exception_nearest"
+            and not self.objectives.policy_nearest_fallback.active
+            and self.proposal is None
+        ):
+            raise ValueError(
+                "selected_path exception_nearest requires an active fallback or proposal"
+            )
+        require_string_mapping(self.collected_policy_inputs, "collected_policy_inputs")
+        for key, value in self.collected_policy_inputs.items():
+            require_non_empty(key, "collected_policy_inputs key")
+            require_non_empty(str(value), f"collected_policy_inputs[{key}]")
+        if not isinstance(self.comparable_inventory, dict):
+            raise ValueError("comparable_inventory must be a mapping")
+        for key, value in self.comparable_inventory.items():
+            require_non_empty(key, "comparable_inventory key")
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f"comparable_inventory[{key}] must be an int")
+            if value < 0:
+                raise ValueError(f"comparable_inventory[{key}] must be non-negative")
+
+
+def build_business_planner_turn(context: BusinessWorkflowContext) -> PlannerTurn:
+    """Build a first-pass business orchestration turn from persisted state."""
+
+    trip_id = context.trip_record.trip.trip_id
+    missing_policy_inputs = _missing_policy_inputs(context)
+    comparable_gaps = _comparable_gaps(context)
+    pending_decisions = _build_pending_decisions(
+        context,
+        missing_policy_inputs,
+        comparable_gaps,
+    )
+    current_stage = _current_stage(context, missing_policy_inputs, comparable_gaps)
+    workflow_status = _workflow_status(context, pending_decisions)
+    phase_statuses = _phase_statuses(
+        context,
+        missing_policy_inputs,
+        comparable_gaps,
+    )
+    actions = _build_actions(
+        context,
+        phase_statuses,
+        missing_policy_inputs,
+        comparable_gaps,
+        pending_decisions,
+    )
+    outputs = _build_outputs(
+        context,
+        phase_statuses,
+        missing_policy_inputs,
+        comparable_gaps,
+        pending_decisions,
+    )
+    open_action_ids = [
+        action.action_id
+        for action in actions
+        if action.status in {"pending", "in_progress"}
+    ]
+    completed_action_ids = [
+        action.action_id
+        for action in actions
+        if action.status in {"completed", "skipped"}
+    ]
+    recent_output_ids = [output.output_id for output in outputs]
+
+    workflow_state = WorkflowStateSnapshot(
+        workflow_state_id=f"workflow-state:{trip_id}:business",
+        trip_id=trip_id,
+        mode="business",
+        workflow_kind="business_planning",
+        current_stage=current_stage,
+        status=workflow_status,
+        recorded_at=context.generated_at,
+        pending_decisions=pending_decisions,
+        open_action_ids=open_action_ids,
+        completed_action_ids=completed_action_ids,
+        recent_output_ids=recent_output_ids,
+        notes=_workflow_notes(
+            context,
+            phase_statuses,
+            missing_policy_inputs,
+            comparable_gaps,
+        ),
+        tags=_workflow_tags(context, comparable_gaps, pending_decisions),
+    )
+    next_step = _build_next_step(
+        context,
+        missing_policy_inputs,
+        comparable_gaps,
+        pending_decisions,
+        outputs,
+    )
+    transition = _build_transition(
+        context,
+        current_stage,
+        missing_policy_inputs,
+        comparable_gaps,
+    )
+
+    return PlannerTurn(
+        turn_id=f"planner-turn:{trip_id}:business:{context.generated_at}",
+        trip_id=trip_id,
+        mode="business",
+        workflow_kind="business_planning",
+        turn_kind="decision_checkpoint" if pending_decisions else "planning_pass",
+        started_at=context.generated_at,
+        workflow_state=workflow_state,
+        transition=transition,
+        next_step=next_step,
+        actions=actions,
+        outputs=outputs,
+        notes=_turn_notes(context, phase_statuses),
+    )
+
+
+def _validate_generated_at(value: str) -> None:
+    require_non_empty(value, "generated_at")
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("generated_at must be an ISO-8601 timestamp") from exc
+
+
+def _slug(value: str) -> str:
+    return "".join(char.lower() if char.isalnum() else "-" for char in value).strip("-")
+
+
+def _missing_policy_inputs(context: BusinessWorkflowContext) -> list[str]:
+    required_fields = context.objectives.justification_readiness.required_fields
+    return [
+        field_name
+        for field_name in required_fields
+        if field_name not in context.collected_policy_inputs
+    ]
+
+
+def _comparable_gaps(context: BusinessWorkflowContext) -> dict[str, int]:
+    gaps: dict[str, int] = {}
+    for (
+        category,
+        required_count,
+    ) in context.objectives.comparable_requirements.required_categories.items():
+        available = context.comparable_inventory.get(category, 0)
+        shortfall = required_count - available
+        if shortfall > 0:
+            gaps[category] = shortfall
+    return gaps
+
+
+def _needs_exception_path(context: BusinessWorkflowContext) -> bool:
+    return context.selected_path == "exception_nearest" or (
+        context.proposal is not None
+        and context.proposal.requested_exception is not None
+    )
+
+
+def _phase_statuses(
+    context: BusinessWorkflowContext,
+    missing_policy_inputs: list[str],
+    comparable_gaps: dict[str, int],
+) -> dict[str, str]:
+    proposal_ready = not missing_policy_inputs and not comparable_gaps
+    fallback_status = "pending"
+    if _needs_exception_path(context):
+        fallback_status = "completed" if context.proposal is not None else "in_progress"
+    elif context.objectives.policy_nearest_fallback.active:
+        fallback_status = "ready"
+
+    return {
+        "profile_confirmation": "completed",
+        "policy_input_assembly": (
+            "completed" if not missing_policy_inputs else "in_progress"
+        ),
+        "comparable_collection": "completed" if not comparable_gaps else "in_progress",
+        "ranked_option_review": (
+            "completed"
+            if context.trip_record.artifact_refs.ranked_result_set_id is not None
+            else "pending"
+        ),
+        "proposal_preparation": (
+            "completed"
+            if context.proposal is not None
+            else ("ready" if proposal_ready else "pending")
+        ),
+        "fallback_or_exception_preparation": fallback_status,
+    }
+
+
+def _current_stage(
+    context: BusinessWorkflowContext,
+    missing_policy_inputs: list[str],
+    comparable_gaps: dict[str, int],
+) -> str:
+    if missing_policy_inputs:
+        return "objective_derivation"
+    if comparable_gaps:
+        return "candidate_generation"
+    if _needs_exception_path(context):
+        return "policy_alignment"
+    return "booking_prep"
+
+
+def _workflow_status(
+    context: BusinessWorkflowContext,
+    pending_decisions: list[PendingDecision],
+) -> str:
+    if pending_decisions:
+        return "waiting_on_user"
+    if _needs_exception_path(context) and context.proposal is None:
+        return "blocked"
+    return "active"
+
+
+def _workflow_tags(
+    context: BusinessWorkflowContext,
+    comparable_gaps: dict[str, int],
+    pending_decisions: list[PendingDecision],
+) -> list[str]:
+    tags = [
+        "business",
+        "orchestration",
+        context.selected_path,
+        context.business_profile.trip_purpose.purpose_type,
+    ]
+    if comparable_gaps:
+        tags.append("comparables_required")
+    if pending_decisions:
+        tags.append("policy_inputs_pending")
+    if _needs_exception_path(context):
+        tags.append("exception_path")
+    return tags
+
+
+def _workflow_notes(
+    context: BusinessWorkflowContext,
+    phase_statuses: dict[str, str],
+    missing_policy_inputs: list[str],
+    comparable_gaps: dict[str, int],
+) -> list[str]:
+    notes = [
+        (
+            "Business orchestration remains distinct from external policy evaluation; "
+            "this scaffold prepares proposal-ready state without making final approvals."
+        ),
+        "phase_statuses:"
+        + ",".join(f"{phase}:{status}" for phase, status in phase_statuses.items()),
+        f"selected_path:{context.selected_path}",
+        (
+            f"policy_state_id:{context.trip_record.artifact_refs.policy_state_id or 'missing'};"
+            f"saved_scenario_ids:{len(context.trip_record.artifact_refs.saved_scenario_ids)}"
+        ),
+    ]
+    if missing_policy_inputs:
+        notes.append("missing_policy_inputs:" + ",".join(missing_policy_inputs))
+    if comparable_gaps:
+        notes.append(
+            "comparable_shortfalls:"
+            + ",".join(
+                f"{key}:{value}" for key, value in sorted(comparable_gaps.items())
+            )
+        )
+    return notes
+
+
+def _turn_notes(
+    context: BusinessWorkflowContext,
+    phase_statuses: dict[str, str],
+) -> list[str]:
+    active_phase = next(
+        (
+            phase
+            for phase, status in phase_statuses.items()
+            if status in {"in_progress", "ready", "pending"}
+        ),
+        "proposal_preparation",
+    )
+    return [
+        (
+            "This scaffold converts business profile, objective, policy, proposal, "
+            "and saved-state references into an explicit planner turn."
+        ),
+        f"selected_path:{context.selected_path}",
+        "active_phase:" + active_phase,
+    ]
+
+
+def _build_pending_decisions(
+    context: BusinessWorkflowContext,
+    missing_policy_inputs: list[str],
+    comparable_gaps: dict[str, int],
+) -> list[PendingDecision]:
+    decisions: list[PendingDecision] = []
+    related_ids = list(context.trip_record.artifact_refs.option_set_ids)
+    if context.trip_record.artifact_refs.policy_state_id is not None:
+        related_ids.append(context.trip_record.artifact_refs.policy_state_id)
+
+    for field_name in missing_policy_inputs:
+        decision_slug = _slug(field_name)
+        decisions.append(
+            PendingDecision(
+                decision_id=f"decision:policy-input:{decision_slug}",
+                prompt=f"Provide the policy-ready detail for {field_name}.",
+                requested_at=context.generated_at,
+                choices=[
+                    DecisionOption(
+                        choice_id=f"choice:{decision_slug}:capture",
+                        label=f"Capture {field_name}",
+                        description="Collect the required policy-facing detail now.",
+                        recommended=True,
+                        metadata={"field": field_name, "path": context.selected_path},
+                    ),
+                    DecisionOption(
+                        choice_id=f"choice:{decision_slug}:defer",
+                        label="Defer and block proposal prep",
+                        description="Leave the proposal packet incomplete until later.",
+                        metadata={"field": field_name, "path": context.selected_path},
+                    ),
+                ],
+                notes=[
+                    "Required for structured policy-ready proposal preparation.",
+                ],
+                related_option_ids=related_ids,
+            )
+        )
+
+    for category, shortfall in sorted(comparable_gaps.items()):
+        decision_slug = _slug(category)
+        required_total = context.objectives.comparable_requirements.required_categories[
+            category
+        ]
+        decisions.append(
+            PendingDecision(
+                decision_id=f"decision:comparables:{decision_slug}",
+                prompt=(
+                    f"Collect {shortfall} more {category} comparable"
+                    f"{'s' if shortfall != 1 else ''} before proposal prep?"
+                ),
+                requested_at=context.generated_at,
+                choices=[
+                    DecisionOption(
+                        choice_id=f"choice:{decision_slug}:collect",
+                        label=f"Collect missing {category} comparables",
+                        description="Keep the packet compliant-first by filling the shortfall.",
+                        recommended=True,
+                        metadata={
+                            "category": category,
+                            "required_total": required_total,
+                            "current_total": context.comparable_inventory.get(
+                                category, 0
+                            ),
+                        },
+                    ),
+                    DecisionOption(
+                        choice_id=f"choice:{decision_slug}:escalate",
+                        label="Carry shortfall into exception prep",
+                        description="Escalate with an explicit explanation of the comparable gap.",
+                        metadata={
+                            "category": category,
+                            "shortfall": shortfall,
+                            "path": context.selected_path,
+                        },
+                    ),
+                ],
+                notes=[
+                    "Comparable collection stays explicit so the policy packet can be audited.",
+                ],
+                related_option_ids=related_ids,
+            )
+        )
+
+    return decisions
+
+
+def _build_actions(
+    context: BusinessWorkflowContext,
+    phase_statuses: dict[str, str],
+    missing_policy_inputs: list[str],
+    comparable_gaps: dict[str, int],
+    pending_decisions: list[PendingDecision],
+) -> list[PlannerAction]:
+    policy_id = context.constraint_set.policy_id if context.constraint_set else ""
+    proposal_id = context.proposal.proposal_id if context.proposal else ""
+
+    actions = [
+        PlannerAction(
+            action_id="action-confirm-business-profile",
+            action_kind="collect_context",
+            title="Confirm business profile, trip, and saved-state context",
+            stage="intake",
+            status="completed",
+            payload={
+                "business_profile_id": context.trip_record.trip.profile_refs.business_profile_id
+                or "",
+                "objective_id": context.trip_record.artifact_refs.objective_id or "",
+                "policy_state_id": context.trip_record.artifact_refs.policy_state_id
+                or "",
+                "saved_scenario_ids": context.trip_record.artifact_refs.saved_scenario_ids,
+            },
+        ),
+        PlannerAction(
+            action_id="action-assemble-policy-inputs",
+            action_kind="collect_context",
+            title="Assemble structured policy inputs for the planning packet",
+            stage="objective_derivation",
+            status="completed" if not missing_policy_inputs else "in_progress",
+            depends_on_action_ids=["action-confirm-business-profile"],
+            payload={
+                "required_fields": context.objectives.justification_readiness.required_fields,
+                "captured_fields": sorted(context.collected_policy_inputs),
+                "missing_fields": missing_policy_inputs,
+                "policy_id": policy_id,
+            },
+        ),
+        PlannerAction(
+            action_id="action-collect-comparables",
+            action_kind="assemble_candidates",
+            title="Collect comparable options for the active business path",
+            stage="candidate_generation",
+            status="completed" if not comparable_gaps else "in_progress",
+            depends_on_action_ids=["action-assemble-policy-inputs"],
+            payload={
+                "required_categories": context.objectives.comparable_requirements.required_categories,
+                "available_counts": context.comparable_inventory,
+                "shortfalls": comparable_gaps,
+            },
+        ),
+        PlannerAction(
+            action_id="action-review-ranked-options",
+            action_kind="rank_options",
+            title="Review ranked compliant-first and fallback business options",
+            stage="ranking",
+            status=(
+                "completed"
+                if context.trip_record.artifact_refs.ranked_result_set_id is not None
+                else "pending"
+            ),
+            depends_on_action_ids=["action-collect-comparables"],
+            payload={
+                "ranked_result_set_id": context.trip_record.artifact_refs.ranked_result_set_id
+                or "",
+                "option_set_ids": context.trip_record.artifact_refs.option_set_ids,
+                "selected_path": context.selected_path,
+            },
+        ),
+        PlannerAction(
+            action_id="action-prepare-policy-packet",
+            action_kind="prepare_policy_summary",
+            title="Prepare the policy-facing proposal packet",
+            stage="policy_alignment",
+            status=(
+                "completed"
+                if context.proposal is not None and not pending_decisions
+                else ("in_progress" if not pending_decisions else "pending")
+            ),
+            depends_on_action_ids=["action-review-ranked-options"],
+            payload={
+                "proposal_id": proposal_id,
+                "constraint_set_id": (
+                    context.proposal.constraint_set_id
+                    if context.proposal is not None
+                    and context.proposal.constraint_set_id is not None
+                    else policy_id
+                ),
+                "phase_status": phase_statuses["proposal_preparation"],
+            },
+        ),
+        PlannerAction(
+            action_id="action-request-path-decision",
+            action_kind="request_decision",
+            title="Confirm the compliant-first or exception-nearest business path",
+            stage="decision_checkpoint",
+            status="pending" if pending_decisions else "skipped",
+            depends_on_action_ids=["action-prepare-policy-packet"],
+            payload={
+                "decision_ids": [
+                    decision.decision_id for decision in pending_decisions
+                ],
+                "selected_path": context.selected_path,
+            },
+        ),
+        PlannerAction(
+            action_id="action-persist-business-state",
+            action_kind="persist_state",
+            title="Persist proposal-prep outputs back into saved-state layers",
+            stage="booking_prep",
+            status=(
+                "pending"
+                if context.proposal is not None and not pending_decisions
+                else "skipped"
+            ),
+            depends_on_action_ids=["action-prepare-policy-packet"],
+            payload={
+                "policy_state_id": context.trip_record.artifact_refs.policy_state_id
+                or "",
+                "saved_scenario_ids": context.trip_record.artifact_refs.saved_scenario_ids,
+                "session_state_id": context.trip_record.artifact_refs.session_state_id
+                or "",
+            },
+        ),
+    ]
+    return actions
+
+
+def _build_outputs(
+    context: BusinessWorkflowContext,
+    phase_statuses: dict[str, str],
+    missing_policy_inputs: list[str],
+    comparable_gaps: dict[str, int],
+    pending_decisions: list[PendingDecision],
+) -> list[PlannerOutput]:
+    outputs: list[PlannerOutput] = []
+    packet_ref_ids = list(context.trip_record.artifact_refs.option_set_ids)
+    if context.trip_record.artifact_refs.policy_state_id is not None:
+        packet_ref_ids.append(context.trip_record.artifact_refs.policy_state_id)
+    packet_ref_ids.extend(context.trip_record.artifact_refs.saved_scenario_ids)
+    if context.proposal is not None:
+        packet_ref_ids.insert(0, context.proposal.proposal_id)
+
+    outputs.append(
+        PlannerOutput(
+            output_id="output-business-status",
+            output_kind="status_update",
+            title="Business workflow scaffold status",
+            emitted_at=context.generated_at,
+            surface="side_panel",
+            summary=(
+                "Business planning is staging profile, policy, comparable, ranked-option, "
+                "proposal, and fallback phases explicitly."
+            ),
+            ref_ids=packet_ref_ids,
+            payload={
+                "selected_path": context.selected_path,
+                "phase_statuses": phase_statuses,
+                "policy_state_id": context.trip_record.artifact_refs.policy_state_id
+                or "",
+                "objective_id": context.trip_record.artifact_refs.objective_id or "",
+            },
+        )
+    )
+
+    if context.proposal is not None or (
+        not missing_policy_inputs and not comparable_gaps
+    ):
+        outputs.insert(
+            0,
+            PlannerOutput(
+                output_id="output-policy-packet",
+                output_kind="policy_summary",
+                title="Policy-ready business proposal scaffold",
+                emitted_at=context.generated_at,
+                surface="policy_packet",
+                summary=(
+                    "The scaffold carries business planning forward as a policy-ready packet "
+                    "without performing the external policy evaluation."
+                ),
+                ref_ids=packet_ref_ids,
+                warnings=list(comparable_gaps),
+                payload={
+                    "selected_path": context.selected_path,
+                    "proposal_id": (
+                        context.proposal.proposal_id if context.proposal else ""
+                    ),
+                    "constraint_set_id": (
+                        context.proposal.constraint_set_id
+                        if context.proposal is not None
+                        and context.proposal.constraint_set_id is not None
+                        else (
+                            context.constraint_set.policy_id
+                            if context.constraint_set is not None
+                            else ""
+                        )
+                    ),
+                    "required_approval_roles": (
+                        context.objectives.exception_path_posture.approval_roles
+                    ),
+                    "missing_policy_inputs": missing_policy_inputs,
+                    "comparable_shortfalls": comparable_gaps,
+                    "saved_scenario_ids": context.trip_record.artifact_refs.saved_scenario_ids,
+                    "policy_state_id": context.trip_record.artifact_refs.policy_state_id
+                    or "",
+                    "external_policy_evaluation_required": True,
+                    "requested_exception_type": (
+                        context.proposal.requested_exception.exception_type
+                        if context.proposal is not None
+                        and context.proposal.requested_exception is not None
+                        else ""
+                    ),
+                },
+            ),
+        )
+
+    if pending_decisions:
+        outputs.append(
+            PlannerOutput(
+                output_id="output-policy-decisions",
+                output_kind="decision_request",
+                title="Structured policy-input decisions required",
+                emitted_at=context.generated_at,
+                surface="planner_chat",
+                summary=(
+                    "Missing policy inputs and comparable gaps are surfaced as "
+                    "structured checkpoint decisions."
+                ),
+                ref_ids=[decision.decision_id for decision in pending_decisions],
+                payload={
+                    "decision_ids": [
+                        decision.decision_id for decision in pending_decisions
+                    ],
+                    "selected_path": context.selected_path,
+                },
+            )
+        )
+
+    if comparable_gaps or _needs_exception_path(context):
+        outputs.append(
+            PlannerOutput(
+                output_id="output-business-warning",
+                output_kind="warning",
+                title="Business policy path needs explicit handling",
+                emitted_at=context.generated_at,
+                surface="planner_chat",
+                summary=(
+                    "The business workflow keeps comparable shortfalls and exception routing "
+                    "visible instead of collapsing them into free-form notes."
+                ),
+                ref_ids=packet_ref_ids,
+                warnings=[
+                    *(
+                        f"missing-comparable:{category}"
+                        for category in sorted(comparable_gaps)
+                    ),
+                    *(
+                        ["exception-path-active"]
+                        if _needs_exception_path(context)
+                        else []
+                    ),
+                ],
+                payload={
+                    "comparable_shortfalls": comparable_gaps,
+                    "selected_path": context.selected_path,
+                    "exception_ready": _needs_exception_path(context),
+                },
+            )
+        )
+
+    return outputs
+
+
+def _build_next_step(
+    context: BusinessWorkflowContext,
+    missing_policy_inputs: list[str],
+    comparable_gaps: dict[str, int],
+    pending_decisions: list[PendingDecision],
+    outputs: list[PlannerOutput],
+) -> NextStepSummary:
+    output_ids = [output.output_id for output in outputs]
+    if missing_policy_inputs:
+        return NextStepSummary(
+            headline="Capture the missing policy-ready inputs before preparing the business proposal packet.",
+            recommended_action_id="action-assemble-policy-inputs",
+            blocking_decision_ids=[
+                decision.decision_id for decision in pending_decisions
+            ],
+            expected_output_ids=output_ids,
+        )
+    if comparable_gaps:
+        return NextStepSummary(
+            headline="Collect the remaining comparables or explicitly escalate the shortfall into exception prep.",
+            recommended_action_id="action-collect-comparables",
+            blocking_decision_ids=[
+                decision.decision_id for decision in pending_decisions
+            ],
+            expected_output_ids=output_ids,
+        )
+    if _needs_exception_path(context):
+        return NextStepSummary(
+            headline="Finish the exception-nearest policy packet and keep the fallback path explicit for later review.",
+            recommended_action_id="action-prepare-policy-packet",
+            blocking_decision_ids=[
+                decision.decision_id for decision in pending_decisions
+            ],
+            expected_output_ids=output_ids,
+        )
+    if context.proposal is None:
+        return NextStepSummary(
+            headline="Prepare the compliant-first policy packet and persist its saved-state references.",
+            recommended_action_id="action-prepare-policy-packet",
+            expected_output_ids=output_ids,
+        )
+    return NextStepSummary(
+        headline="Persist the policy-ready business packet back into saved-state layers.",
+        recommended_action_id="action-persist-business-state",
+        expected_output_ids=output_ids,
+    )
+
+
+def _build_transition(
+    context: BusinessWorkflowContext,
+    current_stage: str,
+    missing_policy_inputs: list[str],
+    comparable_gaps: dict[str, int],
+) -> WorkflowTransition:
+    if missing_policy_inputs:
+        return WorkflowTransition(
+            from_stage="intake",
+            to_stage="objective_derivation",
+            trigger="policy_constraint",
+            changed_at=context.generated_at,
+            reason="Business planning cannot prepare a packet until required policy inputs are captured.",
+            blocker_ids=[
+                f"policy-input:{_slug(name)}" for name in missing_policy_inputs
+            ],
+        )
+    if comparable_gaps:
+        return WorkflowTransition(
+            from_stage="ranking",
+            to_stage="candidate_generation",
+            trigger="policy_constraint",
+            changed_at=context.generated_at,
+            reason="Comparable collection remains incomplete for the active business path.",
+            blocker_ids=[
+                f"comparable:{category}" for category in sorted(comparable_gaps)
+            ],
+            warning_codes=[
+                f"missing-comparable:{category}" for category in sorted(comparable_gaps)
+            ],
+        )
+    if current_stage == "policy_alignment":
+        return WorkflowTransition(
+            from_stage="ranking",
+            to_stage="policy_alignment",
+            trigger="policy_constraint",
+            changed_at=context.generated_at,
+            reason="The selected business path needs explicit exception or fallback preparation.",
+            warning_codes=["exception-path-active"],
+        )
+    return WorkflowTransition(
+        from_stage="ranking",
+        to_stage="booking_prep",
+        trigger="planner_recommendation",
+        changed_at=context.generated_at,
+        reason="Ranked business options are ready to be assembled into a policy-facing proposal packet.",
+    )

--- a/trip_planner/orchestration/feedback.py
+++ b/trip_planner/orchestration/feedback.py
@@ -212,9 +212,11 @@ def build_feedback_loop_result(
         context.session_state,
         updated_at=context.generated_at,
         recent_option_presentations=[
-            updated_presentation
-            if item.presentation_id == presentation.presentation_id
-            else item
+            (
+                updated_presentation
+                if item.presentation_id == presentation.presentation_id
+                else item
+            )
             for item in context.session_state.recent_option_presentations
         ],
     )

--- a/trip_planner/orchestration/models.py
+++ b/trip_planner/orchestration/models.py
@@ -469,7 +469,9 @@ class PlannerTurn:
         ):
             raise ValueError("next_step.recommended_action_id must refer to an action")
         all_known_output_ids = set(output_ids)
-        if not set(self.workflow_state.recent_output_ids).issubset(all_known_output_ids):
+        if not set(self.workflow_state.recent_output_ids).issubset(
+            all_known_output_ids
+        ):
             raise ValueError("workflow_state.recent_output_ids must refer to outputs")
         if not set(self.next_step.expected_output_ids).issubset(all_known_output_ids):
             raise ValueError("next_step.expected_output_ids must refer to outputs")

--- a/trip_planner/ranking/business.py
+++ b/trip_planner/ranking/business.py
@@ -979,9 +979,11 @@ class BusinessRankingEngine:
                 RiskFlag(
                     risk_id=f"risk:{assessment.bundle_id}:{blocking_reason}",
                     code=blocking_reason,
-                    severity="critical"
-                    if not assessment.recommended_for_ranking
-                    else "warning",
+                    severity=(
+                        "critical"
+                        if not assessment.recommended_for_ranking
+                        else "warning"
+                    ),
                     summary=f"Feasibility issue remains unresolved: {blocking_reason}.",
                     blocking=not assessment.recommended_for_ranking,
                 )

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -878,9 +878,9 @@ class LeisureRankingEngine:
                 ),
                 factor_keys=[item.contribution_id for item in dominant],
                 machine_context={
-                    "primary_axis": dominant[0].contribution_id
-                    if dominant
-                    else "anchor_alignment",
+                    "primary_axis": (
+                        dominant[0].contribution_id if dominant else "anchor_alignment"
+                    ),
                     "confidence": f"{confidence_summary.overall_confidence or 0.0:.2f}",
                 },
                 human_summary=[item.label for item in dominant]
@@ -972,9 +972,11 @@ class LeisureRankingEngine:
                 RiskFlag(
                     risk_id=f"risk:{assessment.bundle_id}:{blocking_reason}",
                     code=blocking_reason,
-                    severity="critical"
-                    if not assessment.recommended_for_ranking
-                    else "warning",
+                    severity=(
+                        "critical"
+                        if not assessment.recommended_for_ranking
+                        else "warning"
+                    ),
                     summary=f"Feasibility issue remains unresolved: {blocking_reason}.",
                     blocking=not assessment.recommended_for_ranking,
                 )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #548

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Business planning has different orchestration needs from leisure planning: it must gather policy-relevant facts, collect comparables, surface compliance posture, and prepare policy-ready outputs without turning into the policy system itself. Once business ranking exists, the repo needs a dedicated business orchestration scaffold that manages those steps explicitly.

Parent epic: #543

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#543](https://github.com/stranske/trip-planner/issues/543)
- [#515](https://github.com/stranske/trip-planner/issues/515)
- [#516](https://github.com/stranske/trip-planner/issues/516)
- [#518](https://github.com/stranske/trip-planner/issues/518)
- [#535](https://github.com/stranske/trip-planner/issues/535)
- [#537](https://github.com/stranske/trip-planner/issues/537)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement a business orchestration scaffold that can progress through major phases such as profile confirmation, policy-input assembly, comparable collection, ranked-option review, proposal preparation, and fallback or exception preparation.
- [x] Ensure the scaffold can represent compliant-first and exception-nearest flows explicitly.
- [x] Add support for collecting missing policy-relevant information as structured pending decisions rather than free-form notes.
- [x] Add representative fixtures for at least: a straightforward compliant planning flow, a missing-comparable flow, and an exception-prep flow.
- [x] Write unit tests covering business workflow progression, malformed state, and transition into proposal-preparation outputs.
- [x] Document how this scaffold remains separate from the external policy-evaluation system even while it prepares data for it.

#### Acceptance criteria
- [x] The repo contains a first-pass business planning and policy-prep orchestration scaffold.
- [x] The scaffold can represent compliant-first and exception-nearest planning paths distinctly.
- [x] Tests cover representative business flow progressions and malformed-state failures.
- [x] The resulting outputs are compatible with policy-facing proposal contracts and saved-state layers.
- [x] Documentation makes clear how business orchestration differs from leisure orchestration and from external policy evaluation.

<!-- auto-status-summary:end -->