### PR TITLE
Issue #551: build policy-constraint sync scaffold

### DIFF
--- a/docs/contracts/tpp-execution-contracts.md
+++ b/docs/contracts/tpp-execution-contracts.md
@@ -12,6 +12,7 @@ This contract layer owns transport and execution semantics for the `trip-planner
 
 - `trip_planner/integrations/tpp/contracts.py`
 - `trip_planner/integrations/tpp/client.py`
+- `trip_planner/integrations/tpp/policy_sync.py`
 
 ## Design Rules
 
@@ -22,7 +23,7 @@ This contract layer owns transport and execution semantics for the `trip-planner
 
 ## How Later Issues Build On This
 
-- issue `#551` should use these envelopes when importing policy constraints and organization context.
+- issue `#551` uses these envelopes when importing policy constraints and organization context.
 - issue `#552` should submit `TripPlanProposal` payloads inside these envelopes and read deferred or failed execution state from the same layer.
 - issue `#553` should consume retry and failure records when deciding whether to reoptimize or branch into exception handling.
 - issue `#554` should use the same client abstraction in test harnesses so approval-readiness flows can run against mocks or simulators.

--- a/docs/contracts/tpp-policy-sync.md
+++ b/docs/contracts/tpp-policy-sync.md
@@ -1,0 +1,30 @@
+# TPP Policy Sync Scaffold
+
+This scaffold imports policy constraints and organization context from `Travel-Plan-Permission` into planning-ready local contracts without making `trip-planner` the source of truth for policy evaluation.
+
+## Canonical Modules
+
+- `trip_planner/integrations/tpp/policy_sync.py`
+- `trip_planner/business/policy_contracts.py`
+
+## Imported Output
+
+`TPPPolicySyncService` normalizes a successful `fetch_policy_constraints` response into:
+
+- `PolicyConstraintSet` for ranking, candidate filtering, and business-objective derivation
+- `OrganizationContextSnapshot` for approved channels, comparable requirements, approval triggers, comfort preferences, and class-of-service limits
+- `PolicyFreshness` for snapshot versioning, freshness windows, and invalidation markers
+
+## Consumption Rules
+
+- Ranking and candidate-generation flows may read imported channels, class-of-service limits, documentation rules, and comparable requirements as planning inputs.
+- Orchestration flows may use freshness and invalidation metadata to decide whether policy imports must be refreshed before candidate generation or proposal submission.
+- Imported policy data must stay advisory inside `trip-planner`; final compliance decisions still belong to `Travel-Plan-Permission`.
+- When a snapshot is stale or invalidated, the planner should treat it as unsuitable for final business recommendations and request a fresh import rather than silently trusting it.
+
+## Issue Boundary
+
+- issue `#551` owns import and normalization only
+- issue `#552` should wrap proposal submission in the same execution envelope boundary
+- issue `#553` should use stale or failed sync outcomes to trigger retries or alternative flows
+- issue `#554` should plug the sync layer into approval-readiness and end-to-end harnesses

--- a/tests/fixtures/integrations/tpp/policy/invalidated_policy_sync.json
+++ b/tests/fixtures/integrations/tpp/policy/invalidated_policy_sync.json
@@ -1,0 +1,98 @@
+{
+  "request": {
+    "operation": "fetch_policy_constraints",
+    "request_id": "policy-sync-req-003",
+    "correlation_id": {
+      "value": "corr-policy-sync-003",
+      "issued_by": "trip-planner"
+    },
+    "payload": {
+      "policy_scope": "business_planning",
+      "organization_context": true
+    },
+    "transport_pattern": "sync",
+    "organization_id": "org-acme",
+    "submitted_at": "2026-02-18T10:00:00Z",
+    "metadata": {
+      "consumer": "ranking"
+    }
+  },
+  "response": {
+    "operation": "fetch_policy_constraints",
+    "request_id": "policy-sync-req-003",
+    "correlation_id": {
+      "value": "corr-policy-sync-003",
+      "issued_by": "tpp"
+    },
+    "transport_pattern": "sync",
+    "execution_status": {
+      "state": "succeeded",
+      "terminal": true,
+      "summary": "Policy snapshot has been invalidated.",
+      "external_status": "ok",
+      "updated_at": "2026-02-18T10:00:04Z"
+    },
+    "result_payload": {
+      "constraint_set": {
+        "policy_id": "policy-standard-2026-02",
+        "organization_id": "org-acme",
+        "policy_version": "2026.02",
+        "required_booking_channels": [
+          "Navan"
+        ],
+        "airfare_rules": {
+          "max_cabin": "premium_economy"
+        },
+        "lodging_rules": {
+          "max_nightly_rate_usd": 325
+        },
+        "ground_transport_rules": {},
+        "meal_rules": {
+          "per_diem_usd": 85
+        },
+        "approval_rules": [
+          "international_travel"
+        ],
+        "documentation_rules": [
+          "retain_receipts"
+        ],
+        "allowed_exception_types": [
+          "medical"
+        ]
+      },
+      "organization_context": {
+        "organization_id": "org-acme",
+        "approved_channels": [
+          "Navan"
+        ],
+        "comparable_requirements": {
+          "airfare": 2
+        },
+        "documentation_rules": [
+          "retain_receipts"
+        ],
+        "approval_triggers": [
+          "international_travel"
+        ],
+        "comfort_preferences": {
+          "seat_preference": "aisle"
+        },
+        "class_of_service_limits": {
+          "air": "premium_economy"
+        },
+        "metadata": {
+          "travel_program": "recall-test"
+        }
+      },
+      "freshness": {
+        "snapshot_version": "snapshot-2026-02-18-c",
+        "captured_at": "2026-02-18T09:55:00Z",
+        "fresh_until": "2026-02-19T09:55:00Z",
+        "invalidated_at": "2026-02-18T10:05:00Z",
+        "invalidation_reason": "manual_policy_recall",
+        "status": "invalidated"
+      }
+    },
+    "received_at": "2026-02-18T10:00:06Z"
+  }
+}

--- a/tests/fixtures/integrations/tpp/policy/standard_policy_sync.json
+++ b/tests/fixtures/integrations/tpp/policy/standard_policy_sync.json
@@ -1,0 +1,114 @@
+{
+  "request": {
+    "operation": "fetch_policy_constraints",
+    "request_id": "policy-sync-req-001",
+    "correlation_id": {
+      "value": "corr-policy-sync-001",
+      "issued_by": "trip-planner"
+    },
+    "payload": {
+      "policy_scope": "business_planning",
+      "organization_context": true
+    },
+    "transport_pattern": "sync",
+    "organization_id": "org-acme",
+    "submitted_at": "2026-02-15T12:00:00Z",
+    "metadata": {
+      "consumer": "ranking"
+    }
+  },
+  "response": {
+    "operation": "fetch_policy_constraints",
+    "request_id": "policy-sync-req-001",
+    "correlation_id": {
+      "value": "corr-policy-sync-001",
+      "issued_by": "tpp"
+    },
+    "transport_pattern": "sync",
+    "execution_status": {
+      "state": "succeeded",
+      "terminal": true,
+      "summary": "Constraint import ready.",
+      "external_status": "ok",
+      "updated_at": "2026-02-15T12:00:05Z"
+    },
+    "result_payload": {
+      "constraint_set": {
+        "policy_id": "policy-standard-2026-02",
+        "organization_id": "org-acme",
+        "policy_version": "2026.02",
+        "required_booking_channels": [
+          "Navan",
+          "Concur"
+        ],
+        "airfare_rules": {
+          "max_cabin": "premium_economy",
+          "comparable_quote_count": 2
+        },
+        "lodging_rules": {
+          "max_nightly_rate_usd": 325,
+          "preferred_classes": [
+            "business_hotel",
+            "extended_stay"
+          ]
+        },
+        "ground_transport_rules": {
+          "approved_modes": [
+            "rail",
+            "rental_car"
+          ]
+        },
+        "meal_rules": {
+          "per_diem_usd": 85
+        },
+        "approval_rules": [
+          "international_travel"
+        ],
+        "documentation_rules": [
+          "retain_receipts",
+          "attach_comparables"
+        ],
+        "allowed_exception_types": [
+          "medical",
+          "schedule_risk"
+        ]
+      },
+      "organization_context": {
+        "organization_id": "org-acme",
+        "approved_channels": [
+          "Navan",
+          "Concur"
+        ],
+        "comparable_requirements": {
+          "airfare": 2,
+          "lodging": 2
+        },
+        "documentation_rules": [
+          "retain_receipts",
+          "attach_comparables"
+        ],
+        "approval_triggers": [
+          "international_travel",
+          "lodging_above_cap"
+        ],
+        "comfort_preferences": {
+          "seat_preference": "extra_legroom"
+        },
+        "class_of_service_limits": {
+          "air": "premium_economy",
+          "rail": "business"
+        },
+        "metadata": {
+          "cost_center": "field-sales"
+        }
+      },
+      "freshness": {
+        "snapshot_version": "snapshot-2026-02-15-a",
+        "captured_at": "2026-02-15T11:58:00Z",
+        "fresh_until": "2026-02-16T11:58:00Z",
+        "status": "current"
+      }
+    },
+    "received_at": "2026-02-15T12:00:06Z"
+  }
+}

--- a/tests/fixtures/integrations/tpp/policy/strict_policy_sync.json
+++ b/tests/fixtures/integrations/tpp/policy/strict_policy_sync.json
@@ -1,0 +1,112 @@
+{
+  "request": {
+    "operation": "fetch_policy_constraints",
+    "request_id": "policy-sync-req-002",
+    "correlation_id": {
+      "value": "corr-policy-sync-002",
+      "issued_by": "trip-planner"
+    },
+    "payload": {
+      "policy_scope": "business_planning",
+      "organization_context": true
+    },
+    "transport_pattern": "sync",
+    "organization_id": "org-strict",
+    "submitted_at": "2026-02-17T08:00:00Z",
+    "metadata": {
+      "consumer": "business-orchestration"
+    }
+  },
+  "response": {
+    "operation": "fetch_policy_constraints",
+    "request_id": "policy-sync-req-002",
+    "correlation_id": {
+      "value": "corr-policy-sync-002",
+      "issued_by": "tpp"
+    },
+    "transport_pattern": "sync",
+    "execution_status": {
+      "state": "succeeded",
+      "terminal": true,
+      "summary": "Strict policy constraint import ready.",
+      "external_status": "ok",
+      "updated_at": "2026-02-17T08:00:04Z"
+    },
+    "result_payload": {
+      "constraint_set": {
+        "policy_id": "policy-strict-2026-02",
+        "organization_id": "org-strict",
+        "policy_version": "2026.02.1",
+        "required_booking_channels": [
+          "Concur"
+        ],
+        "airfare_rules": {
+          "max_cabin": "economy",
+          "advance_purchase_days": 14
+        },
+        "lodging_rules": {
+          "max_nightly_rate_usd": 210,
+          "preferred_classes": [
+            "midscale"
+          ]
+        },
+        "ground_transport_rules": {
+          "approved_modes": [
+            "rail"
+          ]
+        },
+        "meal_rules": {
+          "per_diem_usd": 55
+        },
+        "approval_rules": [
+          "international_travel",
+          "vice_president_preapproval"
+        ],
+        "documentation_rules": [
+          "retain_receipts",
+          "manager_justification"
+        ],
+        "allowed_exception_types": [
+          "medical"
+        ]
+      },
+      "organization_context": {
+        "organization_id": "org-strict",
+        "approved_channels": [
+          "Concur"
+        ],
+        "comparable_requirements": {
+          "airfare": 3,
+          "lodging": 2,
+          "ground_transport": 1
+        },
+        "documentation_rules": [
+          "retain_receipts",
+          "manager_justification"
+        ],
+        "approval_triggers": [
+          "international_travel",
+          "lodging_above_cap",
+          "vice_president_preapproval"
+        ],
+        "comfort_preferences": {
+          "hotel_location": "walkable_to_meeting"
+        },
+        "class_of_service_limits": {
+          "air": "economy",
+          "lodging": "midscale"
+        },
+        "metadata": {
+          "travel_program": "global-enterprise"
+        }
+      },
+      "freshness": {
+        "snapshot_version": "snapshot-2026-02-17-b",
+        "captured_at": "2026-02-17T07:58:00Z",
+        "fresh_until": "2026-02-17T20:00:00Z",
+        "status": "current"
+      }
+    },
+    "received_at": "2026-02-17T08:00:05Z"
+  }
+}

--- a/tests/integrations/test_policy_sync.py
+++ b/tests/integrations/test_policy_sync.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.integrations.tpp import (
+    BaseTPPIntegrationClient,
+    PolicySyncError,
+    TPPPolicySyncService,
+    TPPRequestEnvelope,
+    TPPResponseEnvelope,
+    summarize_policy_import,
+)
+
+
+def _fixture_path(name: str) -> Path:
+    return Path("tests/fixtures/integrations/tpp/policy") / name
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+
+
+class FakeTPPPolicyClient(BaseTPPIntegrationClient):
+    def __init__(self, response: TPPResponseEnvelope) -> None:
+        self.response = response
+        self.calls: list[str] = []
+
+    def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        self.calls.append(request.operation)
+        return self.response
+
+
+def test_import_standard_policy_sync_snapshot() -> None:
+    fixture = _load_fixture("standard_policy_sync.json")
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPPolicySyncService(FakeTPPPolicyClient(response))
+
+    imported = service.import_policy_constraints(request)
+    summary = summarize_policy_import(imported, "2026-02-15T14:00:00Z")
+
+    assert imported.constraint_set.policy_id == "policy-standard-2026-02"
+    assert imported.organization_context.comparable_requirements == {
+        "airfare": 2,
+        "lodging": 2,
+    }
+    assert imported.constraint_set.required_booking_channels == ["Navan", "Concur"]
+    assert summary["is_stale"] is False
+    assert summary["documentation_rules"] == [
+        "retain_receipts",
+        "attach_comparables",
+    ]
+
+
+def test_import_stricter_org_policy_preserves_limits_and_triggers() -> None:
+    fixture = _load_fixture("strict_policy_sync.json")
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPPolicySyncService(FakeTPPPolicyClient(response))
+
+    imported = service.import_policy_constraints(request)
+
+    assert imported.constraint_set.airfare_rules["max_cabin"] == "economy"
+    assert imported.constraint_set.lodging_rules["max_nightly_rate_usd"] == 210
+    assert imported.organization_context.class_of_service_limits["air"] == "economy"
+    assert imported.organization_context.approval_triggers == [
+        "international_travel",
+        "lodging_above_cap",
+        "vice_president_preapproval",
+    ]
+
+
+def test_invalidated_policy_snapshot_is_marked_stale() -> None:
+    fixture = _load_fixture("invalidated_policy_sync.json")
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPPolicySyncService(FakeTPPPolicyClient(response))
+
+    imported = service.import_policy_constraints(request)
+
+    assert imported.is_stale("2026-02-18T12:00:00Z") is True
+    assert imported.freshness.status == "invalidated"
+    assert imported.freshness.invalidation_reason == "manual_policy_recall"
+
+
+def test_policy_sync_rejects_malformed_comparable_requirements() -> None:
+    fixture = _load_fixture("standard_policy_sync.json")
+    fixture["response"]["result_payload"]["organization_context"][
+        "comparable_requirements"
+    ]["lodging"] = "two"
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPPolicySyncService(FakeTPPPolicyClient(response))
+
+    with pytest.raises(ValueError, match="comparable_requirements\\[lodging\\]"):
+        service.import_policy_constraints(request)
+
+
+def test_policy_sync_rejects_missing_constraint_set_payload() -> None:
+    fixture = _load_fixture("standard_policy_sync.json")
+    del fixture["response"]["result_payload"]["constraint_set"]
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPPolicySyncService(FakeTPPPolicyClient(response))
+
+    with pytest.raises(ValueError, match="result_payload.constraint_set"):
+        service.import_policy_constraints(request)
+
+
+def test_policy_sync_rejects_non_succeeded_execution_status() -> None:
+    fixture = _load_fixture("standard_policy_sync.json")
+    fixture["response"]["execution_status"]["state"] = "deferred"
+    fixture["response"]["execution_status"]["terminal"] = False
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPPolicySyncService(FakeTPPPolicyClient(response))
+
+    with pytest.raises(PolicySyncError, match="succeeded execution_status"):
+        service.import_policy_constraints(request)

--- a/tests/integrations/test_policy_sync.py
+++ b/tests/integrations/test_policy_sync.py
@@ -14,7 +14,14 @@ from trip_planner.integrations.tpp import (
 
 
 def _fixture_path(name: str) -> Path:
-    return Path("tests/fixtures/integrations/tpp/policy") / name
+    return (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "integrations"
+        / "tpp"
+        / "policy"
+        / name
+    )
 
 
 def _load_fixture(name: str) -> dict:
@@ -117,4 +124,26 @@ def test_policy_sync_rejects_non_succeeded_execution_status() -> None:
     service = TPPPolicySyncService(FakeTPPPolicyClient(response))
 
     with pytest.raises(PolicySyncError, match="succeeded execution_status"):
+        service.import_policy_constraints(request)
+
+
+def test_policy_sync_rejects_mismatched_request_id() -> None:
+    fixture = _load_fixture("standard_policy_sync.json")
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    fixture["response"]["request_id"] = "policy-sync-req-other"
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPPolicySyncService(FakeTPPPolicyClient(response))
+
+    with pytest.raises(PolicySyncError, match="response.request_id"):
+        service.import_policy_constraints(request)
+
+
+def test_policy_sync_rejects_mismatched_correlation_id() -> None:
+    fixture = _load_fixture("standard_policy_sync.json")
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    fixture["response"]["correlation_id"]["value"] = "corr-policy-sync-other"
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPPolicySyncService(FakeTPPPolicyClient(response))
+
+    with pytest.raises(PolicySyncError, match="response.correlation_id"):
         service.import_policy_constraints(request)

--- a/trip_planner/integrations/tpp/__init__.py
+++ b/trip_planner/integrations/tpp/__init__.py
@@ -10,15 +10,29 @@ from .contracts import (
     TPPRetryMetadata,
     TPPCorrelationId,
 )
+from .policy_sync import (
+    OrganizationContextSnapshot,
+    PolicyConstraintImport,
+    PolicyFreshness,
+    PolicySyncError,
+    TPPPolicySyncService,
+    summarize_policy_import,
+)
 
 __all__ = [
     "BaseTPPIntegrationClient",
+    "OrganizationContextSnapshot",
+    "PolicyConstraintImport",
+    "PolicyFreshness",
+    "PolicySyncError",
     "TPPCorrelationId",
     "TPPErrorRecord",
     "TPPExecutionStatus",
     "TPPIntegrationClient",
     "TPPOperationRequest",
+    "TPPPolicySyncService",
     "TPPRequestEnvelope",
     "TPPResponseEnvelope",
     "TPPRetryMetadata",
+    "summarize_policy_import",
 ]

--- a/trip_planner/integrations/tpp/policy_sync.py
+++ b/trip_planner/integrations/tpp/policy_sync.py
@@ -1,0 +1,365 @@
+"""Policy-constraint import scaffolding for Travel-Plan-Permission."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from trip_planner._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_string_mapping,
+    require_strings,
+)
+from trip_planner.business.policy_contracts import PolicyConstraintSet
+
+from .client import TPPIntegrationClient
+from .contracts import TPPRequestEnvelope, TPPResponseEnvelope
+
+POLICY_SYNC_STATES: tuple[str, ...] = ("current", "stale", "invalidated")
+
+
+def _require_mapping(value: Any, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be provided as a mapping")
+    return dict(value)
+
+
+def _optional_mapping(value: Any, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return _require_mapping(value, field_name)
+
+
+def _require_string_list(value: Any, field_name: str) -> list[str]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be provided as a list")
+    values = list(value)
+    require_strings(values, field_name)
+    return values
+
+
+def _optional_string_list(value: Any, field_name: str) -> list[str]:
+    if value is None:
+        return []
+    return _require_string_list(value, field_name)
+
+
+def _parse_timestamp(value: str, field_name: str) -> datetime:
+    require_non_empty(value, field_name)
+    try:
+        normalized = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(normalized).astimezone(UTC)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from exc
+
+
+def _optional_timestamp(value: str | None, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    return _parse_timestamp(value, field_name)
+
+
+def _serialize_timestamp(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(slots=True)
+class PolicyFreshness:
+    snapshot_version: str
+    captured_at: str
+    fresh_until: str | None = None
+    invalidated_at: str | None = None
+    invalidation_reason: str | None = None
+    status: str = "current"
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.snapshot_version, "snapshot_version")
+        _parse_timestamp(self.captured_at, "captured_at")
+        if self.status not in POLICY_SYNC_STATES:
+            raise ValueError(f"status must be one of {POLICY_SYNC_STATES}")
+        if self.fresh_until is not None:
+            fresh_until = _parse_timestamp(self.fresh_until, "fresh_until")
+            captured_at = _parse_timestamp(self.captured_at, "captured_at")
+            if fresh_until < captured_at:
+                raise ValueError("fresh_until must not precede captured_at")
+        if self.invalidated_at is not None:
+            invalidated_at = _parse_timestamp(self.invalidated_at, "invalidated_at")
+            captured_at = _parse_timestamp(self.captured_at, "captured_at")
+            if invalidated_at < captured_at:
+                raise ValueError("invalidated_at must not precede captured_at")
+            require_non_empty(self.invalidation_reason or "", "invalidation_reason")
+        if self.status == "invalidated" and self.invalidated_at is None:
+            raise ValueError("invalidated status requires invalidated_at")
+
+    def is_stale(self, reference_time: str | datetime | None = None) -> bool:
+        if self.status in {"stale", "invalidated"}:
+            return True
+        if self.invalidated_at is not None:
+            return True
+        if self.fresh_until is None:
+            return False
+        if reference_time is None:
+            ref = datetime.now(UTC)
+        elif isinstance(reference_time, datetime):
+            ref = reference_time.astimezone(UTC)
+        else:
+            ref = _parse_timestamp(reference_time, "reference_time")
+        return _parse_timestamp(self.fresh_until, "fresh_until") <= ref
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class OrganizationContextSnapshot:
+    organization_id: str
+    approved_channels: list[str] = field(default_factory=list)
+    comparable_requirements: dict[str, int] = field(default_factory=dict)
+    documentation_rules: list[str] = field(default_factory=list)
+    approval_triggers: list[str] = field(default_factory=list)
+    comfort_preferences: dict[str, Any] = field(default_factory=dict)
+    class_of_service_limits: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.organization_id, "organization_id")
+        require_strings(self.approved_channels, "approved_channels")
+        require_strings(self.documentation_rules, "documentation_rules")
+        require_strings(self.approval_triggers, "approval_triggers")
+        require_string_mapping(self.comfort_preferences, "comfort_preferences")
+        require_string_mapping(self.class_of_service_limits, "class_of_service_limits")
+        require_string_mapping(self.metadata, "metadata")
+        if any(
+            not isinstance(key, str) or not key for key in self.comparable_requirements
+        ):
+            raise ValueError("comparable_requirements must use non-empty string keys")
+        for key, value in self.comparable_requirements.items():
+            if not isinstance(value, int):
+                raise ValueError(f"comparable_requirements[{key}] must be an integer")
+            require_non_negative(value, f"comparable_requirements[{key}]")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PolicyConstraintImport:
+    constraint_set: PolicyConstraintSet
+    organization_context: OrganizationContextSnapshot
+    freshness: PolicyFreshness
+    source_request_id: str
+    source_correlation_id: str
+    raw_payload: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.constraint_set, PolicyConstraintSet):
+            raise ValueError("constraint_set must be a PolicyConstraintSet")
+        if not isinstance(self.organization_context, OrganizationContextSnapshot):
+            raise ValueError(
+                "organization_context must be an OrganizationContextSnapshot"
+            )
+        if not isinstance(self.freshness, PolicyFreshness):
+            raise ValueError("freshness must be a PolicyFreshness")
+        require_non_empty(self.source_request_id, "source_request_id")
+        require_non_empty(self.source_correlation_id, "source_correlation_id")
+        self.raw_payload = _optional_mapping(self.raw_payload, "raw_payload")
+
+    @property
+    def organization_id(self) -> str:
+        return self.constraint_set.organization_id
+
+    def is_stale(self, reference_time: str | datetime | None = None) -> bool:
+        return self.freshness.is_stale(reference_time)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["constraint_set"] = self.constraint_set.to_dict()
+        payload["organization_context"] = self.organization_context.to_dict()
+        payload["freshness"] = self.freshness.to_dict()
+        return payload
+
+
+class PolicySyncError(ValueError):
+    """Raised when a TPP policy import cannot be normalized safely."""
+
+
+class TPPPolicySyncService:
+    """Imports TPP policy responses into ranking-ready local contracts."""
+
+    def __init__(self, client: TPPIntegrationClient) -> None:
+        self.client = client
+
+    def import_policy_constraints(
+        self, request: TPPRequestEnvelope
+    ) -> PolicyConstraintImport:
+        response = self.client.fetch_policy_constraints(request)
+        return self.normalize_response(request, response)
+
+    def normalize_response(
+        self, request: TPPRequestEnvelope, response: TPPResponseEnvelope
+    ) -> PolicyConstraintImport:
+        if request.operation != "fetch_policy_constraints":
+            raise PolicySyncError(
+                "request.operation must be 'fetch_policy_constraints'"
+            )
+        if response.operation != "fetch_policy_constraints":
+            raise PolicySyncError(
+                "response.operation must be 'fetch_policy_constraints'"
+            )
+        if response.execution_status.state != "succeeded":
+            raise PolicySyncError("policy imports require a succeeded execution_status")
+
+        payload = _require_mapping(response.result_payload, "result_payload")
+        constraint_payload = _require_mapping(
+            payload.get("constraint_set"), "result_payload.constraint_set"
+        )
+        context_payload = _optional_mapping(
+            payload.get("organization_context"),
+            "result_payload.organization_context",
+        )
+        freshness_payload = _require_mapping(
+            payload.get("freshness"), "result_payload.freshness"
+        )
+
+        organization_id = constraint_payload.get(
+            "organization_id"
+        ) or context_payload.get("organization_id")
+        if (
+            request.organization_id is not None
+            and organization_id != request.organization_id
+        ):
+            raise PolicySyncError(
+                "response organization_id does not match request.organization_id"
+            )
+
+        constraint_set = PolicyConstraintSet(
+            policy_id=constraint_payload["policy_id"],
+            organization_id=organization_id,
+            policy_version=constraint_payload["policy_version"],
+            required_booking_channels=_optional_string_list(
+                constraint_payload.get("required_booking_channels")
+                or context_payload.get("approved_channels"),
+                "required_booking_channels",
+            ),
+            airfare_rules=_optional_mapping(
+                constraint_payload.get("airfare_rules"), "airfare_rules"
+            ),
+            lodging_rules=_optional_mapping(
+                constraint_payload.get("lodging_rules"), "lodging_rules"
+            ),
+            ground_transport_rules=_optional_mapping(
+                constraint_payload.get("ground_transport_rules"),
+                "ground_transport_rules",
+            ),
+            meal_rules=_optional_mapping(
+                constraint_payload.get("meal_rules"), "meal_rules"
+            ),
+            approval_rules=_optional_string_list(
+                constraint_payload.get("approval_rules")
+                or context_payload.get("approval_triggers"),
+                "approval_rules",
+            ),
+            documentation_rules=_optional_string_list(
+                constraint_payload.get("documentation_rules")
+                or context_payload.get("documentation_rules"),
+                "documentation_rules",
+            ),
+            allowed_exception_types=_optional_string_list(
+                constraint_payload.get("allowed_exception_types"),
+                "allowed_exception_types",
+            ),
+        )
+
+        organization_context = OrganizationContextSnapshot(
+            organization_id=organization_id,
+            approved_channels=_optional_string_list(
+                context_payload.get("approved_channels")
+                or constraint_payload.get("required_booking_channels"),
+                "approved_channels",
+            ),
+            comparable_requirements={
+                key: value
+                for key, value in _optional_mapping(
+                    context_payload.get("comparable_requirements"),
+                    "comparable_requirements",
+                ).items()
+            },
+            documentation_rules=_optional_string_list(
+                context_payload.get("documentation_rules")
+                or constraint_payload.get("documentation_rules"),
+                "organization_context.documentation_rules",
+            ),
+            approval_triggers=_optional_string_list(
+                context_payload.get("approval_triggers")
+                or constraint_payload.get("approval_rules"),
+                "approval_triggers",
+            ),
+            comfort_preferences=_optional_mapping(
+                context_payload.get("comfort_preferences"), "comfort_preferences"
+            ),
+            class_of_service_limits=_optional_mapping(
+                context_payload.get("class_of_service_limits"),
+                "class_of_service_limits",
+            ),
+            metadata=_optional_mapping(context_payload.get("metadata"), "metadata"),
+        )
+
+        freshness = PolicyFreshness(
+            snapshot_version=freshness_payload.get(
+                "snapshot_version", constraint_set.policy_version
+            ),
+            captured_at=freshness_payload.get("captured_at")
+            or response.received_at
+            or response.execution_status.updated_at
+            or request.submitted_at
+            or "",
+            fresh_until=freshness_payload.get("fresh_until"),
+            invalidated_at=freshness_payload.get("invalidated_at"),
+            invalidation_reason=freshness_payload.get("invalidation_reason"),
+            status=freshness_payload.get("status", "current"),
+        )
+
+        return PolicyConstraintImport(
+            constraint_set=constraint_set,
+            organization_context=organization_context,
+            freshness=freshness,
+            source_request_id=response.request_id,
+            source_correlation_id=response.correlation_id.value,
+            raw_payload=payload,
+        )
+
+
+def summarize_policy_import(
+    imported: PolicyConstraintImport, reference_time: str | datetime | None = None
+) -> dict[str, Any]:
+    """Expose a compact summary for ranking and orchestration handoff."""
+
+    summary = {
+        "organization_id": imported.organization_id,
+        "policy_id": imported.constraint_set.policy_id,
+        "policy_version": imported.constraint_set.policy_version,
+        "approved_channels": list(imported.organization_context.approved_channels),
+        "approval_triggers": list(imported.organization_context.approval_triggers),
+        "documentation_rules": list(imported.constraint_set.documentation_rules),
+        "comparable_requirements": dict(
+            imported.organization_context.comparable_requirements
+        ),
+        "is_stale": imported.is_stale(reference_time),
+        "freshness": imported.freshness.to_dict(),
+    }
+    summary["freshness"]["captured_at"] = _serialize_timestamp(
+        _parse_timestamp(imported.freshness.captured_at, "captured_at")
+    )
+    if imported.freshness.fresh_until is not None:
+        summary["freshness"]["fresh_until"] = _serialize_timestamp(
+            _parse_timestamp(imported.freshness.fresh_until, "fresh_until")
+        )
+    if imported.freshness.invalidated_at is not None:
+        summary["freshness"]["invalidated_at"] = _serialize_timestamp(
+            _parse_timestamp(imported.freshness.invalidated_at, "invalidated_at")
+        )
+    return summary

--- a/trip_planner/integrations/tpp/policy_sync.py
+++ b/trip_planner/integrations/tpp/policy_sync.py
@@ -46,6 +46,13 @@ def _optional_string_list(value: Any, field_name: str) -> list[str]:
     return _require_string_list(value, field_name)
 
 
+def _require_string_field(value: Any, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be provided as a string")
+    require_non_empty(value, field_name)
+    return value
+
+
 def _parse_timestamp(value: str, field_name: str) -> datetime:
     require_non_empty(value, field_name)
     try:
@@ -130,6 +137,13 @@ class OrganizationContextSnapshot:
         require_strings(self.approved_channels, "approved_channels")
         require_strings(self.documentation_rules, "documentation_rules")
         require_strings(self.approval_triggers, "approval_triggers")
+        self.comfort_preferences = _require_mapping(
+            self.comfort_preferences, "comfort_preferences"
+        )
+        self.class_of_service_limits = _require_mapping(
+            self.class_of_service_limits, "class_of_service_limits"
+        )
+        self.metadata = _require_mapping(self.metadata, "metadata")
         require_string_mapping(self.comfort_preferences, "comfort_preferences")
         require_string_mapping(self.class_of_service_limits, "class_of_service_limits")
         require_string_mapping(self.metadata, "metadata")
@@ -212,6 +226,14 @@ class TPPPolicySyncService:
             )
         if response.execution_status.state != "succeeded":
             raise PolicySyncError("policy imports require a succeeded execution_status")
+        if response.request_id != request.request_id:
+            raise PolicySyncError(
+                "response.request_id does not match request.request_id"
+            )
+        if response.correlation_id.value != request.correlation_id.value:
+            raise PolicySyncError(
+                "response.correlation_id does not match request.correlation_id"
+            )
 
         payload = _require_mapping(response.result_payload, "result_payload")
         constraint_payload = _require_mapping(
@@ -225,9 +247,11 @@ class TPPPolicySyncService:
             payload.get("freshness"), "result_payload.freshness"
         )
 
-        organization_id = constraint_payload.get(
-            "organization_id"
-        ) or context_payload.get("organization_id")
+        organization_id = _require_string_field(
+            constraint_payload.get("organization_id")
+            or context_payload.get("organization_id"),
+            "organization_id",
+        )
         if (
             request.organization_id is not None
             and organization_id != request.organization_id
@@ -338,7 +362,8 @@ def summarize_policy_import(
 ) -> dict[str, Any]:
     """Expose a compact summary for ranking and orchestration handoff."""
 
-    summary = {
+    freshness_summary = imported.freshness.to_dict()
+    summary: dict[str, Any] = {
         "organization_id": imported.organization_id,
         "policy_id": imported.constraint_set.policy_id,
         "policy_version": imported.constraint_set.policy_version,
@@ -349,17 +374,17 @@ def summarize_policy_import(
             imported.organization_context.comparable_requirements
         ),
         "is_stale": imported.is_stale(reference_time),
-        "freshness": imported.freshness.to_dict(),
+        "freshness": freshness_summary,
     }
-    summary["freshness"]["captured_at"] = _serialize_timestamp(
+    freshness_summary["captured_at"] = _serialize_timestamp(
         _parse_timestamp(imported.freshness.captured_at, "captured_at")
     )
     if imported.freshness.fresh_until is not None:
-        summary["freshness"]["fresh_until"] = _serialize_timestamp(
+        freshness_summary["fresh_until"] = _serialize_timestamp(
             _parse_timestamp(imported.freshness.fresh_until, "fresh_until")
         )
     if imported.freshness.invalidated_at is not None:
-        summary["freshness"]["invalidated_at"] = _serialize_timestamp(
+        freshness_summary["invalidated_at"] = _serialize_timestamp(
             _parse_timestamp(imported.freshness.invalidated_at, "invalidated_at")
         )
     return summary


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #551

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Business planning depends on having the right policy constraints and organization context before candidate generation and ranking finalize. The repo therefore needs a dedicated sync layer that can import policy constraints, approved channels, and organization-specific context from `Travel-Plan-Permission` without hard-coding them into local profiles.

Parent epic: #549

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#549](https://github.com/stranske/trip-planner/issues/549)
- [#516](https://github.com/stranske/trip-planner/issues/516)
- [#518](https://github.com/stranske/trip-planner/issues/518)
- [#550](https://github.com/stranske/trip-planner/issues/550)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement a sync scaffold that can request and store `PolicyConstraintSet` and related organization context from the external integration layer.
- [x] Ensure imported policy inputs can represent approved channels, comparable requirements, documentation rules, comfort or class-of-service limits, and approval triggers.
- [x] Add support for freshness metadata, version identifiers, and invalidation markers so stale policy inputs are detectable.
- [x] Add representative fixtures for at least: a standard compliant policy set, a stricter organization policy set, and a stale or invalidated policy snapshot.
- [x] Write unit tests covering import, normalization, stale-policy handling, and malformed external payloads.
- [x] Document how synced policy constraints should feed business ranking and orchestration layers without becoming the source of truth for policy evaluation.

#### Acceptance criteria
- [x] The repo contains a policy-constraint import and organization-context sync scaffold.
- [x] Imported policy inputs preserve freshness and version metadata explicitly.
- [x] Tests cover representative policy imports, stale-policy handling, and malformed payload failures.
- [x] The output shape is compatible with business planning and ranking layers.
- [x] Documentation preserves the distinction between imported policy inputs and authoritative external evaluation.

**Head SHA:** 3ea4b4f9beae28209cfc3170ab154b91aec36246
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23933702523) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23933702534) |
<!-- auto-status-summary:end -->