### PR TITLE
Issue #552: add proposal submission and result ingestion scaffold

### DIFF
--- a/docs/contracts/tpp-execution-contracts.md
+++ b/docs/contracts/tpp-execution-contracts.md
@@ -13,6 +13,8 @@ This contract layer owns transport and execution semantics for the `trip-planner
 - `trip_planner/integrations/tpp/contracts.py`
 - `trip_planner/integrations/tpp/client.py`
 - `trip_planner/integrations/tpp/policy_sync.py`
+- `trip_planner/integrations/tpp/submission.py`
+- `trip_planner/integrations/tpp/results.py`
 
 ## Design Rules
 
@@ -27,3 +29,5 @@ This contract layer owns transport and execution semantics for the `trip-planner
 - issue `#552` should submit `TripPlanProposal` payloads inside these envelopes and read deferred or failed execution state from the same layer.
 - issue `#553` should consume retry and failure records when deciding whether to reoptimize or branch into exception handling.
 - issue `#554` should use the same client abstraction in test harnesses so approval-readiness flows can run against mocks or simulators.
+
+See [tpp-proposal-execution.md](tpp-proposal-execution.md) for the submission and evaluation-result persistence boundary built on top of this execution layer.

--- a/docs/contracts/tpp-proposal-execution.md
+++ b/docs/contracts/tpp-proposal-execution.md
@@ -1,0 +1,28 @@
+# TPP Proposal Submission And Result Storage
+
+This scaffold defines how `trip-planner` should submit a `TripPlanProposal`, persist execution metadata, and normalize later `PolicyEvaluationResult` payloads without mixing transport state into business planning contracts.
+
+## Canonical Modules
+
+- `trip_planner/integrations/tpp/submission.py`
+- `trip_planner/integrations/tpp/results.py`
+- `trip_planner/business/policy_contracts.py`
+
+## Submission Rules
+
+- Submit a `TripPlanProposal` through `TPPProposalSubmissionService` using the existing `TPPRequestEnvelope` / `TPPResponseEnvelope` boundary.
+- Persist the returned `ProposalSubmissionRecord` with explicit linkage for `trip_id`, `proposal_id`, `proposal_version`, and optional `scenario_id`.
+- Treat `execution_id`, queue state, retry metadata, and status endpoints as transport metadata, not as business-policy verdicts.
+
+## Evaluation Result Rules
+
+- Normalize fetched results through `TPPEvaluationResultIngestionService`.
+- Persist `PersistedEvaluationResult` records with the same proposal linkage fields so later reoptimization and approval-packaging work can follow one stable lineage chain.
+- Allow pending or deferred execution states to persist without inventing a final compliance outcome.
+- Only create `PolicyEvaluationResult` objects once the execution status is `succeeded` and the payload is complete.
+
+## Separation Of Concerns
+
+- `TripPlanProposal` remains the canonical planner-side proposal payload.
+- `PolicyEvaluationResult` remains the canonical compliance and approval outcome payload.
+- The new integration services only add correlation, execution, retry, and lineage metadata around those business contracts.

--- a/tests/fixtures/integrations/tpp/results/approved_evaluation.json
+++ b/tests/fixtures/integrations/tpp/results/approved_evaluation.json
@@ -1,0 +1,62 @@
+{
+  "request": {
+    "operation": "fetch_evaluation_result",
+    "request_id": "req-result-approved",
+    "correlation_id": {
+      "value": "corr-result-approved",
+      "issued_by": "trip-planner"
+    },
+    "payload": {
+      "execution_id": "exec-approved-001"
+    },
+    "transport_pattern": "async",
+    "organization_id": "org-acme",
+    "trip_id": "trip-100",
+    "proposal_id": "proposal-123",
+    "submitted_at": "2026-04-03T02:15:00Z"
+  },
+  "response": {
+    "operation": "fetch_evaluation_result",
+    "request_id": "req-result-approved",
+    "correlation_id": {
+      "value": "corr-result-approved",
+      "issued_by": "trip-planner"
+    },
+    "transport_pattern": "async",
+    "execution_status": {
+      "state": "succeeded",
+      "terminal": true,
+      "summary": "Policy evaluation completed",
+      "external_status": "200 OK",
+      "updated_at": "2026-04-03T02:15:04Z"
+    },
+    "result_payload": {
+      "execution_id": "exec-approved-001",
+      "trip_id": "trip-100",
+      "proposal_id": "proposal-123",
+      "proposal_version": "proposal-v3",
+      "scenario_id": "scenario-a",
+      "evaluation_result": {
+        "evaluation_id": "eval-approved-001",
+        "proposal_id": "proposal-123",
+        "status": "compliant",
+        "approval_requirements": [
+          {
+            "role": "manager",
+            "reason": "International travel",
+            "mandatory": true
+          }
+        ],
+        "failure_reasons": [],
+        "preferred_alternatives": [],
+        "exception_guidance": [],
+        "notes": [
+          "Policy constraints satisfied."
+        ],
+        "compliance_score": 0.98
+      }
+    },
+    "received_at": "2026-04-03T02:15:04Z",
+    "status_endpoint": "https://tpp.example.test/executions/exec-approved-001"
+  }
+}

--- a/tests/fixtures/integrations/tpp/results/deferred_evaluation.json
+++ b/tests/fixtures/integrations/tpp/results/deferred_evaluation.json
@@ -1,0 +1,53 @@
+{
+  "request": {
+    "operation": "fetch_evaluation_result",
+    "request_id": "req-result-deferred",
+    "correlation_id": {
+      "value": "corr-result-deferred",
+      "issued_by": "trip-planner"
+    },
+    "payload": {
+      "execution_id": "exec-deferred-001"
+    },
+    "transport_pattern": "async",
+    "organization_id": "org-acme",
+    "trip_id": "trip-100",
+    "proposal_id": "proposal-123",
+    "submitted_at": "2026-04-03T02:22:00Z"
+  },
+  "response": {
+    "operation": "fetch_evaluation_result",
+    "request_id": "req-result-deferred",
+    "correlation_id": {
+      "value": "corr-result-deferred",
+      "issued_by": "trip-planner"
+    },
+    "transport_pattern": "async",
+    "execution_status": {
+      "state": "deferred",
+      "terminal": false,
+      "summary": "Evaluator is still processing the request",
+      "external_status": "202 Accepted",
+      "poll_after_seconds": 45,
+      "updated_at": "2026-04-03T02:22:10Z"
+    },
+    "result_payload": {
+      "execution_id": "exec-deferred-001",
+      "trip_id": "trip-100",
+      "proposal_id": "proposal-123",
+      "proposal_version": "proposal-v3",
+      "scenario_id": "scenario-a",
+      "queue_state": "awaiting_policy_engine"
+    },
+    "retry": {
+      "attempt": 0,
+      "max_attempts": 5,
+      "retryable": true,
+      "backoff_seconds": 45,
+      "next_retry_at": "2026-04-03T02:22:55Z",
+      "reason": "Policy evaluation not finished"
+    },
+    "received_at": "2026-04-03T02:22:10Z",
+    "status_endpoint": "https://tpp.example.test/executions/exec-deferred-001"
+  }
+}

--- a/tests/fixtures/integrations/tpp/results/non_compliant_evaluation.json
+++ b/tests/fixtures/integrations/tpp/results/non_compliant_evaluation.json
@@ -1,0 +1,72 @@
+{
+  "request": {
+    "operation": "fetch_evaluation_result",
+    "request_id": "req-result-non-compliant",
+    "correlation_id": {
+      "value": "corr-result-non-compliant",
+      "issued_by": "trip-planner"
+    },
+    "payload": {
+      "execution_id": "exec-rejected-001"
+    },
+    "transport_pattern": "async",
+    "organization_id": "org-acme",
+    "trip_id": "trip-100",
+    "proposal_id": "proposal-123",
+    "submitted_at": "2026-04-03T02:18:00Z"
+  },
+  "response": {
+    "operation": "fetch_evaluation_result",
+    "request_id": "req-result-non-compliant",
+    "correlation_id": {
+      "value": "corr-result-non-compliant",
+      "issued_by": "trip-planner"
+    },
+    "transport_pattern": "async",
+    "execution_status": {
+      "state": "succeeded",
+      "terminal": true,
+      "summary": "Policy evaluation completed with compliance failures",
+      "external_status": "200 OK",
+      "updated_at": "2026-04-03T02:18:08Z"
+    },
+    "result_payload": {
+      "execution_id": "exec-rejected-001",
+      "trip_id": "trip-100",
+      "proposal_id": "proposal-123",
+      "proposal_version": "proposal-v3",
+      "scenario_id": "scenario-a",
+      "evaluation_result": {
+        "evaluation_id": "eval-rejected-001",
+        "proposal_id": "proposal-123",
+        "status": "non_compliant",
+        "approval_requirements": [],
+        "failure_reasons": [
+          {
+            "code": "lodging_cap_exceeded",
+            "message": "Nightly lodging exceeds the allowed cap.",
+            "severity": "blocking",
+            "related_category": "lodging"
+          }
+        ],
+        "preferred_alternatives": [
+          {
+            "category": "lodging",
+            "summary": "Use a compliant downtown property",
+            "rationale": "Alternative meets nightly cap and booking-channel requirements.",
+            "comparable_ref": "lodging-alt-2"
+          }
+        ],
+        "exception_guidance": [
+          "Provide vice president approval if traveler must remain at the conference hotel."
+        ],
+        "notes": [
+          "Proposal requires lodging changes before submission can pass."
+        ],
+        "compliance_score": 0.42
+      }
+    },
+    "received_at": "2026-04-03T02:18:08Z",
+    "status_endpoint": "https://tpp.example.test/executions/exec-rejected-001"
+  }
+}

--- a/tests/integrations/test_results.py
+++ b/tests/integrations/test_results.py
@@ -13,7 +13,14 @@ from trip_planner.integrations.tpp import (
 
 
 def _fixture_path(name: str) -> Path:
-    return Path("tests/fixtures/integrations/tpp/results") / name
+    return (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "integrations"
+        / "tpp"
+        / "results"
+        / name
+    )
 
 
 def _load_fixture(name: str) -> dict:
@@ -93,6 +100,43 @@ def test_result_ingestion_rejects_succeeded_payload_without_evaluation_result() 
     service = TPPEvaluationResultIngestionService(FakeTPPResultClient(response))
 
     with pytest.raises(EvaluationResultIngestionError, match="evaluation_result"):
+        service.fetch_evaluation_result(
+            request,
+            proposal_version="proposal-v3",
+            scenario_id="scenario-a",
+        )
+
+
+def test_result_ingestion_rejects_missing_linkage_trip_id_with_clear_error() -> None:
+    fixture = _load_fixture("approved_evaluation.json")
+    fixture["request"]["trip_id"] = None
+    del fixture["response"]["result_payload"]["trip_id"]
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPEvaluationResultIngestionService(FakeTPPResultClient(response))
+
+    with pytest.raises(EvaluationResultIngestionError, match="trip_id is required"):
+        service.fetch_evaluation_result(
+            request,
+            proposal_version="proposal-v3",
+            scenario_id="scenario-a",
+        )
+
+
+def test_result_ingestion_rejects_missing_linkage_proposal_id_with_clear_error() -> (
+    None
+):
+    fixture = _load_fixture("approved_evaluation.json")
+    fixture["request"]["proposal_id"] = None
+    del fixture["response"]["result_payload"]["proposal_id"]
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPEvaluationResultIngestionService(FakeTPPResultClient(response))
+
+    with pytest.raises(
+        EvaluationResultIngestionError,
+        match="proposal_id is required",
+    ):
         service.fetch_evaluation_result(
             request,
             proposal_version="proposal-v3",

--- a/tests/integrations/test_results.py
+++ b/tests/integrations/test_results.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.integrations.tpp import (
+    BaseTPPIntegrationClient,
+    EvaluationResultIngestionError,
+    TPPEvaluationResultIngestionService,
+    TPPRequestEnvelope,
+    TPPResponseEnvelope,
+)
+
+
+def _fixture_path(name: str) -> Path:
+    return Path("tests/fixtures/integrations/tpp/results") / name
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+
+
+class FakeTPPResultClient(BaseTPPIntegrationClient):
+    def __init__(self, response: TPPResponseEnvelope) -> None:
+        self.response = response
+
+    def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        return self.response
+
+
+def test_result_ingestion_normalizes_approved_evaluation() -> None:
+    fixture = _load_fixture("approved_evaluation.json")
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPEvaluationResultIngestionService(FakeTPPResultClient(response))
+
+    record = service.fetch_evaluation_result(
+        request,
+        proposal_version="proposal-v3",
+        scenario_id="scenario-a",
+    )
+
+    assert record.linkage.execution_id == "exec-approved-001"
+    assert record.linkage.trip_id == "trip-100"
+    assert record.evaluation_result is not None
+    assert record.evaluation_result.status == "compliant"
+    assert record.evaluation_result.approval_requirements[0].role == "manager"
+    assert record.is_pending is False
+
+
+def test_result_ingestion_normalizes_non_compliant_result() -> None:
+    fixture = _load_fixture("non_compliant_evaluation.json")
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPEvaluationResultIngestionService(FakeTPPResultClient(response))
+
+    record = service.fetch_evaluation_result(
+        request,
+        proposal_version="proposal-v3",
+        scenario_id="scenario-a",
+    )
+
+    assert record.evaluation_result is not None
+    assert record.evaluation_result.status == "non_compliant"
+    assert record.evaluation_result.failure_reasons[0].code == "lodging_cap_exceeded"
+    assert record.evaluation_result.preferred_alternatives[0].category == "lodging"
+
+
+def test_result_ingestion_keeps_deferred_responses_pending() -> None:
+    fixture = _load_fixture("deferred_evaluation.json")
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPEvaluationResultIngestionService(FakeTPPResultClient(response))
+
+    record = service.fetch_evaluation_result(
+        request,
+        proposal_version="proposal-v3",
+        scenario_id="scenario-a",
+    )
+
+    assert record.evaluation_result is None
+    assert record.execution_status.state == "deferred"
+    assert record.is_pending is True
+    assert record.retry is not None
+    assert record.retry.backoff_seconds == 45
+
+
+def test_result_ingestion_rejects_succeeded_payload_without_evaluation_result() -> None:
+    fixture = _load_fixture("approved_evaluation.json")
+    del fixture["response"]["result_payload"]["evaluation_result"]
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPEvaluationResultIngestionService(FakeTPPResultClient(response))
+
+    with pytest.raises(EvaluationResultIngestionError, match="evaluation_result"):
+        service.fetch_evaluation_result(
+            request,
+            proposal_version="proposal-v3",
+            scenario_id="scenario-a",
+        )

--- a/tests/integrations/test_submission.py
+++ b/tests/integrations/test_submission.py
@@ -14,7 +14,10 @@ from trip_planner.integrations.tpp import (
 
 
 def _fixture_path(name: str) -> Path:
-    return Path("tests/fixtures/integrations/tpp") / name
+    fixtures_dir = (
+        Path(__file__).resolve().parents[1] / "fixtures" / "integrations" / "tpp"
+    )
+    return fixtures_dir / name
 
 
 def _load_fixture(name: str) -> dict:
@@ -32,7 +35,7 @@ def _proposal_fixture() -> TripPlanProposal:
                 "traveler_experience": "frequent",
                 "home_airport": "ORD",
                 "loyalty_programs": ["United"],
-                "mobility_or_access_needs": []
+                "mobility_or_access_needs": [],
             },
             "selected_options": [
                 {
@@ -45,9 +48,9 @@ def _proposal_fixture() -> TripPlanProposal:
                         "currency": "USD",
                         "typical_amount": 620.0,
                         "min_amount": 620.0,
-                        "max_amount": 620.0
+                        "max_amount": 620.0,
                     },
-                    "justification_refs": ["fare-policy"]
+                    "justification_refs": ["fare-policy"],
                 },
                 {
                     "category": "lodging",
@@ -59,10 +62,10 @@ def _proposal_fixture() -> TripPlanProposal:
                         "currency": "USD",
                         "typical_amount": 245.0,
                         "min_amount": 245.0,
-                        "max_amount": 245.0
+                        "max_amount": 245.0,
                     },
-                    "justification_refs": ["meeting-proximity"]
-                }
+                    "justification_refs": ["meeting-proximity"],
+                },
             ],
             "cost_summary": {
                 "currency": "USD",
@@ -71,9 +74,9 @@ def _proposal_fixture() -> TripPlanProposal:
                     "airfare": 620.0,
                     "lodging": 490.0,
                     "ground_transport": 75.0,
-                    "meals": 80.0
+                    "meals": 80.0,
                 },
-                "notes": ["Costs include taxes and expected local transport."]
+                "notes": ["Costs include taxes and expected local transport."],
             },
             "comparables": [
                 {
@@ -85,16 +88,16 @@ def _proposal_fixture() -> TripPlanProposal:
                         "currency": "USD",
                         "typical_amount": 198.0,
                         "min_amount": 198.0,
-                        "max_amount": 198.0
+                        "max_amount": 198.0,
                     },
-                    "notes": ["Available but farther from venue."]
+                    "notes": ["Available but farther from venue."],
                 }
             ],
             "justifications": [
                 {
                     "category": "lodging",
                     "summary": "Conference hotel shortens transfer time before the keynote.",
-                    "evidence": ["venue_adjacent"]
+                    "evidence": ["venue_adjacent"],
                 }
             ],
             "booking_channel_summaries": [
@@ -102,11 +105,11 @@ def _proposal_fixture() -> TripPlanProposal:
                     "category": "airfare",
                     "selected_channel": "Navan",
                     "approved": True,
-                    "rationale": "Preferred company channel"
+                    "rationale": "Preferred company channel",
                 }
             ],
             "approval_notes": ["International leg requires manager review."],
-            "constraint_set_id": "policy-standard-2026-02"
+            "constraint_set_id": "policy-standard-2026-02",
         }
     )
 

--- a/tests/integrations/test_submission.py
+++ b/tests/integrations/test_submission.py
@@ -1,0 +1,161 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from trip_planner.business.policy_contracts import TripPlanProposal
+from trip_planner.integrations.tpp import (
+    BaseTPPIntegrationClient,
+    ProposalSubmissionError,
+    TPPProposalSubmissionService,
+    TPPRequestEnvelope,
+    TPPResponseEnvelope,
+)
+
+
+def _fixture_path(name: str) -> Path:
+    return Path("tests/fixtures/integrations/tpp") / name
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+
+
+def _proposal_fixture() -> TripPlanProposal:
+    return TripPlanProposal.from_dict(
+        {
+            "proposal_id": "proposal-123",
+            "trip_id": "trip-100",
+            "mode": "business",
+            "traveler_context": {
+                "employee_type": "employee",
+                "traveler_experience": "frequent",
+                "home_airport": "ORD",
+                "loyalty_programs": ["United"],
+                "mobility_or_access_needs": []
+            },
+            "selected_options": [
+                {
+                    "category": "airfare",
+                    "option_id": "flight-1",
+                    "label": "United 123",
+                    "vendor": "United",
+                    "booking_channel": "Navan",
+                    "estimated_cost": {
+                        "currency": "USD",
+                        "typical_amount": 620.0,
+                        "min_amount": 620.0,
+                        "max_amount": 620.0
+                    },
+                    "justification_refs": ["fare-policy"]
+                },
+                {
+                    "category": "lodging",
+                    "option_id": "hotel-1",
+                    "label": "Conference Hotel",
+                    "vendor": "Marriott",
+                    "booking_channel": "Navan",
+                    "estimated_cost": {
+                        "currency": "USD",
+                        "typical_amount": 245.0,
+                        "min_amount": 245.0,
+                        "max_amount": 245.0
+                    },
+                    "justification_refs": ["meeting-proximity"]
+                }
+            ],
+            "cost_summary": {
+                "currency": "USD",
+                "total_estimated_cost": 1265.0,
+                "category_estimates": {
+                    "airfare": 620.0,
+                    "lodging": 490.0,
+                    "ground_transport": 75.0,
+                    "meals": 80.0
+                },
+                "notes": ["Costs include taxes and expected local transport."]
+            },
+            "comparables": [
+                {
+                    "category": "lodging",
+                    "label": "Compliant Hotel",
+                    "vendor": "Hilton",
+                    "booking_channel": "Concur",
+                    "estimated_cost": {
+                        "currency": "USD",
+                        "typical_amount": 198.0,
+                        "min_amount": 198.0,
+                        "max_amount": 198.0
+                    },
+                    "notes": ["Available but farther from venue."]
+                }
+            ],
+            "justifications": [
+                {
+                    "category": "lodging",
+                    "summary": "Conference hotel shortens transfer time before the keynote.",
+                    "evidence": ["venue_adjacent"]
+                }
+            ],
+            "booking_channel_summaries": [
+                {
+                    "category": "airfare",
+                    "selected_channel": "Navan",
+                    "approved": True,
+                    "rationale": "Preferred company channel"
+                }
+            ],
+            "approval_notes": ["International leg requires manager review."],
+            "constraint_set_id": "policy-standard-2026-02"
+        }
+    )
+
+
+class FakeTPPSubmissionClient(BaseTPPIntegrationClient):
+    def __init__(self, response: TPPResponseEnvelope) -> None:
+        self.response = response
+
+    def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        return self.response
+
+
+def test_submission_normalizes_deferred_response_and_linkage() -> None:
+    fixture = _load_fixture("proposal_submit_deferred.json")
+    proposal = _proposal_fixture()
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPProposalSubmissionService(FakeTPPSubmissionClient(response))
+
+    record = service.submit_proposal(
+        request,
+        proposal,
+        proposal_version="proposal-v3",
+        scenario_id="scenario-a",
+    )
+
+    assert record.linkage.trip_id == "trip-100"
+    assert record.linkage.proposal_id == "proposal-123"
+    assert record.linkage.proposal_version == "proposal-v3"
+    assert record.linkage.scenario_id == "scenario-a"
+    assert record.execution_id == "exec-001"
+    assert record.execution_status.state == "deferred"
+    assert record.requires_polling is True
+    assert record.retry is not None
+    assert record.retry.next_retry_at == "2026-04-03T00:41:31Z"
+
+
+def test_submission_rejects_non_terminal_response_without_execution_id() -> None:
+    fixture = _load_fixture("proposal_submit_deferred.json")
+    proposal = _proposal_fixture()
+    del fixture["response"]["result_payload"]["execution_id"]
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+    service = TPPProposalSubmissionService(FakeTPPSubmissionClient(response))
+
+    with pytest.raises(ProposalSubmissionError, match="execution_id"):
+        service.submit_proposal(
+            request,
+            proposal,
+            proposal_version="proposal-v3",
+            scenario_id="scenario-a",
+        )

--- a/trip_planner/integrations/tpp/__init__.py
+++ b/trip_planner/integrations/tpp/__init__.py
@@ -18,6 +18,18 @@ from .policy_sync import (
     TPPPolicySyncService,
     summarize_policy_import,
 )
+from .results import (
+    EvaluationResultIngestionError,
+    PersistedEvaluationResult,
+    ProposalEvaluationLinkage,
+    TPPEvaluationResultIngestionService,
+)
+from .submission import (
+    ProposalSubmissionError,
+    ProposalSubmissionLinkage,
+    ProposalSubmissionRecord,
+    TPPProposalSubmissionService,
+)
 
 __all__ = [
     "BaseTPPIntegrationClient",
@@ -25,14 +37,22 @@ __all__ = [
     "PolicyConstraintImport",
     "PolicyFreshness",
     "PolicySyncError",
+    "PersistedEvaluationResult",
+    "ProposalEvaluationLinkage",
+    "ProposalSubmissionError",
+    "ProposalSubmissionLinkage",
+    "ProposalSubmissionRecord",
     "TPPCorrelationId",
     "TPPErrorRecord",
+    "TPPEvaluationResultIngestionService",
     "TPPExecutionStatus",
     "TPPIntegrationClient",
     "TPPOperationRequest",
+    "TPPProposalSubmissionService",
     "TPPPolicySyncService",
     "TPPRequestEnvelope",
     "TPPResponseEnvelope",
     "TPPRetryMetadata",
+    "EvaluationResultIngestionError",
     "summarize_policy_import",
 ]

--- a/trip_planner/integrations/tpp/results.py
+++ b/trip_planner/integrations/tpp/results.py
@@ -1,0 +1,237 @@
+"""Evaluation-result ingestion scaffolding for Travel-Plan-Permission."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner._validators import require_non_empty
+from trip_planner.business.policy_contracts import PolicyEvaluationResult
+
+from .client import TPPIntegrationClient
+from .contracts import (
+    TPPErrorRecord,
+    TPPExecutionStatus,
+    TPPRequestEnvelope,
+    TPPResponseEnvelope,
+    TPPRetryMetadata,
+)
+
+
+def _optional_mapping(value: Any, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be provided as a mapping")
+    return dict(value)
+
+
+def _optional_string(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be provided as a string")
+    require_non_empty(value, field_name)
+    return value
+
+
+@dataclass(slots=True)
+class ProposalEvaluationLinkage:
+    trip_id: str
+    proposal_id: str
+    proposal_version: str
+    scenario_id: str | None = None
+    execution_id: str | None = None
+    organization_id: str | None = None
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.proposal_id, "proposal_id")
+        require_non_empty(self.proposal_version, "proposal_version")
+        for field_name in ("scenario_id", "execution_id", "organization_id"):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_non_empty(value, field_name)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class PersistedEvaluationResult:
+    linkage: ProposalEvaluationLinkage
+    request_id: str
+    correlation_id: str
+    transport_pattern: str
+    execution_status: TPPExecutionStatus
+    evaluation_result: PolicyEvaluationResult | None = None
+    status_endpoint: str | None = None
+    request_payload: dict[str, Any] = field(default_factory=dict)
+    response_payload: dict[str, Any] = field(default_factory=dict)
+    retry: TPPRetryMetadata | None = None
+    error: TPPErrorRecord | None = None
+    received_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.linkage, ProposalEvaluationLinkage):
+            raise ValueError("linkage must be a ProposalEvaluationLinkage")
+        require_non_empty(self.request_id, "request_id")
+        require_non_empty(self.correlation_id, "correlation_id")
+        require_non_empty(self.transport_pattern, "transport_pattern")
+        if not isinstance(self.execution_status, TPPExecutionStatus):
+            raise ValueError("execution_status must be a TPPExecutionStatus")
+        if self.evaluation_result is not None and not isinstance(
+            self.evaluation_result, PolicyEvaluationResult
+        ):
+            raise ValueError("evaluation_result must be a PolicyEvaluationResult")
+        self.request_payload = _optional_mapping(self.request_payload, "request_payload")
+        self.response_payload = _optional_mapping(
+            self.response_payload, "response_payload"
+        )
+        if self.retry is not None and not isinstance(self.retry, TPPRetryMetadata):
+            raise ValueError("retry must be a TPPRetryMetadata when provided")
+        if self.error is not None and not isinstance(self.error, TPPErrorRecord):
+            raise ValueError("error must be a TPPErrorRecord when provided")
+        _optional_string(self.status_endpoint, "status_endpoint")
+        _optional_string(self.received_at, "received_at")
+        if self.execution_status.state == "succeeded" and self.evaluation_result is None:
+            raise ValueError(
+                "succeeded evaluation responses must include a normalized evaluation_result"
+            )
+
+    @property
+    def is_pending(self) -> bool:
+        return self.execution_status.state in {
+            "accepted",
+            "running",
+            "deferred",
+            "retry_scheduled",
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["linkage"] = self.linkage.to_dict()
+        payload["execution_status"] = self.execution_status.to_dict()
+        if self.evaluation_result is not None:
+            payload["evaluation_result"] = self.evaluation_result.to_dict()
+        if self.retry is not None:
+            payload["retry"] = self.retry.to_dict()
+        if self.error is not None:
+            payload["error"] = self.error.to_dict()
+        return payload
+
+
+class EvaluationResultIngestionError(ValueError):
+    """Raised when a TPP evaluation-result payload cannot be normalized safely."""
+
+
+class TPPEvaluationResultIngestionService:
+    """Fetch and normalize policy-evaluation results for persistence."""
+
+    def __init__(self, client: TPPIntegrationClient) -> None:
+        self.client = client
+
+    def fetch_evaluation_result(
+        self,
+        request: TPPRequestEnvelope,
+        *,
+        proposal_version: str,
+        scenario_id: str | None = None,
+    ) -> PersistedEvaluationResult:
+        response = self.client.fetch_evaluation_result(request)
+        return self.normalize_response(
+            request,
+            response,
+            proposal_version=proposal_version,
+            scenario_id=scenario_id,
+        )
+
+    def normalize_response(
+        self,
+        request: TPPRequestEnvelope,
+        response: TPPResponseEnvelope,
+        *,
+        proposal_version: str,
+        scenario_id: str | None = None,
+    ) -> PersistedEvaluationResult:
+        if request.operation != "fetch_evaluation_result":
+            raise EvaluationResultIngestionError(
+                "request.operation must be 'fetch_evaluation_result'"
+            )
+        if response.operation != "fetch_evaluation_result":
+            raise EvaluationResultIngestionError(
+                "response.operation must be 'fetch_evaluation_result'"
+            )
+        if response.request_id != request.request_id:
+            raise EvaluationResultIngestionError(
+                "response.request_id does not match request.request_id"
+            )
+        if response.correlation_id.value != request.correlation_id.value:
+            raise EvaluationResultIngestionError(
+                "response.correlation_id does not match request.request_id"
+            )
+
+        payload = _optional_mapping(response.result_payload, "result_payload")
+        linkage = ProposalEvaluationLinkage(
+            trip_id=_optional_string(payload.get("trip_id"), "result_payload.trip_id")
+            or request.trip_id
+            or "",
+            proposal_id=(
+                _optional_string(
+                    payload.get("proposal_id"),
+                    "result_payload.proposal_id",
+                )
+                or request.proposal_id
+                or ""
+            ),
+            proposal_version=(
+                _optional_string(
+                    payload.get("proposal_version"),
+                    "result_payload.proposal_version",
+                )
+                or proposal_version
+            ),
+            scenario_id=(
+                _optional_string(
+                    payload.get("scenario_id"),
+                    "result_payload.scenario_id",
+                )
+                or scenario_id
+            ),
+            execution_id=_optional_string(
+                payload.get("execution_id"),
+                "result_payload.execution_id",
+            ),
+            organization_id=request.organization_id,
+        )
+
+        evaluation_result: PolicyEvaluationResult | None = None
+        if response.execution_status.state == "succeeded":
+            result_payload = _optional_mapping(
+                payload.get("evaluation_result"),
+                "result_payload.evaluation_result",
+            )
+            if not result_payload:
+                raise EvaluationResultIngestionError(
+                    "result_payload.evaluation_result is required for succeeded responses"
+                )
+            evaluation_result = PolicyEvaluationResult.from_dict(result_payload)
+            if evaluation_result.proposal_id != linkage.proposal_id:
+                raise EvaluationResultIngestionError(
+                    "evaluation_result.proposal_id does not match linked proposal_id"
+                )
+
+        return PersistedEvaluationResult(
+            linkage=linkage,
+            request_id=request.request_id,
+            correlation_id=request.correlation_id.value,
+            transport_pattern=response.transport_pattern,
+            execution_status=response.execution_status,
+            evaluation_result=evaluation_result,
+            status_endpoint=response.status_endpoint,
+            request_payload=request.payload,
+            response_payload=payload,
+            retry=response.retry,
+            error=response.error,
+            received_at=response.received_at,
+        )

--- a/trip_planner/integrations/tpp/results.py
+++ b/trip_planner/integrations/tpp/results.py
@@ -84,7 +84,9 @@ class PersistedEvaluationResult:
             self.evaluation_result, PolicyEvaluationResult
         ):
             raise ValueError("evaluation_result must be a PolicyEvaluationResult")
-        self.request_payload = _optional_mapping(self.request_payload, "request_payload")
+        self.request_payload = _optional_mapping(
+            self.request_payload, "request_payload"
+        )
         self.response_payload = _optional_mapping(
             self.response_payload, "response_payload"
         )
@@ -94,7 +96,10 @@ class PersistedEvaluationResult:
             raise ValueError("error must be a TPPErrorRecord when provided")
         _optional_string(self.status_endpoint, "status_endpoint")
         _optional_string(self.received_at, "received_at")
-        if self.execution_status.state == "succeeded" and self.evaluation_result is None:
+        if (
+            self.execution_status.state == "succeeded"
+            and self.evaluation_result is None
+        ):
             raise ValueError(
                 "succeeded evaluation responses must include a normalized evaluation_result"
             )
@@ -168,22 +173,33 @@ class TPPEvaluationResultIngestionService:
             )
         if response.correlation_id.value != request.correlation_id.value:
             raise EvaluationResultIngestionError(
-                "response.correlation_id does not match request.request_id"
+                "response.correlation_id does not match request.correlation_id"
             )
 
         payload = _optional_mapping(response.result_payload, "result_payload")
+        payload_trip_id = _optional_string(
+            payload.get("trip_id"),
+            "result_payload.trip_id",
+        )
+        linkage_trip_id = payload_trip_id or request.trip_id
+        if not linkage_trip_id:
+            raise EvaluationResultIngestionError(
+                "trip_id is required in result_payload.trip_id when request.trip_id is missing"
+            )
+
+        payload_proposal_id = _optional_string(
+            payload.get("proposal_id"),
+            "result_payload.proposal_id",
+        )
+        linkage_proposal_id = payload_proposal_id or request.proposal_id
+        if not linkage_proposal_id:
+            raise EvaluationResultIngestionError(
+                "proposal_id is required in result_payload.proposal_id when request.proposal_id is missing"
+            )
+
         linkage = ProposalEvaluationLinkage(
-            trip_id=_optional_string(payload.get("trip_id"), "result_payload.trip_id")
-            or request.trip_id
-            or "",
-            proposal_id=(
-                _optional_string(
-                    payload.get("proposal_id"),
-                    "result_payload.proposal_id",
-                )
-                or request.proposal_id
-                or ""
-            ),
+            trip_id=linkage_trip_id,
+            proposal_id=linkage_proposal_id,
             proposal_version=(
                 _optional_string(
                     payload.get("proposal_version"),

--- a/trip_planner/integrations/tpp/submission.py
+++ b/trip_planner/integrations/tpp/submission.py
@@ -1,0 +1,230 @@
+"""Proposal submission scaffolding for Travel-Plan-Permission."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from trip_planner._validators import require_non_empty
+from trip_planner.business.policy_contracts import TripPlanProposal
+
+from .client import TPPIntegrationClient
+from .contracts import (
+    TPPErrorRecord,
+    TPPExecutionStatus,
+    TPPRequestEnvelope,
+    TPPResponseEnvelope,
+    TPPRetryMetadata,
+)
+
+
+def _optional_mapping(value: Any, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be provided as a mapping")
+    return dict(value)
+
+
+def _optional_string(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be provided as a string")
+    require_non_empty(value, field_name)
+    return value
+
+
+@dataclass(slots=True)
+class ProposalSubmissionLinkage:
+    trip_id: str
+    proposal_id: str
+    proposal_version: str
+    scenario_id: str | None = None
+    constraint_set_id: str | None = None
+    organization_id: str | None = None
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.trip_id, "trip_id")
+        require_non_empty(self.proposal_id, "proposal_id")
+        require_non_empty(self.proposal_version, "proposal_version")
+        for field_name in ("scenario_id", "constraint_set_id", "organization_id"):
+            value = getattr(self, field_name)
+            if value is not None:
+                require_non_empty(value, field_name)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class ProposalSubmissionRecord:
+    proposal: TripPlanProposal
+    linkage: ProposalSubmissionLinkage
+    request_id: str
+    correlation_id: str
+    transport_pattern: str
+    execution_status: TPPExecutionStatus
+    execution_id: str | None = None
+    queue_state: str | None = None
+    status_endpoint: str | None = None
+    request_payload: dict[str, Any] = field(default_factory=dict)
+    response_payload: dict[str, Any] = field(default_factory=dict)
+    retry: TPPRetryMetadata | None = None
+    error: TPPErrorRecord | None = None
+    submitted_at: str | None = None
+    received_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.proposal, TripPlanProposal):
+            raise ValueError("proposal must be a TripPlanProposal")
+        if not isinstance(self.linkage, ProposalSubmissionLinkage):
+            raise ValueError("linkage must be a ProposalSubmissionLinkage")
+        require_non_empty(self.request_id, "request_id")
+        require_non_empty(self.correlation_id, "correlation_id")
+        require_non_empty(self.transport_pattern, "transport_pattern")
+        if not isinstance(self.execution_status, TPPExecutionStatus):
+            raise ValueError("execution_status must be a TPPExecutionStatus")
+        self.request_payload = _optional_mapping(self.request_payload, "request_payload")
+        self.response_payload = _optional_mapping(
+            self.response_payload, "response_payload"
+        )
+        for field_name in (
+            "execution_id",
+            "queue_state",
+            "status_endpoint",
+            "submitted_at",
+            "received_at",
+        ):
+            _optional_string(getattr(self, field_name), field_name)
+        if self.retry is not None and not isinstance(self.retry, TPPRetryMetadata):
+            raise ValueError("retry must be a TPPRetryMetadata when provided")
+        if self.error is not None and not isinstance(self.error, TPPErrorRecord):
+            raise ValueError("error must be a TPPErrorRecord when provided")
+
+    @property
+    def requires_polling(self) -> bool:
+        return self.execution_status.state in {
+            "accepted",
+            "running",
+            "deferred",
+            "retry_scheduled",
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["proposal"] = self.proposal.to_dict()
+        payload["linkage"] = self.linkage.to_dict()
+        payload["execution_status"] = self.execution_status.to_dict()
+        if self.retry is not None:
+            payload["retry"] = self.retry.to_dict()
+        if self.error is not None:
+            payload["error"] = self.error.to_dict()
+        return payload
+
+
+class ProposalSubmissionError(ValueError):
+    """Raised when a TPP proposal submission cannot be normalized safely."""
+
+
+class TPPProposalSubmissionService:
+    """Submit business proposals and persist their transport metadata."""
+
+    def __init__(self, client: TPPIntegrationClient) -> None:
+        self.client = client
+
+    def submit_proposal(
+        self,
+        request: TPPRequestEnvelope,
+        proposal: TripPlanProposal,
+        *,
+        proposal_version: str,
+        scenario_id: str | None = None,
+    ) -> ProposalSubmissionRecord:
+        response = self.client.submit_proposal(request)
+        return self.normalize_response(
+            request,
+            proposal,
+            response,
+            proposal_version=proposal_version,
+            scenario_id=scenario_id,
+        )
+
+    def normalize_response(
+        self,
+        request: TPPRequestEnvelope,
+        proposal: TripPlanProposal,
+        response: TPPResponseEnvelope,
+        *,
+        proposal_version: str,
+        scenario_id: str | None = None,
+    ) -> ProposalSubmissionRecord:
+        if request.operation != "submit_proposal":
+            raise ProposalSubmissionError(
+                "request.operation must be 'submit_proposal'"
+            )
+        if response.operation != "submit_proposal":
+            raise ProposalSubmissionError(
+                "response.operation must be 'submit_proposal'"
+            )
+        if response.request_id != request.request_id:
+            raise ProposalSubmissionError(
+                "response.request_id does not match request.request_id"
+            )
+        if response.correlation_id.value != request.correlation_id.value:
+            raise ProposalSubmissionError(
+                "response.correlation_id does not match request.correlation_id"
+            )
+        if request.proposal_id is not None and request.proposal_id != proposal.proposal_id:
+            raise ProposalSubmissionError(
+                "request.proposal_id does not match proposal.proposal_id"
+            )
+        if request.trip_id is not None and request.trip_id != proposal.trip_id:
+            raise ProposalSubmissionError("request.trip_id does not match proposal.trip_id")
+
+        response_payload = _optional_mapping(response.result_payload, "result_payload")
+        linkage = ProposalSubmissionLinkage(
+            trip_id=proposal.trip_id,
+            proposal_id=proposal.proposal_id,
+            proposal_version=proposal_version,
+            scenario_id=(
+                _optional_string(
+                    response_payload.get("scenario_id"),
+                    "result_payload.scenario_id",
+                )
+                or scenario_id
+            ),
+            constraint_set_id=proposal.constraint_set_id,
+            organization_id=request.organization_id,
+        )
+
+        execution_id = _optional_string(
+            response_payload.get("execution_id"),
+            "result_payload.execution_id",
+        )
+        if response.execution_status.state in {"accepted", "running", "deferred"}:
+            if execution_id is None:
+                raise ProposalSubmissionError(
+                    "result_payload.execution_id is required for non-terminal submissions"
+                )
+
+        return ProposalSubmissionRecord(
+            proposal=proposal,
+            linkage=linkage,
+            request_id=request.request_id,
+            correlation_id=request.correlation_id.value,
+            transport_pattern=response.transport_pattern,
+            execution_status=response.execution_status,
+            execution_id=execution_id,
+            queue_state=_optional_string(
+                response_payload.get("queue_state"),
+                "result_payload.queue_state",
+            ),
+            status_endpoint=response.status_endpoint,
+            request_payload=request.payload,
+            response_payload=response_payload,
+            retry=response.retry,
+            error=response.error,
+            submitted_at=request.submitted_at,
+            received_at=response.received_at,
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #552

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Once the planner can prepare policy-ready proposals, it still needs an execution path to submit them, ingest evaluation responses, and persist the result state. Without that scaffold, the business side cannot actually close the loop between local planning and external policy evaluation.

Parent epic: #549

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#549](https://github.com/stranske/trip-planner/issues/549)
- [#516](https://github.com/stranske/trip-planner/issues/516)
- [#537](https://github.com/stranske/trip-planner/issues/537)
- [#550](https://github.com/stranske/trip-planner/issues/550)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement a submission scaffold that sends `TripPlanProposal` payloads through the integration-client layer and records request metadata.
- [x] Implement normalized ingestion for returned `PolicyEvaluationResult` payloads, including status, approval requirements, failure reasons, preferred alternatives, and exception guidance.
- [x] Ensure evaluation results are persisted and linked to the originating trip, scenario, and proposal version.
- [x] Add representative fixtures for at least: an approved proposal, a failed proposal, and a deferred or asynchronous evaluation response.
- [x] Write unit tests covering submission metadata, result ingestion, malformed response handling, and persistence linkage.
- [x] Document how proposal execution and evaluation-result storage should relate to business orchestration and reoptimization.

#### Acceptance criteria
- [x] The repo contains a scaffold for proposal submission and evaluation-result ingestion.
- [x] Evaluation results are normalized and linked to trips or scenarios explicitly.
- [x] Tests cover approved, failed, and deferred evaluation outcomes plus malformed-payload failures.
- [x] The output shape is compatible with later reoptimization and approval-readiness work.
- [x] Documentation makes clear that submission and result ingestion are separate from local planning logic.

**Head SHA:** 9accba5d0304a0115d7c23248873c68ef7f94953
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23943007527) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23943007335) |
<!-- auto-status-summary:end -->