### PR TITLE
Issue #556: add frontend app shell foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [Core domain contracts](docs/domain-contracts.md)
 - [Business travel profile](docs/business-travel-profile.md)
 - [Planner UI integration](docs/planner-ui-integration.md)
+- [Frontend app shell foundation](docs/frontend-app-shell-foundation.md)
 - [Source and quality model](docs/source-quality-model.md)
 - [Source channel strategy](docs/source-channel-strategy.md)
 - [Legacy itinerary methodology](docs/methodology.md)

--- a/bundle/app-shell/app-shell.js
+++ b/bundle/app-shell/app-shell.js
@@ -46,6 +46,30 @@ const APP_ROUTES = /** @type {const} */ ([
   },
 ]);
 
+const HTML_ESCAPE_LOOKUP = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function escapeHtml(value) {
+  return String(value ?? "").replace(/[&<>"']/g, (character) => HTML_ESCAPE_LOOKUP[character]);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function escapeAttribute(value) {
+  return escapeHtml(value);
+}
+
 /**
  * @param {FrontendShellState["session"]} session
  * @param {FrontendTripSummaryRecord[]} trips
@@ -165,13 +189,23 @@ export function createAppShellStore(initialState) {
       notify();
     },
     setActiveTrip(tripId) {
+      const isTripChange = state.active_trip_id !== tripId;
       state = buildAppShellState({
         ...state,
         active_trip_id: tripId,
-        workspace: {
-          ...state.workspace,
-          trip_id: tripId,
-        },
+        workspace: isTripChange
+          ? {
+              trip_id: tripId,
+              status: "empty",
+              planner_panel_state: null,
+              loading_message: null,
+              error_message: null,
+              persistence_summary: state.workspace.persistence_summary,
+            }
+          : {
+              ...state.workspace,
+              trip_id: tripId,
+            },
       });
       notify();
     },
@@ -216,17 +250,17 @@ function formatStatusLabel(status) {
  */
 function renderTripSummaryCard(trip) {
   return `
-    <button type="button" class="shell-trip-card" data-shell-trip="${trip.trip_id}">
+    <button type="button" class="shell-trip-card" data-shell-trip="${escapeAttribute(trip.trip_id)}">
       <div class="shell-trip-card-header">
-        <strong>${trip.title}</strong>
-        <span class="shell-mode-pill shell-mode-pill--${trip.mode}">${trip.mode}</span>
+        <strong>${escapeHtml(trip.title)}</strong>
+        <span class="shell-mode-pill shell-mode-pill--${escapeAttribute(trip.mode)}">${escapeHtml(trip.mode)}</span>
       </div>
-      <p>${trip.summary}</p>
+      <p>${escapeHtml(trip.summary)}</p>
       <div class="shell-chip-row">
-        <span class="shell-chip">${trip.status}</span>
-        <span class="shell-chip">${trip.primary_regions.join(" · ")}</span>
-        <span class="shell-chip">${trip.scenario_count} scenarios</span>
-        <span class="shell-chip">${trip.pending_checkpoint_count} checkpoints</span>
+        <span class="shell-chip">${escapeHtml(trip.status)}</span>
+        <span class="shell-chip">${escapeHtml(trip.primary_regions.join(" · "))}</span>
+        <span class="shell-chip">${escapeHtml(`${trip.scenario_count} scenarios`)}</span>
+        <span class="shell-chip">${escapeHtml(`${trip.pending_checkpoint_count} checkpoints`)}</span>
       </div>
     </button>
   `;
@@ -245,11 +279,11 @@ function renderRouteTabs(state) {
             <button
               type="button"
               class="shell-route-tab${route.route_id === state.active_route ? " is-active" : ""}"
-              data-shell-route="${route.route_id}"
+              data-shell-route="${escapeAttribute(route.route_id)}"
               aria-pressed="${route.route_id === state.active_route}"
             >
-              <span>${route.label}</span>
-              <small>${route.description}</small>
+              <span>${escapeHtml(route.label)}</span>
+              <small>${escapeHtml(route.description)}</small>
             </button>
           `
         )
@@ -273,9 +307,9 @@ export function renderWorkspaceStatusBoundary(workspace) {
     "Select a trip to start the workspace shell.";
 
   return `
-    <section class="shell-status shell-status--${workspace.status}" aria-label="Workspace status">
-      <strong>${formatStatusLabel(workspace.status)}</strong>
-      <p>${message}</p>
+    <section class="shell-status shell-status--${escapeAttribute(workspace.status)}" aria-label="Workspace status">
+      <strong>${escapeHtml(formatStatusLabel(workspace.status))}</strong>
+      <p>${escapeHtml(message)}</p>
     </section>
   `;
 }
@@ -290,12 +324,12 @@ function renderDashboardView(state) {
       <div class="shell-hero">
         <div>
           <p class="shell-eyebrow">Signed-in planning home</p>
-          <h2>${state.session.display_name}</h2>
-          <p>${state.session.organization ?? "Independent traveler"} can resume saved trips or launch a new flow once issue #557 adds entry screens.</p>
+          <h2>${escapeHtml(state.session.display_name)}</h2>
+          <p>${escapeHtml(state.session.organization ?? "Independent traveler")} can resume saved trips or launch a new flow once issue #557 adds entry screens.</p>
         </div>
         <div class="shell-chip-row">
-          <span class="shell-chip">${state.trips.length} saved trips</span>
-          <span class="shell-chip">default ${state.session.default_trip_mode} mode</span>
+          <span class="shell-chip">${escapeHtml(`${state.trips.length} saved trips`)}</span>
+          <span class="shell-chip">${escapeHtml(`default ${state.session.default_trip_mode} mode`)}</span>
         </div>
       </div>
       <section class="shell-panel">
@@ -313,7 +347,7 @@ function renderDashboardView(state) {
           <span class="shell-meta">what later issues should plug into</span>
         </div>
         <ul class="shell-list">
-          ${state.workspace.persistence_summary.map((item) => `<li>${item}</li>`).join("")}
+          ${state.workspace.persistence_summary.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}
         </ul>
       </section>
     </section>
@@ -341,24 +375,24 @@ function renderTripWorkspaceView(state) {
       ${boundary}
       <div class="shell-hero">
         <div>
-          <p class="shell-eyebrow">${activeTrip.mode} workspace</p>
-          <h2>${activeTrip.title}</h2>
-          <p>${activeTrip.summary}</p>
+          <p class="shell-eyebrow">${escapeHtml(`${activeTrip.mode} workspace`)}</p>
+          <h2>${escapeHtml(activeTrip.title)}</h2>
+          <p>${escapeHtml(activeTrip.summary)}</p>
         </div>
         <div class="shell-chip-row">
-          <span class="shell-chip">${activeTrip.start_date ?? "TBD"} to ${activeTrip.end_date ?? "TBD"}</span>
-          <span class="shell-chip">${activeTrip.primary_regions.join(" · ")}</span>
-          <span class="shell-chip">${activeTrip.scenario_count} scenarios</span>
+          <span class="shell-chip">${escapeHtml(`${activeTrip.start_date ?? "TBD"} to ${activeTrip.end_date ?? "TBD"}`)}</span>
+          <span class="shell-chip">${escapeHtml(activeTrip.primary_regions.join(" · "))}</span>
+          <span class="shell-chip">${escapeHtml(`${activeTrip.scenario_count} scenarios`)}</span>
         </div>
       </div>
       <section class="shell-panel">
         <div class="shell-panel-header">
           <h3>Workspace shell contract</h3>
-          <span class="shell-meta">${formatStatusLabel(state.workspace.status)}</span>
+          <span class="shell-meta">${escapeHtml(formatStatusLabel(state.workspace.status))}</span>
         </div>
-        <p>${scenarioSummary}</p>
+        <p>${escapeHtml(scenarioSummary)}</p>
         <ul class="shell-list">
-          ${state.workspace.persistence_summary.map((item) => `<li>${item}</li>`).join("")}
+          ${state.workspace.persistence_summary.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}
         </ul>
       </section>
     </section>
@@ -382,13 +416,13 @@ function renderPlannerWorkspaceView(state) {
       <section class="shell-panel">
         <div class="shell-panel-header">
           <h3>Planner route</h3>
-          <span class="shell-meta">${plannerState.planner_behavior.trip_stage}</span>
+          <span class="shell-meta">${escapeHtml(plannerState.planner_behavior.trip_stage)}</span>
         </div>
-        <p>${plannerState.trip.summary}</p>
+        <p>${escapeHtml(plannerState.trip.summary)}</p>
         <div class="shell-chip-row">
-          <span class="shell-chip">${plannerState.outputs.length} outputs</span>
-          <span class="shell-chip">${plannerState.pending_decisions.length} pending decisions</span>
-          <span class="shell-chip">${plannerState.option_set.options.length} options</span>
+          <span class="shell-chip">${escapeHtml(`${plannerState.outputs.length} outputs`)}</span>
+          <span class="shell-chip">${escapeHtml(`${plannerState.pending_decisions.length} pending decisions`)}</span>
+          <span class="shell-chip">${escapeHtml(`${plannerState.option_set.options.length} options`)}</span>
         </div>
       </section>
       <section class="shell-panel">
@@ -398,7 +432,10 @@ function renderPlannerWorkspaceView(state) {
         </div>
         <ul class="shell-list">
           ${plannerState.next_step_actions
-            .map((action) => `<li><strong>${action.label}:</strong> ${action.description}</li>`)
+            .map(
+              (action) =>
+                `<li><strong>${escapeHtml(action.label)}:</strong> ${escapeHtml(action.description)}</li>`
+            )
             .join("")}
         </ul>
       </section>
@@ -425,13 +462,13 @@ function renderApprovalCenterView(state) {
       <section class="shell-panel">
         <div class="shell-panel-header">
           <h3>Approval posture</h3>
-          <span class="shell-meta">${policy.status}</span>
+          <span class="shell-meta">${escapeHtml(policy.status)}</span>
         </div>
-        <p>${state.workspace.planner_panel_state.trip.summary}</p>
+        <p>${escapeHtml(state.workspace.planner_panel_state.trip.summary)}</p>
         <div class="shell-chip-row">
-          <span class="shell-chip">${policy.approval_requirements.length} approvers</span>
-          <span class="shell-chip">${proposal.comparables.length} comparables</span>
-          <span class="shell-chip">${proposal.justifications?.length ?? 0} justifications</span>
+          <span class="shell-chip">${escapeHtml(`${policy.approval_requirements.length} approvers`)}</span>
+          <span class="shell-chip">${escapeHtml(`${proposal.comparables.length} comparables`)}</span>
+          <span class="shell-chip">${escapeHtml(`${proposal.justifications?.length ?? 0} justifications`)}</span>
         </div>
       </section>
       <section class="shell-panel">
@@ -441,7 +478,10 @@ function renderApprovalCenterView(state) {
         </div>
         <ul class="shell-list">
           ${policy.approval_requirements
-            .map((requirement) => `<li>${requirement.role}: ${requirement.reason}</li>`)
+            .map(
+              (requirement) =>
+                `<li>${escapeHtml(requirement.role)}: ${escapeHtml(requirement.reason)}</li>`
+            )
             .join("")}
         </ul>
       </section>
@@ -477,16 +517,16 @@ export function renderAppShellLayout(state) {
   const activeTrip = state.trips.find((trip) => trip.trip_id === state.active_trip_id) ?? null;
 
   return `
-    <section class="planner-app-shell" data-shell-route="${state.active_route}">
+    <section class="planner-app-shell" data-shell-route="${escapeAttribute(state.active_route)}">
       <header class="shell-header">
         <div>
           <p class="shell-eyebrow">Trip planner application shell</p>
           <h1>Mode-aware travel planning foundation</h1>
-          <p>${activeTrip ? `Active trip: ${activeTrip.title}` : "Choose a trip context to enter the workspace shell."}</p>
+          <p>${escapeHtml(activeTrip ? `Active trip: ${activeTrip.title}` : "Choose a trip context to enter the workspace shell.")}</p>
         </div>
         <div class="shell-account-summary">
-          <strong>${state.session.display_name}</strong>
-          <span>${state.session.organization ?? "Independent traveler"}</span>
+          <strong>${escapeHtml(state.session.display_name)}</strong>
+          <span>${escapeHtml(state.session.organization ?? "Independent traveler")}</span>
         </div>
       </header>
       ${renderRouteTabs(state)}
@@ -509,6 +549,10 @@ export function renderAppShell(mountNode, initialState) {
   };
 
   const handleClick = (event) => {
+    if (!(event.target instanceof Element)) {
+      return;
+    }
+
     const routeTarget = event.target.closest("[data-shell-route]");
     if (routeTarget?.dataset.shellRoute) {
       store.setRoute(routeTarget.dataset.shellRoute);

--- a/bundle/app-shell/app-shell.js
+++ b/bundle/app-shell/app-shell.js
@@ -1,0 +1,551 @@
+/**
+ * Frontend application-shell foundation for issue #556.
+ *
+ * @import {
+ *   AppRouteId,
+ *   FrontendAppRouteRecord,
+ *   FrontendShellState,
+ *   FrontendTripSummaryRecord,
+ *   FrontendWorkspaceRecord,
+ *   WorkspaceStatus,
+ * } from "./contracts"
+ */
+
+const APP_ROUTES = /** @type {const} */ ([
+  {
+    route_id: "dashboard",
+    label: "Dashboard",
+    path: "/app",
+    description: "Saved trips, launch points, and account-level planning signals.",
+    requires_active_trip: false,
+    modes: ["leisure", "business"],
+  },
+  {
+    route_id: "trip_workspace",
+    label: "Trip Workspace",
+    path: "/app/trip",
+    description: "Trip summary, scenario staging, and saved-workspace context.",
+    requires_active_trip: true,
+    modes: ["leisure", "business"],
+  },
+  {
+    route_id: "planner_workspace",
+    label: "Planner",
+    path: "/app/trip/planner",
+    description: "Interactive planning checkpoints and next-step actions.",
+    requires_active_trip: true,
+    modes: ["leisure", "business"],
+  },
+  {
+    route_id: "approval_center",
+    label: "Approval Readiness",
+    path: "/app/trip/approval",
+    description: "Business-trip policy posture, comparables, and approval packet progress.",
+    requires_active_trip: true,
+    modes: ["business"],
+  },
+]);
+
+/**
+ * @param {FrontendShellState["session"]} session
+ * @param {FrontendTripSummaryRecord[]} trips
+ * @param {string | null} activeTripId
+ * @returns {FrontendTripSummaryRecord | null}
+ */
+function resolveActiveTrip(session, trips, activeTripId) {
+  if (activeTripId) {
+    return trips.find((trip) => trip.trip_id === activeTripId) ?? null;
+  }
+
+  return (
+    trips.find((trip) => trip.mode === session.default_trip_mode) ??
+    trips[0] ??
+    null
+  );
+}
+
+/**
+ * @param {FrontendTripSummaryRecord | null} activeTrip
+ * @param {FrontendWorkspaceRecord} workspace
+ * @returns {FrontendAppRouteRecord[]}
+ */
+export function getShellRoutes(activeTrip, workspace) {
+  return APP_ROUTES.filter((route) => {
+    if (route.requires_active_trip && !activeTrip) {
+      return false;
+    }
+
+    if (route.route_id === "approval_center") {
+      return Boolean(
+        activeTrip?.mode === "business" || workspace.planner_panel_state?.policy_evaluation
+      );
+    }
+
+    return !activeTrip || route.modes.includes(activeTrip.mode);
+  });
+}
+
+/**
+ * @param {FrontendTripSummaryRecord | null} activeTrip
+ * @param {FrontendWorkspaceRecord} workspace
+ * @returns {AppRouteId}
+ */
+function getDefaultRoute(activeTrip, workspace) {
+  if (!activeTrip) {
+    return "dashboard";
+  }
+
+  if (activeTrip.mode === "business" && workspace.planner_panel_state?.policy_evaluation) {
+    return "approval_center";
+  }
+
+  return "trip_workspace";
+}
+
+/**
+ * @param {{
+ *   session: FrontendShellState["session"];
+ *   trips?: FrontendTripSummaryRecord[];
+ *   active_trip_id?: string | null;
+ *   active_route?: AppRouteId;
+ *   workspace?: Partial<FrontendWorkspaceRecord>;
+ * }} input
+ * @returns {FrontendShellState}
+ */
+export function buildAppShellState(input) {
+  const trips = input.trips ?? [];
+  const activeTrip = resolveActiveTrip(input.session, trips, input.active_trip_id ?? null);
+  const workspace = {
+    trip_id: input.workspace?.trip_id ?? activeTrip?.trip_id ?? null,
+    status:
+      input.workspace?.status ??
+      (activeTrip ? "ready" : "empty"),
+    planner_panel_state: input.workspace?.planner_panel_state ?? null,
+    loading_message: input.workspace?.loading_message ?? null,
+    error_message: input.workspace?.error_message ?? null,
+    persistence_summary: input.workspace?.persistence_summary ?? [],
+  };
+  const routes = getShellRoutes(activeTrip, workspace);
+  const defaultRoute = getDefaultRoute(activeTrip, workspace);
+  const activeRoute =
+    routes.find((route) => route.route_id === input.active_route)?.route_id ?? defaultRoute;
+
+  return {
+    session: input.session,
+    routes,
+    active_route: activeRoute,
+    trips,
+    active_trip_id: activeTrip?.trip_id ?? null,
+    workspace,
+  };
+}
+
+/**
+ * @param {FrontendShellState} initialState
+ */
+export function createAppShellStore(initialState) {
+  /** @type {FrontendShellState} */
+  let state = buildAppShellState(initialState);
+  const listeners = new Set();
+
+  const notify = () => {
+    listeners.forEach((listener) => listener(state));
+  };
+
+  return {
+    getState() {
+      return state;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    setRoute(routeId) {
+      state = buildAppShellState({ ...state, active_route: routeId });
+      notify();
+    },
+    setActiveTrip(tripId) {
+      state = buildAppShellState({
+        ...state,
+        active_trip_id: tripId,
+        workspace: {
+          ...state.workspace,
+          trip_id: tripId,
+        },
+      });
+      notify();
+    },
+    setWorkspaceStatus(status, message = null) {
+      state = buildAppShellState({
+        ...state,
+        workspace: {
+          ...state.workspace,
+          status,
+          loading_message: status === "loading" ? message : null,
+          error_message: status === "error" ? message : null,
+        },
+      });
+      notify();
+    },
+  };
+}
+
+/**
+ * @param {WorkspaceStatus} status
+ * @returns {string}
+ */
+function formatStatusLabel(status) {
+  if (status === "loading") {
+    return "Loading";
+  }
+
+  if (status === "error") {
+    return "Needs attention";
+  }
+
+  if (status === "empty") {
+    return "Waiting for trip context";
+  }
+
+  return "Ready";
+}
+
+/**
+ * @param {FrontendTripSummaryRecord} trip
+ * @returns {string}
+ */
+function renderTripSummaryCard(trip) {
+  return `
+    <button type="button" class="shell-trip-card" data-shell-trip="${trip.trip_id}">
+      <div class="shell-trip-card-header">
+        <strong>${trip.title}</strong>
+        <span class="shell-mode-pill shell-mode-pill--${trip.mode}">${trip.mode}</span>
+      </div>
+      <p>${trip.summary}</p>
+      <div class="shell-chip-row">
+        <span class="shell-chip">${trip.status}</span>
+        <span class="shell-chip">${trip.primary_regions.join(" · ")}</span>
+        <span class="shell-chip">${trip.scenario_count} scenarios</span>
+        <span class="shell-chip">${trip.pending_checkpoint_count} checkpoints</span>
+      </div>
+    </button>
+  `;
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {string}
+ */
+function renderRouteTabs(state) {
+  return `
+    <nav class="shell-route-tabs" aria-label="Application shell routes">
+      ${state.routes
+        .map(
+          (route) => `
+            <button
+              type="button"
+              class="shell-route-tab${route.route_id === state.active_route ? " is-active" : ""}"
+              data-shell-route="${route.route_id}"
+              aria-pressed="${route.route_id === state.active_route}"
+            >
+              <span>${route.label}</span>
+              <small>${route.description}</small>
+            </button>
+          `
+        )
+        .join("")}
+    </nav>
+  `;
+}
+
+/**
+ * @param {FrontendWorkspaceRecord} workspace
+ * @returns {string}
+ */
+export function renderWorkspaceStatusBoundary(workspace) {
+  if (workspace.status === "ready") {
+    return "";
+  }
+
+  const message =
+    workspace.loading_message ??
+    workspace.error_message ??
+    "Select a trip to start the workspace shell.";
+
+  return `
+    <section class="shell-status shell-status--${workspace.status}" aria-label="Workspace status">
+      <strong>${formatStatusLabel(workspace.status)}</strong>
+      <p>${message}</p>
+    </section>
+  `;
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {string}
+ */
+function renderDashboardView(state) {
+  return `
+    <section class="shell-view shell-view--dashboard">
+      <div class="shell-hero">
+        <div>
+          <p class="shell-eyebrow">Signed-in planning home</p>
+          <h2>${state.session.display_name}</h2>
+          <p>${state.session.organization ?? "Independent traveler"} can resume saved trips or launch a new flow once issue #557 adds entry screens.</p>
+        </div>
+        <div class="shell-chip-row">
+          <span class="shell-chip">${state.trips.length} saved trips</span>
+          <span class="shell-chip">default ${state.session.default_trip_mode} mode</span>
+        </div>
+      </div>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Saved trips</h3>
+          <span class="shell-meta">mode-aware shell entry points</span>
+        </div>
+        <div class="shell-trip-grid">
+          ${state.trips.map((trip) => renderTripSummaryCard(trip)).join("")}
+        </div>
+      </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>State integration seams</h3>
+          <span class="shell-meta">what later issues should plug into</span>
+        </div>
+        <ul class="shell-list">
+          ${state.workspace.persistence_summary.map((item) => `<li>${item}</li>`).join("")}
+        </ul>
+      </section>
+    </section>
+  `;
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {string}
+ */
+function renderTripWorkspaceView(state) {
+  const activeTrip = state.trips.find((trip) => trip.trip_id === state.active_trip_id) ?? null;
+  const boundary = renderWorkspaceStatusBoundary(state.workspace);
+  if (!activeTrip) {
+    return boundary;
+  }
+
+  const plannerState = state.workspace.planner_panel_state;
+  const scenarioSummary = plannerState
+    ? `${plannerState.outputs.length} outputs, ${plannerState.pending_decisions.length} decision checkpoint, ${plannerState.option_set.options.length} surfaced options`
+    : "Planner payload not mounted yet.";
+
+  return `
+    <section class="shell-view shell-view--workspace">
+      ${boundary}
+      <div class="shell-hero">
+        <div>
+          <p class="shell-eyebrow">${activeTrip.mode} workspace</p>
+          <h2>${activeTrip.title}</h2>
+          <p>${activeTrip.summary}</p>
+        </div>
+        <div class="shell-chip-row">
+          <span class="shell-chip">${activeTrip.start_date ?? "TBD"} to ${activeTrip.end_date ?? "TBD"}</span>
+          <span class="shell-chip">${activeTrip.primary_regions.join(" · ")}</span>
+          <span class="shell-chip">${activeTrip.scenario_count} scenarios</span>
+        </div>
+      </div>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Workspace shell contract</h3>
+          <span class="shell-meta">${formatStatusLabel(state.workspace.status)}</span>
+        </div>
+        <p>${scenarioSummary}</p>
+        <ul class="shell-list">
+          ${state.workspace.persistence_summary.map((item) => `<li>${item}</li>`).join("")}
+        </ul>
+      </section>
+    </section>
+  `;
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {string}
+ */
+function renderPlannerWorkspaceView(state) {
+  const boundary = renderWorkspaceStatusBoundary(state.workspace);
+  const plannerState = state.workspace.planner_panel_state;
+  if (!plannerState) {
+    return `${boundary}<p class="shell-empty-state">Planner route will hydrate once orchestration state is available.</p>`;
+  }
+
+  return `
+    <section class="shell-view shell-view--planner">
+      ${boundary}
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Planner route</h3>
+          <span class="shell-meta">${plannerState.planner_behavior.trip_stage}</span>
+        </div>
+        <p>${plannerState.trip.summary}</p>
+        <div class="shell-chip-row">
+          <span class="shell-chip">${plannerState.outputs.length} outputs</span>
+          <span class="shell-chip">${plannerState.pending_decisions.length} pending decisions</span>
+          <span class="shell-chip">${plannerState.option_set.options.length} options</span>
+        </div>
+      </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Immediate actions</h3>
+          <span class="shell-meta">carried from canonical planner state</span>
+        </div>
+        <ul class="shell-list">
+          ${plannerState.next_step_actions
+            .map((action) => `<li><strong>${action.label}:</strong> ${action.description}</li>`)
+            .join("")}
+        </ul>
+      </section>
+    </section>
+  `;
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {string}
+ */
+function renderApprovalCenterView(state) {
+  const boundary = renderWorkspaceStatusBoundary(state.workspace);
+  const policy = state.workspace.planner_panel_state?.policy_evaluation;
+  const proposal = state.workspace.planner_panel_state?.proposal;
+
+  if (!policy || !proposal) {
+    return `${boundary}<p class="shell-empty-state">Approval readiness activates only for business trips with policy evaluation output.</p>`;
+  }
+
+  return `
+    <section class="shell-view shell-view--approval">
+      ${boundary}
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Approval posture</h3>
+          <span class="shell-meta">${policy.status}</span>
+        </div>
+        <p>${state.workspace.planner_panel_state.trip.summary}</p>
+        <div class="shell-chip-row">
+          <span class="shell-chip">${policy.approval_requirements.length} approvers</span>
+          <span class="shell-chip">${proposal.comparables.length} comparables</span>
+          <span class="shell-chip">${proposal.justifications?.length ?? 0} justifications</span>
+        </div>
+      </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Approval packet seams</h3>
+          <span class="shell-meta">proposal + policy evaluation</span>
+        </div>
+        <ul class="shell-list">
+          ${policy.approval_requirements
+            .map((requirement) => `<li>${requirement.role}: ${requirement.reason}</li>`)
+            .join("")}
+        </ul>
+      </section>
+    </section>
+  `;
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {string}
+ */
+function renderActiveView(state) {
+  if (state.active_route === "trip_workspace") {
+    return renderTripWorkspaceView(state);
+  }
+
+  if (state.active_route === "planner_workspace") {
+    return renderPlannerWorkspaceView(state);
+  }
+
+  if (state.active_route === "approval_center") {
+    return renderApprovalCenterView(state);
+  }
+
+  return renderDashboardView(state);
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {string}
+ */
+export function renderAppShellLayout(state) {
+  const activeTrip = state.trips.find((trip) => trip.trip_id === state.active_trip_id) ?? null;
+
+  return `
+    <section class="planner-app-shell" data-shell-route="${state.active_route}">
+      <header class="shell-header">
+        <div>
+          <p class="shell-eyebrow">Trip planner application shell</p>
+          <h1>Mode-aware travel planning foundation</h1>
+          <p>${activeTrip ? `Active trip: ${activeTrip.title}` : "Choose a trip context to enter the workspace shell."}</p>
+        </div>
+        <div class="shell-account-summary">
+          <strong>${state.session.display_name}</strong>
+          <span>${state.session.organization ?? "Independent traveler"}</span>
+        </div>
+      </header>
+      ${renderRouteTabs(state)}
+      <main class="shell-main">
+        ${renderActiveView(state)}
+      </main>
+    </section>
+  `;
+}
+
+/**
+ * @param {HTMLElement & { innerHTML: string }} mountNode
+ * @param {FrontendShellState} initialState
+ */
+export function renderAppShell(mountNode, initialState) {
+  const store = createAppShellStore(initialState);
+
+  const rerender = () => {
+    mountNode.innerHTML = renderAppShellLayout(store.getState());
+  };
+
+  const handleClick = (event) => {
+    const routeTarget = event.target.closest("[data-shell-route]");
+    if (routeTarget?.dataset.shellRoute) {
+      store.setRoute(routeTarget.dataset.shellRoute);
+      mountNode.dispatchEvent(
+        new CustomEvent("shell:route-change", {
+          detail: store.getState().active_route,
+        })
+      );
+      return;
+    }
+
+    const tripTarget = event.target.closest("[data-shell-trip]");
+    if (tripTarget?.dataset.shellTrip) {
+      store.setActiveTrip(tripTarget.dataset.shellTrip);
+      mountNode.dispatchEvent(
+        new CustomEvent("shell:trip-change", {
+          detail: store.getState().active_trip_id,
+        })
+      );
+    }
+  };
+
+  const unsubscribe = store.subscribe(rerender);
+  mountNode.addEventListener("click", handleClick);
+  rerender();
+
+  return {
+    getState: store.getState,
+    setRoute(routeId) {
+      store.setRoute(routeId);
+    },
+    setActiveTrip(tripId) {
+      store.setActiveTrip(tripId);
+    },
+    destroy() {
+      unsubscribe();
+      mountNode.removeEventListener("click", handleClick);
+    },
+  };
+}

--- a/bundle/app-shell/contracts.d.ts
+++ b/bundle/app-shell/contracts.d.ts
@@ -1,0 +1,65 @@
+/**
+ * Frontend declarations for the application shell layer.
+ *
+ * The shell composes persisted trip state, orchestration planner state,
+ * and approval-readiness signals without redefining the underlying
+ * domain contracts in UI-only shapes.
+ */
+
+import type { PlannerPanelState, TripRecord } from "../planner/orchestration-contracts";
+
+export type AppRouteId =
+  | "dashboard"
+  | "trip_workspace"
+  | "planner_workspace"
+  | "approval_center";
+
+export type WorkspaceStatus = "ready" | "loading" | "empty" | "error";
+
+export interface SessionUserRecord {
+  user_id: string;
+  display_name: string;
+  organization?: string | null;
+  default_trip_mode: "leisure" | "business";
+}
+
+export interface FrontendTripSummaryRecord {
+  trip_id: TripRecord["trip_id"];
+  title: TripRecord["title"];
+  summary: TripRecord["summary"];
+  mode: TripRecord["mode"];
+  status: TripRecord["status"];
+  start_date: TripRecord["trip_frame"]["start_date"];
+  end_date: TripRecord["trip_frame"]["end_date"];
+  primary_regions: TripRecord["trip_frame"]["primary_regions"];
+  scenario_count: number;
+  pending_checkpoint_count: number;
+  policy_state: PlannerPanelState["policy_evaluation"]["status"] | null;
+}
+
+export interface FrontendAppRouteRecord {
+  route_id: AppRouteId;
+  label: string;
+  path: string;
+  description: string;
+  requires_active_trip: boolean;
+  modes: Array<"leisure" | "business">;
+}
+
+export interface FrontendWorkspaceRecord {
+  trip_id: string | null;
+  status: WorkspaceStatus;
+  planner_panel_state: PlannerPanelState | null;
+  loading_message: string | null;
+  error_message: string | null;
+  persistence_summary: string[];
+}
+
+export interface FrontendShellState {
+  session: SessionUserRecord;
+  routes: FrontendAppRouteRecord[];
+  active_route: AppRouteId;
+  trips: FrontendTripSummaryRecord[];
+  active_trip_id: string | null;
+  workspace: FrontendWorkspaceRecord;
+}

--- a/bundle/app-shell/mock-state.js
+++ b/bundle/app-shell/mock-state.js
@@ -1,0 +1,336 @@
+/**
+ * Representative application-shell fixtures for issue #556.
+ *
+ * @import {
+ *   FrontendShellState,
+ * } from "./contracts"
+ */
+
+const signedInSession = {
+  user_id: "user-17",
+  display_name: "Avery Stone",
+  organization: "Northwind Advisory",
+  default_trip_mode: "leisure",
+};
+
+const leisurePlannerPanelState = {
+  trip: {
+    trip_id: "trip-leisure-lisbon-oct",
+    user_id: "user-17",
+    mode: "leisure",
+    status: "active",
+    trip_frame: {
+      start_date: "2025-10-03",
+      end_date: "2025-10-09",
+      duration_days: 7,
+      primary_regions: ["Lisbon", "Sintra Coast"],
+      traveler_party: {
+        kind: "pair",
+        traveler_count: 2,
+        notes: "Keep one soft landing day after arrival.",
+      },
+    },
+    profile_refs: {
+      leisure_profile_id: "profile-leisure-17",
+    },
+    title: "Lisbon reset with room to wander",
+    summary: "Walkability, food value, and a lighter first two days are driving the plan.",
+  },
+  option_set: {
+    option_set_id: "option-set-lodging-01",
+    trip_id: "trip-leisure-lisbon-oct",
+    purpose: "profile_learning",
+    scope: "lodging",
+    title: "Stay shape for the first half of the trip",
+    options: [
+      {
+        option_id: "option-central",
+        kind: "lodging",
+        label: "Central walkable hotel",
+        summary: "Smaller room, faster access to dinners and tram routes.",
+        drawbacks: ["More noise risk."],
+        explanation: ["Best when evening spontaneity matters most."],
+      },
+      {
+        option_id: "option-quiet",
+        kind: "lodging",
+        label: "Calmer riverside guesthouse",
+        summary: "Larger room and quieter nights with longer transit legs.",
+        drawbacks: ["Less immediate old-city access."],
+        explanation: ["Best when recovery time matters more than being central."],
+      },
+    ],
+    comparison_axes: [
+      { key: "walkability", label: "Walkability", direction: "higher_better" },
+      { key: "quiet", label: "Night Quiet", direction: "higher_better" },
+      { key: "price", label: "Nightly Cost", direction: "lower_better" },
+    ],
+    explanation: [
+      "The shell should carry canonical option-set meaning forward into later workspace views.",
+    ],
+  },
+  proposal: null,
+  policy_evaluation: null,
+  pending_decisions: [
+    {
+      decision_id: "lodging-signal",
+      title: "Choose the better base camp",
+      prompt: "Which tradeoff feels more like the trip you want?",
+      choices: [
+        "Stay central and accept tighter rooms.",
+        "Prioritize recovery quiet and a little extra transit.",
+      ],
+    },
+  ],
+  outputs: [
+    {
+      output_id: "summary-01",
+      title: "Planner read",
+      body: "The planner is asking for one specific lodging signal instead of another abstract preference dump.",
+      tags: ["leisure", "decision-ready"],
+    },
+  ],
+  planner_behavior: {
+    trip_stage: "compare",
+    ask_before_next_major_change: true,
+    target_research_passes: 3,
+    target_options_before_checkpoint: 2,
+    surface_options_early: true,
+    explanation_density: "standard",
+  },
+  next_step_actions: [
+    {
+      action_id: "answer-lodging-signal",
+      action_kind: "answer_decision",
+      label: "Answer the lodging decision",
+      description: "Tell the planner whether central access or recovery quiet should win.",
+      emphasis: "primary",
+      target_section: "decisions",
+    },
+  ],
+};
+
+const businessPlannerPanelState = {
+  trip: {
+    trip_id: "trip-client-audit-sea",
+    user_id: "user-17",
+    mode: "business",
+    status: "active",
+    trip_frame: {
+      start_date: "2025-06-17",
+      end_date: "2025-06-20",
+      duration_days: 4,
+      primary_regions: ["Seattle", "Bellevue"],
+      traveler_party: {
+        kind: "solo",
+        traveler_count: 1,
+        notes: "Pre-dawn client audit and a policy exception for the hotel zone.",
+      },
+    },
+    profile_refs: {
+      business_profile_id: "profile-business-4",
+    },
+    title: "Seattle audit trip with approval packet",
+    summary: "The plan is close to submission, but the hotel zone still needs an exception path.",
+  },
+  option_set: {
+    option_set_id: "option-set-policy-01",
+    trip_id: "trip-client-audit-sea",
+    purpose: "approval_review",
+    scope: "lodging",
+    title: "Approval-ready lodging set",
+    options: [
+      {
+        option_id: "option-hotel-near-client",
+        kind: "lodging",
+        label: "Hotel near client site",
+        summary: "Reduces early-morning transit risk but requires an exception packet.",
+        drawbacks: ["Outside standard hotel zone."],
+        explanation: ["Best fit for the audit window and pre-dawn departure timing."],
+      },
+    ],
+    comparison_axes: [
+      { key: "policy_fit", label: "Policy Fit", direction: "higher_better" },
+      { key: "arrival_risk", label: "Arrival Risk", direction: "lower_better" },
+    ],
+    explanation: ["Approval comparables and justifications should stay attached to canonical proposal data."],
+  },
+  proposal: {
+    proposal_id: "proposal-client-audit-01",
+    comparables: [
+      {
+        category: "lodging",
+        label: "Standard downtown policy hotel",
+        vendor: "Harbor Suites",
+        booking_channel: "corp-portal",
+        estimated_cost: {
+          currency: "USD",
+          typical_amount: 289,
+        },
+        notes: ["Compliant but adds a 5:10am transfer for the client audit."],
+      },
+    ],
+    justifications: [
+      {
+        category: "lodging",
+        summary: "Closer lodging materially lowers missed-audit risk.",
+        evidence: ["5:45am client-site arrival requirement", "No later compliant shuttle option"],
+      },
+    ],
+    approval_notes: ["Exception packet draft is ready for travel ops review."],
+    requested_exception: {
+      exception_type: "preferred_hotel_zone",
+      reason: "Lower arrival risk for pre-dawn audit window.",
+      requested_approval_roles: ["travel_ops", "engagement_partner"],
+      notes: ["Hotel remains within negotiated budget ceiling."],
+    },
+  },
+  policy_evaluation: {
+    evaluation_id: "policy-eval-77",
+    proposal_id: "proposal-client-audit-01",
+    status: "exception_required",
+    approval_requirements: [
+      { role: "travel_ops", reason: "Hotel zone exception", mandatory: true },
+      { role: "engagement_partner", reason: "Client-site timing risk", mandatory: true },
+    ],
+    failure_reasons: [],
+    preferred_alternatives: [
+      {
+        category: "lodging",
+        summary: "Downtown compliant hotel with longer morning transfer.",
+        rationale: "Compliant baseline for exception comparison.",
+        comparable_ref: "comp-1",
+      },
+    ],
+    exception_guidance: ["Attach the pre-dawn timing evidence to the submission."],
+    notes: ["Policy system found no blocking spend variance."],
+    compliance_score: 0.82,
+  },
+  pending_decisions: [
+    {
+      decision_id: "approval-confirmation",
+      title: "Confirm the exception posture",
+      prompt: "Should the planner prepare the exception packet now?",
+      choices: ["Prepare approval packet", "Re-open compliant alternative"],
+    },
+  ],
+  outputs: [
+    {
+      output_id: "approval-summary-01",
+      title: "Approval summary",
+      body: "The route is ready for travel-ops review once the exception packet is attached.",
+      tags: ["business", "approval-ready"],
+    },
+  ],
+  planner_behavior: {
+    trip_stage: "approval",
+    ask_before_next_major_change: true,
+    target_research_passes: 1,
+    target_options_before_checkpoint: 1,
+    surface_options_early: true,
+    explanation_density: "lean",
+  },
+  next_step_actions: [
+    {
+      action_id: "prepare-approval-packet",
+      action_kind: "prepare_approval",
+      label: "Prepare approval packet",
+      description: "Bundle comparables, justification, and approver list for review.",
+      emphasis: "primary",
+      target_section: "approval",
+    },
+  ],
+};
+
+/** @type {FrontendShellState} */
+export const signedInDashboardShellState = {
+  session: signedInSession,
+  routes: [],
+  active_route: "dashboard",
+  trips: [
+    {
+      trip_id: leisurePlannerPanelState.trip.trip_id,
+      title: leisurePlannerPanelState.trip.title,
+      summary: leisurePlannerPanelState.trip.summary,
+      mode: leisurePlannerPanelState.trip.mode,
+      status: leisurePlannerPanelState.trip.status,
+      start_date: leisurePlannerPanelState.trip.trip_frame.start_date,
+      end_date: leisurePlannerPanelState.trip.trip_frame.end_date,
+      primary_regions: leisurePlannerPanelState.trip.trip_frame.primary_regions,
+      scenario_count: 3,
+      pending_checkpoint_count: 1,
+      policy_state: null,
+    },
+    {
+      trip_id: businessPlannerPanelState.trip.trip_id,
+      title: businessPlannerPanelState.trip.title,
+      summary: businessPlannerPanelState.trip.summary,
+      mode: businessPlannerPanelState.trip.mode,
+      status: businessPlannerPanelState.trip.status,
+      start_date: businessPlannerPanelState.trip.trip_frame.start_date,
+      end_date: businessPlannerPanelState.trip.trip_frame.end_date,
+      primary_regions: businessPlannerPanelState.trip.trip_frame.primary_regions,
+      scenario_count: 2,
+      pending_checkpoint_count: 1,
+      policy_state: businessPlannerPanelState.policy_evaluation.status,
+    },
+  ],
+  active_trip_id: null,
+  workspace: {
+    trip_id: null,
+    status: "empty",
+    planner_panel_state: null,
+    loading_message: null,
+    error_message: null,
+    persistence_summary: [
+      "Account is signed in and can resume saved leisure or business trips.",
+      "Trip launch should branch into issue #557 once account and entry flows land.",
+    ],
+  },
+};
+
+/** @type {FrontendShellState} */
+export const activeLeisureTripShellState = {
+  session: signedInSession,
+  routes: [],
+  active_route: "trip_workspace",
+  trips: signedInDashboardShellState.trips,
+  active_trip_id: leisurePlannerPanelState.trip.trip_id,
+  workspace: {
+    trip_id: leisurePlannerPanelState.trip.trip_id,
+    status: "ready",
+    planner_panel_state: leisurePlannerPanelState,
+    loading_message: null,
+    error_message: null,
+    persistence_summary: [
+      "Scenario history is available from saved-trip state.",
+      "Planner checkpoints should reuse orchestration payloads rather than page-local copies.",
+    ],
+  },
+};
+
+/** @type {FrontendShellState} */
+export const activeBusinessTripShellState = {
+  session: signedInSession,
+  routes: [],
+  active_route: "approval_center",
+  trips: signedInDashboardShellState.trips,
+  active_trip_id: businessPlannerPanelState.trip.trip_id,
+  workspace: {
+    trip_id: businessPlannerPanelState.trip.trip_id,
+    status: "ready",
+    planner_panel_state: businessPlannerPanelState,
+    loading_message: null,
+    error_message: null,
+    persistence_summary: [
+      "Approval comparables and packet metadata should remain attached to the proposal contract.",
+      "Business approval surfaces should sit beside planner state, not replace it.",
+    ],
+  },
+};
+
+export const appShellStateMocks = {
+  signed_in_dashboard: signedInDashboardShellState,
+  active_leisure_trip: activeLeisureTripShellState,
+  active_business_trip: activeBusinessTripShellState,
+};

--- a/docs/frontend-app-shell-foundation.md
+++ b/docs/frontend-app-shell-foundation.md
@@ -1,0 +1,84 @@
+# Frontend App Shell Foundation
+
+This document records the implementation boundary for issue `#556`.
+
+The goal is to stand up the first reusable application shell for `trip-planner` without prematurely locking the repo into a heavyweight frontend framework rewrite.
+
+## What Issue #556 Owns
+
+Issue `#556` establishes:
+
+- a mode-aware route shell for dashboard, trip workspace, planner, and approval surfaces
+- shared workspace loading, empty, and error-state treatment
+- explicit seams between persisted trip state, orchestration planner payloads, and business approval output
+- representative frontend fixtures for signed-in, active leisure, and active business trip contexts
+- deterministic frontend tests that prove route, shell, and state transitions
+
+It does not yet own full account-entry flows, workspace panes, maps, or final side-panel interaction polish. Those stay with `#557` through `#560`.
+
+## Current Implementation Surface
+
+The shell foundation lives in:
+
+- `bundle/app-shell/contracts.d.ts`
+- `bundle/app-shell/mock-state.js`
+- `bundle/app-shell/app-shell.js`
+- `tests/planner/test_app_shell_state.mjs`
+
+This keeps the application shell close to the existing planner bundle until a later dedicated frontend package exists.
+
+## Route Model
+
+The shell currently treats these routes as canonical:
+
+| Route | Purpose | Visibility rule |
+| --- | --- | --- |
+| `dashboard` | signed-in home, saved-trip selection, launch surface | always visible |
+| `trip_workspace` | active trip context, scenario staging, persistence summary | requires active trip |
+| `planner_workspace` | orchestration-driven checkpoints and next-step actions | requires active trip |
+| `approval_center` | business approval posture, comparables, and packet seams | business mode or active policy evaluation |
+
+The shell is responsible for deciding which routes are visible from the active trip context. Later issues should not hard-code their own mode-specific nav trees.
+
+## State Integration Seams
+
+The shell composes three state sources:
+
+1. session and saved-trip summaries from the persistence layer (`#537`)
+2. active planning payloads from orchestration (`#543`) through `PlannerPanelState`
+3. business approval posture from proposal plus policy evaluation outputs (`#549`)
+
+The shell should summarize those states, not redefine them.
+
+Practical rule:
+
+- use shell-local UI state only for route selection, active trip selection, and workspace-status handling
+- keep trip, option, proposal, and policy meaning in the canonical contracts and planner mirrors
+
+## Shared Status Rules
+
+All child frontend issues should reuse the shell status boundary model:
+
+- `loading`: a route is mounted but still hydrating saved state or planner payloads
+- `empty`: there is no trip or no route-specific payload yet
+- `error`: the shell has enough context to describe a deterministic blocker
+- `ready`: the route can render its primary content
+
+This avoids each later page inventing a different loading or empty-state vocabulary.
+
+## Representative Fixtures
+
+Issue `#556` ships three shell fixtures:
+
+- signed-in dashboard with saved leisure and business trips
+- active leisure trip workspace with planner checkpoint state
+- active business trip workspace with approval-readiness state
+
+Later issues should extend those fixtures instead of replacing them with unrelated page-local mocks.
+
+## Handoff To Later Issues
+
+- `#557` should plug trip-entry and account-launch flows into the dashboard route.
+- `#558` should deepen the trip workspace route with scenario, ranking, and budget panes.
+- `#559` should attach maps and timeline views to the trip workspace without changing the shell route contract.
+- `#560` should connect the planner and approval routes to the more detailed planner-side-panel surfaces already living under `bundle/planner/`.

--- a/docs/frontend-application-layer-epic.md
+++ b/docs/frontend-application-layer-epic.md
@@ -76,6 +76,7 @@ The epic acceptance criteria from `#555` map to child issue outcomes as follows:
 Use these documents together when implementing the child issues:
 
 - [Product architecture brief](product-architecture-brief.md)
+- [Frontend app shell foundation](frontend-app-shell-foundation.md)
 - [Planner UI integration](planner-ui-integration.md)
 - [Orchestration, interactive planning, and in-trip adjustment epic](orchestration-interactive-planning-epic.md)
 - [Policy integration execution epic](policy-integration-execution-epic.md)

--- a/tests/planner/test_app_shell_state.mjs
+++ b/tests/planner/test_app_shell_state.mjs
@@ -151,6 +151,9 @@ test("app shell store updates route and active trip while preserving visible she
 
   store.setActiveTrip("trip-client-audit-sea");
   assert.equal(store.getState().active_trip_id, "trip-client-audit-sea");
+  assert.equal(store.getState().workspace.trip_id, "trip-client-audit-sea");
+  assert.equal(store.getState().workspace.status, "empty");
+  assert.equal(store.getState().workspace.planner_panel_state, null);
 
   store.setRoute("approval_center");
   assert.equal(store.getState().active_route, "approval_center");
@@ -173,4 +176,43 @@ test("mounted app shell rerenders on route and trip changes", () => {
 
   controller.destroy();
   assert.equal(mountNode.listeners.has("click"), false);
+});
+
+test("mounted app shell ignores click events from non-element targets", () => {
+  const mountNode = new FakeMountNode();
+  const controller = renderAppShell(mountNode, activeBusinessTripShellState);
+
+  mountNode.click({});
+  assert.equal(controller.getState().active_route, "approval_center");
+});
+
+test("app shell layout escapes user-provided HTML-sensitive content", () => {
+  const rendered = renderAppShellLayout({
+    ...activeBusinessTripShellState,
+    active_route: "dashboard",
+    session: {
+      ...activeBusinessTripShellState.session,
+      display_name: "<Admin>",
+      organization: "Ops & Risk",
+    },
+    workspace: {
+      ...activeBusinessTripShellState.workspace,
+      persistence_summary: ["Line <b>bold</b> & ready"],
+    },
+    trips: activeBusinessTripShellState.trips.map((trip, index) =>
+      index === 1
+        ? {
+            ...trip,
+            title: "<script>alert(1)</script>",
+            summary: "Line <b>bold</b> & ready",
+          }
+        : trip
+    ),
+  });
+
+  assert.match(rendered, /&lt;Admin&gt;/);
+  assert.match(rendered, /Ops &amp; Risk/);
+  assert.match(rendered, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(rendered, /Line &lt;b&gt;bold&lt;\/b&gt; &amp; ready/);
+  assert.doesNotMatch(rendered, /<script>alert\(1\)<\/script>/);
 });

--- a/tests/planner/test_app_shell_state.mjs
+++ b/tests/planner/test_app_shell_state.mjs
@@ -1,0 +1,176 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import url from "node:url";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../..");
+
+class FakeElement {}
+class FakeHTMLElement extends FakeElement {}
+
+globalThis.Element = FakeElement;
+globalThis.HTMLElement = FakeHTMLElement;
+
+class FakeMountNode extends FakeHTMLElement {
+  constructor() {
+    super();
+    this.innerHTML = "";
+    this.listeners = new Map();
+    this.dispatchedEvents = [];
+  }
+
+  addEventListener(type, listener) {
+    this.listeners.set(type, listener);
+  }
+
+  removeEventListener(type, listener) {
+    if (this.listeners.get(type) === listener) {
+      this.listeners.delete(type);
+    }
+  }
+
+  click(target) {
+    const listener = this.listeners.get("click");
+    if (listener) {
+      listener({ target });
+    }
+  }
+
+  dispatchEvent(event) {
+    this.dispatchedEvents.push(event);
+    return true;
+  }
+}
+
+class FakeButton extends FakeHTMLElement {
+  constructor(dataset) {
+    super();
+    this.dataset = dataset;
+  }
+
+  closest(selector) {
+    if (selector === "[data-shell-route]" && this.dataset.shellRoute) {
+      return this;
+    }
+
+    if (selector === "[data-shell-trip]" && this.dataset.shellTrip) {
+      return this;
+    }
+
+    return null;
+  }
+}
+
+class FakeCustomEvent {
+  constructor(type, init = {}) {
+    this.type = type;
+    this.detail = init.detail;
+  }
+}
+
+globalThis.CustomEvent = FakeCustomEvent;
+
+async function loadModule(relativePath) {
+  const source = await fs.readFile(path.join(repoRoot, relativePath), "utf8");
+  return import(`data:text/javascript,${encodeURIComponent(source)}`);
+}
+
+const {
+  appShellStateMocks,
+  signedInDashboardShellState,
+  activeLeisureTripShellState,
+  activeBusinessTripShellState,
+} = await loadModule("bundle/app-shell/mock-state.js");
+const {
+  buildAppShellState,
+  createAppShellStore,
+  getShellRoutes,
+  renderAppShell,
+  renderAppShellLayout,
+  renderWorkspaceStatusBoundary,
+} = await loadModule("bundle/app-shell/app-shell.js");
+
+test("app shell mock catalog exposes signed-in, leisure, and business contexts", () => {
+  assert.equal(appShellStateMocks.signed_in_dashboard, signedInDashboardShellState);
+  assert.equal(appShellStateMocks.active_leisure_trip, activeLeisureTripShellState);
+  assert.equal(appShellStateMocks.active_business_trip, activeBusinessTripShellState);
+});
+
+test("app shell derives a dashboard route when no active trip is selected", () => {
+  const state = buildAppShellState(signedInDashboardShellState);
+
+  assert.equal(state.active_route, "dashboard");
+  assert.equal(state.active_trip_id, "trip-leisure-lisbon-oct");
+  assert.match(renderAppShellLayout(state), /Signed-in planning home/);
+  assert.match(renderAppShellLayout(state), /Seattle audit trip with approval packet/);
+});
+
+test("shell routes stay mode-aware for leisure and business trips", () => {
+  const leisureRoutes = getShellRoutes(
+    activeLeisureTripShellState.trips[0],
+    activeLeisureTripShellState.workspace
+  );
+  const businessRoutes = getShellRoutes(
+    activeBusinessTripShellState.trips[1],
+    activeBusinessTripShellState.workspace
+  );
+
+  assert.deepEqual(
+    leisureRoutes.map((route) => route.route_id),
+    ["dashboard", "trip_workspace", "planner_workspace"]
+  );
+  assert.deepEqual(
+    businessRoutes.map((route) => route.route_id),
+    ["dashboard", "trip_workspace", "planner_workspace", "approval_center"]
+  );
+});
+
+test("workspace status boundary renders deterministic loading and error copy", () => {
+  assert.match(
+    renderWorkspaceStatusBoundary({
+      ...activeLeisureTripShellState.workspace,
+      status: "loading",
+      loading_message: "Hydrating saved scenarios from persistence.",
+    }),
+    /Hydrating saved scenarios from persistence/
+  );
+  assert.match(
+    renderWorkspaceStatusBoundary({
+      ...activeLeisureTripShellState.workspace,
+      status: "error",
+      error_message: "Scenario state drifted out of sync.",
+    }),
+    /Scenario state drifted out of sync/
+  );
+});
+
+test("app shell store updates route and active trip while preserving visible shell output", () => {
+  const store = createAppShellStore(signedInDashboardShellState);
+
+  store.setActiveTrip("trip-client-audit-sea");
+  assert.equal(store.getState().active_trip_id, "trip-client-audit-sea");
+
+  store.setRoute("approval_center");
+  assert.equal(store.getState().active_route, "approval_center");
+});
+
+test("mounted app shell rerenders on route and trip changes", () => {
+  const mountNode = new FakeMountNode();
+  const controller = renderAppShell(mountNode, activeBusinessTripShellState);
+
+  assert.match(mountNode.innerHTML, /Approval posture/);
+  assert.equal(controller.getState().active_trip_id, "trip-client-audit-sea");
+
+  mountNode.click(new FakeButton({ shellRoute: "planner_workspace" }));
+  assert.equal(controller.getState().active_route, "planner_workspace");
+  assert.match(mountNode.innerHTML, /Immediate actions/);
+
+  mountNode.click(new FakeButton({ shellRoute: "approval_center" }));
+  assert.equal(controller.getState().active_route, "approval_center");
+  assert.match(mountNode.innerHTML, /travel_ops: Hotel zone exception/);
+
+  controller.destroy();
+  assert.equal(mountNode.listeners.has("click"), false);
+});

--- a/tsconfig.planner.json
+++ b/tsconfig.planner.json
@@ -10,5 +10,10 @@
     "lib": ["ES2022", "DOM"],
     "skipLibCheck": true
   },
-  "include": ["bundle/planner/**/*.js", "bundle/planner/**/*.d.ts"]
+  "include": [
+    "bundle/planner/**/*.js",
+    "bundle/planner/**/*.d.ts",
+    "bundle/app-shell/**/*.js",
+    "bundle/app-shell/**/*.d.ts"
+  ]
 }


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #556

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Before specific screens can be built, the repo needs a coherent frontend shell with routing, shared state boundaries, API or repository integration seams, loading/error handling, and mode-aware navigation. Without that foundation, later UI issues will either duplicate state wiring or drift into disconnected pages.

Parent epic: #555

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#555](https://github.com/stranske/trip-planner/issues/555)
- [#537](https://github.com/stranske/trip-planner/issues/537)
- [#543](https://github.com/stranske/trip-planner/issues/543)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Establish the frontend app shell, route structure, and layout primitives needed for leisure and business planning flows.
- [x] Define how frontend state integrates with persisted user, trip, scenario, and session-state layers without duplicating backend models ad hoc.
- [x] Build shared loading, empty, and error-state patterns for trip-loading, scenario-loading, and planner-action workflows.
- [x] Add mode-aware navigation so leisure and business views can share the shell while exposing distinct workflow entry points.
- [x] Add representative screen-state fixtures or mocks for at least: signed-in dashboard, active leisure trip, and active business trip contexts.
- [x] Write frontend tests covering routing, shell rendering, and key shared-state transitions.
- [x] Document the frontend architecture boundaries so later UI work plugs into the same shell and state conventions.

#### Acceptance criteria
- [x] The repo contains a reusable frontend app-shell foundation with routing and shared state seams.
- [x] Leisure and business flows can coexist in the same shell without one-off navigation hacks.
- [x] Shared loading and error states exist for core planning surfaces.
- [x] Tests cover representative route and state cases.
- [x] Documentation makes clear how later frontend issues should build on the shell.

**Head SHA:** cdda8f3d6260b2f997895fb7648bd0d867570b43
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23953351426) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23953351416) |
<!-- auto-status-summary:end -->
