### PR TITLE
Issue #559: build route visualization surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - [Leisure preference schema draft](docs/leisure-preference-schema.md)
 - [Preference learning model](docs/preference-learning-model.md)
 - [Preference roadmap](docs/preference-roadmap.md)
+- [Frontend route visualization](docs/frontend-route-visualization.md)
 - [Planning autonomy and revealed preference contracts](docs/contracts/planning-autonomy.md)
 - [Shared planning contracts](docs/shared-planning-contracts.md)
 - [Normalized inventory contracts epic](docs/normalized-inventory-contracts-epic.md)

--- a/bundle/app-shell/app-shell.js
+++ b/bundle/app-shell/app-shell.js
@@ -328,7 +328,6 @@ export function createAppShellStore(initialState) {
       }
 
       const isTripChange = state.workspace.trip_id !== session.trip_id;
-
       state = buildAppShellState({
         ...state,
         active_trip_id: session.trip_id,
@@ -748,11 +747,11 @@ function renderScenarioSwitcher(workspace, tripMode) {
                 type="button"
                 class="shell-trip-card shell-trip-card--launch${scenario.scenario_id === workspace.active_visualization_scenario_id ? " is-active" : ""}"
                 data-shell-visualization-scenario="${escapeAttribute(scenario.scenario_id)}"
-                aria-pressed="${scenario.scenario_id === workspace.active_visualization_scenario_id}"
+                aria-pressed="${scenario.scenario_id === workspace.active_visualization_scenario_id ? "true" : "false"}"
               >
                 <div class="shell-trip-card-header">
                   <strong>${escapeHtml(scenario.title)}</strong>
-                  <span class="shell-mode-pill shell-mode-pill--${escapeAttribute(tripMode)}">${escapeHtml(scenario.variant_label)}</span>
+                  <span class="shell-mode-pill shell-mode-pill--${escapeAttribute(scenario.mode)}">${escapeHtml(scenario.variant_label)}</span>
                 </div>
                 <p>${escapeHtml(scenario.summary)}</p>
                 <div class="shell-chip-row">

--- a/bundle/app-shell/app-shell.js
+++ b/bundle/app-shell/app-shell.js
@@ -8,6 +8,7 @@
  *   FrontendLaunchFlowRecord,
  *   FrontendRecentSessionRecord,
  *   FrontendShellState,
+ *   FrontendScenarioVisualizationRecord,
  *   FrontendTripSummaryRecord,
  *   LaunchFlowId,
  *   FrontendWorkspaceRecord,
@@ -99,6 +100,32 @@ function normalizeAccountEntry(session, accountEntry) {
 }
 
 /**
+ * @param {FrontendWorkspaceRecord | Partial<FrontendWorkspaceRecord> | undefined} workspace
+ * @returns {FrontendWorkspaceRecord["visualization_scenarios"]}
+ */
+function normalizeVisualizationScenarios(workspace) {
+  return workspace?.visualization_scenarios ?? [];
+}
+
+/**
+ * @param {FrontendWorkspaceRecord | Partial<FrontendWorkspaceRecord> | undefined} workspace
+ * @returns {string | null}
+ */
+function resolveActiveVisualizationScenarioId(workspace) {
+  const scenarios = normalizeVisualizationScenarios(workspace);
+  if (scenarios.length === 0) {
+    return null;
+  }
+
+  const requestedScenarioId = workspace?.active_visualization_scenario_id;
+  if (requestedScenarioId && scenarios.some((scenario) => scenario.scenario_id === requestedScenarioId)) {
+    return requestedScenarioId;
+  }
+
+  return scenarios[0].scenario_id;
+}
+
+/**
  * @param {FrontendShellState["session"]} session
  * @param {FrontendTripSummaryRecord[]} trips
  * @param {string | null} activeTripId
@@ -169,6 +196,7 @@ export function buildAppShellState(input) {
   const trips = input.trips ?? [];
   const activeTrip = resolveActiveTrip(input.session, trips, input.active_trip_id ?? null);
   const accountEntry = normalizeAccountEntry(input.session, input.account_entry);
+  const visualizationScenarios = normalizeVisualizationScenarios(input.workspace);
   const workspace = {
     trip_id: input.workspace?.trip_id ?? activeTrip?.trip_id ?? null,
     status:
@@ -181,6 +209,8 @@ export function buildAppShellState(input) {
     loading_message: input.workspace?.loading_message ?? null,
     error_message: input.workspace?.error_message ?? null,
     persistence_summary: input.workspace?.persistence_summary ?? [],
+    visualization_scenarios: visualizationScenarios,
+    active_visualization_scenario_id: resolveActiveVisualizationScenarioId(input.workspace),
   };
   const routes = getShellRoutes(activeTrip, workspace);
   const defaultRoute = getDefaultRoute(activeTrip, workspace);
@@ -238,6 +268,8 @@ export function createAppShellStore(initialState) {
               loading_message: null,
               error_message: null,
               persistence_summary: state.workspace.persistence_summary,
+              visualization_scenarios: [],
+              active_visualization_scenario_id: null,
             }
           : {
               ...state.workspace,
@@ -258,15 +290,17 @@ export function createAppShellStore(initialState) {
           ...state.account_entry,
           selected_launch_id: launchId,
         },
-          workspace: {
-            ...state.workspace,
-            status: "empty",
-            scenario_summaries: [],
-            checkpoint_history: [],
-            budget_summary: null,
-            loading_message: null,
-            error_message: null,
-          },
+        workspace: {
+          ...state.workspace,
+          status: "empty",
+          scenario_summaries: [],
+          checkpoint_history: [],
+          budget_summary: null,
+          loading_message: null,
+          error_message: null,
+          visualization_scenarios: [],
+          active_visualization_scenario_id: null,
+        },
       });
       notify();
     },
@@ -293,6 +327,8 @@ export function createAppShellStore(initialState) {
         return;
       }
 
+      const isTripChange = state.workspace.trip_id !== session.trip_id;
+
       state = buildAppShellState({
         ...state,
         active_trip_id: session.trip_id,
@@ -306,11 +342,33 @@ export function createAppShellStore(initialState) {
           trip_id: session.trip_id,
           status: "loading",
           planner_panel_state: null,
-          scenario_summaries: [],
-          checkpoint_history: [],
-          budget_summary: null,
+          scenario_summaries: isTripChange ? [] : state.workspace.scenario_summaries,
+          checkpoint_history: isTripChange ? [] : state.workspace.checkpoint_history,
+          budget_summary: isTripChange ? null : state.workspace.budget_summary,
           loading_message: "Rehydrating the saved session entry point.",
           error_message: null,
+          visualization_scenarios: isTripChange ? [] : state.workspace.visualization_scenarios,
+          active_visualization_scenario_id: isTripChange
+            ? null
+            : state.workspace.active_visualization_scenario_id,
+        },
+      });
+      notify();
+    },
+    setVisualizationScenario(scenarioId) {
+      if (
+        !state.workspace.visualization_scenarios.some(
+          (scenario) => scenario.scenario_id === scenarioId
+        )
+      ) {
+        return;
+      }
+
+      state = buildAppShellState({
+        ...state,
+        workspace: {
+          ...state.workspace,
+          active_visualization_scenario_id: scenarioId,
         },
       });
       notify();
@@ -536,6 +594,181 @@ function renderRouteTabs(state) {
 }
 
 /**
+ * @param {FrontendScenarioVisualizationRecord | null} scenario
+ * @returns {string}
+ */
+function renderScenarioMapPanel(scenario) {
+  if (!scenario) {
+    return `
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Scenario map surface</h3>
+          <span class="shell-meta">waiting for route context</span>
+        </div>
+        <p class="shell-empty-state">Select a visualization scenario to render anchors, route segments, and travel-burden signals.</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="shell-panel">
+      <div class="shell-panel-header">
+        <h3>Scenario map surface</h3>
+        <span class="shell-meta">${escapeHtml(scenario.map_status === "ready" ? "map-ready" : "fallback schematic")}</span>
+      </div>
+      <p>${escapeHtml(scenario.map_summary)}</p>
+      <div class="shell-chip-row">
+        <span class="shell-chip">${escapeHtml(scenario.route_shape)}</span>
+        <span class="shell-chip">${escapeHtml(scenario.movement_burden)}</span>
+        <span class="shell-chip">${escapeHtml(scenario.tradeoff_summary)}</span>
+      </div>
+      <section class="shell-panel shell-panel--sub">
+        <div class="shell-panel-header">
+          <h3>Route anchors</h3>
+          <span class="shell-meta">${escapeHtml(`${scenario.anchors.length} major stops`)}</span>
+        </div>
+        <ul class="shell-list">
+          ${scenario.anchors
+            .map(
+              (anchor) =>
+                `<li><strong>${escapeHtml(anchor.label)}:</strong> ${escapeHtml(anchor.kind)} · ${escapeHtml(anchor.summary)}</li>`
+            )
+            .join("")}
+        </ul>
+      </section>
+      <section class="shell-panel shell-panel--sub">
+        <div class="shell-panel-header">
+          <h3>Route segments</h3>
+          <span class="shell-meta">movement burden and transfer risk</span>
+        </div>
+        <ul class="shell-list">
+          ${scenario.route_segments
+            .map(
+              (segment) =>
+                `<li><strong>${escapeHtml(segment.label)}:</strong> ${escapeHtml(`${segment.from_label} to ${segment.to_label}`)} · ${escapeHtml(segment.mode)} · ${escapeHtml(segment.duration_label)} · ${escapeHtml(segment.burden_label)}${segment.warning ? ` · ${escapeHtml(segment.warning)}` : ""}</li>`
+            )
+            .join("")}
+        </ul>
+      </section>
+    </section>
+  `;
+}
+
+/**
+ * @param {FrontendScenarioVisualizationRecord | null} scenario
+ * @returns {string}
+ */
+function renderScenarioTimelinePanel(scenario) {
+  if (!scenario) {
+    return `
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Timeline structure</h3>
+          <span class="shell-meta">waiting for day plan</span>
+        </div>
+        <p class="shell-empty-state">Timeline views will appear after the planner publishes day blocks and movement posture.</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="shell-panel">
+      <div class="shell-panel-header">
+        <h3>Timeline structure</h3>
+        <span class="shell-meta">${escapeHtml(`${scenario.timeline_days.length} mapped days`)}</span>
+      </div>
+      <div class="shell-trip-grid">
+        ${scenario.timeline_days
+          .map(
+            (day) => `
+              <article class="shell-panel shell-panel--sub">
+                <div class="shell-panel-header">
+                  <h3>${escapeHtml(day.label)}</h3>
+                  <span class="shell-meta">${escapeHtml(day.posture)}</span>
+                </div>
+                <p>${escapeHtml(day.movement_summary)}</p>
+                <ul class="shell-list">
+                  ${day.blocks
+                    .map(
+                      (block) =>
+                        `<li><strong>${escapeHtml(block.time_label)} · ${escapeHtml(block.label)}:</strong> ${escapeHtml(block.kind)} · ${escapeHtml(block.summary)}</li>`
+                    )
+                    .join("")}
+                </ul>
+              </article>
+            `
+          )
+          .join("")}
+      </div>
+    </section>
+  `;
+}
+
+/**
+ * @param {FrontendWorkspaceRecord} workspace
+ * @returns {FrontendScenarioVisualizationRecord | null}
+ */
+function getActiveVisualizationScenario(workspace) {
+  return (
+    workspace.visualization_scenarios.find(
+      (scenario) => scenario.scenario_id === workspace.active_visualization_scenario_id
+    ) ?? null
+  );
+}
+
+/**
+ * @param {FrontendWorkspaceRecord} workspace
+ * @param {"leisure" | "business"} tripMode
+ * @returns {string}
+ */
+function renderScenarioSwitcher(workspace, tripMode) {
+  if (workspace.visualization_scenarios.length === 0) {
+    return `
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Scenario route alternatives</h3>
+          <span class="shell-meta">missing route visualization payload</span>
+        </div>
+        <p class="shell-empty-state">Map provider data is unavailable, so the shell should fall back to textual route summaries until route outputs are present.</p>
+      </section>
+    `;
+  }
+
+  return `
+    <section class="shell-panel">
+      <div class="shell-panel-header">
+        <h3>Scenario route alternatives</h3>
+        <span class="shell-meta">switch between rendered route variants</span>
+      </div>
+      <div class="shell-trip-grid">
+        ${workspace.visualization_scenarios
+          .map(
+            (scenario) => `
+              <button
+                type="button"
+                class="shell-trip-card shell-trip-card--launch${scenario.scenario_id === workspace.active_visualization_scenario_id ? " is-active" : ""}"
+                data-shell-visualization-scenario="${escapeAttribute(scenario.scenario_id)}"
+                aria-pressed="${scenario.scenario_id === workspace.active_visualization_scenario_id}"
+              >
+                <div class="shell-trip-card-header">
+                  <strong>${escapeHtml(scenario.title)}</strong>
+                  <span class="shell-mode-pill shell-mode-pill--${escapeAttribute(tripMode)}">${escapeHtml(scenario.variant_label)}</span>
+                </div>
+                <p>${escapeHtml(scenario.summary)}</p>
+                <div class="shell-chip-row">
+                  <span class="shell-chip">${escapeHtml(scenario.route_shape)}</span>
+                  <span class="shell-chip">${escapeHtml(scenario.movement_burden)}</span>
+                </div>
+              </button>
+            `
+          )
+          .join("")}
+      </div>
+    </section>
+  `;
+}
+
+/**
  * @param {FrontendWorkspaceRecord} workspace
  * @returns {string}
  */
@@ -665,6 +898,7 @@ function renderTripWorkspaceView(state) {
   }
 
   const plannerState = state.workspace.planner_panel_state;
+  const activeScenario = getActiveVisualizationScenario(state.workspace);
   const scenarioSummary = plannerState
     ? `${plannerState.outputs.length} outputs, ${plannerState.pending_decisions.length} decision checkpoint, ${plannerState.option_set.options.length} surfaced options`
     : "Planner payload not mounted yet.";
@@ -790,6 +1024,9 @@ function renderTripWorkspaceView(state) {
             : "<p class=\"shell-empty-state\">Budget posture will appear once persisted budget state is attached.</p>"
         }
       </section>
+      ${renderScenarioSwitcher(state.workspace, activeTrip.mode)}
+      ${renderScenarioMapPanel(activeScenario)}
+      ${renderScenarioTimelinePanel(activeScenario)}
     </section>
   `;
 }
@@ -801,6 +1038,7 @@ function renderTripWorkspaceView(state) {
 function renderPlannerWorkspaceView(state) {
   const boundary = renderWorkspaceStatusBoundary(state.workspace);
   const plannerState = state.workspace.planner_panel_state;
+  const activeScenario = getActiveVisualizationScenario(state.workspace);
   if (!plannerState) {
     return `${boundary}<p class="shell-empty-state">Planner route will hydrate once orchestration state is available.</p>`;
   }
@@ -834,6 +1072,27 @@ function renderPlannerWorkspaceView(state) {
             .join("")}
         </ul>
       </section>
+      <section class="shell-panel">
+        <div class="shell-panel-header">
+          <h3>Route coherence and burden</h3>
+          <span class="shell-meta">planner-facing visualization summary</span>
+        </div>
+        ${
+          activeScenario
+            ? `
+              <p>${escapeHtml(activeScenario.tradeoff_summary)}</p>
+              <ul class="shell-list">
+                ${activeScenario.route_warnings.length
+                  ? activeScenario.route_warnings
+                      .map((warning) => `<li>${escapeHtml(warning)}</li>`)
+                      .join("")
+                  : "<li>No route warnings for the selected scenario.</li>"}
+              </ul>
+            `
+            : '<p class="shell-empty-state">Map provider data is unavailable, so planner review should rely on textual burden summaries until route outputs hydrate.</p>'
+        }
+      </section>
+      ${renderScenarioTimelinePanel(activeScenario)}
     </section>
   `;
 }
@@ -989,6 +1248,17 @@ export function renderAppShell(mountNode, initialState) {
           detail: store.getState().active_trip_id,
         })
       );
+      return;
+    }
+
+    const visualizationTarget = event.target.closest("[data-shell-visualization-scenario]");
+    if (visualizationTarget?.dataset.shellVisualizationScenario) {
+      store.setVisualizationScenario(visualizationTarget.dataset.shellVisualizationScenario);
+      mountNode.dispatchEvent(
+        new CustomEvent("shell:visualization-change", {
+          detail: store.getState().workspace.active_visualization_scenario_id,
+        })
+      );
     }
   };
 
@@ -1009,6 +1279,9 @@ export function renderAppShell(mountNode, initialState) {
     },
     resumeSession(sessionId) {
       store.resumeSession(sessionId);
+    },
+    setVisualizationScenario(scenarioId) {
+      store.setVisualizationScenario(scenarioId);
     },
     destroy() {
       unsubscribe();

--- a/bundle/app-shell/contracts.d.ts
+++ b/bundle/app-shell/contracts.d.ts
@@ -132,6 +132,56 @@ export interface FrontendAppRouteRecord {
   modes: Array<"leisure" | "business">;
 }
 
+export interface FrontendVisualizationAnchorRecord {
+  anchor_id: string;
+  label: string;
+  kind: "destination" | "lodging" | "activity" | "meeting" | "transfer";
+  summary: string;
+}
+
+export interface FrontendVisualizationRouteSegmentRecord {
+  segment_id: string;
+  label: string;
+  mode: "walk" | "rail" | "car" | "flight" | "ferry" | "tram" | "rideshare";
+  from_label: string;
+  to_label: string;
+  duration_label: string;
+  burden_label: string;
+  warning: string | null;
+}
+
+export interface FrontendVisualizationTimelineBlockRecord {
+  block_id: string;
+  label: string;
+  kind: "arrival" | "recovery" | "transit" | "stay" | "meeting" | "buffer" | "activity";
+  time_label: string;
+  summary: string;
+}
+
+export interface FrontendVisualizationTimelineDayRecord {
+  day_id: string;
+  label: string;
+  posture: string;
+  movement_summary: string;
+  blocks: FrontendVisualizationTimelineBlockRecord[];
+}
+
+export interface FrontendScenarioVisualizationRecord {
+  scenario_id: string;
+  title: string;
+  variant_label: string;
+  summary: string;
+  route_shape: string;
+  movement_burden: string;
+  tradeoff_summary: string;
+  map_status: "ready" | "fallback";
+  map_summary: string;
+  route_warnings: string[];
+  anchors: FrontendVisualizationAnchorRecord[];
+  route_segments: FrontendVisualizationRouteSegmentRecord[];
+  timeline_days: FrontendVisualizationTimelineDayRecord[];
+}
+
 export interface FrontendWorkspaceRecord {
   trip_id: string | null;
   status: WorkspaceStatus;
@@ -142,6 +192,8 @@ export interface FrontendWorkspaceRecord {
   loading_message: string | null;
   error_message: string | null;
   persistence_summary: string[];
+  visualization_scenarios: FrontendScenarioVisualizationRecord[];
+  active_visualization_scenario_id: string | null;
 }
 
 export interface FrontendShellState {

--- a/bundle/app-shell/contracts.d.ts
+++ b/bundle/app-shell/contracts.d.ts
@@ -168,6 +168,7 @@ export interface FrontendVisualizationTimelineDayRecord {
 
 export interface FrontendScenarioVisualizationRecord {
   scenario_id: string;
+  mode: TripMode;
   title: string;
   variant_label: string;
   summary: string;

--- a/bundle/app-shell/mock-state.js
+++ b/bundle/app-shell/mock-state.js
@@ -541,6 +541,7 @@ const inTripRevisionBudgetSummary = {
 const leisureVisualizationScenarios = [
   {
     scenario_id: "scenario-lisbon-regional-loop",
+    mode: "leisure",
     title: "Lisbon regional loop",
     variant_label: "base route",
     summary: "Keeps Lisbon as the lodging anchor while layering one Sintra day and one riverfront recovery day.",
@@ -643,6 +644,7 @@ const leisureVisualizationScenarios = [
   },
   {
     scenario_id: "scenario-lisbon-scenic-transit",
+    mode: "leisure",
     title: "Scenic transit variant",
     variant_label: "scenic route",
     summary: "Trades one extra transfer for ferry and tram segments that turn the route itself into part of the trip value.",
@@ -721,6 +723,7 @@ const leisureVisualizationScenarios = [
 const businessVisualizationScenarios = [
   {
     scenario_id: "scenario-seattle-meeting-window",
+    mode: "business",
     title: "Meeting-window compliant route",
     variant_label: "business base route",
     summary: "Centers the hotel near the client site so the pre-dawn audit window stays resilient.",

--- a/bundle/app-shell/mock-state.js
+++ b/bundle/app-shell/mock-state.js
@@ -538,6 +538,276 @@ const inTripRevisionBudgetSummary = {
   ],
 };
 
+const leisureVisualizationScenarios = [
+  {
+    scenario_id: "scenario-lisbon-regional-loop",
+    title: "Lisbon regional loop",
+    variant_label: "base route",
+    summary: "Keeps Lisbon as the lodging anchor while layering one Sintra day and one riverfront recovery day.",
+    route_shape: "regional cluster",
+    movement_burden: "low transfer burden",
+    tradeoff_summary: "Best route coherence with one medium-transfer excursion day.",
+    map_status: "ready",
+    map_summary: "Map surface should emphasize the Lisbon core, Sintra rail branch, and recovery-friendly riverside fallback anchors.",
+    route_warnings: [
+      "Sintra day can stack hill fatigue after a late arrival evening.",
+    ],
+    anchors: [
+      {
+        anchor_id: "anchor-lisbon-base",
+        label: "Baixa base hotel",
+        kind: "lodging",
+        summary: "Central lodging anchor for walkable dinners and tram access.",
+      },
+      {
+        anchor_id: "anchor-sintra",
+        label: "Sintra day cluster",
+        kind: "destination",
+        summary: "Regional excursion anchor with a single rail transfer.",
+      },
+      {
+        anchor_id: "anchor-riverside",
+        label: "Belém recovery block",
+        kind: "activity",
+        summary: "Low-friction afternoon fallback for a lighter day.",
+      },
+    ],
+    route_segments: [
+      {
+        segment_id: "segment-arrival",
+        label: "Arrival to base",
+        mode: "tram",
+        from_label: "Airport",
+        to_label: "Baixa base hotel",
+        duration_label: "35 min",
+        burden_label: "light arrival burden",
+        warning: null,
+      },
+      {
+        segment_id: "segment-sintra",
+        label: "Regional day loop",
+        mode: "rail",
+        from_label: "Rossio",
+        to_label: "Sintra day cluster",
+        duration_label: "45 min each way",
+        burden_label: "moderate day-trip burden",
+        warning: "Watch hill fatigue if the prior night runs late.",
+      },
+    ],
+    timeline_days: [
+      {
+        day_id: "day-1",
+        label: "Day 1 arrival",
+        posture: "soft landing",
+        movement_summary: "Keep the first evening compact and fully walkable.",
+        blocks: [
+          {
+            block_id: "block-1",
+            label: "Hotel check-in",
+            kind: "arrival",
+            time_label: "15:00",
+            summary: "Drop bags and keep the first neighborhood radius small.",
+          },
+          {
+            block_id: "block-2",
+            label: "Baixa dinner loop",
+            kind: "activity",
+            time_label: "19:00",
+            summary: "Short walk loop with low commitment if arrival runs late.",
+          },
+        ],
+      },
+      {
+        day_id: "day-3",
+        label: "Day 3 Sintra excursion",
+        posture: "regional move day",
+        movement_summary: "One out-and-back rail segment plus hill-heavy exploration.",
+        blocks: [
+          {
+            block_id: "block-3",
+            label: "Rossio departure",
+            kind: "transit",
+            time_label: "08:15",
+            summary: "Board the first rail leg before the station crowds build.",
+          },
+          {
+            block_id: "block-4",
+            label: "Castle + garden cluster",
+            kind: "activity",
+            time_label: "10:00",
+            summary: "Keep one recovery break between hill sections.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    scenario_id: "scenario-lisbon-scenic-transit",
+    title: "Scenic transit variant",
+    variant_label: "scenic route",
+    summary: "Trades one extra transfer for ferry and tram segments that turn the route itself into part of the trip value.",
+    route_shape: "scenic transit chain",
+    movement_burden: "medium transfer burden",
+    tradeoff_summary: "Higher route delight, but more transfer exposure and less slack for late starts.",
+    map_status: "ready",
+    map_summary: "Map should emphasize the ferry stitch, tram spine, and where scenic movement increases transfer exposure.",
+    route_warnings: [
+      "Ferry timing narrows the margin for a slow morning.",
+      "Scenic route variant adds one extra transfer on the river crossing.",
+    ],
+    anchors: [
+      {
+        anchor_id: "anchor-ferry",
+        label: "River ferry stitch",
+        kind: "transfer",
+        summary: "The scenic crossing is part of the route value, not just transit overhead.",
+      },
+      {
+        anchor_id: "anchor-tram",
+        label: "Historic tram spine",
+        kind: "activity",
+        summary: "Route keeps hillside access scenic rather than taxi-heavy.",
+      },
+    ],
+    route_segments: [
+      {
+        segment_id: "segment-ferry",
+        label: "River crossing",
+        mode: "ferry",
+        from_label: "Cais do Sodré",
+        to_label: "Cacilhas",
+        duration_label: "15 min",
+        burden_label: "light scenic burden",
+        warning: "Missing the ferry pushes the afternoon sequence off by 30 minutes.",
+      },
+      {
+        segment_id: "segment-tram",
+        label: "Hillside tram arc",
+        mode: "tram",
+        from_label: "Cacilhas return",
+        to_label: "Alfama ridge",
+        duration_label: "30 min",
+        burden_label: "moderate crowding risk",
+        warning: null,
+      },
+    ],
+    timeline_days: [
+      {
+        day_id: "day-2",
+        label: "Day 2 scenic transfer day",
+        posture: "route-first day",
+        movement_summary: "The movement experience is the headline, so the route needs visible slack markers.",
+        blocks: [
+          {
+            block_id: "block-5",
+            label: "Ferry boarding buffer",
+            kind: "buffer",
+            time_label: "09:10",
+            summary: "Hold a 20-minute margin so the scenic chain stays intact.",
+          },
+          {
+            block_id: "block-6",
+            label: "Riverfront lunch",
+            kind: "stay",
+            time_label: "12:30",
+            summary: "Pause between ferry and tram segments to cut transfer fatigue.",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const businessVisualizationScenarios = [
+  {
+    scenario_id: "scenario-seattle-meeting-window",
+    title: "Meeting-window compliant route",
+    variant_label: "business base route",
+    summary: "Centers the hotel near the client site so the pre-dawn audit window stays resilient.",
+    route_shape: "hub and spoke",
+    movement_burden: "low morning risk",
+    tradeoff_summary: "Best for arrival certainty, but requires exception-ready lodging context.",
+    map_status: "ready",
+    map_summary: "Map should foreground the hotel-to-client corridor, Bellevue meeting window, and return buffer for the approval packet.",
+    route_warnings: [
+      "Hotel zone exception remains the main non-route blocker.",
+      "Cross-lake traffic can erase the evening buffer if departure slips.",
+    ],
+    anchors: [
+      {
+        anchor_id: "anchor-hotel",
+        label: "Client-adjacent hotel",
+        kind: "lodging",
+        summary: "Chosen to preserve the 5:45am arrival window.",
+      },
+      {
+        anchor_id: "anchor-client",
+        label: "Audit site",
+        kind: "meeting",
+        summary: "Hard arrival target with no acceptable late window.",
+      },
+      {
+        anchor_id: "anchor-bellevue",
+        label: "Bellevue follow-up",
+        kind: "meeting",
+        summary: "Secondary meeting block that tightens the afternoon transfer sequence.",
+      },
+    ],
+    route_segments: [
+      {
+        segment_id: "segment-audit-drive",
+        label: "Pre-dawn audit corridor",
+        mode: "car",
+        from_label: "Client-adjacent hotel",
+        to_label: "Audit site",
+        duration_label: "12 min",
+        burden_label: "low arrival risk",
+        warning: null,
+      },
+      {
+        segment_id: "segment-bellevue",
+        label: "Cross-lake meeting hop",
+        mode: "rideshare",
+        from_label: "Audit site",
+        to_label: "Bellevue follow-up",
+        duration_label: "28 min",
+        burden_label: "medium traffic burden",
+        warning: "Traffic spikes can consume the lunch buffer.",
+      },
+    ],
+    timeline_days: [
+      {
+        day_id: "day-1",
+        label: "Audit day",
+        posture: "constrained meeting window",
+        movement_summary: "Very little slack until the primary audit block is complete.",
+        blocks: [
+          {
+            block_id: "block-7",
+            label: "Hotel departure",
+            kind: "transit",
+            time_label: "05:20",
+            summary: "Leave before the road network starts shifting into commuter congestion.",
+          },
+          {
+            block_id: "block-8",
+            label: "Client audit",
+            kind: "meeting",
+            time_label: "05:45",
+            summary: "Primary hard-window work block that anchors the route choice.",
+          },
+          {
+            block_id: "block-9",
+            label: "Bellevue debrief",
+            kind: "meeting",
+            time_label: "14:00",
+            summary: "Secondary meeting with a narrow traffic buffer.",
+          },
+        ],
+      },
+    ],
+  },
+];
 /** @type {FrontendShellState} */
 export const firstTimeLeisureDashboardShellState = {
   session: firstTimeLeisureSession,
@@ -565,6 +835,8 @@ export const firstTimeLeisureDashboardShellState = {
       "First-trip launch should create persisted account, trip, and session records together.",
       "Empty-state onboarding must stay deterministic until live identity and session APIs arrive.",
     ],
+    visualization_scenarios: [],
+    active_visualization_scenario_id: null,
   },
 };
 
@@ -645,6 +917,8 @@ export const signedInDashboardShellState = {
       "Account is signed in and can resume saved leisure or business trips.",
       "Trip launch should branch into issue #557 once account and entry flows land.",
     ],
+    visualization_scenarios: [],
+    active_visualization_scenario_id: null,
   },
 };
 
@@ -695,6 +969,8 @@ export const businessPolicyStartDashboardShellState = {
       "Business launch should create the trip shell together with policy and approval capture.",
       "Session-entry must preserve why the traveler is starting a policy-aware trip before the planner workspace mounts.",
     ],
+    visualization_scenarios: [],
+    active_visualization_scenario_id: null,
   },
 };
 
@@ -720,6 +996,8 @@ export const activeLeisureTripShellState = {
       "Planner checkpoints should reuse orchestration payloads rather than page-local copies.",
       "Budget variants should stay linked to persisted budget-state ids rather than UI-only totals.",
     ],
+    visualization_scenarios: leisureVisualizationScenarios,
+    active_visualization_scenario_id: "scenario-lisbon-regional-loop",
   },
 };
 
@@ -744,6 +1022,8 @@ export const activeBusinessTripShellState = {
       "Approval comparables and packet metadata should remain attached to the proposal contract.",
       "Business approval surfaces should sit beside planner state, not replace it.",
     ],
+    visualization_scenarios: businessVisualizationScenarios,
+    active_visualization_scenario_id: "scenario-seattle-meeting-window",
   },
 };
 

--- a/docs/frontend-route-visualization.md
+++ b/docs/frontend-route-visualization.md
@@ -1,0 +1,22 @@
+# Frontend Route Visualization
+
+Issue `#559` adds visualization-oriented shell surfaces that consume route and feasibility outputs without duplicating route logic client-side.
+
+## Surface family
+
+- `trip_workspace` now carries scenario route alternatives, a textual map surface, and timeline structure for the selected scenario.
+- `planner_workspace` mirrors the selected scenario's burden warnings so route coherence stays visible next to canonical planner actions.
+- The shell only renders route and timeline artifacts already produced upstream. It does not calculate route shapes, meeting feasibility, or movement scoring on the client.
+
+## Consumption boundary
+
+- `visualization_scenarios` should arrive as pre-shaped route visualization records attached to the workspace payload.
+- Each scenario record should already encode anchor points, route segments, movement burden labels, timeline blocks, and any warnings surfaced by backend ranking or feasibility layers.
+- `active_visualization_scenario_id` selects the currently rendered scenario. Switching scenarios in the shell changes presentation only.
+- When map provider output is absent, the shell should degrade to textual route summaries instead of synthesizing route logic locally.
+
+## Representative states
+
+- Leisure regional loop: low-friction base with one regional excursion.
+- Scenic transit route: higher transfer load because route delight is part of the traveler objective.
+- Business constrained-window route: meeting timing and arrival certainty dominate the route presentation.

--- a/tests/planner/test_app_shell_state.mjs
+++ b/tests/planner/test_app_shell_state.mjs
@@ -336,6 +336,14 @@ test("mounted app shell can switch between visualization scenarios", () => {
   );
   assert.match(mountNode.innerHTML, /Lisbon regional loop/);
   assert.match(mountNode.innerHTML, /Sintra day cluster/);
+  assert.match(
+    mountNode.innerHTML,
+    /data-shell-visualization-scenario="scenario-lisbon-regional-loop"[^>]*aria-pressed="true"/
+  );
+  assert.match(
+    mountNode.innerHTML,
+    /data-shell-visualization-scenario="scenario-lisbon-scenic-transit"[^>]*aria-pressed="false"/
+  );
 
   mountNode.click(
     new FakeButton({
@@ -349,7 +357,10 @@ test("mounted app shell can switch between visualization scenarios", () => {
   );
   assert.match(mountNode.innerHTML, /Scenic transit variant/);
   assert.match(mountNode.innerHTML, /River ferry stitch/);
-  assert.match(mountNode.innerHTML, /aria-pressed="true"/);
+  assert.match(
+    mountNode.innerHTML,
+    /data-shell-visualization-scenario="scenario-lisbon-scenic-transit"[^>]*aria-pressed="true"/
+  );
   assert.match(mountNode.innerHTML, /shell-mode-pill--leisure/);
 });
 
@@ -361,6 +372,7 @@ test("trip workspace keeps scenario switcher mode aligned to the active business
 
   assert.match(rendered, /shell-mode-pill--business/);
   assert.match(rendered, /aria-pressed="true"/);
+  assert.match(rendered, /shell-mode-pill--business">business base route/);
 });
 
 test("trip workspace falls back to textual guidance when map data is missing", () => {

--- a/tests/planner/test_app_shell_state.mjs
+++ b/tests/planner/test_app_shell_state.mjs
@@ -70,6 +70,13 @@ class FakeButton extends FakeHTMLElement {
       return this;
     }
 
+    if (
+      selector === "[data-shell-visualization-scenario]" &&
+      this.dataset.shellVisualizationScenario
+    ) {
+      return this;
+    }
+
     return null;
   }
 }
@@ -209,6 +216,8 @@ test("entry store switches launch flows and resumes saved sessions", () => {
     store.getState().workspace.loading_message,
     "Rehydrating the saved session entry point."
   );
+  assert.deepEqual(store.getState().workspace.visualization_scenarios, []);
+  assert.equal(store.getState().workspace.active_visualization_scenario_id, null);
 });
 
 test("entry store reports a deterministic error for missing sessions", () => {
@@ -292,6 +301,83 @@ test("trip workspace can render an in-trip revised scenario without losing saved
   assert.match(revisedWorkspace, /Rain-adjusted active plan/);
   assert.match(revisedWorkspace, /In-trip replanning checkpoint/);
   assert.match(revisedWorkspace, /\$145 over target unless the revised scenario holds/);
+});
+
+test("trip workspace renders map and timeline surfaces for route alternatives", () => {
+  const rendered = renderAppShellLayout(activeLeisureTripShellState);
+
+  assert.match(rendered, /Scenario route alternatives/);
+  assert.match(rendered, /Scenario map surface/);
+  assert.match(rendered, /Timeline structure/);
+  assert.match(rendered, /Lisbon regional loop/);
+  assert.match(rendered, /Scenic transit variant/);
+  assert.match(rendered, /Sintra day cluster/);
+  assert.match(rendered, /Day 3 Sintra excursion/);
+});
+
+test("planner workspace surfaces route coherence warnings from the selected visualization scenario", () => {
+  const rendered = renderAppShellLayout({
+    ...activeLeisureTripShellState,
+    active_route: "planner_workspace",
+  });
+
+  assert.match(rendered, /Route coherence and burden/);
+  assert.match(rendered, /Best route coherence with one medium-transfer excursion day/);
+  assert.match(rendered, /Sintra day can stack hill fatigue after a late arrival evening/);
+});
+
+test("mounted app shell can switch between visualization scenarios", () => {
+  const mountNode = new FakeMountNode();
+  const controller = renderAppShell(mountNode, activeLeisureTripShellState);
+
+  assert.equal(
+    controller.getState().workspace.active_visualization_scenario_id,
+    "scenario-lisbon-regional-loop"
+  );
+  assert.match(mountNode.innerHTML, /Lisbon regional loop/);
+  assert.match(mountNode.innerHTML, /Sintra day cluster/);
+
+  mountNode.click(
+    new FakeButton({
+      shellVisualizationScenario: "scenario-lisbon-scenic-transit",
+    })
+  );
+
+  assert.equal(
+    controller.getState().workspace.active_visualization_scenario_id,
+    "scenario-lisbon-scenic-transit"
+  );
+  assert.match(mountNode.innerHTML, /Scenic transit variant/);
+  assert.match(mountNode.innerHTML, /River ferry stitch/);
+  assert.match(mountNode.innerHTML, /aria-pressed="true"/);
+  assert.match(mountNode.innerHTML, /shell-mode-pill--leisure/);
+});
+
+test("trip workspace keeps scenario switcher mode aligned to the active business trip", () => {
+  const rendered = renderAppShellLayout({
+    ...activeBusinessTripShellState,
+    active_route: "trip_workspace",
+  });
+
+  assert.match(rendered, /shell-mode-pill--business/);
+  assert.match(rendered, /aria-pressed="true"/);
+});
+
+test("trip workspace falls back to textual guidance when map data is missing", () => {
+  const rendered = renderAppShellLayout({
+    ...activeLeisureTripShellState,
+    workspace: {
+      ...activeLeisureTripShellState.workspace,
+      visualization_scenarios: [],
+      active_visualization_scenario_id: null,
+    },
+  });
+
+  assert.match(rendered, /missing route visualization payload/);
+  assert.match(
+    rendered,
+    /Map provider data is unavailable, so the shell should fall back to textual route summaries/
+  );
 });
 
 test("mounted app shell ignores click events from non-element targets", () => {


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #559

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Route shape, movement cost, and spatial context are central to this product. The planner needs map and timeline surfaces that can show routes, place clusters, movement burden, and daily or multi-day structure rather than reducing the trip to lists and tables.

Parent epic: #555

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#555](https://github.com/stranske/trip-planner/issues/555)
- [#533](https://github.com/stranske/trip-planner/issues/533)
- [#536](https://github.com/stranske/trip-planner/issues/536)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Build map and route-visualization surfaces that can display destinations, route segments, lodging bases, and major activity anchors for a scenario.
- [x] Build timeline-style views that can show day structure, movement days, recovery blocks, and major itinerary segments.
- [x] Ensure the visualizations can surface route coherence, travel burden, and important warnings or tradeoffs from backend feasibility or ranking layers.
- [x] Add representative UI states or mocks for at least: a leisure regional route, a scenic-transit route, and a business trip with constrained meeting windows.
- [x] Write frontend tests covering scenario visualization rendering, route-switching, and fallback or missing-map-data cases.
- [x] Document how map and timeline surfaces should consume route and feasibility outputs without duplicating route logic client-side.

#### Acceptance criteria
- [x] The repo contains primary maps and timeline surfaces for trip scenarios.
- [x] Visualizations can reflect route structure, movement burden, and major scenario tradeoffs.
- [x] Tests cover representative rendering and missing-data cases.
- [x] Leisure and business scenarios can both be visualized through the same high-level surface family.
- [x] Documentation clarifies the boundary between backend route logic and frontend visualization.

**Head SHA:** c7e1767d4a90bf3aceec6d5765eb7d84a9cedea1
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23959048552) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23959048486) |
<!-- auto-status-summary:end -->
