### PR TITLE
Issue #528 follow-up: fix separate-emission summaries

### DIFF
--- a/tests/ingestion/test_lodging_pipeline.py
+++ b/tests/ingestion/test_lodging_pipeline.py
@@ -42,7 +42,9 @@ def _build_resolution(payload: dict[str, Any]) -> EntityResolution:
         status=payload["status"],
         canonical_entity_id=payload["canonical_entity_id"],
         summary=payload["summary"],
-        match_candidates=[MatchCandidate(**item) for item in payload.get("match_candidates", [])],
+        match_candidates=[
+            MatchCandidate(**item) for item in payload.get("match_candidates", [])
+        ],
         conflicts=[AttributeConflict(**item) for item in payload.get("conflicts", [])],
         review_required=payload.get("review_required", False),
     )

--- a/tests/ingestion/test_transport_pipeline.py
+++ b/tests/ingestion/test_transport_pipeline.py
@@ -44,7 +44,9 @@ def _build_resolution(payload: dict[str, Any]) -> EntityResolution:
         status=payload["status"],
         canonical_entity_id=payload["canonical_entity_id"],
         summary=payload["summary"],
-        match_candidates=[MatchCandidate(**item) for item in payload.get("match_candidates", [])],
+        match_candidates=[
+            MatchCandidate(**item) for item in payload.get("match_candidates", [])
+        ],
         conflicts=[AttributeConflict(**item) for item in payload.get("conflicts", [])],
         review_required=payload.get("review_required", False),
     )
@@ -93,7 +95,9 @@ def test_transport_pipeline_merges_duplicates_and_retains_review_gaps() -> None:
     assert result.summary.emitted_options == 1
     assert result.summary.skipped_records == 0
     assert result.summary.filtered_record_ids == []
-    assert result.summary.low_confidence_option_ids == ["transport-paris-amsterdam-eurostar"]
+    assert result.summary.low_confidence_option_ids == [
+        "transport-paris-amsterdam-eurostar"
+    ]
     assert len(result.transport_options[0].source_refs) == 2
     assert len(result.unresolved_conflicts) == 1
     assert {warning.code for warning in result.warnings} == {

--- a/trip_planner/ingestion/lodging_pipeline.py
+++ b/trip_planner/ingestion/lodging_pipeline.py
@@ -43,11 +43,18 @@ class LodgingIngestionResult:
         require_non_empty(self.snapshot_id, "snapshot_id")
         if any(not isinstance(item, LodgingOption) for item in self.lodging_options):
             raise ValueError("lodging_options must contain LodgingOption instances")
-        if any(not isinstance(item, AttributeConflict) for item in self.unresolved_conflicts):
-            raise ValueError("unresolved_conflicts must contain AttributeConflict instances")
+        if any(
+            not isinstance(item, AttributeConflict)
+            for item in self.unresolved_conflicts
+        ):
+            raise ValueError(
+                "unresolved_conflicts must contain AttributeConflict instances"
+            )
         if any(not isinstance(item, IngestionWarning) for item in self.warnings):
             raise ValueError("warnings must contain IngestionWarning instances")
-        if self.handoff is not None and not isinstance(self.handoff, NormalizationHandoff):
+        if self.handoff is not None and not isinstance(
+            self.handoff, NormalizationHandoff
+        ):
             raise ValueError("handoff must be a NormalizationHandoff when provided")
         if not isinstance(self.summary, IngestionSummary):
             raise ValueError("summary must be an IngestionSummary")
@@ -71,7 +78,9 @@ def ingest_lodging_snapshot(
     resolutions = resolutions or []
     dedup_decisions = dedup_decisions or []
     warnings = [warning_from_issue(issue) for issue in snapshot.issues]
-    resolution_map = {resolution.resolution_id: resolution for resolution in resolutions}
+    resolution_map = {
+        resolution.resolution_id: resolution for resolution in resolutions
+    }
     emitted_ids: set[str] = set()
     filtered_record_ids: list[str] = []
     low_confidence_option_ids: list[str] = []
@@ -80,15 +89,22 @@ def ingest_lodging_snapshot(
     provenance_refs: list[ProvenanceReference] = []
 
     for decision in dedup_decisions:
-        if decision.entity_scope != "lodging" or decision.option_kind != snapshot.option_kind:
+        if (
+            decision.entity_scope != "lodging"
+            or decision.option_kind != snapshot.option_kind
+        ):
             continue
         record_ids = _record_ids_for_decision(decision, resolution_map)
-        candidate_records = _records_for_decision(snapshot.records, decision, resolution_map)
+        candidate_records = _records_for_decision(
+            snapshot.records, decision, resolution_map
+        )
         preserved_conflicts.extend(unresolved_conflicts(decision.preserved_conflicts))
         if decision.decision == "suppress":
             emitted_ids.update(record_ids)
             filtered_record_ids.extend(
-                record_id for record_id in record_ids if record_id not in filtered_record_ids
+                record_id
+                for record_id in record_ids
+                if record_id not in filtered_record_ids
             )
             continue
         if decision.decision in {"keep_separate", "needs_review"}:
@@ -109,9 +125,14 @@ def ingest_lodging_snapshot(
                     snapshot,
                     _separate_option_id(decision.canonical_entity_id, record),
                 )
-                option.notes.extend([f"dedup_decision:{decision.decision_id}", *decision.notes])
+                option.notes.extend(
+                    [f"dedup_decision:{decision.decision_id}", *decision.notes]
+                )
                 option.feasibility.constraints.extend(
-                    [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                    [
+                        f"{conflict.attribute_path}:{conflict.reason}"
+                        for conflict in unresolved
+                    ]
                 )
                 record_warnings = record.payload.get("normalization_warnings", [])
                 if record_warnings:
@@ -180,13 +201,21 @@ def ingest_lodging_snapshot(
             [record], snapshot, _canonical_option_id(record, resolution)
         )
         if resolution is not None:
-            option.notes.extend([f"resolution:{resolution.resolution_id}", *resolution.notes])
+            option.notes.extend(
+                [f"resolution:{resolution.resolution_id}", *resolution.notes]
+            )
             unresolved = unresolved_conflicts(resolution.conflicts)
             preserved_conflicts.extend(unresolved)
             option.feasibility.constraints.extend(
-                [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                [
+                    f"{conflict.attribute_path}:{conflict.reason}"
+                    for conflict in unresolved
+                ]
             )
-            if resolution.review_required or _lowest_match_confidence(resolution) < 0.75:
+            if (
+                resolution.review_required
+                or _lowest_match_confidence(resolution) < 0.75
+            ):
                 low_confidence_option_ids.append(option.option_id)
         record_warnings = record.payload.get("normalization_warnings", [])
         if record_warnings:
@@ -228,7 +257,9 @@ def ingest_lodging_snapshot(
             warning.warning_id for warning in warnings if warning.severity == "error"
         ],
         provenance_refs=provenance_refs,
-        notes=["Lodging ingestion scaffolding emitted normalized options from raw snapshots."],
+        notes=[
+            "Lodging ingestion scaffolding emitted normalized options from raw snapshots."
+        ],
     )
     return LodgingIngestionResult(
         pipeline_id=f"lodging-ingestion:{snapshot.snapshot_id}",
@@ -314,7 +345,9 @@ def _resolution_for_record(
     return None
 
 
-def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution | None) -> str:
+def _canonical_option_id(
+    record: RawSourceRecord, resolution: EntityResolution | None
+) -> str:
     if resolution is not None:
         return resolution.canonical_entity_id
     return f"lodging-{record.provider_entity_id}"

--- a/trip_planner/ingestion/transport_pipeline.py
+++ b/trip_planner/ingestion/transport_pipeline.py
@@ -40,13 +40,22 @@ class TransportIngestionResult:
     def __post_init__(self) -> None:
         require_non_empty(self.pipeline_id, "pipeline_id")
         require_non_empty(self.snapshot_id, "snapshot_id")
-        if any(not isinstance(item, TransportOption) for item in self.transport_options):
+        if any(
+            not isinstance(item, TransportOption) for item in self.transport_options
+        ):
             raise ValueError("transport_options must contain TransportOption instances")
-        if any(not isinstance(item, AttributeConflict) for item in self.unresolved_conflicts):
-            raise ValueError("unresolved_conflicts must contain AttributeConflict instances")
+        if any(
+            not isinstance(item, AttributeConflict)
+            for item in self.unresolved_conflicts
+        ):
+            raise ValueError(
+                "unresolved_conflicts must contain AttributeConflict instances"
+            )
         if any(not isinstance(item, IngestionWarning) for item in self.warnings):
             raise ValueError("warnings must contain IngestionWarning instances")
-        if self.handoff is not None and not isinstance(self.handoff, NormalizationHandoff):
+        if self.handoff is not None and not isinstance(
+            self.handoff, NormalizationHandoff
+        ):
             raise ValueError("handoff must be a NormalizationHandoff when provided")
         if not isinstance(self.summary, IngestionSummary):
             raise ValueError("summary must be an IngestionSummary")
@@ -70,7 +79,9 @@ def ingest_transport_snapshot(
     resolutions = resolutions or []
     dedup_decisions = dedup_decisions or []
     warnings = [warning_from_issue(issue) for issue in snapshot.issues]
-    resolution_map = {resolution.resolution_id: resolution for resolution in resolutions}
+    resolution_map = {
+        resolution.resolution_id: resolution for resolution in resolutions
+    }
     emitted_ids: set[str] = set()
     filtered_record_ids: list[str] = []
     low_confidence_option_ids: list[str] = []
@@ -79,7 +90,10 @@ def ingest_transport_snapshot(
     provenance_refs = []
 
     for decision in dedup_decisions:
-        if decision.entity_scope != "transport" or decision.option_kind != snapshot.option_kind:
+        if (
+            decision.entity_scope != "transport"
+            or decision.option_kind != snapshot.option_kind
+        ):
             continue
         record_ids = _record_ids_for_decision(decision, resolution_map)
         records = _records_for_decision(snapshot.records, decision, resolution_map)
@@ -87,7 +101,9 @@ def ingest_transport_snapshot(
         if decision.decision == "suppress":
             emitted_ids.update(record_ids)
             filtered_record_ids.extend(
-                record_id for record_id in record_ids if record_id not in filtered_record_ids
+                record_id
+                for record_id in record_ids
+                if record_id not in filtered_record_ids
             )
             continue
         if decision.decision in {"keep_separate", "needs_review"}:
@@ -108,9 +124,14 @@ def ingest_transport_snapshot(
                     snapshot,
                     _separate_option_id(decision.canonical_entity_id, record),
                 )
-                option.notes.extend([f"dedup_decision:{decision.decision_id}", *decision.notes])
+                option.notes.extend(
+                    [f"dedup_decision:{decision.decision_id}", *decision.notes]
+                )
                 option.feasibility.constraints.extend(
-                    [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                    [
+                        f"{conflict.attribute_path}:{conflict.reason}"
+                        for conflict in unresolved
+                    ]
                 )
                 record_warnings = record.payload.get("normalization_warnings", [])
                 if record_warnings:
@@ -142,7 +163,9 @@ def ingest_transport_snapshot(
                 )
             )
             continue
-        option = _transport_option_from_records(records, snapshot, decision.canonical_entity_id)
+        option = _transport_option_from_records(
+            records, snapshot, decision.canonical_entity_id
+        )
         option.notes.extend([f"dedup_decision:{decision.decision_id}", *decision.notes])
         option.feasibility.constraints.extend(
             [
@@ -177,13 +200,21 @@ def ingest_transport_snapshot(
             [record], snapshot, _canonical_option_id(record, resolution)
         )
         if resolution is not None:
-            option.notes.extend([f"resolution:{resolution.resolution_id}", *resolution.notes])
+            option.notes.extend(
+                [f"resolution:{resolution.resolution_id}", *resolution.notes]
+            )
             unresolved = unresolved_conflicts(resolution.conflicts)
             preserved_conflicts.extend(unresolved)
             option.feasibility.constraints.extend(
-                [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                [
+                    f"{conflict.attribute_path}:{conflict.reason}"
+                    for conflict in unresolved
+                ]
             )
-            if resolution.review_required or _lowest_match_confidence(resolution) < 0.75:
+            if (
+                resolution.review_required
+                or _lowest_match_confidence(resolution) < 0.75
+            ):
                 low_confidence_option_ids.append(option.option_id)
         record_warnings = record.payload.get("normalization_warnings", [])
         if record_warnings:
@@ -225,7 +256,9 @@ def ingest_transport_snapshot(
             warning.warning_id for warning in warnings if warning.severity == "error"
         ],
         provenance_refs=provenance_refs,
-        notes=["Transport ingestion scaffolding emitted normalized options from raw snapshots."],
+        notes=[
+            "Transport ingestion scaffolding emitted normalized options from raw snapshots."
+        ],
     )
     return TransportIngestionResult(
         pipeline_id=f"transport-ingestion:{snapshot.snapshot_id}",
@@ -308,7 +341,9 @@ def _resolution_for_record(
     return None
 
 
-def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution | None) -> str:
+def _canonical_option_id(
+    record: RawSourceRecord, resolution: EntityResolution | None
+) -> str:
     if resolution is not None:
         return resolution.canonical_entity_id
     return f"transport-{record.provider_entity_id}"


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #528

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Lodging and transport are the most operationally consequential inventory categories for early planning. Once source adapters and normalized option contracts exist, the repo needs a first ingestion scaffold that can turn raw source snapshots into normalized lodging and transport options with provenance, feasibility, and source-confidence information attached.

Parent epic: #525

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#525](https://github.com/stranske/trip-planner/issues/525)
- [#521](https://github.com/stranske/trip-planner/issues/521)
- [#522](https://github.com/stranske/trip-planner/issues/522)
- [#526](https://github.com/stranske/trip-planner/issues/526)
- [#527](https://github.com/stranske/trip-planner/issues/527)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement pipeline scaffolding that accepts raw lodging and transport snapshots, applies entity resolution or deduplication, and emits normalized `LodgingOption` and `TransportOption` objects.
- [x] Ensure the pipeline records source provenance, freshness, unresolved conflicts, and normalization warnings alongside the normalized outputs.
- [x] Add representative ingestion fixtures for at least one lodging source and one transport source, plus one case with duplicate or conflicting records.
- [x] Add tests covering happy-path normalization, duplicate handling, and degraded-source cases.
- [x] Document the pipeline stages so later live adapters can plug in without reworking the normalized object layer.
- [x] Expose enough pipeline summary metadata that later candidate-generation logic can filter out unusable or low-confidence outputs.

#### Acceptance criteria
- [x] The repo contains working ingestion scaffolding for lodging and transport snapshots into normalized option objects.
- [x] Provenance, normalization warnings, and unresolved conflicts remain visible in the emitted results.
- [x] Tests cover at least one clean path and one degraded or duplicate path for both lodging and transport.
- [x] Pipeline stages are documented clearly enough for later adapter implementation work.
- [x] The output shape is compatible with issues #521 and #522 rather than inventing alternative option objects.

#### Follow-up disposition
Verifier concerns on merged PR #614 were resolved in this bounded follow-up:
- `keep_separate` / `needs_review` lodging and transport outputs now get stable unique option ids instead of colliding ids
- merged-away records no longer inflate `filtered_record_ids`
- `skipped_records` now reflects truly filtered-out records only

#### Validation
- `pytest tests/ingestion/test_lodging_pipeline.py tests/ingestion/test_transport_pipeline.py`
- `ruff format`

**Head SHA:** a9e317e3e9039353d15d9fb001be8ec73b154c00
**Merge commit:** 125af5189f2fbf48ce55e0c397ae6e50f01baf5f
<!-- auto-status-summary:end -->
