### PR TITLE
Issue #533 follow-up: fix overnight feasibility cutoff anchoring

### DIFF
--- a/tests/itinerary/test_feasibility.py
+++ b/tests/itinerary/test_feasibility.py
@@ -126,6 +126,9 @@ def test_overnight_checkin_window_accepts_late_evening_arrival() -> None:
         _fixture_path("coherent_low_friction_route.json").read_text(encoding="utf-8")
     )
     payload["transport_options"][0]["timing_summary"][
+        "departure_local"
+    ] = "2026-04-10T21:45:00+09:00"
+    payload["transport_options"][0]["timing_summary"][
         "arrival_local"
     ] = "2026-04-10T23:30:00+09:00"
     payload["lodging_options"][0]["booking_terms"]["checkin_window"] = "15:00-01:00"
@@ -135,6 +138,27 @@ def test_overnight_checkin_window_accepts_late_evening_arrival() -> None:
     assert "late_arrival_checkin_conflict" not in assessment.blocking_reasons
     assert all(
         conflict.code != "late_arrival_checkin_conflict"
+        for conflict in assessment.timing_conflicts
+    )
+
+
+def test_overnight_checkin_window_blocks_next_day_post_cutoff_arrival() -> None:
+    payload = json.loads(
+        _fixture_path("coherent_low_friction_route.json").read_text(encoding="utf-8")
+    )
+    payload["transport_options"][0]["timing_summary"][
+        "departure_local"
+    ] = "2026-04-10T22:00:00+09:00"
+    payload["transport_options"][0]["timing_summary"][
+        "arrival_local"
+    ] = "2026-04-11T01:30:00+09:00"
+    payload["lodging_options"][0]["booking_terms"]["checkin_window"] = "15:00-01:00"
+
+    assessment = evaluate_bundle_feasibility(InventoryBundle.from_dict(payload))
+
+    assert "late_arrival_checkin_conflict" in assessment.blocking_reasons
+    assert any(
+        conflict.code == "late_arrival_checkin_conflict"
         for conflict in assessment.timing_conflicts
     )
 

--- a/trip_planner/itinerary/feasibility.py
+++ b/trip_planner/itinerary/feasibility.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 from trip_planner._validators import (
     require_non_empty,
@@ -188,6 +188,11 @@ def _arrival_conflicts(
             )
             for lodging in matching_lodging
         }
+        departure = _dt(
+            transport.timing_summary.departure_local,
+            field_key=f"transport:{transport.option_id}:departure_local",
+            missing_data_fields=missing_data_fields,
+        )
         arrival = _dt(
             transport.timing_summary.arrival_local,
             field_key=f"transport:{transport.option_id}:arrival_local",
@@ -200,10 +205,11 @@ def _arrival_conflicts(
             if window is None:
                 continue
             start_time, end_time = window
-            arrival_time = arrival.timetz().replace(tzinfo=None)
+            anchor_date = departure.date() if departure is not None else arrival.date()
+            window_close = datetime.combine(anchor_date, end_time, arrival.tzinfo)
             if end_time < start_time:
-                continue
-            if arrival_time > end_time:
+                window_close += timedelta(days=1)
+            if arrival > window_close:
                 conflicts.append(
                     TimingConflict(
                         conflict_id=f"timing:{transport.option_id}:{lodging.option_id}:arrival",


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #533

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Candidate sets are not useful until the planner can evaluate whether they are internally feasible at the trip and movement level. The system needs a reusable feasibility layer that understands travel time, transfer burden, move density, lodging/activity timing conflicts, and map-aware movement costs before any final ranking can be trusted.

Parent epic: #531

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#531](https://github.com/stranske/trip-planner/issues/531)
- [#522](https://github.com/stranske/trip-planner/issues/522)
- [#523](https://github.com/stranske/trip-planner/issues/523)
- [#524](https://github.com/stranske/trip-planner/issues/524)
- [#530](https://github.com/stranske/trip-planner/issues/530)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define contracts for feasibility checks, move-cost summaries, travel-time estimates, timing conflicts, and route-continuity warnings.
- [x] Implement a first-pass evaluator that can assess intercity moves, transfer burden, check-in and check-out timing interactions, and daily density conflicts using map-aware or distance-aware inputs.
- [x] Ensure the evaluator can emit both hard infeasibility results and softer friction penalties for later ranking layers.
- [x] Add representative fixtures for at least: a coherent low-friction route, a route with excessive transfer burden, a route with unrealistic same-day chaining, and a business trip with tight schedule protection needs.
- [x] Write unit tests covering feasible, marginal, and infeasible cases plus missing-data behavior.
- [x] Document how later ranking and route-search layers should consume feasibility output instead of re-implementing travel realism ad hoc.

#### Acceptance criteria
- [x] The repo contains canonical feasibility and move-cost contracts plus a first-pass evaluator.
- [x] The evaluator distinguishes hard infeasibility from soft friction or realism penalties.
- [x] Leisure and business cases can both be represented through the same lower-level feasibility layer.
- [x] Tests cover representative feasible, marginal, and infeasible cases.
- [x] Documentation clarifies that ranking must consume feasibility outputs rather than bypass them.

**Head SHA:** 45c4fc1c2af1fc8dae314eaabea613662e3b024c
**Latest Runs:** ⏹️ cancelled — Gate
**Required:** gate: ⏹️ cancelled

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents Bot Comment Handler | ⏹️ cancelled | [View run](https://github.com/stranske/trip-planner/actions/runs/24017025033) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24017343564) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24017343538) |
| Create Issue from Verification (DEPRECATED) | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24017024973) |
| Create Issue from Verification (Enhanced) | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24017024983) |
| Create New PR from Verification | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24017024971) |
| Gate | ⏹️ cancelled | [View run](https://github.com/stranske/trip-planner/actions/runs/24017025039) |
<!-- auto-status-summary:end -->
