### PR TITLE
Issue #558: build trip workspace surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [Planner UI integration](docs/planner-ui-integration.md)
 - [Frontend app shell foundation](docs/frontend-app-shell-foundation.md)
 - [Frontend entry flows](docs/frontend-entry-flows.md)
+- [Frontend trip workspace](docs/frontend-trip-workspace.md)
 - [Source and quality model](docs/source-quality-model.md)
 - [Source channel strategy](docs/source-channel-strategy.md)
 - [Legacy itinerary methodology](docs/methodology.md)

--- a/bundle/app-shell/app-shell.js
+++ b/bundle/app-shell/app-shell.js
@@ -175,6 +175,9 @@ export function buildAppShellState(input) {
       input.workspace?.status ??
       (activeTrip ? "ready" : "empty"),
     planner_panel_state: input.workspace?.planner_panel_state ?? null,
+    scenario_summaries: input.workspace?.scenario_summaries ?? [],
+    checkpoint_history: input.workspace?.checkpoint_history ?? [],
+    budget_summary: input.workspace?.budget_summary ?? null,
     loading_message: input.workspace?.loading_message ?? null,
     error_message: input.workspace?.error_message ?? null,
     persistence_summary: input.workspace?.persistence_summary ?? [],
@@ -229,6 +232,9 @@ export function createAppShellStore(initialState) {
               trip_id: tripId,
               status: "empty",
               planner_panel_state: null,
+              scenario_summaries: [],
+              checkpoint_history: [],
+              budget_summary: null,
               loading_message: null,
               error_message: null,
               persistence_summary: state.workspace.persistence_summary,
@@ -252,12 +258,15 @@ export function createAppShellStore(initialState) {
           ...state.account_entry,
           selected_launch_id: launchId,
         },
-        workspace: {
-          ...state.workspace,
-          status: "empty",
-          loading_message: null,
-          error_message: null,
-        },
+          workspace: {
+            ...state.workspace,
+            status: "empty",
+            scenario_summaries: [],
+            checkpoint_history: [],
+            budget_summary: null,
+            loading_message: null,
+            error_message: null,
+          },
       });
       notify();
     },
@@ -273,6 +282,9 @@ export function createAppShellStore(initialState) {
           workspace: {
             ...state.workspace,
             status: "error",
+            scenario_summaries: [],
+            checkpoint_history: [],
+            budget_summary: null,
             loading_message: null,
             error_message: "Selected session is no longer available.",
           },
@@ -294,6 +306,9 @@ export function createAppShellStore(initialState) {
           trip_id: session.trip_id,
           status: "loading",
           planner_panel_state: null,
+          scenario_summaries: [],
+          checkpoint_history: [],
+          budget_summary: null,
           loading_message: "Rehydrating the saved session entry point.",
           error_message: null,
         },
@@ -653,6 +668,7 @@ function renderTripWorkspaceView(state) {
   const scenarioSummary = plannerState
     ? `${plannerState.outputs.length} outputs, ${plannerState.pending_decisions.length} decision checkpoint, ${plannerState.option_set.options.length} surfaced options`
     : "Planner payload not mounted yet.";
+  const budgetSummary = state.workspace.budget_summary;
 
   return `
     <section class="shell-view shell-view--workspace">
@@ -678,6 +694,101 @@ function renderTripWorkspaceView(state) {
         <ul class="shell-list">
           ${state.workspace.persistence_summary.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}
         </ul>
+      </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Scenario comparison</h3>
+          <span class="shell-meta">${escapeHtml(`${state.workspace.scenario_summaries.length} saved scenario views`)}</span>
+        </div>
+        <div class="shell-trip-grid">
+          ${state.workspace.scenario_summaries
+            .map(
+              (scenario) => `
+                <article class="shell-panel shell-panel--profile">
+                  <div class="shell-panel-header">
+                    <h3>${escapeHtml(scenario.title)}</h3>
+                    <span class="shell-meta">${escapeHtml(scenario.status)}</span>
+                  </div>
+                  <p>${escapeHtml(scenario.summary)}</p>
+                  <p class="shell-meta">${escapeHtml(scenario.comparison_note)}</p>
+                  <div class="shell-chip-row">
+                    <span class="shell-chip">${escapeHtml(`${scenario.option_count} ranked options`)}</span>
+                    ${
+                      scenario.checkpoint_id
+                        ? `<span class="shell-chip">${escapeHtml(`checkpoint ${scenario.checkpoint_id}`)}</span>`
+                        : ""
+                    }
+                    ${
+                      scenario.budget_variant_id
+                        ? `<span class="shell-chip">${escapeHtml(`budget ${scenario.budget_variant_id}`)}</span>`
+                        : ""
+                    }
+                  </div>
+                </article>
+              `
+            )
+            .join("")}
+        </div>
+      </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Ranked alternatives</h3>
+          <span class="shell-meta">${escapeHtml(plannerState?.option_set.title ?? "planner option set pending")}</span>
+        </div>
+        ${
+          plannerState
+            ? `
+              <ul class="shell-list">
+                ${plannerState.option_set.options
+                  .map(
+                    (option) =>
+                      `<li><strong>${escapeHtml(option.label)}:</strong> ${escapeHtml(option.summary)} (${escapeHtml(option.explanation.join(" "))})</li>`
+                  )
+                  .join("")}
+              </ul>
+            `
+            : "<p class=\"shell-empty-state\">Ranked alternatives will appear once the planner payload mounts.</p>"
+        }
+      </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Checkpoint history</h3>
+          <span class="shell-meta">${escapeHtml(`${state.workspace.checkpoint_history.length} saved checkpoints`)}</span>
+        </div>
+        <ul class="shell-list">
+          ${state.workspace.checkpoint_history
+            .map(
+              (checkpoint) =>
+                `<li><strong>${escapeHtml(checkpoint.label)}:</strong> ${escapeHtml(checkpoint.summary)} (${escapeHtml(`${checkpoint.status} · ${checkpoint.updated_label}`)})</li>`
+            )
+            .join("")}
+        </ul>
+      </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Budget posture</h3>
+          <span class="shell-meta">${escapeHtml(budgetSummary?.status ?? "not loaded")}</span>
+        </div>
+        ${
+          budgetSummary
+            ? `
+              <p>${escapeHtml(`${budgetSummary.variance_label}. Selected plan ${budgetSummary.currency} ${budgetSummary.selected_total}.`)}</p>
+              <div class="shell-chip-row">
+                <span class="shell-chip">${escapeHtml(`baseline ${budgetSummary.currency} ${budgetSummary.baseline_total}`)}</span>
+                <span class="shell-chip">${escapeHtml(`actual ${budgetSummary.currency} ${budgetSummary.actual_total}`)}</span>
+                <span class="shell-chip">${escapeHtml(budgetSummary.categories.join(" · "))}</span>
+              </div>
+              <ul class="shell-list">
+                ${budgetSummary.variants
+                  .map(
+                    (variant) =>
+                      `<li><strong>${escapeHtml(variant.label)}:</strong> ${escapeHtml(`${budgetSummary.currency} ${variant.total_amount} (${variant.variance_label})`)}</li>`
+                  )
+                  .join("")}
+              </ul>
+            `
+            : "<p class=\"shell-empty-state\">Budget posture will appear once persisted budget state is attached.</p>"
+        }
       </section>
     </section>
   `;

--- a/bundle/app-shell/contracts.d.ts
+++ b/bundle/app-shell/contracts.d.ts
@@ -44,6 +44,46 @@ export interface FrontendTripSummaryRecord {
   policy_state: PlannerPanelState["policy_evaluation"]["status"] | null;
 }
 
+export interface FrontendWorkspaceScenarioRecord {
+  scenario_id: string;
+  title: string;
+  summary: string;
+  status: "active" | "fallback" | "revised";
+  comparison_note: string;
+  option_count: number;
+  checkpoint_id: string | null;
+  budget_variant_id: string | null;
+}
+
+export interface FrontendWorkspaceCheckpointRecord {
+  checkpoint_id: string;
+  label: string;
+  summary: string;
+  status: "current" | "saved" | "revisit";
+  scenario_id: string;
+  updated_label: string;
+}
+
+export interface FrontendWorkspaceBudgetVariantRecord {
+  variant_id: string;
+  scenario_id: string;
+  label: string;
+  total_amount: number;
+  variance_label: string;
+}
+
+export interface FrontendWorkspaceBudgetRecord {
+  budget_state_id: string;
+  currency: string;
+  baseline_total: number;
+  selected_total: number;
+  actual_total: number;
+  status: "healthy" | "watch" | "over";
+  variance_label: string;
+  categories: string[];
+  variants: FrontendWorkspaceBudgetVariantRecord[];
+}
+
 export interface FrontendTravelerProfileRecord {
   profile_id: string;
   mode: TripMode;
@@ -96,6 +136,9 @@ export interface FrontendWorkspaceRecord {
   trip_id: string | null;
   status: WorkspaceStatus;
   planner_panel_state: PlannerPanelState | null;
+  scenario_summaries: FrontendWorkspaceScenarioRecord[];
+  checkpoint_history: FrontendWorkspaceCheckpointRecord[];
+  budget_summary: FrontendWorkspaceBudgetRecord | null;
   loading_message: string | null;
   error_message: string | null;
   persistence_summary: string[];

--- a/bundle/app-shell/mock-state.js
+++ b/bundle/app-shell/mock-state.js
@@ -331,6 +331,213 @@ const businessPlannerPanelState = {
   ],
 };
 
+const leisureWorkspaceScenarios = [
+  {
+    scenario_id: "scenario-lisbon-central",
+    title: "Central Lisbon base",
+    summary: "Keeps tram access and evening spontaneity high for the first half of the trip.",
+    status: "active",
+    comparison_note: "Best score for walkability and short decision loops.",
+    option_count: 3,
+    checkpoint_id: "checkpoint-lisbon-lodging",
+    budget_variant_id: "budget-lisbon-central",
+  },
+  {
+    scenario_id: "scenario-lisbon-riverside",
+    title: "Quiet riverside fallback",
+    summary: "Trades central access for quieter recovery nights and a larger room footprint.",
+    status: "fallback",
+    comparison_note: "Lower nightly spend with a longer first-leg transit pattern.",
+    option_count: 2,
+    checkpoint_id: "checkpoint-lisbon-lodging",
+    budget_variant_id: "budget-lisbon-riverside",
+  },
+];
+
+const leisureCheckpointHistory = [
+  {
+    checkpoint_id: "checkpoint-lisbon-lodging",
+    label: "Lodging tradeoff checkpoint",
+    summary: "Waiting on the central-versus-quiet base-camp preference.",
+    status: "current",
+    scenario_id: "scenario-lisbon-central",
+    updated_label: "Updated 2h ago",
+  },
+  {
+    checkpoint_id: "checkpoint-lisbon-seed",
+    label: "Trip brief capture",
+    summary: "Seeded walkability, fatigue, and soft-landing preferences into the workspace.",
+    status: "saved",
+    scenario_id: "scenario-lisbon-central",
+    updated_label: "Saved yesterday",
+  },
+];
+
+const leisureBudgetSummary = {
+  budget_state_id: "budget-lisbon-01",
+  currency: "USD",
+  baseline_total: 3200,
+  selected_total: 3110,
+  actual_total: 0,
+  status: "healthy",
+  variance_label: "$90 under target",
+  categories: ["lodging", "local transit", "dining"],
+  variants: [
+    {
+      variant_id: "budget-lisbon-central",
+      scenario_id: "scenario-lisbon-central",
+      label: "Central base",
+      total_amount: 3110,
+      variance_label: "$90 under target",
+    },
+    {
+      variant_id: "budget-lisbon-riverside",
+      scenario_id: "scenario-lisbon-riverside",
+      label: "Quiet fallback",
+      total_amount: 2960,
+      variance_label: "$240 under target",
+    },
+  ],
+};
+
+const businessWorkspaceScenarios = [
+  {
+    scenario_id: "scenario-sea-near-client",
+    title: "Primary exception-ready scenario",
+    summary: "Keeps the hotel close to the client site and preserves a low-risk arrival window.",
+    status: "active",
+    comparison_note: "Best operational fit, but requires a hotel-zone exception.",
+    option_count: 1,
+    checkpoint_id: "checkpoint-sea-approval",
+    budget_variant_id: "budget-sea-primary",
+  },
+  {
+    scenario_id: "scenario-sea-downtown",
+    title: "Compliant downtown fallback",
+    summary: "Avoids the exception packet at the cost of a 5:10am transfer and higher arrival risk.",
+    status: "fallback",
+    comparison_note: "Compliance-first alternative for travel-ops review.",
+    option_count: 1,
+    checkpoint_id: "checkpoint-sea-approval",
+    budget_variant_id: "budget-sea-fallback",
+  },
+];
+
+const businessCheckpointHistory = [
+  {
+    checkpoint_id: "checkpoint-sea-approval",
+    label: "Approval packet review",
+    summary: "Comparables and justification are ready for travel ops review.",
+    status: "current",
+    scenario_id: "scenario-sea-near-client",
+    updated_label: "Updated 30m ago",
+  },
+  {
+    checkpoint_id: "checkpoint-sea-kickoff",
+    label: "Policy-aware kickoff",
+    summary: "Captured traveler purpose, audit timing, and exception posture before planning.",
+    status: "saved",
+    scenario_id: "scenario-sea-near-client",
+    updated_label: "Saved yesterday",
+  },
+];
+
+const businessBudgetSummary = {
+  budget_state_id: "budget-sea-01",
+  currency: "USD",
+  baseline_total: 1850,
+  selected_total: 1810,
+  actual_total: 0,
+  status: "watch",
+  variance_label: "$40 under target before exception review",
+  categories: ["lodging", "air", "ground transport"],
+  variants: [
+    {
+      variant_id: "budget-sea-primary",
+      scenario_id: "scenario-sea-near-client",
+      label: "Near-client hotel",
+      total_amount: 1810,
+      variance_label: "$40 under target",
+    },
+    {
+      variant_id: "budget-sea-fallback",
+      scenario_id: "scenario-sea-downtown",
+      label: "Downtown fallback",
+      total_amount: 1725,
+      variance_label: "$125 under target",
+    },
+  ],
+};
+
+const inTripRevisionWorkspaceScenarios = [
+  {
+    scenario_id: "scenario-lisbon-rain-reset",
+    title: "Rain-adjusted active plan",
+    summary: "Rebalances the final two days around indoor stops and lower transfer friction.",
+    status: "revised",
+    comparison_note: "Current best fit after weather drift and spend pressure.",
+    option_count: 3,
+    checkpoint_id: "checkpoint-lisbon-replan",
+    budget_variant_id: "budget-lisbon-rain-reset",
+  },
+  {
+    scenario_id: "scenario-lisbon-central",
+    title: "Original central base",
+    summary: "The pre-replan scenario is still saved as a fallback if conditions improve.",
+    status: "fallback",
+    comparison_note: "Preserved for comparison against the revised route shape.",
+    option_count: 3,
+    checkpoint_id: "checkpoint-lisbon-lodging",
+    budget_variant_id: "budget-lisbon-central",
+  },
+];
+
+const inTripRevisionCheckpointHistory = [
+  {
+    checkpoint_id: "checkpoint-lisbon-replan",
+    label: "In-trip replanning checkpoint",
+    summary: "Weather drift and actual spend triggered a scenario refresh mid-trip.",
+    status: "current",
+    scenario_id: "scenario-lisbon-rain-reset",
+    updated_label: "Updated 20m ago",
+  },
+  {
+    checkpoint_id: "checkpoint-lisbon-lodging",
+    label: "Original lodging decision",
+    summary: "The initial stay-shape decision remains saved for comparison.",
+    status: "revisit",
+    scenario_id: "scenario-lisbon-central",
+    updated_label: "Saved 2 days ago",
+  },
+];
+
+const inTripRevisionBudgetSummary = {
+  budget_state_id: "budget-lisbon-02",
+  currency: "USD",
+  baseline_total: 3200,
+  selected_total: 3345,
+  actual_total: 1860,
+  status: "watch",
+  variance_label: "$145 over target unless the revised scenario holds",
+  categories: ["lodging", "rail", "museum swaps"],
+  variants: [
+    {
+      variant_id: "budget-lisbon-rain-reset",
+      scenario_id: "scenario-lisbon-rain-reset",
+      label: "Rain-adjusted plan",
+      total_amount: 3345,
+      variance_label: "$145 over target",
+    },
+    {
+      variant_id: "budget-lisbon-central",
+      scenario_id: "scenario-lisbon-central",
+      label: "Original plan",
+      total_amount: 3480,
+      variance_label: "$280 over target",
+    },
+  ],
+};
+
 /** @type {FrontendShellState} */
 export const firstTimeLeisureDashboardShellState = {
   session: firstTimeLeisureSession,
@@ -349,6 +556,9 @@ export const firstTimeLeisureDashboardShellState = {
     trip_id: null,
     status: "empty",
     planner_panel_state: null,
+    scenario_summaries: [],
+    checkpoint_history: [],
+    budget_summary: null,
     loading_message: null,
     error_message: null,
     persistence_summary: [
@@ -426,6 +636,9 @@ export const signedInDashboardShellState = {
     trip_id: null,
     status: "empty",
     planner_panel_state: null,
+    scenario_summaries: [],
+    checkpoint_history: [],
+    budget_summary: null,
     loading_message: null,
     error_message: null,
     persistence_summary: [
@@ -473,6 +686,9 @@ export const businessPolicyStartDashboardShellState = {
     trip_id: null,
     status: "empty",
     planner_panel_state: null,
+    scenario_summaries: [],
+    checkpoint_history: [],
+    budget_summary: null,
     loading_message: null,
     error_message: null,
     persistence_summary: [
@@ -494,11 +710,15 @@ export const activeLeisureTripShellState = {
     trip_id: leisurePlannerPanelState.trip.trip_id,
     status: "ready",
     planner_panel_state: leisurePlannerPanelState,
+    scenario_summaries: leisureWorkspaceScenarios,
+    checkpoint_history: leisureCheckpointHistory,
+    budget_summary: leisureBudgetSummary,
     loading_message: null,
     error_message: null,
     persistence_summary: [
       "Scenario history is available from saved-trip state.",
       "Planner checkpoints should reuse orchestration payloads rather than page-local copies.",
+      "Budget variants should stay linked to persisted budget-state ids rather than UI-only totals.",
     ],
   },
 };
@@ -515,11 +735,44 @@ export const activeBusinessTripShellState = {
     trip_id: businessPlannerPanelState.trip.trip_id,
     status: "ready",
     planner_panel_state: businessPlannerPanelState,
+    scenario_summaries: businessWorkspaceScenarios,
+    checkpoint_history: businessCheckpointHistory,
+    budget_summary: businessBudgetSummary,
     loading_message: null,
     error_message: null,
     persistence_summary: [
       "Approval comparables and packet metadata should remain attached to the proposal contract.",
       "Business approval surfaces should sit beside planner state, not replace it.",
+    ],
+  },
+};
+
+/** @type {FrontendShellState} */
+export const inTripRevisionShellState = {
+  session: signedInSession,
+  routes: [],
+  active_route: "trip_workspace",
+  trips: signedInDashboardShellState.trips,
+  active_trip_id: leisurePlannerPanelState.trip.trip_id,
+  account_entry: signedInDashboardShellState.account_entry,
+  workspace: {
+    trip_id: leisurePlannerPanelState.trip.trip_id,
+    status: "ready",
+    planner_panel_state: {
+      ...leisurePlannerPanelState,
+      trip: {
+        ...leisurePlannerPanelState.trip,
+        summary: "Mid-trip replanning is active after weather drift and a tighter spend posture.",
+      },
+    },
+    scenario_summaries: inTripRevisionWorkspaceScenarios,
+    checkpoint_history: inTripRevisionCheckpointHistory,
+    budget_summary: inTripRevisionBudgetSummary,
+    loading_message: null,
+    error_message: null,
+    persistence_summary: [
+      "Revised scenarios should stay linked to the same persisted trip id while checkpoint history keeps the original branch visible.",
+      "Budget drift should point to saved budget-state variants instead of mutating ranked option records.",
     ],
   },
 };
@@ -530,4 +783,5 @@ export const appShellStateMocks = {
   business_policy_start_dashboard: businessPolicyStartDashboardShellState,
   active_leisure_trip: activeLeisureTripShellState,
   active_business_trip: activeBusinessTripShellState,
+  in_trip_revision: inTripRevisionShellState,
 };

--- a/docs/frontend-application-layer-epic.md
+++ b/docs/frontend-application-layer-epic.md
@@ -78,6 +78,7 @@ Use these documents together when implementing the child issues:
 - [Product architecture brief](product-architecture-brief.md)
 - [Frontend app shell foundation](frontend-app-shell-foundation.md)
 - [Frontend entry flows](frontend-entry-flows.md)
+- [Frontend trip workspace](frontend-trip-workspace.md)
 - [Planner UI integration](planner-ui-integration.md)
 - [Orchestration, interactive planning, and in-trip adjustment epic](orchestration-interactive-planning-epic.md)
 - [Policy integration execution epic](policy-integration-execution-epic.md)

--- a/docs/frontend-trip-workspace.md
+++ b/docs/frontend-trip-workspace.md
@@ -1,0 +1,40 @@
+# Frontend Trip Workspace
+
+This document records the workspace surface built for issue `#558`.
+
+## What Issue #558 Owns
+
+Issue `#558` deepens the `trip_workspace` route from the app shell with:
+
+- scenario comparison cards that stay linked to saved scenario ids
+- ranked-alternative summaries anchored to the canonical planner option set
+- checkpoint history that points back to saved planner checkpoints
+- budget posture summaries tied to persisted budget-state variants
+
+It does not own maps, route visualizations, side-panel interactions, or live collaboration flows.
+
+## State Mapping
+
+The workspace intentionally composes existing backend-facing seams instead of inventing parallel page models:
+
+1. `PlannerPanelState` remains the source for ranked alternatives and active checkpoint outputs.
+2. `FrontendWorkspaceRecord.scenario_summaries` provides a small UI summary layer over saved scenario branches.
+3. `FrontendWorkspaceRecord.checkpoint_history` keeps checkpoint lineage visible without copying full planner turns.
+4. `FrontendWorkspaceRecord.budget_summary` points to persisted budget-state ids and scenario-linked variants.
+
+The practical rule is that the workspace may summarize scenario, checkpoint, and budget state, but it should not redefine canonical trip, planner, ranking, or budget contracts.
+
+## Representative Fixtures
+
+Issue `#558` extends the shell fixtures with three route-ready workspace contexts:
+
+- leisure scenario comparison with an active and fallback branch
+- business primary-versus-fallback approval review
+- an in-trip revised scenario that preserves prior checkpoint history
+
+These fixtures live in `bundle/app-shell/mock-state.js` so later route work can reuse them instead of inventing disconnected mocks.
+
+## Handoff
+
+- `#559` should attach maps and route/timeline views to these workspace summaries.
+- `#560` should let the planner side panel drive the same scenario and checkpoint records instead of replacing them.

--- a/tests/planner/test_app_shell_state.mjs
+++ b/tests/planner/test_app_shell_state.mjs
@@ -95,6 +95,7 @@ const {
   businessPolicyStartDashboardShellState,
   activeLeisureTripShellState,
   activeBusinessTripShellState,
+  inTripRevisionShellState,
 } = await loadModule("bundle/app-shell/mock-state.js");
 const {
   buildAppShellState,
@@ -117,6 +118,7 @@ test("app shell mock catalog exposes signed-in, leisure, and business contexts",
   );
   assert.equal(appShellStateMocks.active_leisure_trip, activeLeisureTripShellState);
   assert.equal(appShellStateMocks.active_business_trip, activeBusinessTripShellState);
+  assert.equal(appShellStateMocks.in_trip_revision, inTripRevisionShellState);
 });
 
 test("app shell derives a dashboard route when no active trip is selected", () => {
@@ -185,6 +187,9 @@ test("app shell store updates route and active trip while preserving visible she
   assert.equal(store.getState().workspace.trip_id, "trip-client-audit-sea");
   assert.equal(store.getState().workspace.status, "empty");
   assert.equal(store.getState().workspace.planner_panel_state, null);
+  assert.deepEqual(store.getState().workspace.scenario_summaries, []);
+  assert.deepEqual(store.getState().workspace.checkpoint_history, []);
+  assert.equal(store.getState().workspace.budget_summary, null);
 
   store.setRoute("approval_center");
   assert.equal(store.getState().active_route, "approval_center");
@@ -253,6 +258,34 @@ test("mounted dashboard rerenders on launch and session entry interactions", () 
   mountNode.click(new FakeButton({ shellSession: "session-leisure-lisbon-planner" }));
   assert.equal(controller.getState().active_trip_id, "trip-leisure-lisbon-oct");
   assert.equal(controller.getState().active_route, "planner_workspace");
+  assert.equal(controller.getState().workspace.status, "loading");
+});
+
+test("trip workspace renders scenario, checkpoint, and budget surfaces for leisure and business contexts", () => {
+  const leisureWorkspace = renderAppShellLayout(activeLeisureTripShellState);
+  const businessWorkspace = renderAppShellLayout({
+    ...activeBusinessTripShellState,
+    active_route: "trip_workspace",
+  });
+
+  assert.match(leisureWorkspace, /Scenario comparison/);
+  assert.match(leisureWorkspace, /Central Lisbon base/);
+  assert.match(leisureWorkspace, /Quiet riverside fallback/);
+  assert.match(leisureWorkspace, /Budget posture/);
+  assert.match(leisureWorkspace, /\$90 under target/);
+
+  assert.match(businessWorkspace, /Primary exception-ready scenario/);
+  assert.match(businessWorkspace, /Compliant downtown fallback/);
+  assert.match(businessWorkspace, /Approval-ready lodging set/);
+  assert.match(businessWorkspace, /\$40 under target before exception review/);
+});
+
+test("trip workspace can render an in-trip revised scenario without losing saved history", () => {
+  const revisedWorkspace = renderAppShellLayout(inTripRevisionShellState);
+
+  assert.match(revisedWorkspace, /Rain-adjusted active plan/);
+  assert.match(revisedWorkspace, /In-trip replanning checkpoint/);
+  assert.match(revisedWorkspace, /\$145 over target unless the revised scenario holds/);
 });
 
 test("mounted app shell ignores click events from non-element targets", () => {

--- a/tests/planner/test_app_shell_state.mjs
+++ b/tests/planner/test_app_shell_state.mjs
@@ -262,11 +262,15 @@ test("mounted dashboard rerenders on launch and session entry interactions", () 
 });
 
 test("trip workspace renders scenario, checkpoint, and budget surfaces for leisure and business contexts", () => {
-  const leisureWorkspace = renderAppShellLayout(activeLeisureTripShellState);
-  const businessWorkspace = renderAppShellLayout({
-    ...activeBusinessTripShellState,
-    active_route: "trip_workspace",
-  });
+  const leisureWorkspace = renderAppShellLayout(
+    buildAppShellState(activeLeisureTripShellState)
+  );
+  const businessWorkspace = renderAppShellLayout(
+    buildAppShellState({
+      ...activeBusinessTripShellState,
+      active_route: "trip_workspace",
+    })
+  );
 
   assert.match(leisureWorkspace, /Scenario comparison/);
   assert.match(leisureWorkspace, /Central Lisbon base/);
@@ -281,7 +285,9 @@ test("trip workspace renders scenario, checkpoint, and budget surfaces for leisu
 });
 
 test("trip workspace can render an in-trip revised scenario without losing saved history", () => {
-  const revisedWorkspace = renderAppShellLayout(inTripRevisionShellState);
+  const revisedWorkspace = renderAppShellLayout(
+    buildAppShellState(inTripRevisionShellState)
+  );
 
   assert.match(revisedWorkspace, /Rain-adjusted active plan/);
   assert.match(revisedWorkspace, /In-trip replanning checkpoint/);
@@ -297,28 +303,30 @@ test("mounted app shell ignores click events from non-element targets", () => {
 });
 
 test("app shell layout escapes user-provided HTML-sensitive content", () => {
-  const rendered = renderAppShellLayout({
-    ...activeBusinessTripShellState,
-    active_route: "dashboard",
-    session: {
-      ...activeBusinessTripShellState.session,
-      display_name: "<Admin>",
-      organization: "Ops & Risk",
-    },
-    workspace: {
-      ...activeBusinessTripShellState.workspace,
-      persistence_summary: ["Line <b>bold</b> & ready"],
-    },
-    trips: activeBusinessTripShellState.trips.map((trip, index) =>
-      index === 1
-        ? {
-            ...trip,
-            title: "<script>alert(1)</script>",
-            summary: "Line <b>bold</b> & ready",
-          }
-        : trip
-    ),
-  });
+  const rendered = renderAppShellLayout(
+    buildAppShellState({
+      ...activeBusinessTripShellState,
+      active_route: "dashboard",
+      session: {
+        ...activeBusinessTripShellState.session,
+        display_name: "<Admin>",
+        organization: "Ops & Risk",
+      },
+      workspace: {
+        ...activeBusinessTripShellState.workspace,
+        persistence_summary: ["Line <b>bold</b> & ready"],
+      },
+      trips: activeBusinessTripShellState.trips.map((trip, index) =>
+        index === 1
+          ? {
+              ...trip,
+              title: "<script>alert(1)</script>",
+              summary: "Line <b>bold</b> & ready",
+            }
+          : trip
+      ),
+    })
+  );
 
   assert.match(rendered, /&lt;Admin&gt;/);
   assert.match(rendered, /Ops &amp; Risk/);


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #558

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The trip workspace will be the main user-facing surface of the planner. It needs to present scenarios, ranked alternatives, budget posture, and saved revisions in a way that reflects the backend planning model rather than flattening everything into one undifferentiated page.

Parent epic: #555

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#555](https://github.com/stranske/trip-planner/issues/555)
- [#540](https://github.com/stranske/trip-planner/issues/540)
- [#541](https://github.com/stranske/trip-planner/issues/541)
- [#531](https://github.com/stranske/trip-planner/issues/531)
- [#536](https://github.com/stranske/trip-planner/issues/536)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Build a trip workspace layout that can present current scenario, alternative scenarios, ranked option groups, budget posture, and saved checkpoints coherently.
- [x] Ensure the workspace can handle both leisure and business trip contexts while surfacing mode-specific differences when needed.
- [x] Add views or subpanels for scenario comparison, checkpoint history, and budget or spend context.
- [x] Add representative UI states or mocks for at least: leisure scenario comparison, business primary-versus-fallback scenario review, and in-trip revised scenario view.
- [x] Write frontend tests covering workspace rendering, scenario switching, checkpoint selection, and budget-view state handling.
- [x] Document how the workspace consumes persisted trip, scenario, and ranking layers.

#### Acceptance criteria
- [x] The repo contains a trip workspace surface that can present current and alternative planning states coherently.
- [x] The workspace can consume scenarios, rankings, checkpoints, and budget state without inventing incompatible frontend-only data shapes.
- [x] Tests cover representative workspace and scenario-switching cases.
- [x] Leisure and business workspaces can share layout structure while surfacing important differences.
- [x] Documentation explains how the workspace maps to saved scenarios and ranked outputs.

**Head SHA:** 41048a3a2da12f5c274457dfb4d88d3dfc64e385
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23957175951) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23957175947) |
<!-- auto-status-summary:end -->
