### PR TITLE
Issue #530: filter origin-only candidate seeds

### DIFF
--- a/tests/candidates/test_generation.py
+++ b/tests/candidates/test_generation.py
@@ -106,6 +106,9 @@ def test_business_candidate_generation_filters_policy_violations_and_marks_polic
 
     assert candidate_set.purpose == "policy_comparison"
     assert candidate_set.filter_summary.policy_exclusion_count == 1
+    assert [seed.bundle.composition_summary.primary_destination_id for seed in candidate_set.seeds] == [
+        "dest-city-chicago"
+    ]
     assert candidate_set.seeds[0].policy_ready is True
     assert candidate_set.seeds[0].bundle.transport_options[0].origin_id == "dest-home-ord"
     assert candidate_set.seeds[0].bundle.lodging_options[0].option_id == (
@@ -116,6 +119,15 @@ def test_business_candidate_generation_filters_policy_violations_and_marks_polic
         for exclusion in candidate_set.exclusions
     )
     assert candidate_set.to_option_set().comparison_axes[-1].key == "policy_ready"
+
+
+def test_business_candidate_generation_skips_origin_only_transport_seed() -> None:
+    scenario = _load_scenario("business_initial_candidates.json")
+
+    candidate_set = generate_candidate_set(**scenario)
+
+    assert len(candidate_set.seeds) == 1
+    assert candidate_set.seeds[0].candidate_id == "candidate:dest-city-chicago:policy_comparison"
 
 
 def test_business_candidate_generation_excludes_non_usd_lodging_for_usd_policy_cap() -> None:

--- a/trip_planner/candidates/generation.py
+++ b/trip_planner/candidates/generation.py
@@ -188,6 +188,13 @@ def _build_candidate_seeds(
             key=lambda item: item.significance_summary.overall_signal or 0.0,
             reverse=True,
         )
+        if not _should_emit_seed(
+            destination=destination,
+            destination_lodging=destination_lodging,
+            destination_transport=destination_transport,
+            destination_activity=destination_activity,
+        ):
+            continue
         if not (destination_lodging or destination_transport or destination_activity):
             continue
         bundle_destinations = _bundle_destinations(
@@ -576,6 +583,21 @@ def _bundle_tradeoffs(
     for activity_option in activity_options:
         risks.extend(activity_option.feasibility.constraints)
     return _dedupe_strings(risks)
+
+
+def _should_emit_seed(
+    *,
+    destination: Destination,
+    destination_lodging: list[LodgingOption],
+    destination_transport: list[TransportOption],
+    destination_activity: list[ActivityOption],
+) -> bool:
+    if destination_lodging or destination_activity:
+        return True
+    return any(
+        option.destination_id == destination.destination_id
+        for option in destination_transport
+    )
 
 
 def _bundle_dependencies(


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #530

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
After ingestion pipelines emit normalized objects, the planner still needs a deterministic layer that can assemble early candidate sets for downstream ranking, revealed-preference comparison, and policy-ready business planning. Without that layer, normalized inventory remains a pile of objects rather than a usable planning input.

Parent epic: #525

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#525](https://github.com/stranske/trip-planner/issues/525)
- [#514](https://github.com/stranske/trip-planner/issues/514)
- [#524](https://github.com/stranske/trip-planner/issues/524)
- [#528](https://github.com/stranske/trip-planner/issues/528)
- [#529](https://github.com/stranske/trip-planner/issues/529)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define candidate-set and filter-summary contracts for early option selection, including inclusion reasons, exclusion reasons, and unresolved-risk summaries.
- [x] Implement a first-pass candidate-generation scaffold that accepts normalized destinations, lodging options, transport options, and activity options and emits filtered candidate sets or bundle seeds.
- [x] Ensure the scaffold can support both leisure revealed-preference comparisons and later business-policy-aware planning inputs.
- [x] Add representative fixtures for at least: a leisure route-learning comparison set, a lodging-focused narrowing set, and a business-compliant initial candidate set.
- [x] Add tests covering candidate inclusion, exclusion for feasibility or freshness reasons, and preservation of explanation metadata.
- [x] Document the boundary between candidate generation and later ranking or route optimization so future work does not collapse them back together.

#### Acceptance criteria
- [x] The repo contains canonical early candidate-generation and filtering contracts downstream from ingestion and upstream from ranking.
- [x] Candidate sets preserve explanation metadata, provenance context, and exclusion reasons.
- [x] The scaffold can support both leisure and business planning inputs.
- [x] Tests cover inclusion, exclusion, and mixed candidate-set outputs.
- [x] Documentation keeps candidate generation distinct from final scoring or route search.

**Head SHA:** 18d2f1330725e5575cc81ea30b045d4bf6215245
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24000462958) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24000462954) |
| Agents Verifier | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/24000223148) |
<!-- auto-status-summary:end -->

