### PR TITLE
Issue #529 follow-up: fix ingestion verifier gaps

### DIFF
--- a/tests/ingestion/test_activity_pipeline.py
+++ b/tests/ingestion/test_activity_pipeline.py
@@ -92,7 +92,8 @@ def test_activity_pipeline_merges_duplicates_and_preserves_review_gaps() -> None
     assert result.handoff is not None
     assert result.handoff.status == "partial"
     assert result.summary.emitted_options == 1
-    assert result.summary.filtered_record_ids == ["record-activity-b"]
+    assert result.summary.skipped_records == 0
+    assert result.summary.filtered_record_ids == []
     assert result.summary.low_confidence_option_ids == ["activity-kyoto-night-market"]
     assert len(result.activity_options[0].source_refs) == 2
     assert len(result.unresolved_conflicts) == 1
@@ -115,11 +116,12 @@ def test_activity_pipeline_keeps_separate_decisions_as_individual_options() -> N
 
     assert result.handoff is not None
     assert result.summary.emitted_options == 2
+    assert result.summary.skipped_records == 0
     assert result.summary.filtered_record_ids == []
     assert len(result.unresolved_conflicts) == 1
     assert sorted(option.option_id for option in result.activity_options) == [
-        "activity-kyoto-night-market",
-        "activity-kyoto-night-market",
+        "activity-kyoto-night-market-record-activity-a",
+        "activity-kyoto-night-market-record-activity-b",
     ]
 
 
@@ -137,6 +139,7 @@ def test_activity_pipeline_suppresses_records_from_suppressed_decisions() -> Non
     assert result.handoff is not None
     assert result.handoff.status == "blocked"
     assert result.summary.emitted_options == 0
+    assert result.summary.skipped_records == 2
     assert result.summary.filtered_record_ids == [
         "record-activity-a",
         "record-activity-b",

--- a/tests/ingestion/test_destination_pipeline.py
+++ b/tests/ingestion/test_destination_pipeline.py
@@ -95,9 +95,11 @@ def test_destination_pipeline_merges_duplicates_and_preserves_operational_gaps()
     assert result.handoff is not None
     assert result.handoff.status == "partial"
     assert result.summary.emitted_options == 1
-    assert result.summary.filtered_record_ids == ["record-destination-b"]
+    assert result.summary.skipped_records == 0
+    assert result.summary.filtered_record_ids == []
     assert result.summary.low_confidence_option_ids == ["dest-city-kyoto"]
-    assert len(result.destinations[0].source_refs) == 2
+    assert len(result.destinations[0].source_refs) == 3
+    assert result.destinations[0].source_refs[2].contribution_kind == "comparison"
     assert result.destinations[0].operational_notes[0].summary.startswith("Bus crowding")
     assert (
         "Operational source notes shoulder-season crowding can spike around festivals."
@@ -146,11 +148,12 @@ def test_destination_pipeline_keeps_separate_decisions_as_individual_destination
 
     assert result.handoff is not None
     assert result.summary.emitted_options == 2
+    assert result.summary.skipped_records == 0
     assert result.summary.filtered_record_ids == []
     assert len(result.unresolved_conflicts) == 1
     assert sorted(destination.destination_id for destination in result.destinations) == [
-        "dest-city-kyoto",
-        "dest-city-kyoto",
+        "dest-city-kyoto-record-destination-a",
+        "dest-city-kyoto-record-destination-b",
     ]
 
 
@@ -168,6 +171,7 @@ def test_destination_pipeline_suppresses_records_from_suppressed_decisions() -> 
     assert result.handoff is not None
     assert result.handoff.status == "blocked"
     assert result.summary.emitted_options == 0
+    assert result.summary.skipped_records == 2
     assert result.summary.filtered_record_ids == [
         "record-destination-a",
         "record-destination-b",

--- a/trip_planner/ingestion/activity_pipeline.py
+++ b/trip_planner/ingestion/activity_pipeline.py
@@ -83,6 +83,7 @@ def ingest_activity_snapshot(
         if decision.entity_scope != "activity" or decision.option_kind != snapshot.option_kind:
             continue
         record_ids = _record_ids_for_decision(decision, resolution_map)
+        records = _records_for_decision(snapshot.records, decision, resolution_map)
         preserved_conflicts.extend(unresolved_conflicts(decision.preserved_conflicts))
         if decision.decision == "suppress":
             emitted_ids.update(record_ids)
@@ -91,10 +92,52 @@ def ingest_activity_snapshot(
             )
             continue
         if decision.decision in {"keep_separate", "needs_review"}:
+            if not records:
+                warnings.append(
+                    IngestionWarning(
+                        warning_id=f"{decision.decision_id}:missing-records",
+                        severity="warning",
+                        code="missing_decision_records",
+                        message="Dedup decision did not map to any raw activity records.",
+                    )
+                )
+                continue
+            unresolved = unresolved_conflicts(decision.preserved_conflicts)
+            for record in records:
+                option = _activity_option_from_records(
+                    [record],
+                    snapshot,
+                    _separate_option_id(decision.canonical_entity_id, record),
+                )
+                option.notes.extend(
+                    [f"dedup_decision:{decision.decision_id}", *decision.notes]
+                )
+                option.feasibility.constraints.extend(
+                    [
+                        f"{conflict.attribute_path}:{conflict.reason}"
+                        for conflict in unresolved
+                    ]
+                )
+                record_warnings = record.payload.get("normalization_warnings", [])
+                if record_warnings:
+                    warnings.append(
+                        IngestionWarning(
+                            warning_id=f"{record.record_id}:normalization",
+                            severity="warning",
+                            code="normalization_warning",
+                            message="; ".join(record_warnings),
+                            record_ids=[record.record_id],
+                        )
+                    )
+                    option.notes.extend(record_warnings)
+                activity_options.append(option)
+                provenance_refs.extend(option.source_refs)
+                emitted_ids.add(record.record_id)
+                if decision.decision == "needs_review" or decision.confidence < 0.75:
+                    low_confidence_option_ids.append(option.option_id)
             continue
         if decision.decision != "merge":
             continue
-        records = _records_for_decision(snapshot.records, decision, resolution_map)
         if not records:
             warnings.append(
                 IngestionWarning(
@@ -130,7 +173,6 @@ def ingest_activity_snapshot(
                 option.notes.extend(record_warnings)
         activity_options.append(option)
         emitted_ids.update(record.record_id for record in records)
-        filtered_record_ids.extend(record.record_id for record in records[1:])
         provenance_refs.extend(option.source_refs)
 
     for record in snapshot.records:
@@ -174,7 +216,7 @@ def ingest_activity_snapshot(
     summary = IngestionSummary(
         total_records=len(snapshot.records),
         emitted_options=len(activity_options),
-        skipped_records=max(0, len(snapshot.records) - len(activity_options)),
+        skipped_records=len(filtered_record_ids),
         degraded_options=sum(1 for option in activity_options if option.notes),
         unresolved_conflicts=len(preserved_conflicts),
         low_confidence_option_ids=sorted(set(low_confidence_option_ids)),
@@ -297,6 +339,10 @@ def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution |
     if isinstance(payload_option_id, str) and payload_option_id:
         return payload_option_id
     return record.provider_entity_id
+
+
+def _separate_option_id(canonical_entity_id: str, record: RawSourceRecord) -> str:
+    return f"{canonical_entity_id}-{record.record_id}"
 
 
 def _lowest_match_confidence(resolution: EntityResolution) -> float:

--- a/trip_planner/ingestion/destination_pipeline.py
+++ b/trip_planner/ingestion/destination_pipeline.py
@@ -83,6 +83,7 @@ def ingest_destination_snapshot(
         if decision.entity_scope != "destination" or decision.option_kind != snapshot.option_kind:
             continue
         record_ids = _record_ids_for_decision(decision, resolution_map)
+        records = _records_for_decision(snapshot.records, decision, resolution_map)
         preserved_conflicts.extend(unresolved_conflicts(decision.preserved_conflicts))
         if decision.decision == "suppress":
             emitted_ids.update(record_ids)
@@ -91,10 +92,38 @@ def ingest_destination_snapshot(
             )
             continue
         if decision.decision in {"keep_separate", "needs_review"}:
+            if not records:
+                warnings.append(
+                    IngestionWarning(
+                        warning_id=f"{decision.decision_id}:missing-records",
+                        severity="warning",
+                        code="missing_decision_records",
+                        message="Dedup decision did not map to any raw destination records.",
+                    )
+                )
+                continue
+            unresolved = unresolved_conflicts(decision.preserved_conflicts)
+            for record in records:
+                destination, refs = _destination_from_records(
+                    [record],
+                    snapshot,
+                    _separate_destination_id(decision.canonical_entity_id, record),
+                )
+                destination = _append_resolution_refs(
+                    destination,
+                    snapshot,
+                    _resolutions_for_record(record.record_id, resolutions),
+                )
+                _append_record_warnings(destination, [record], warnings)
+                destinations.append(destination)
+                provenance_refs.extend(refs)
+                emitted_ids.add(record.record_id)
+                if decision.decision == "needs_review" or decision.confidence < 0.75:
+                    low_confidence_destination_ids.append(destination.destination_id)
+                preserved_conflicts.extend(unresolved)
             continue
         if decision.decision != "merge":
             continue
-        records = _records_for_decision(snapshot.records, decision, resolution_map)
         if not records:
             warnings.append(
                 IngestionWarning(
@@ -111,9 +140,13 @@ def ingest_destination_snapshot(
         _append_record_warnings(destination, records, warnings)
         if decision.confidence < 0.75:
             low_confidence_destination_ids.append(destination.destination_id)
+        destination = _append_resolution_refs(
+            destination,
+            snapshot,
+            _resolutions_for_decision(decision, resolution_map),
+        )
         destinations.append(destination)
         emitted_ids.update(record.record_id for record in records)
-        filtered_record_ids.extend(record.record_id for record in records[1:])
         provenance_refs.extend(refs)
 
     for record in snapshot.records:
@@ -123,8 +156,10 @@ def ingest_destination_snapshot(
         destination_id = _canonical_destination_id(record, resolution)
         destination, refs = _destination_from_records([record], snapshot, destination_id)
         if resolution is not None:
-            destination.source_refs.extend(
-                _resolution_source_ref(snapshot, resolution, destination_id)
+            destination = _append_resolution_refs(
+                destination,
+                snapshot,
+                [resolution],
             )
             unresolved = unresolved_conflicts(resolution.conflicts)
             preserved_conflicts.extend(unresolved)
@@ -144,7 +179,7 @@ def ingest_destination_snapshot(
     summary = IngestionSummary(
         total_records=len(snapshot.records),
         emitted_options=len(destinations),
-        skipped_records=max(0, len(snapshot.records) - len(destinations)),
+        skipped_records=len(filtered_record_ids),
         degraded_options=sum(
             1
             for destination in destinations
@@ -304,6 +339,24 @@ def _resolution_source_ref(
     ]
 
 
+def _append_resolution_refs(
+    destination: Destination,
+    snapshot: RawSnapshot,
+    resolutions: list[EntityResolution],
+) -> Destination:
+    existing_ids = {ref.provenance_id for ref in destination.source_refs}
+    for resolution in resolutions:
+        for ref in _resolution_source_ref(
+            snapshot,
+            resolution,
+            destination.destination_id,
+        ):
+            if ref.provenance_id not in existing_ids:
+                destination.source_refs.append(ref)
+                existing_ids.add(ref.provenance_id)
+    return destination
+
+
 def _records_for_decision(
     records: list[RawSourceRecord],
     decision: DeduplicationDecision,
@@ -330,6 +383,38 @@ def _record_ids_for_decision(
     return list(dict.fromkeys(record_ids))
 
 
+def _resolutions_for_decision(
+    decision: DeduplicationDecision,
+    resolution_map: dict[str, EntityResolution],
+) -> list[EntityResolution]:
+    seen: set[str] = set()
+    matched: list[EntityResolution] = []
+    for resolution_id in decision.resolution_ids:
+        resolution = resolution_map.get(resolution_id)
+        if resolution is None or resolution.resolution_id in seen:
+            continue
+        seen.add(resolution.resolution_id)
+        matched.append(resolution)
+    return matched
+
+
+def _resolutions_for_record(
+    record_id: str,
+    resolutions: list[EntityResolution],
+) -> list[EntityResolution]:
+    seen: set[str] = set()
+    matched: list[EntityResolution] = []
+    for resolution in resolutions:
+        if resolution.resolution_id in seen:
+            continue
+        for candidate in resolution.match_candidates:
+            if record_id in candidate.source_record_ids:
+                seen.add(resolution.resolution_id)
+                matched.append(resolution)
+                break
+    return matched
+
+
 def _resolution_for_record(
     record_id: str,
     resolutions: list[EntityResolution],
@@ -348,6 +433,10 @@ def _canonical_destination_id(record: RawSourceRecord, resolution: EntityResolut
     if isinstance(payload_destination_id, str) and payload_destination_id:
         return payload_destination_id
     return record.provider_entity_id
+
+
+def _separate_destination_id(canonical_entity_id: str, record: RawSourceRecord) -> str:
+    return f"{canonical_entity_id}-{record.record_id}"
 
 
 def _lowest_match_confidence(resolution: EntityResolution) -> float:


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #529

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Activities and destinations will often rely more heavily on editorial, specialist, and official sources than lodging and transport do. The repo therefore needs separate ingestion scaffolding for place and activity data so it can normalize those sources without forcing them into the same pipeline assumptions as inventory-heavy categories.

Parent epic: #525

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#525](https://github.com/stranske/trip-planner/issues/525)
- [#520](https://github.com/stranske/trip-planner/issues/520)
- [#523](https://github.com/stranske/trip-planner/issues/523)
- [#526](https://github.com/stranske/trip-planner/issues/526)
- [#527](https://github.com/stranske/trip-planner/issues/527)
- [#615](https://github.com/stranske/trip-planner/issues/615)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement pipeline scaffolding that accepts raw destination and activity snapshots, applies entity resolution or deduplication, and emits normalized `Destination` and `ActivityOption` objects.
- [x] Ensure the pipeline can preserve editorial significance signals, official operational constraints, and source-specific caveats without flattening them away.
- [x] Add representative ingestion fixtures for at least one editorial or guide source, one official or operational source, and one case with overlapping or conflicting place or activity records.
- [x] Add tests covering happy-path normalization, overlapping-source handling, and degraded-source cases.
- [x] Document how place and activity ingestion differs from lodging and transport ingestion, especially around significance and operational uncertainty.
- [x] Expose enough pipeline summary metadata that later candidate-generation logic can filter by confidence, freshness, or unresolved ambiguity.

#### Acceptance criteria
- [x] The repo contains working ingestion scaffolding for destination and activity snapshots into normalized planning objects.
- [x] Editorial, official, and specialist source signals can survive into normalized outputs with provenance.
- [x] Tests cover clean, overlapping, and degraded cases for both destinations and activities.
- [x] Documentation explains the distinct ingestion concerns for places and activities.
- [x] The output shape is compatible with issues #520 and #523 rather than inventing alternative destination or activity models.

**Head SHA:** 0d56b9eb08fa6ece5c8c370a4c5f717224e15578
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/23997665598) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/23997665592) |
<!-- auto-status-summary:end -->