### PR TITLE
Issue #557: build trip launch flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - [Business travel profile](docs/business-travel-profile.md)
 - [Planner UI integration](docs/planner-ui-integration.md)
 - [Frontend app shell foundation](docs/frontend-app-shell-foundation.md)
+- [Frontend entry flows](docs/frontend-entry-flows.md)
 - [Source and quality model](docs/source-quality-model.md)
 - [Source channel strategy](docs/source-channel-strategy.md)
 - [Legacy itinerary methodology](docs/methodology.md)

--- a/bundle/app-shell/app-shell.js
+++ b/bundle/app-shell/app-shell.js
@@ -3,9 +3,13 @@
  *
  * @import {
  *   AppRouteId,
- *   FrontendAppRouteRecord,
+  *   FrontendAppRouteRecord,
+ *   FrontendAccountEntryRecord,
+ *   FrontendLaunchFlowRecord,
+ *   FrontendRecentSessionRecord,
  *   FrontendShellState,
  *   FrontendTripSummaryRecord,
+ *   LaunchFlowId,
  *   FrontendWorkspaceRecord,
  *   WorkspaceStatus,
  * } from "./contracts"
@@ -72,6 +76,30 @@ function escapeAttribute(value) {
 
 /**
  * @param {FrontendShellState["session"]} session
+ * @param {FrontendAccountEntryRecord | Partial<FrontendAccountEntryRecord> | undefined} accountEntry
+ * @returns {FrontendAccountEntryRecord}
+ */
+function normalizeAccountEntry(session, accountEntry) {
+  const launchFlows = accountEntry?.launch_flows ?? [];
+  const selectedLaunchId = launchFlows.some(
+    (flow) => flow.launch_id === accountEntry?.selected_launch_id
+  )
+    ? accountEntry?.selected_launch_id
+    : launchFlows.find((flow) => flow.mode === session.default_trip_mode)?.launch_id ??
+      launchFlows[0]?.launch_id ??
+      null;
+
+  return {
+    traveler_profiles: accountEntry?.traveler_profiles ?? [],
+    recent_sessions: accountEntry?.recent_sessions ?? [],
+    launch_flows: launchFlows,
+    selected_launch_id: selectedLaunchId,
+    empty_state_message: accountEntry?.empty_state_message ?? null,
+  };
+}
+
+/**
+ * @param {FrontendShellState["session"]} session
  * @param {FrontendTripSummaryRecord[]} trips
  * @param {string | null} activeTripId
  * @returns {FrontendTripSummaryRecord | null}
@@ -132,6 +160,7 @@ function getDefaultRoute(activeTrip, workspace) {
  *   trips?: FrontendTripSummaryRecord[];
  *   active_trip_id?: string | null;
  *   active_route?: AppRouteId;
+ *   account_entry?: Partial<FrontendAccountEntryRecord>;
  *   workspace?: Partial<FrontendWorkspaceRecord>;
  * }} input
  * @returns {FrontendShellState}
@@ -139,6 +168,7 @@ function getDefaultRoute(activeTrip, workspace) {
 export function buildAppShellState(input) {
   const trips = input.trips ?? [];
   const activeTrip = resolveActiveTrip(input.session, trips, input.active_trip_id ?? null);
+  const accountEntry = normalizeAccountEntry(input.session, input.account_entry);
   const workspace = {
     trip_id: input.workspace?.trip_id ?? activeTrip?.trip_id ?? null,
     status:
@@ -160,6 +190,7 @@ export function buildAppShellState(input) {
     active_route: activeRoute,
     trips,
     active_trip_id: activeTrip?.trip_id ?? null,
+    account_entry: accountEntry,
     workspace,
   };
 }
@@ -209,6 +240,66 @@ export function createAppShellStore(initialState) {
       });
       notify();
     },
+    setEntryLaunch(launchId) {
+      if (!state.account_entry.launch_flows.some((flow) => flow.launch_id === launchId)) {
+        return;
+      }
+
+      state = buildAppShellState({
+        ...state,
+        active_route: "dashboard",
+        account_entry: {
+          ...state.account_entry,
+          selected_launch_id: launchId,
+        },
+        workspace: {
+          ...state.workspace,
+          status: "empty",
+          loading_message: null,
+          error_message: null,
+        },
+      });
+      notify();
+    },
+    resumeSession(sessionId) {
+      const session = state.account_entry.recent_sessions.find(
+        (candidate) => candidate.session_id === sessionId
+      );
+
+      if (!session?.trip_id) {
+        state = buildAppShellState({
+          ...state,
+          active_route: "dashboard",
+          workspace: {
+            ...state.workspace,
+            status: "error",
+            loading_message: null,
+            error_message: "Selected session is no longer available.",
+          },
+        });
+        notify();
+        return;
+      }
+
+      state = buildAppShellState({
+        ...state,
+        active_trip_id: session.trip_id,
+        active_route: session.resume_route,
+        account_entry: {
+          ...state.account_entry,
+          selected_launch_id: "resume_existing_trip",
+        },
+        workspace: {
+          ...state.workspace,
+          trip_id: session.trip_id,
+          status: "empty",
+          planner_panel_state: null,
+          loading_message: "Rehydrating the saved session entry point.",
+          error_message: null,
+        },
+      });
+      notify();
+    },
     setWorkspaceStatus(status, message = null) {
       state = buildAppShellState({
         ...state,
@@ -245,6 +336,26 @@ function formatStatusLabel(status) {
 }
 
 /**
+ * @param {FrontendRecentSessionRecord} session
+ * @returns {string}
+ */
+function renderRecentSessionCard(session) {
+  return `
+    <button type="button" class="shell-trip-card shell-trip-card--session" data-shell-session="${escapeAttribute(session.session_id)}">
+      <div class="shell-trip-card-header">
+        <strong>${escapeHtml(session.label)}</strong>
+        <span class="shell-mode-pill shell-mode-pill--${escapeAttribute(session.mode)}">${escapeHtml(session.mode)}</span>
+      </div>
+      <p>${escapeHtml(session.summary)}</p>
+      <div class="shell-chip-row">
+        <span class="shell-chip">${escapeHtml(session.last_active_label)}</span>
+        <span class="shell-chip">${escapeHtml(`resume ${session.resume_route}`)}</span>
+      </div>
+    </button>
+  `;
+}
+
+/**
  * @param {FrontendTripSummaryRecord} trip
  * @returns {string}
  */
@@ -263,6 +374,123 @@ function renderTripSummaryCard(trip) {
         <span class="shell-chip">${escapeHtml(`${trip.pending_checkpoint_count} checkpoints`)}</span>
       </div>
     </button>
+  `;
+}
+
+/**
+ * @param {FrontendLaunchFlowRecord} flow
+ * @param {boolean} isSelected
+ * @returns {string}
+ */
+function renderLaunchFlowCard(flow, isSelected) {
+  return `
+    <button
+      type="button"
+      class="shell-trip-card shell-trip-card--launch${isSelected ? " is-active" : ""}"
+      data-shell-launch="${escapeAttribute(flow.launch_id)}"
+    >
+      <div class="shell-trip-card-header">
+        <strong>${escapeHtml(flow.title)}</strong>
+        <span class="shell-mode-pill shell-mode-pill--${escapeAttribute(flow.mode)}">${escapeHtml(flow.mode)}</span>
+      </div>
+      <p>${escapeHtml(flow.summary)}</p>
+      <div class="shell-chip-row">
+        <span class="shell-chip">${escapeHtml(flow.cta_label)}</span>
+        <span class="shell-chip">${escapeHtml(`${flow.starting_needs.length} startup cues`)}</span>
+      </div>
+    </button>
+  `;
+}
+
+/**
+ * @param {FrontendShellState["account_entry"]["traveler_profiles"][number]} profile
+ * @returns {string}
+ */
+function renderTravelerProfileCard(profile) {
+  return `
+    <article class="shell-panel shell-panel--profile">
+      <div class="shell-panel-header">
+        <h3>${escapeHtml(profile.label)}</h3>
+        <span class="shell-meta">${escapeHtml(profile.mode)}</span>
+      </div>
+      <p>${escapeHtml(profile.summary)}</p>
+      <p class="shell-meta">${escapeHtml(profile.readiness)}</p>
+    </article>
+  `;
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {FrontendLaunchFlowRecord | null}
+ */
+function getSelectedLaunchFlow(state) {
+  return (
+    state.account_entry.launch_flows.find(
+      (flow) => flow.launch_id === state.account_entry.selected_launch_id
+    ) ?? null
+  );
+}
+
+/**
+ * @param {FrontendShellState} state
+ * @returns {string}
+ */
+function renderSelectedLaunchFlow(state) {
+  const flow = getSelectedLaunchFlow(state);
+  if (!flow) {
+    return `
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Launch detail</h3>
+          <span class="shell-meta">no launch selected</span>
+        </div>
+        <p>Select a launch option to see the startup data the entry layer must persist.</p>
+      </section>
+    `;
+  }
+
+  const linkedSession = flow.recent_session_id
+    ? state.account_entry.recent_sessions.find(
+        (session) => session.session_id === flow.recent_session_id
+      )
+    : null;
+  const linkedTrip = flow.trip_id
+    ? state.trips.find((trip) => trip.trip_id === flow.trip_id) ?? null
+    : null;
+
+  return `
+    <section class="shell-panel">
+      <div class="shell-panel-header">
+        <h3>${escapeHtml(flow.title)}</h3>
+        <span class="shell-meta">${escapeHtml(flow.cta_label)}</span>
+      </div>
+      <p>${escapeHtml(flow.summary)}</p>
+      <ul class="shell-list">
+        ${flow.starting_needs.map((need) => `<li>${escapeHtml(need)}</li>`).join("")}
+      </ul>
+      <div class="shell-chip-row">
+        ${
+          flow.profile_id
+            ? `<span class="shell-chip">${escapeHtml(`profile ${flow.profile_id}`)}</span>`
+            : ""
+        }
+        ${
+          linkedSession
+            ? `<span class="shell-chip">${escapeHtml(`session ${linkedSession.label}`)}</span>`
+            : ""
+        }
+        ${
+          linkedTrip
+            ? `<span class="shell-chip">${escapeHtml(`trip ${linkedTrip.title}`)}</span>`
+            : ""
+        }
+      </div>
+      ${
+        flow.policy_context
+          ? `<p class="shell-meta">${escapeHtml(flow.policy_context)}</p>`
+          : ""
+      }
+    </section>
   `;
 }
 
@@ -319,27 +547,83 @@ export function renderWorkspaceStatusBoundary(workspace) {
  * @returns {string}
  */
 function renderDashboardView(state) {
+  const hasRecentSessions = state.account_entry.recent_sessions.length > 0;
+  const hasSavedTrips = state.trips.length > 0;
+
   return `
     <section class="shell-view shell-view--dashboard">
       <div class="shell-hero">
         <div>
           <p class="shell-eyebrow">Signed-in planning home</p>
           <h2>${escapeHtml(state.session.display_name)}</h2>
-          <p>${escapeHtml(state.session.organization ?? "Independent traveler")} can resume saved trips or launch a new flow once issue #557 adds entry screens.</p>
+          <p>${escapeHtml(state.session.organization ?? "Independent traveler")} can enter saved planning work, launch a new leisure or business trip, and keep mode-specific startup needs visible from the first screen.</p>
         </div>
         <div class="shell-chip-row">
           <span class="shell-chip">${escapeHtml(`${state.trips.length} saved trips`)}</span>
+          <span class="shell-chip">${escapeHtml(`${state.account_entry.recent_sessions.length} recent sessions`)}</span>
           <span class="shell-chip">${escapeHtml(`default ${state.session.default_trip_mode} mode`)}</span>
         </div>
       </div>
+      ${
+        state.account_entry.empty_state_message
+          ? `
+            <section class="shell-status shell-status--empty" aria-label="Entry empty state">
+              <strong>Trip entry is ready for first use</strong>
+              <p>${escapeHtml(state.account_entry.empty_state_message)}</p>
+            </section>
+          `
+          : ""
+      }
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Recent sessions</h3>
+          <span class="shell-meta">resume the last planner or approval checkpoint</span>
+        </div>
+        ${
+          hasRecentSessions
+            ? `
+              <div class="shell-trip-grid">
+                ${state.account_entry.recent_sessions.map((session) => renderRecentSessionCard(session)).join("")}
+              </div>
+            `
+            : "<p class=\"shell-empty-state\">No resumable sessions yet. The next trip launch will create the first one.</p>"
+        }
+      </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Trip launch flows</h3>
+          <span class="shell-meta">new leisure, new business, and resume entry paths</span>
+        </div>
+        <div class="shell-trip-grid">
+          ${state.account_entry.launch_flows
+            .map((flow) => renderLaunchFlowCard(flow, flow.launch_id === state.account_entry.selected_launch_id))
+            .join("")}
+        </div>
+      </section>
+      ${renderSelectedLaunchFlow(state)}
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Traveler profile context</h3>
+          <span class="shell-meta">what account-entry should carry into launch</span>
+        </div>
+        <div class="shell-trip-grid">
+          ${state.account_entry.traveler_profiles.map((profile) => renderTravelerProfileCard(profile)).join("")}
+        </div>
+      </section>
       <section class="shell-panel">
         <div class="shell-panel-header">
           <h3>Saved trips</h3>
           <span class="shell-meta">mode-aware shell entry points</span>
         </div>
-        <div class="shell-trip-grid">
-          ${state.trips.map((trip) => renderTripSummaryCard(trip)).join("")}
-        </div>
+        ${
+          hasSavedTrips
+            ? `
+              <div class="shell-trip-grid">
+                ${state.trips.map((trip) => renderTripSummaryCard(trip)).join("")}
+              </div>
+            `
+            : "<p class=\"shell-empty-state\">No saved trips yet. Launching a new trip should seed the first persisted trip summary.</p>"
+        }
       </section>
       <section class="shell-panel">
         <div class="shell-panel-header">
@@ -572,6 +856,28 @@ export function renderAppShell(mountNode, initialState) {
           detail: store.getState().active_trip_id,
         })
       );
+      return;
+    }
+
+    const launchTarget = event.target.closest("[data-shell-launch]");
+    if (launchTarget?.dataset.shellLaunch) {
+      store.setEntryLaunch(launchTarget.dataset.shellLaunch);
+      mountNode.dispatchEvent(
+        new CustomEvent("shell:launch-change", {
+          detail: store.getState().account_entry.selected_launch_id,
+        })
+      );
+      return;
+    }
+
+    const sessionTarget = event.target.closest("[data-shell-session]");
+    if (sessionTarget?.dataset.shellSession) {
+      store.resumeSession(sessionTarget.dataset.shellSession);
+      mountNode.dispatchEvent(
+        new CustomEvent("shell:session-resume", {
+          detail: store.getState().active_trip_id,
+        })
+      );
     }
   };
 
@@ -586,6 +892,12 @@ export function renderAppShell(mountNode, initialState) {
     },
     setActiveTrip(tripId) {
       store.setActiveTrip(tripId);
+    },
+    setEntryLaunch(launchId) {
+      store.setEntryLaunch(launchId);
+    },
+    resumeSession(sessionId) {
+      store.resumeSession(sessionId);
     },
     destroy() {
       unsubscribe();

--- a/bundle/app-shell/app-shell.js
+++ b/bundle/app-shell/app-shell.js
@@ -292,7 +292,7 @@ export function createAppShellStore(initialState) {
         workspace: {
           ...state.workspace,
           trip_id: session.trip_id,
-          status: "empty",
+          status: "loading",
           planner_panel_state: null,
           loading_message: "Rehydrating the saved session entry point.",
           error_message: null,
@@ -801,7 +801,7 @@ export function renderAppShellLayout(state) {
   const activeTrip = state.trips.find((trip) => trip.trip_id === state.active_trip_id) ?? null;
 
   return `
-    <section class="planner-app-shell" data-shell-route="${escapeAttribute(state.active_route)}">
+    <section class="planner-app-shell" data-shell-active-route="${escapeAttribute(state.active_route)}">
       <header class="shell-header">
         <div>
           <p class="shell-eyebrow">Trip planner application shell</p>
@@ -837,7 +837,7 @@ export function renderAppShell(mountNode, initialState) {
       return;
     }
 
-    const routeTarget = event.target.closest("[data-shell-route]");
+    const routeTarget = event.target.closest("button[data-shell-route]");
     if (routeTarget?.dataset.shellRoute) {
       store.setRoute(routeTarget.dataset.shellRoute);
       mountNode.dispatchEvent(

--- a/bundle/app-shell/contracts.d.ts
+++ b/bundle/app-shell/contracts.d.ts
@@ -14,13 +14,20 @@ export type AppRouteId =
   | "planner_workspace"
   | "approval_center";
 
+export type TripMode = "leisure" | "business";
+
+export type LaunchFlowId =
+  | "new_leisure_trip"
+  | "new_business_trip"
+  | "resume_existing_trip";
+
 export type WorkspaceStatus = "ready" | "loading" | "empty" | "error";
 
 export interface SessionUserRecord {
   user_id: string;
   display_name: string;
   organization?: string | null;
-  default_trip_mode: "leisure" | "business";
+  default_trip_mode: TripMode;
 }
 
 export interface FrontendTripSummaryRecord {
@@ -35,6 +42,45 @@ export interface FrontendTripSummaryRecord {
   scenario_count: number;
   pending_checkpoint_count: number;
   policy_state: PlannerPanelState["policy_evaluation"]["status"] | null;
+}
+
+export interface FrontendTravelerProfileRecord {
+  profile_id: string;
+  mode: TripMode;
+  label: string;
+  summary: string;
+  readiness: string;
+}
+
+export interface FrontendRecentSessionRecord {
+  session_id: string;
+  trip_id: TripRecord["trip_id"] | null;
+  mode: TripMode;
+  label: string;
+  summary: string;
+  last_active_label: string;
+  resume_route: AppRouteId;
+}
+
+export interface FrontendLaunchFlowRecord {
+  launch_id: LaunchFlowId;
+  mode: TripMode;
+  title: string;
+  summary: string;
+  cta_label: string;
+  starting_needs: string[];
+  profile_id: string | null;
+  trip_id: TripRecord["trip_id"] | null;
+  recent_session_id: string | null;
+  policy_context: string | null;
+}
+
+export interface FrontendAccountEntryRecord {
+  traveler_profiles: FrontendTravelerProfileRecord[];
+  recent_sessions: FrontendRecentSessionRecord[];
+  launch_flows: FrontendLaunchFlowRecord[];
+  selected_launch_id: LaunchFlowId | null;
+  empty_state_message: string | null;
 }
 
 export interface FrontendAppRouteRecord {
@@ -61,5 +107,6 @@ export interface FrontendShellState {
   active_route: AppRouteId;
   trips: FrontendTripSummaryRecord[];
   active_trip_id: string | null;
+  account_entry: FrontendAccountEntryRecord;
   workspace: FrontendWorkspaceRecord;
 }

--- a/bundle/app-shell/mock-state.js
+++ b/bundle/app-shell/mock-state.js
@@ -13,6 +13,95 @@ const signedInSession = {
   default_trip_mode: "leisure",
 };
 
+const firstTimeLeisureSession = {
+  user_id: "user-26",
+  display_name: "Mina Patel",
+  organization: null,
+  default_trip_mode: "leisure",
+};
+
+const businessEntrySession = {
+  user_id: "user-44",
+  display_name: "Jordan Lee",
+  organization: "Northwind Advisory",
+  default_trip_mode: "business",
+};
+
+const travelerProfiles = {
+  leisure_primary: {
+    profile_id: "profile-leisure-17",
+    mode: "leisure",
+    label: "Leisure profile",
+    summary: "Prefers walkable neighborhoods, low-friction transit days, and one soft landing day.",
+    readiness: "Ready to seed a new leisure trip from learned pace and comfort preferences.",
+  },
+  leisure_new_user: {
+    profile_id: "profile-leisure-26",
+    mode: "leisure",
+    label: "Starter leisure profile",
+    summary: "No saved trips yet, but the account already captured destination style and pace preferences.",
+    readiness: "Needs a first trip brief to turn starter preferences into reusable trip state.",
+  },
+  business_primary: {
+    profile_id: "profile-business-4",
+    mode: "business",
+    label: "Business travel profile",
+    summary: "Carries traveler role, approval path, and hotel policy context for client-facing travel.",
+    readiness: "Ready to start a policy-aware trip with approval routing and purpose capture.",
+  },
+};
+
+const launchFlows = {
+  new_leisure_trip: {
+    launch_id: "new_leisure_trip",
+    mode: "leisure",
+    title: "Start a new leisure trip",
+    summary: "Translate traveler preferences into destination framing, pace, and budget-aware setup.",
+    cta_label: "Start leisure trip",
+    starting_needs: [
+      "Trip brief with dates, destination ideas, and traveler party context.",
+      "Preference cues for pace, walkability, comfort, and budget.",
+      "A seed itinerary question that tells the planner what to optimize first.",
+    ],
+    profile_id: travelerProfiles.leisure_primary.profile_id,
+    trip_id: null,
+    recent_session_id: null,
+    policy_context: null,
+  },
+  new_business_trip: {
+    launch_id: "new_business_trip",
+    mode: "business",
+    title: "Start a new business trip",
+    summary: "Capture travel purpose, employer policy context, and approval posture before workspace planning.",
+    cta_label: "Start business trip",
+    starting_needs: [
+      "Business purpose, traveler role, and client or event context.",
+      "Policy-linked lodging, airfare, or approval constraints from the business profile.",
+      "A routing decision for whether the planner should prepare approval evidence immediately.",
+    ],
+    profile_id: travelerProfiles.business_primary.profile_id,
+    trip_id: null,
+    recent_session_id: null,
+    policy_context: "Hotel zone, approval roles, and spend posture should be seeded from the business profile.",
+  },
+  resume_existing_trip: {
+    launch_id: "resume_existing_trip",
+    mode: "leisure",
+    title: "Resume an existing trip",
+    summary: "Re-enter the most recent session and rehydrate trip context without rebuilding the shell.",
+    cta_label: "Resume latest session",
+    starting_needs: [
+      "Most recent session id and the route it should reopen.",
+      "Saved trip summary and the last persisted workspace checkpoint.",
+      "A deterministic fallback if the session payload is no longer available.",
+    ],
+    profile_id: travelerProfiles.leisure_primary.profile_id,
+    trip_id: "trip-leisure-lisbon-oct",
+    recent_session_id: "session-leisure-lisbon-planner",
+    policy_context: null,
+  },
+};
+
 const leisurePlannerPanelState = {
   trip: {
     trip_id: "trip-leisure-lisbon-oct",
@@ -243,6 +332,33 @@ const businessPlannerPanelState = {
 };
 
 /** @type {FrontendShellState} */
+export const firstTimeLeisureDashboardShellState = {
+  session: firstTimeLeisureSession,
+  routes: [],
+  active_route: "dashboard",
+  trips: [],
+  active_trip_id: null,
+  account_entry: {
+    traveler_profiles: [travelerProfiles.leisure_new_user],
+    recent_sessions: [],
+    launch_flows: [launchFlows.new_leisure_trip, launchFlows.new_business_trip],
+    selected_launch_id: "new_leisure_trip",
+    empty_state_message: "No saved trips yet. Start with a leisure brief or open a policy-aware business launch.",
+  },
+  workspace: {
+    trip_id: null,
+    status: "empty",
+    planner_panel_state: null,
+    loading_message: null,
+    error_message: null,
+    persistence_summary: [
+      "First-trip launch should create persisted account, trip, and session records together.",
+      "Empty-state onboarding must stay deterministic until live identity and session APIs arrive.",
+    ],
+  },
+};
+
+/** @type {FrontendShellState} */
 export const signedInDashboardShellState = {
   session: signedInSession,
   routes: [],
@@ -276,6 +392,36 @@ export const signedInDashboardShellState = {
     },
   ],
   active_trip_id: null,
+  account_entry: {
+    traveler_profiles: [travelerProfiles.leisure_primary, travelerProfiles.business_primary],
+    recent_sessions: [
+      {
+        session_id: "session-leisure-lisbon-planner",
+        trip_id: leisurePlannerPanelState.trip.trip_id,
+        mode: "leisure",
+        label: "Resume Lisbon comparison",
+        summary: "Return to the lodging checkpoint with one open decision and three saved scenarios.",
+        last_active_label: "Worked 2h ago",
+        resume_route: "planner_workspace",
+      },
+      {
+        session_id: "session-business-audit-approval",
+        trip_id: businessPlannerPanelState.trip.trip_id,
+        mode: "business",
+        label: "Resume Seattle approval packet",
+        summary: "Reopen the exception packet and approval-ready comparables for travel ops review.",
+        last_active_label: "Worked yesterday",
+        resume_route: "approval_center",
+      },
+    ],
+    launch_flows: [
+      launchFlows.new_leisure_trip,
+      launchFlows.new_business_trip,
+      launchFlows.resume_existing_trip,
+    ],
+    selected_launch_id: "resume_existing_trip",
+    empty_state_message: null,
+  },
   workspace: {
     trip_id: null,
     status: "empty",
@@ -290,12 +436,60 @@ export const signedInDashboardShellState = {
 };
 
 /** @type {FrontendShellState} */
+export const businessPolicyStartDashboardShellState = {
+  session: businessEntrySession,
+  routes: [],
+  active_route: "dashboard",
+  trips: [signedInDashboardShellState.trips[1]],
+  active_trip_id: null,
+  account_entry: {
+    traveler_profiles: [travelerProfiles.business_primary, travelerProfiles.leisure_primary],
+    recent_sessions: [
+      {
+        session_id: "session-business-policy-start",
+        trip_id: businessPlannerPanelState.trip.trip_id,
+        mode: "business",
+        label: "Resume policy-linked kickoff",
+        summary: "Continue the trip-start flow with traveler purpose, policy posture, and approver context already loaded.",
+        last_active_label: "Worked 30m ago",
+        resume_route: "trip_workspace",
+      },
+    ],
+    launch_flows: [
+      launchFlows.new_business_trip,
+      {
+        ...launchFlows.resume_existing_trip,
+        mode: "business",
+        trip_id: businessPlannerPanelState.trip.trip_id,
+        recent_session_id: "session-business-policy-start",
+        summary: "Resume the latest business kickoff and keep policy-linked trip start intact.",
+      },
+      launchFlows.new_leisure_trip,
+    ],
+    selected_launch_id: "new_business_trip",
+    empty_state_message: null,
+  },
+  workspace: {
+    trip_id: null,
+    status: "empty",
+    planner_panel_state: null,
+    loading_message: null,
+    error_message: null,
+    persistence_summary: [
+      "Business launch should create the trip shell together with policy and approval capture.",
+      "Session-entry must preserve why the traveler is starting a policy-aware trip before the planner workspace mounts.",
+    ],
+  },
+};
+
+/** @type {FrontendShellState} */
 export const activeLeisureTripShellState = {
   session: signedInSession,
   routes: [],
   active_route: "trip_workspace",
   trips: signedInDashboardShellState.trips,
   active_trip_id: leisurePlannerPanelState.trip.trip_id,
+  account_entry: signedInDashboardShellState.account_entry,
   workspace: {
     trip_id: leisurePlannerPanelState.trip.trip_id,
     status: "ready",
@@ -316,6 +510,7 @@ export const activeBusinessTripShellState = {
   active_route: "approval_center",
   trips: signedInDashboardShellState.trips,
   active_trip_id: businessPlannerPanelState.trip.trip_id,
+  account_entry: signedInDashboardShellState.account_entry,
   workspace: {
     trip_id: businessPlannerPanelState.trip.trip_id,
     status: "ready",
@@ -330,7 +525,9 @@ export const activeBusinessTripShellState = {
 };
 
 export const appShellStateMocks = {
+  first_time_leisure_dashboard: firstTimeLeisureDashboardShellState,
   signed_in_dashboard: signedInDashboardShellState,
+  business_policy_start_dashboard: businessPolicyStartDashboardShellState,
   active_leisure_trip: activeLeisureTripShellState,
   active_business_trip: activeBusinessTripShellState,
 };

--- a/docs/frontend-app-shell-foundation.md
+++ b/docs/frontend-app-shell-foundation.md
@@ -78,7 +78,7 @@ Later issues should extend those fixtures instead of replacing them with unrelat
 
 ## Handoff To Later Issues
 
-- `#557` should plug trip-entry and account-launch flows into the dashboard route.
+- `#557` now plugs trip-entry and account-launch flows into the dashboard route through `account_entry` launch, profile, and recent-session surfaces.
 - `#558` should deepen the trip workspace route with scenario, ranking, and budget panes.
 - `#559` should attach maps and timeline views to the trip workspace without changing the shell route contract.
 - `#560` should connect the planner and approval routes to the more detailed planner-side-panel surfaces already living under `bundle/planner/`.

--- a/docs/frontend-application-layer-epic.md
+++ b/docs/frontend-application-layer-epic.md
@@ -77,6 +77,7 @@ Use these documents together when implementing the child issues:
 
 - [Product architecture brief](product-architecture-brief.md)
 - [Frontend app shell foundation](frontend-app-shell-foundation.md)
+- [Frontend entry flows](frontend-entry-flows.md)
 - [Planner UI integration](planner-ui-integration.md)
 - [Orchestration, interactive planning, and in-trip adjustment epic](orchestration-interactive-planning-epic.md)
 - [Policy integration execution epic](policy-integration-execution-epic.md)

--- a/docs/frontend-entry-flows.md
+++ b/docs/frontend-entry-flows.md
@@ -1,0 +1,62 @@
+# Frontend Entry Flows
+
+This document records the implementation boundary for issue `#557`.
+
+The goal is to make the dashboard route act like a real application entry layer instead of a passive list of saved trips.
+
+## What Issue #557 Owns
+
+Issue `#557` adds:
+
+- recent-session entry cards that reopen saved planner or approval work
+- launch surfaces for new leisure trips, new business trips, and resume-existing-trip flows
+- traveler-profile context panels that show what account state should seed each launch path
+- representative dashboard fixtures for first-time leisure, returning leisure, and business policy-start entry states
+- deterministic tests for launch selection, resume behavior, and invalid-session handling
+
+It does not yet own the full trip workspace, maps, or deeper planner interaction surfaces. Those stay with `#558` through `#560`.
+
+## Entry Surface Model
+
+The dashboard now carries a typed `account_entry` payload with four responsibilities:
+
+1. `traveler_profiles`
+   The account-side profiles that should seed launch behavior without redefining domain meaning in UI-local models.
+2. `recent_sessions`
+   Resume targets with a saved `trip_id`, human summary, and the route that should reopen first.
+3. `launch_flows`
+   Mode-specific entry options for leisure, business, and resume flows.
+4. `selected_launch_id`
+   The currently focused launch detail so the dashboard can explain what startup data needs to be persisted.
+
+## Persistence Expectations
+
+The entry layer should connect to persisted state in this order:
+
+- account identity and traveler profiles provide the initial launch context
+- saved trip summaries determine whether the user is resuming or creating a new trip
+- recent session records reopen the last meaningful route without recreating trip state
+- workspace hydration happens after entry selection, not before
+
+Practical rule:
+
+- keep launch-specific meaning inside the canonical account, trip, and session records
+- use shell-local state only for launch selection and deterministic resume/error handling
+
+## Mode-Specific Startup Needs
+
+The dashboard should keep leisure and business launches intentionally distinct:
+
+- leisure launch emphasizes trip brief, traveler party, pace, and preference cues
+- business launch emphasizes travel purpose, employer policy posture, and approval context
+- resume flow emphasizes session identity, last route, and deterministic fallback handling
+
+## Representative Fixtures
+
+Issue `#557` ships three dashboard entry fixtures:
+
+- first-time leisure user with no saved trips yet
+- returning leisure user with saved trips and resumable planner work
+- business user with policy-linked trip start and approval-aware launch context
+
+Later issues should extend these entry states instead of replacing them with page-local mocks.

--- a/tests/planner/test_app_shell_state.mjs
+++ b/tests/planner/test_app_shell_state.mjs
@@ -59,6 +59,14 @@ class FakeButton extends FakeHTMLElement {
       return this;
     }
 
+    if (selector === "[data-shell-launch]" && this.dataset.shellLaunch) {
+      return this;
+    }
+
+    if (selector === "[data-shell-session]" && this.dataset.shellSession) {
+      return this;
+    }
+
     return null;
   }
 }
@@ -79,7 +87,9 @@ async function loadModule(relativePath) {
 
 const {
   appShellStateMocks,
+  firstTimeLeisureDashboardShellState,
   signedInDashboardShellState,
+  businessPolicyStartDashboardShellState,
   activeLeisureTripShellState,
   activeBusinessTripShellState,
 } = await loadModule("bundle/app-shell/mock-state.js");
@@ -93,7 +103,15 @@ const {
 } = await loadModule("bundle/app-shell/app-shell.js");
 
 test("app shell mock catalog exposes signed-in, leisure, and business contexts", () => {
+  assert.equal(
+    appShellStateMocks.first_time_leisure_dashboard,
+    firstTimeLeisureDashboardShellState
+  );
   assert.equal(appShellStateMocks.signed_in_dashboard, signedInDashboardShellState);
+  assert.equal(
+    appShellStateMocks.business_policy_start_dashboard,
+    businessPolicyStartDashboardShellState
+  );
   assert.equal(appShellStateMocks.active_leisure_trip, activeLeisureTripShellState);
   assert.equal(appShellStateMocks.active_business_trip, activeBusinessTripShellState);
 });
@@ -103,8 +121,18 @@ test("app shell derives a dashboard route when no active trip is selected", () =
 
   assert.equal(state.active_route, "dashboard");
   assert.equal(state.active_trip_id, "trip-leisure-lisbon-oct");
+  assert.equal(state.account_entry.selected_launch_id, "resume_existing_trip");
   assert.match(renderAppShellLayout(state), /Signed-in planning home/);
   assert.match(renderAppShellLayout(state), /Seattle audit trip with approval packet/);
+});
+
+test("first-time leisure entry defaults to a new leisure launch", () => {
+  const state = buildAppShellState(firstTimeLeisureDashboardShellState);
+
+  assert.equal(state.account_entry.selected_launch_id, "new_leisure_trip");
+  assert.match(renderAppShellLayout(state), /Trip entry is ready for first use/);
+  assert.match(renderAppShellLayout(state), /Start a new leisure trip/);
+  assert.match(renderAppShellLayout(state), /No saved trips yet/);
 });
 
 test("shell routes stay mode-aware for leisure and business trips", () => {
@@ -159,6 +187,33 @@ test("app shell store updates route and active trip while preserving visible she
   assert.equal(store.getState().active_route, "approval_center");
 });
 
+test("entry store switches launch flows and resumes saved sessions", () => {
+  const store = createAppShellStore(signedInDashboardShellState);
+
+  store.setEntryLaunch("new_business_trip");
+  assert.equal(store.getState().account_entry.selected_launch_id, "new_business_trip");
+
+  store.resumeSession("session-business-audit-approval");
+  assert.equal(store.getState().active_trip_id, "trip-client-audit-sea");
+  assert.equal(store.getState().active_route, "approval_center");
+  assert.equal(
+    store.getState().workspace.loading_message,
+    "Rehydrating the saved session entry point."
+  );
+});
+
+test("entry store reports a deterministic error for missing sessions", () => {
+  const store = createAppShellStore(firstTimeLeisureDashboardShellState);
+
+  store.resumeSession("missing-session");
+  assert.equal(store.getState().active_route, "dashboard");
+  assert.equal(store.getState().workspace.status, "error");
+  assert.equal(
+    store.getState().workspace.error_message,
+    "Selected session is no longer available."
+  );
+});
+
 test("mounted app shell rerenders on route and trip changes", () => {
   const mountNode = new FakeMountNode();
   const controller = renderAppShell(mountNode, activeBusinessTripShellState);
@@ -176,6 +231,24 @@ test("mounted app shell rerenders on route and trip changes", () => {
 
   controller.destroy();
   assert.equal(mountNode.listeners.has("click"), false);
+});
+
+test("mounted dashboard rerenders on launch and session entry interactions", () => {
+  const mountNode = new FakeMountNode();
+  const controller = renderAppShell(mountNode, signedInDashboardShellState);
+
+  assert.match(mountNode.innerHTML, /Resume an existing trip/);
+
+  mountNode.click(new FakeButton({ shellLaunch: "new_business_trip" }));
+  assert.equal(controller.getState().account_entry.selected_launch_id, "new_business_trip");
+  assert.match(
+    mountNode.innerHTML,
+    /Hotel zone, approval roles, and spend posture should be seeded/
+  );
+
+  mountNode.click(new FakeButton({ shellSession: "session-leisure-lisbon-planner" }));
+  assert.equal(controller.getState().active_trip_id, "trip-leisure-lisbon-oct");
+  assert.equal(controller.getState().active_route, "planner_workspace");
 });
 
 test("mounted app shell ignores click events from non-element targets", () => {

--- a/tests/planner/test_app_shell_state.mjs
+++ b/tests/planner/test_app_shell_state.mjs
@@ -51,7 +51,10 @@ class FakeButton extends FakeHTMLElement {
   }
 
   closest(selector) {
-    if (selector === "[data-shell-route]" && this.dataset.shellRoute) {
+    if (
+      (selector === "[data-shell-route]" || selector === "button[data-shell-route]") &&
+      this.dataset.shellRoute
+    ) {
       return this;
     }
 
@@ -196,6 +199,7 @@ test("entry store switches launch flows and resumes saved sessions", () => {
   store.resumeSession("session-business-audit-approval");
   assert.equal(store.getState().active_trip_id, "trip-client-audit-sea");
   assert.equal(store.getState().active_route, "approval_center");
+  assert.equal(store.getState().workspace.status, "loading");
   assert.equal(
     store.getState().workspace.loading_message,
     "Rehydrating the saved session entry point."


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #557

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The app needs a clean way for users to enter the system, select or create trips, and move into the right planning mode. Without explicit account and trip-entry surfaces, the backend persistence work will not translate into a usable planner entry point.

Parent epic: #555

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#555](https://github.com/stranske/trip-planner/issues/555)
- [#538](https://github.com/stranske/trip-planner/issues/538)
- [#539](https://github.com/stranske/trip-planner/issues/539)
- [#542](https://github.com/stranske/trip-planner/issues/542)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Build account and entry surfaces that can show saved trips, recent sessions, and traveler-profile context for a signed-in user.
- [x] Build trip-launch flows for at least: new leisure trip, new business trip, and resume existing trip.
- [x] Ensure the entry flow can surface mode-specific starting needs, such as preference-driven setup for leisure and policy-context or purpose-driven setup for business.
- [x] Add representative UI states or mocks for at least: first-time leisure user, returning leisure user with saved trips, and business user with policy-linked trip start.
- [x] Write frontend tests covering major entry flows, invalid or empty-state handling, and trip resume behavior.
- [x] Document how these entry flows should connect to persisted account, trip, and session-state layers.

#### Acceptance criteria
- [x] Users can enter the app, access saved trips, and launch or resume both leisure and business trips through coherent frontend flows.
- [x] The entry layer respects the persistence and trip-state contracts defined earlier in the backlog.
- [x] Tests cover representative launch and resume cases plus empty-state handling.
- [x] Business and leisure start flows remain intentionally distinct where needed.
- [x] Documentation explains how entry flows connect to later trip-workspace views.

**Head SHA:** 64dd7bd2bd34221c6554963d6b0afe3f36be733b
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/23953471515) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23953473394) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23953473322) |
| CI | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23953473340) |
| Claude Code Review | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23953473187) |
| Claude Code Review (Opt-in) | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23953473200) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23953472525) |
| Gate | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23953473326) |
| Health 45 Agents Guard | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23953473173) |
<!-- auto-status-summary:end -->
