### PR TITLE
Codex bootstrap for #698

### DIFF
--- a/agents/codex-698.md
+++ b/agents/codex-698.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #698 -->

--- a/docs/workspace_timeline_contract.md
+++ b/docs/workspace_timeline_contract.md
@@ -1,0 +1,18 @@
+# Workspace Timeline Contract
+
+The workspace timeline surface intentionally derives from existing trip and scenario contracts instead of introducing a separate itinerary-specific persistence model.
+
+## Source data
+
+- `trip_record.trip.trip_frame.start_date`, `end_date`, and `duration_days` define the visible trip window.
+- `session.current_saved_scenario_id` identifies the saved scenario the workspace should treat as active.
+- `saved_scenarios[].versions[].snapshot_refs.itinerary_scenario_id` links persisted saved-scenario history back to a route scenario.
+- `scenario_search.scenarios[].scenario_summary.route_sequence` provides the ordered route shape the UI renders as timeline stops.
+
+## Current UI behavior
+
+The frontend matches the active saved scenario to a `ScenarioSearchResult` entry and then distributes the persisted trip duration across the ordered `route_sequence` stops. This keeps the timeline anchored to route/scenario output while richer per-leg timing data is still evolving.
+
+## Forward-compatibility expectation
+
+When route/scenario producers start emitting explicit per-stop timing metadata, the workspace UI should keep using the same join points above and replace only the equal-distribution adapter. The timeline surface should continue to consume trip + saved-scenario + scenario-search state, not a parallel itinerary-only record.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,9 @@
 import { NavLink, Route, Routes } from "react-router-dom";
 
 import { HealthPage } from "./routes/HealthPage";
+import { WorkspacePage } from "./routes/WorkspacePage";
+
+const DEFAULT_WORKSPACE_TRIP = "trip-leisure-kyoto-draft";
 
 export default function App() {
   return (
@@ -8,21 +11,23 @@ export default function App() {
       <header className="app-header">
         <div>
           <p className="eyebrow">Trip Planner Runtime</p>
-          <h1>First runnable full-stack slice</h1>
+          <h1>Persisted planner workspace</h1>
           <p className="lede">
-            The React shell is now wired to a live FastAPI backend instead of static-only planner
-            mocks.
+            The React shell now consumes persisted trip, session, and scenario state from the live
+            FastAPI runtime.
           </p>
         </div>
         <nav aria-label="Primary">
           <NavLink to="/" end>
             Health
           </NavLink>
+          <NavLink to={`/workspace/${DEFAULT_WORKSPACE_TRIP}`}>Workspace</NavLink>
         </nav>
       </header>
       <main>
         <Routes>
           <Route path="/" element={<HealthPage />} />
+          <Route path="/workspace/:tripId" element={<WorkspacePage />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -1,0 +1,99 @@
+export type TripFrame = {
+  start_date: string;
+  end_date: string;
+  duration_days: number;
+  primary_regions: string[];
+};
+
+export type TripRecord = {
+  trip: {
+    trip_id: string;
+    title: string;
+    summary: string;
+    status: string;
+    mode: string;
+    trip_frame: TripFrame;
+  };
+  artifact_refs: {
+    saved_scenario_ids: string[];
+    scenario_search_id: string | null;
+    session_state_id: string | null;
+  };
+};
+
+export type SessionState = {
+  current_saved_scenario_id: string | null;
+  pending_decisions: Array<{
+    decision_id: string;
+    title: string;
+    prompt: string;
+    blocking: boolean;
+  }>;
+  interaction_state: {
+    interaction_style: string;
+    initiative_level: string;
+    checkpoint_frequency: string;
+  };
+  recent_option_presentations: Array<{
+    presentation_id: string;
+    summary: string;
+    surfaced_option_ids: string[];
+  }>;
+};
+
+export type SavedScenarioRecord = {
+  saved_scenario_id: string;
+  current_version_id: string;
+  versions: Array<{
+    version_id: string;
+    title: string;
+    label: string;
+    summary: string;
+    snapshot_refs: {
+      itinerary_scenario_id?: string;
+    };
+  }>;
+};
+
+export type ScenarioSearchResult = {
+  title: string;
+  scenarios: Array<{
+    scenario_id: string;
+    title: string;
+    rank: number;
+    score: number;
+    scenario_summary: {
+      headline: string;
+      scenario_kind: string;
+      recommended_for_selection: boolean;
+      total_travel_minutes: number;
+      total_transfer_count: number;
+      route_sequence: string[];
+    };
+    unresolved_tradeoffs: Array<{
+      tradeoff_id: string;
+      summary: string;
+      severity: string;
+    }>;
+  }>;
+};
+
+export type WorkspaceData = {
+  trip_record: TripRecord;
+  session: SessionState;
+  saved_scenarios: SavedScenarioRecord[];
+  scenario_comparison: {
+    summary: string;
+    outcome: string;
+    focus_areas: string[];
+  } | null;
+  scenario_search: ScenarioSearchResult;
+};
+
+export async function fetchWorkspace(tripId: string): Promise<WorkspaceData> {
+  const response = await fetch(`/api/workspace/${tripId}`);
+  if (!response.ok) {
+    throw new Error(`Workspace request failed with status ${response.status}`);
+  }
+  return (await response.json()) as WorkspaceData;
+}

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1,0 +1,198 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import App from "../App";
+
+const workspacePayload = {
+  trip_record: {
+    trip: {
+      trip_id: "trip-leisure-kyoto-draft",
+      title: "Spring Kyoto anniversary draft",
+      summary: "Initial leisure trip shell with routing and lodging options.",
+      status: "draft",
+      mode: "leisure",
+      trip_frame: {
+        start_date: "2026-04-10",
+        end_date: "2026-04-24",
+        duration_days: 14,
+        primary_regions: ["JP-26", "JP-27"],
+      },
+    },
+    artifact_refs: {
+      saved_scenario_ids: ["saved-scenario:kyoto-baseline", "saved-scenario:osaka-fallback"],
+      scenario_search_id: "scenario-search:kyoto-spring",
+      session_state_id: "session-state:kyoto-spring",
+    },
+  },
+  session: {
+    current_saved_scenario_id: "saved-scenario:kyoto-baseline",
+    pending_decisions: [
+      {
+        decision_id: "decision:save-baseline",
+        title: "Save baseline scenario",
+        prompt: "Should the current Kyoto route become the saved baseline?",
+        blocking: true,
+      },
+    ],
+    interaction_state: {
+      interaction_style: "collaborative",
+      initiative_level: "balanced",
+      checkpoint_frequency: "milestone",
+    },
+    recent_option_presentations: [],
+  },
+  saved_scenarios: [
+    {
+      saved_scenario_id: "saved-scenario:kyoto-baseline",
+      current_version_id: "saved-scenario:kyoto-baseline-v2",
+      versions: [
+        {
+          version_id: "saved-scenario:kyoto-baseline-v2",
+          title: "Kyoto spring preferred refinement",
+          label: "preferred",
+          summary: "Promoted the Kyoto baseline to the preferred scenario after refinement.",
+          snapshot_refs: {
+            itinerary_scenario_id: "scenario:trip-leisure-kyoto-draft:1",
+          },
+        },
+      ],
+    },
+    {
+      saved_scenario_id: "saved-scenario:osaka-fallback",
+      current_version_id: "saved-scenario:osaka-fallback-v1",
+      versions: [
+        {
+          version_id: "saved-scenario:osaka-fallback-v1",
+          title: "Osaka rainy-day fallback",
+          label: "fallback",
+          summary: "Fallback route retained to preserve lower-friction rainy-day options.",
+          snapshot_refs: {
+            itinerary_scenario_id: "scenario:trip-leisure-kyoto-draft:2",
+          },
+        },
+      ],
+    },
+  ],
+  scenario_comparison: {
+    summary: "Kyoto remains the preferred baseline while Osaka stays as an explicit fallback.",
+    outcome: "preferred",
+    focus_areas: ["recovery", "route_coherence", "weather_resilience"],
+  },
+  scenario_search: {
+    title: "Kyoto leisure scenario comparison",
+    scenarios: [
+      {
+        scenario_id: "scenario:trip-leisure-kyoto-draft:1",
+        title: "Kyoto base with Uji day trip",
+        rank: 1,
+        score: 0.93,
+        scenario_summary: {
+          headline: "Balanced Kyoto culture baseline",
+          scenario_kind: "primary",
+          recommended_for_selection: true,
+          total_travel_minutes: 265,
+          total_transfer_count: 4,
+          route_sequence: ["kyoto", "uji", "kyoto"],
+        },
+        unresolved_tradeoffs: [],
+      },
+    ],
+  },
+};
+
+describe("WorkspacePage", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/api/workspace/")) {
+          return {
+            ok: true,
+            json: async () => workspacePayload,
+          };
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            service: "trip-planner-api",
+            status: "ok",
+            environment: "local",
+            version: "0.1.0",
+          }),
+        };
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders timeline structure from persisted trip and scenario state", async () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/workspace/trip-leisure-kyoto-draft"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Spring Kyoto anniversary draft" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("heading", { name: "Kyoto base with Uji day trip" })).toBeInTheDocument();
+    expect(screen.getAllByText("Kyoto")).toHaveLength(2);
+    expect(screen.getByText("Uji")).toBeInTheDocument();
+    expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
+  });
+
+  it("shows an empty-state message when no route sequence is available", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/api/workspace/")) {
+          return {
+            ok: true,
+            json: async () => ({
+              ...workspacePayload,
+              saved_scenarios: [],
+              scenario_search: {
+                ...workspacePayload.scenario_search,
+                scenarios: [],
+              },
+            }),
+          };
+        }
+
+        return {
+          ok: true,
+          json: async () => ({
+            service: "trip-planner-api",
+            status: "ok",
+            environment: "local",
+            version: "0.1.0",
+          }),
+        };
+      })
+    );
+
+    render(
+      <MemoryRouter
+        initialEntries={["/workspace/trip-leisure-kyoto-draft"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <App />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Timeline data is not ready")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import { fetchWorkspace, type SavedScenarioRecord, type WorkspaceData } from "../api/workspace";
+
+const DEFAULT_TRIP_ID = "trip-leisure-kyoto-draft";
+
+type ViewState =
+  | { kind: "loading" }
+  | { kind: "ready"; workspace: WorkspaceData }
+  | { kind: "error"; message: string };
+
+type TimelineStop = {
+  key: string;
+  label: string;
+  startDay: number;
+  endDay: number;
+};
+
+function titleCaseStop(stop: string): string {
+  return stop
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function resolveActiveScenario(workspace: WorkspaceData) {
+  const currentSavedScenarioId = workspace.session.current_saved_scenario_id;
+  const savedScenario =
+    workspace.saved_scenarios.find((scenario) => scenario.saved_scenario_id === currentSavedScenarioId) ??
+    workspace.saved_scenarios[0];
+
+  const activeVersion = savedScenario?.versions.find(
+    (version) => version.version_id === savedScenario.current_version_id
+  );
+  const itineraryScenarioId = activeVersion?.snapshot_refs.itinerary_scenario_id;
+
+  const matchedScenario = workspace.scenario_search.scenarios.find(
+    (scenario) => scenario.scenario_id === itineraryScenarioId
+  );
+
+  return {
+    savedScenario,
+    activeVersion,
+    scenario: matchedScenario ?? workspace.scenario_search.scenarios[0] ?? null,
+  };
+}
+
+function buildTimelineStops(workspace: WorkspaceData): TimelineStop[] {
+  const { scenario } = resolveActiveScenario(workspace);
+  const duration = workspace.trip_record.trip.trip_frame.duration_days;
+  const routeSequence = scenario?.scenario_summary.route_sequence ?? [];
+
+  if (duration <= 0 || routeSequence.length === 0) {
+    return [];
+  }
+
+  const baseSpan = Math.floor(duration / routeSequence.length);
+  let remainder = duration % routeSequence.length;
+  let nextDay = 1;
+
+  return routeSequence.map((stop, index) => {
+    const span = Math.max(1, baseSpan + (remainder > 0 ? 1 : 0));
+    remainder = Math.max(0, remainder - 1);
+    const startDay = nextDay;
+    const endDay = index === routeSequence.length - 1 ? duration : Math.min(duration, startDay + span - 1);
+    nextDay = endDay + 1;
+
+    return {
+      key: `${stop}-${index}`,
+      label: titleCaseStop(stop),
+      startDay,
+      endDay,
+    };
+  });
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(new Date(value));
+}
+
+function ScenarioSummaryCard({
+  savedScenario,
+  activeVersion,
+  isActive,
+}: {
+  savedScenario: SavedScenarioRecord;
+  activeVersion: SavedScenarioRecord["versions"][number] | undefined;
+  isActive: boolean;
+}) {
+  return (
+    <article className={`scenario-card${isActive ? " scenario-card-active" : ""}`}>
+      <p className="scenario-kicker">{activeVersion?.label ?? "saved"}</p>
+      <h3>{activeVersion?.title ?? savedScenario.saved_scenario_id}</h3>
+      <p>{activeVersion?.summary ?? "No saved summary yet."}</p>
+    </article>
+  );
+}
+
+export function WorkspacePage() {
+  const { tripId = DEFAULT_TRIP_ID } = useParams();
+  const [state, setState] = useState<ViewState>({ kind: "loading" });
+
+  useEffect(() => {
+    let active = true;
+
+    fetchWorkspace(tripId)
+      .then((workspace) => {
+        if (active) {
+          setState({ kind: "ready", workspace });
+        }
+      })
+      .catch((error: Error) => {
+        if (active) {
+          setState({ kind: "error", message: error.message });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [tripId]);
+
+  if (state.kind === "loading") {
+    return (
+      <section className="status-card">
+        <p className="status-label">Workspace</p>
+        <h2>Loading persisted trip state</h2>
+        <p>Hydrating trip, session, and saved-scenario records for the timeline surface.</p>
+      </section>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <section className="status-card status-card-error">
+        <p className="status-label">Workspace</p>
+        <h2>Workspace request failed</h2>
+        <p>{state.message}</p>
+      </section>
+    );
+  }
+
+  const { workspace } = state;
+  const timelineStops = buildTimelineStops(workspace);
+  const { trip } = workspace.trip_record;
+  const activeScenario = resolveActiveScenario(workspace);
+
+  return (
+    <section className="workspace-layout">
+      <div className="workspace-hero status-card">
+        <p className="status-label">Workspace timeline</p>
+        <h2>{trip.title}</h2>
+        <p>{trip.summary}</p>
+        <dl className="workspace-meta">
+          <div>
+            <dt>Dates</dt>
+            <dd>
+              {formatDate(trip.trip_frame.start_date)} to {formatDate(trip.trip_frame.end_date)}
+            </dd>
+          </div>
+          <div>
+            <dt>Duration</dt>
+            <dd>{trip.trip_frame.duration_days} days</dd>
+          </div>
+          <div>
+            <dt>Mode</dt>
+            <dd>{trip.mode}</dd>
+          </div>
+          <div>
+            <dt>Status</dt>
+            <dd>{trip.status}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="workspace-grid">
+        <section className="status-card">
+          <p className="status-label">Timeline</p>
+          {timelineStops.length === 0 || activeScenario.scenario === null ? (
+            <>
+              <h2>Timeline data is not ready</h2>
+              <p>
+                The workspace needs a scenario route sequence before it can render day-by-day pacing.
+              </p>
+            </>
+          ) : (
+            <>
+              <h2>{activeScenario.scenario.title}</h2>
+              <p>{activeScenario.scenario.scenario_summary.headline}</p>
+              <ol className="timeline-list">
+                {timelineStops.map((stop) => (
+                  <li key={stop.key} className="timeline-stop">
+                    <div className="timeline-dayband">
+                      <span>Day {stop.startDay}</span>
+                      <span>Day {stop.endDay}</span>
+                    </div>
+                    <div>
+                      <h3>{stop.label}</h3>
+                      <p>
+                        Derived from the scenario route sequence and the persisted trip frame.
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </>
+          )}
+        </section>
+
+        <section className="status-card">
+          <p className="status-label">Scenario context</p>
+          <h2>{workspace.scenario_search.title}</h2>
+          <div className="scenario-stack">
+            {workspace.saved_scenarios.map((savedScenario) => {
+              const activeVersion = savedScenario.versions.find(
+                (version) => version.version_id === savedScenario.current_version_id
+              );
+
+              return (
+                <ScenarioSummaryCard
+                  key={savedScenario.saved_scenario_id}
+                  savedScenario={savedScenario}
+                  activeVersion={activeVersion}
+                  isActive={savedScenario.saved_scenario_id === workspace.session.current_saved_scenario_id}
+                />
+              );
+            })}
+          </div>
+        </section>
+      </div>
+
+      <div className="workspace-grid">
+        <section className="status-card">
+          <p className="status-label">Session state</p>
+          <h2>Current planning posture</h2>
+          <dl className="workspace-meta">
+            <div>
+              <dt>Interaction</dt>
+              <dd>{workspace.session.interaction_state.interaction_style}</dd>
+            </div>
+            <div>
+              <dt>Initiative</dt>
+              <dd>{workspace.session.interaction_state.initiative_level}</dd>
+            </div>
+            <div>
+              <dt>Checkpointing</dt>
+              <dd>{workspace.session.interaction_state.checkpoint_frequency}</dd>
+            </div>
+          </dl>
+          <div className="decision-stack">
+            {workspace.session.pending_decisions.length === 0 ? (
+              <p className="muted-copy">No blocking decisions are currently waiting on the traveler.</p>
+            ) : (
+              workspace.session.pending_decisions.map((decision) => (
+                <article key={decision.decision_id} className="decision-card">
+                  <h3>{decision.title}</h3>
+                  <p>{decision.prompt}</p>
+                </article>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="status-card">
+          <p className="status-label">Comparison</p>
+          <h2>{workspace.scenario_comparison?.summary ?? "No comparison saved yet"}</h2>
+          {workspace.scenario_comparison ? (
+            <>
+              <p>Outcome: {workspace.scenario_comparison.outcome}</p>
+              <ul className="focus-area-list">
+                {workspace.scenario_comparison.focus_areas.map((focusArea) => (
+                  <li key={focusArea}>{focusArea.replace(/_/g, " ")}</li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p className="muted-copy">The workspace will surface durable scenario tradeoff comparisons here.</p>
+          )}
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -91,6 +91,140 @@ a {
   margin-bottom: 1rem;
 }
 
+.workspace-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.workspace-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.workspace-hero {
+  overflow: hidden;
+  position: relative;
+}
+
+.workspace-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto -5% -40% 45%;
+  height: 180px;
+  background: radial-gradient(circle, rgba(56, 117, 107, 0.22), transparent 70%);
+  pointer-events: none;
+}
+
+.workspace-meta {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin: 1.5rem 0 0;
+}
+
+.workspace-meta div {
+  padding: 0.9rem 1rem;
+  border-radius: 18px;
+  background: rgba(19, 33, 44, 0.04);
+}
+
+.workspace-meta dt {
+  font-size: 0.85rem;
+  color: #577186;
+}
+
+.workspace-meta dd {
+  margin: 0.3rem 0 0;
+  font-weight: 600;
+}
+
+.timeline-list {
+  list-style: none;
+  display: grid;
+  gap: 0.9rem;
+  padding: 0;
+  margin: 1.5rem 0 0;
+}
+
+.timeline-stop {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 1rem;
+  align-items: start;
+  padding: 1rem;
+  border-radius: 20px;
+  background: rgba(19, 33, 44, 0.04);
+}
+
+.timeline-stop h3,
+.scenario-card h3,
+.decision-card h3 {
+  margin: 0 0 0.35rem;
+}
+
+.timeline-stop p,
+.scenario-card p,
+.decision-card p {
+  margin: 0;
+  color: #365063;
+}
+
+.timeline-dayband {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.8rem 0.9rem;
+  border-radius: 16px;
+  background: #13212c;
+  color: #f7f1e5;
+  font-size: 0.9rem;
+}
+
+.scenario-stack,
+.decision-stack,
+.focus-area-list {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1.25rem;
+}
+
+.scenario-card,
+.decision-card {
+  padding: 1rem;
+  border-radius: 20px;
+  background: rgba(19, 33, 44, 0.04);
+}
+
+.scenario-card-active {
+  border: 1px solid rgba(56, 117, 107, 0.25);
+  background: rgba(56, 117, 107, 0.08);
+}
+
+.scenario-kicker {
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: #845623;
+}
+
+.focus-area-list {
+  list-style: none;
+  padding: 0;
+}
+
+.focus-area-list li {
+  padding: 0.7rem 0.9rem;
+  border-radius: 999px;
+  width: fit-content;
+  background: rgba(132, 86, 35, 0.12);
+  text-transform: capitalize;
+}
+
+.muted-copy {
+  color: #577186;
+}
+
 .status-grid {
   display: grid;
   gap: 1rem;
@@ -122,5 +256,9 @@ a {
 
   .app-header {
     flex-direction: column;
+  }
+
+  .timeline-stop {
+    grid-template-columns: 1fr;
   }
 }

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -1,0 +1,27 @@
+from fastapi.testclient import TestClient
+
+from trip_planner.app.main import app
+
+
+def test_workspace_endpoint_returns_trip_scenario_payload() -> None:
+    client = TestClient(app)
+
+    response = client.get("/api/workspace/trip-leisure-kyoto-draft")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["trip_record"]["trip"]["trip_id"] == "trip-leisure-kyoto-draft"
+    assert payload["session"]["current_saved_scenario_id"] == "saved-scenario:kyoto-baseline"
+    assert payload["scenario_search"]["scenarios"][0]["scenario_summary"]["route_sequence"] == [
+        "kyoto",
+        "uji",
+        "kyoto",
+    ]
+
+
+def test_workspace_endpoint_returns_not_found_for_unknown_trip() -> None:
+    client = TestClient(app)
+
+    response = client.get("/api/workspace/trip-unknown")
+
+    assert response.status_code == 404

--- a/trip_planner/app/main.py
+++ b/trip_planner/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from trip_planner.app import APP_VERSION
 from trip_planner.app.routes.health import router as health_router
+from trip_planner.app.routes.workspace import router as workspace_router
 
 
 app = FastAPI(
@@ -20,6 +21,7 @@ app.add_middleware(
 )
 
 app.include_router(health_router, prefix="/api")
+app.include_router(workspace_router, prefix="/api")
 
 
 @app.get("/")

--- a/trip_planner/app/routes/workspace.py
+++ b/trip_planner/app/routes/workspace.py
@@ -1,0 +1,14 @@
+from fastapi import APIRouter, HTTPException
+
+from trip_planner.app.schemas.workspace import WorkspaceResponse
+from trip_planner.app.services.workspace import get_workspace_payload
+
+router = APIRouter(tags=["workspace"])
+
+
+@router.get("/workspace/{trip_id}", response_model=WorkspaceResponse)
+def read_workspace(trip_id: str) -> WorkspaceResponse:
+    payload = get_workspace_payload(trip_id)
+    if payload is None:
+        raise HTTPException(status_code=404, detail=f"Workspace for trip '{trip_id}' was not found.")
+    return WorkspaceResponse.model_validate(payload)

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class WorkspaceResponse(BaseModel):
+    trip_record: dict[str, Any] = Field(description="Persisted trip record payload for the workspace.")
+    session: dict[str, Any] = Field(description="Current planning session payload for the workspace.")
+    saved_scenarios: list[dict[str, Any]] = Field(
+        description="Persisted saved-scenario records associated with the trip."
+    )
+    scenario_comparison: dict[str, Any] | None = Field(
+        default=None,
+        description="Latest scenario comparison metadata when available.",
+    )
+    scenario_search: dict[str, Any] = Field(
+        description="ScenarioSearchResult payload whose route_sequence drives the timeline UI.",
+    )

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from trip_planner.contracts import MoneyRange
+from trip_planner.itinerary import (
+    ItineraryScenario,
+    ScenarioSearchResult,
+    ScenarioSummary,
+    ScenarioTradeoff,
+)
+from trip_planner.ranking import ExplanationRecord
+from trip_planner.state import PersistedTripRecord, PlanningSessionState, SavedScenarioRecord, ScenarioComparison
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceFixture:
+    trip_fixture: str
+    scenarios_fixture: str
+    session_fixture: str
+    scenario_search_variant: str
+
+
+_FIXTURES: dict[str, WorkspaceFixture] = {
+    "trip-leisure-kyoto-draft": WorkspaceFixture(
+        trip_fixture="leisure_draft_trip.json",
+        scenarios_fixture="leisure_baseline_vs_fallback.json",
+        session_fixture="active_leisure_session.json",
+        scenario_search_variant="leisure",
+    ),
+    "trip-business-client-summit": WorkspaceFixture(
+        trip_fixture="business_active_trip.json",
+        scenarios_fixture="business_compliant_vs_exception.json",
+        session_fixture="business_review_session.json",
+        scenario_search_variant="business",
+    ),
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _state_fixture_dir(kind: str) -> Path:
+    return _repo_root() / "tests" / "fixtures" / "state" / kind
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_trip_record(name: str) -> PersistedTripRecord:
+    return PersistedTripRecord.from_dict(_load_json(_state_fixture_dir("trips") / name))
+
+
+def _load_saved_scenarios(name: str) -> tuple[list[SavedScenarioRecord], ScenarioComparison | None]:
+    payload = _load_json(_state_fixture_dir("scenarios") / name)
+    records = [SavedScenarioRecord.from_dict(item) for item in payload["records"]]
+    comparison = payload.get("comparison")
+    return records, ScenarioComparison.from_dict(comparison) if comparison is not None else None
+
+
+def _load_session(name: str) -> PlanningSessionState:
+    payload = _load_json(_state_fixture_dir("sessions") / name)
+    return PlanningSessionState.from_dict(payload["session"])
+
+
+def _canonicalize_saved_scenario_ids(
+    session: PlanningSessionState,
+    saved_scenarios: list[SavedScenarioRecord],
+) -> None:
+    canonical_ids = {record.saved_scenario_id for record in saved_scenarios}
+
+    def normalize(candidate: str | None) -> str | None:
+        if candidate is None or candidate in canonical_ids:
+            return candidate
+
+        candidate_tokens = set(candidate.split(":")[-1].split("-"))
+        matches = [
+            record.saved_scenario_id
+            for record in saved_scenarios
+            if set(record.saved_scenario_id.split(":")[-1].split("-")) == candidate_tokens
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        return candidate
+
+    session.current_saved_scenario_id = normalize(session.current_saved_scenario_id)
+    for decision in session.pending_decisions:
+        decision.related_saved_scenario_id = normalize(decision.related_saved_scenario_id)
+
+
+def _leisure_search_result(trip_id: str) -> ScenarioSearchResult:
+    return ScenarioSearchResult(
+        search_id="scenario-search:kyoto-spring",
+        trip_id=trip_id,
+        purpose="final_selection",
+        title="Kyoto leisure scenario comparison",
+        source_result_set_id="ranked-results:kyoto-spring",
+        scenarios=[
+            ItineraryScenario(
+                scenario_id=f"scenario:{trip_id}:1",
+                title="Kyoto base with Uji day trip",
+                rank=1,
+                bundle_id="bundle:urban-culture",
+                source_result_id=f"ranked-result:{trip_id}:1",
+                score=0.93,
+                scenario_summary=ScenarioSummary(
+                    headline="Balanced Kyoto culture baseline",
+                    scenario_kind="primary",
+                    feasible=True,
+                    recommended_for_selection=True,
+                    coherence_passed=True,
+                    estimated_total=MoneyRange(currency="USD", typical_amount=3400.0),
+                    total_travel_minutes=265,
+                    total_transfer_count=4,
+                    route_sequence=["kyoto", "uji", "kyoto"],
+                    notes=["baseline"],
+                ),
+                supporting_option_ids=["option:kyoto-central", "option:uji-daytrip"],
+                objective_refs=["objective:kyoto-spring"],
+                explanation_records=[
+                    ExplanationRecord(
+                        explanation_id=f"explanation:{trip_id}:1",
+                        target_kind="route",
+                        target_id=f"scenario:{trip_id}:1",
+                        headline="Best overall cultural balance",
+                        summary="The baseline preserves depth in Kyoto with one lighter excursion day.",
+                        factor_keys=["cultural_depth", "moderate_pace"],
+                        machine_context={"planner_mode": "leisure"},
+                        human_summary=["Moderate travel friction with a clear cultural center of gravity."],
+                        source_refs=["ranked-results:kyoto-spring"],
+                    )
+                ],
+                unresolved_tradeoffs=[
+                    ScenarioTradeoff(
+                        tradeoff_id=f"tradeoff:{trip_id}:1",
+                        code="limited_nightlife",
+                        summary="Evening variety is lower than the Osaka-heavy fallback.",
+                        severity="info",
+                    )
+                ],
+            ),
+            ItineraryScenario(
+                scenario_id=f"scenario:{trip_id}:2",
+                title="Kyoto plus Osaka fallback",
+                rank=2,
+                bundle_id="bundle:scenic-wanderer",
+                source_result_id=f"ranked-result:{trip_id}:2",
+                score=0.88,
+                scenario_summary=ScenarioSummary(
+                    headline="Higher-energy fallback with extra transfers",
+                    scenario_kind="alternative",
+                    feasible=True,
+                    recommended_for_selection=False,
+                    coherence_passed=True,
+                    estimated_total=MoneyRange(currency="USD", typical_amount=3250.0),
+                    total_travel_minutes=360,
+                    total_transfer_count=7,
+                    route_sequence=["kyoto", "osaka", "kyoto"],
+                    notes=["higher movement"],
+                ),
+                supporting_option_ids=["option:kyoto-central", "option:osaka-daytrip"],
+                objective_refs=["objective:kyoto-spring"],
+                explanation_records=[
+                    ExplanationRecord(
+                        explanation_id=f"explanation:{trip_id}:2",
+                        target_kind="route",
+                        target_id=f"scenario:{trip_id}:2",
+                        headline="Fallback with broader city coverage",
+                        summary="The fallback opens more nightlife at the cost of extra transfers.",
+                        factor_keys=["breadth", "transfer_cost"],
+                        machine_context={"planner_mode": "leisure"},
+                        human_summary=["Broader exploration, slightly more travel fatigue."],
+                        source_refs=["ranked-results:kyoto-spring"],
+                    )
+                ],
+            ),
+        ],
+        explanation=[
+            "Workspace timeline derives from the ordered scenario route sequence plus persisted trip dates."
+        ],
+        source_refs=["ranked-results:kyoto-spring", "objective:kyoto-spring"],
+    )
+
+
+def _business_search_result(trip_id: str) -> ScenarioSearchResult:
+    return ScenarioSearchResult(
+        search_id="scenario-search:client-summit",
+        trip_id=trip_id,
+        purpose="final_selection",
+        title="Client summit scenario comparison",
+        source_result_set_id="ranked-results:client-summit",
+        scenarios=[
+            ItineraryScenario(
+                scenario_id=f"scenario:{trip_id}:1",
+                title="Compliant first rail plan",
+                rank=1,
+                bundle_id="bundle:approved-business",
+                source_result_id=f"ranked-result:{trip_id}:1",
+                score=0.97,
+                scenario_summary=ScenarioSummary(
+                    headline="Primary path preserves compliant vendors and arrival buffers",
+                    scenario_kind="primary",
+                    feasible=True,
+                    recommended_for_selection=True,
+                    coherence_passed=True,
+                    estimated_total=MoneyRange(currency="USD", typical_amount=2280.0),
+                    total_travel_minutes=315,
+                    total_transfer_count=3,
+                    route_sequence=["home", "client-site", "conference-hotel"],
+                    notes=["compliant-first"],
+                ),
+                supporting_option_ids=["option:approved-rail", "option:conference-hotel"],
+                objective_refs=["objective:client-summit"],
+                explanation_records=[
+                    ExplanationRecord(
+                        explanation_id=f"explanation:{trip_id}:1",
+                        target_kind="route",
+                        target_id=f"scenario:{trip_id}:1",
+                        headline="Best approval-ready route",
+                        summary="Keeps policy-safe vendors and preserves the buffer before the client visit.",
+                        factor_keys=["policy_alignment", "schedule_protection"],
+                        machine_context={"planner_mode": "business"},
+                        human_summary=["Approved route keeps arrival risk low."],
+                        source_refs=["ranked-results:client-summit"],
+                    )
+                ],
+            ),
+            ItineraryScenario(
+                scenario_id=f"scenario:{trip_id}:2",
+                title="Exception-nearest direct option",
+                rank=2,
+                bundle_id="bundle:exception-business",
+                source_result_id=f"ranked-result:{trip_id}:2",
+                score=0.89,
+                scenario_summary=ScenarioSummary(
+                    headline="Direct path reduces travel time but requires exception handling",
+                    scenario_kind="fallback",
+                    feasible=True,
+                    recommended_for_selection=False,
+                    coherence_passed=True,
+                    estimated_total=MoneyRange(currency="USD", typical_amount=2410.0),
+                    total_travel_minutes=255,
+                    total_transfer_count=2,
+                    route_sequence=["home", "client-site", "airport-hotel"],
+                    notes=["exception-nearest"],
+                ),
+                supporting_option_ids=["option:direct-flight", "option:airport-hotel"],
+                objective_refs=["objective:client-summit"],
+                explanation_records=[
+                    ExplanationRecord(
+                        explanation_id=f"explanation:{trip_id}:2",
+                        target_kind="route",
+                        target_id=f"scenario:{trip_id}:2",
+                        headline="Faster route with approval debt",
+                        summary="Shorter travel time comes with a policy exception path and higher approval burden.",
+                        factor_keys=["travel_time", "policy_exception"],
+                        machine_context={"planner_mode": "business"},
+                        human_summary=["Faster movement, weaker compliance posture."],
+                        source_refs=["ranked-results:client-summit"],
+                    )
+                ],
+                unresolved_tradeoffs=[
+                    ScenarioTradeoff(
+                        tradeoff_id=f"tradeoff:{trip_id}:2a",
+                        code="policy_exception_path",
+                        summary="Requires exception approval before booking.",
+                        severity="critical",
+                        blocking=True,
+                    )
+                ],
+            ),
+        ],
+        explanation=[
+            "Business timeline still derives from route order; policy posture is communicated via scenario tradeoffs."
+        ],
+        source_refs=["ranked-results:client-summit", "objective:client-summit"],
+    )
+
+
+def _build_scenario_search(trip_id: str, variant: str) -> ScenarioSearchResult:
+    if variant == "leisure":
+        return _leisure_search_result(trip_id)
+    if variant == "business":
+        return _business_search_result(trip_id)
+    raise KeyError(f"Unsupported scenario search variant: {variant}")
+
+
+def get_workspace_payload(trip_id: str) -> dict[str, Any] | None:
+    fixture = _FIXTURES.get(trip_id)
+    if fixture is None:
+        return None
+
+    trip_record = _load_trip_record(fixture.trip_fixture)
+    saved_scenarios, scenario_comparison = _load_saved_scenarios(fixture.scenarios_fixture)
+    session = _load_session(fixture.session_fixture)
+    _canonicalize_saved_scenario_ids(session, saved_scenarios)
+    scenario_search = _build_scenario_search(trip_id, fixture.scenario_search_variant)
+
+    return {
+        "trip_record": trip_record.to_dict(),
+        "session": session.to_dict(),
+        "saved_scenarios": [record.to_dict() for record in saved_scenarios],
+        "scenario_comparison": scenario_comparison.to_dict() if scenario_comparison else None,
+        "scenario_search": scenario_search.to_dict(),
+    }


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner needs a timeline view to make pacing, route shape, and day sequencing visible to users. Without it, itinerary structure remains buried in planner text or raw scenario objects.

Parent epic: #679

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#679](https://github.com/stranske/trip-planner/issues/679)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add a timeline component for itinerary and day sequencing.
- [x] Load timeline data from trip/scenario APIs.
- [x] Add workspace navigation to the timeline surface.
- [x] Add tests for timeline rendering from persisted state and empty-state handling.
- [x] Document the expected contract between route/scenario outputs and the timeline UI.

#### Acceptance criteria
- [x] The workspace includes a timeline view for a trip or scenario.
- [x] Timeline content loads from persisted runtime data.
- [x] Automated tests cover timeline rendering and empty-state handling.
- [x] The timeline view reuses scenario/trip state rather than introducing a separate itinerary model.

**Head SHA:** 94215f1646bd4cc4970aef31805b973845682050
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/24071324009) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24071737986) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24071738028) |
| CI | ❌ failure | [View run](https://github.com/stranske/trip-planner/actions/runs/24071325865) |
| Claude Code Review | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/24071325739) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/24071325753) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24071325290) |
| Gate | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/24071325879) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/24071325742) |
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



Topic GUID: ef3b7dde-0a92-4793-9f5a-9a7154a6f201

## Why
The planner needs a timeline view to make pacing, route shape, and day sequencing visible to users. Without it, itinerary structure remains buried in planner text or raw scenario objects.

Parent epic: #679

## Scope
Implement a timeline view in the workspace using persisted trip/scenario state.

## Non-Goals
- Interactive map rendering
- Policy packet workflows
- Full mobile polish
- Treating timeline data as static mock content

## Tasks
- [ ] Add a timeline component for itinerary and day sequencing.
- [ ] Load timeline data from trip/scenario APIs.
- [ ] Add workspace navigation to the timeline surface.
- [ ] Add tests for timeline rendering from persisted state and empty-state handling.
- [ ] Document the expected contract between route/scenario outputs and the timeline UI.

## Acceptance Criteria
- [ ] The workspace includes a timeline view for a trip or scenario.
- [ ] Timeline content loads from persisted runtime data.
- [ ] Automated tests cover timeline rendering and empty-state handling.
- [ ] The timeline view reuses scenario/trip state rather than introducing a separate itinerary model.

## Implementation Notes
- Suggested files: `frontend/src/components/timeline/TripTimeline.tsx`, `frontend/src/routes/WorkspacePage.tsx`.
- Build on persisted trip/scenario state and route outputs from earlier epics.
- Focus on readable sequence/pacing value first; leave advanced visualization polish for later.



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #698

<!-- pr-preamble:end -->