### PR TITLE
Issue #685: persist scenario and planning history

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - business trip planning that optimizes against company travel constraints and exports policy-ready plans
 
 The runtime baseline now treats the saved trip record as the durable planning container. New scenario, budget, workspace, and policy work should attach to a persisted trip instead of inventing a parallel root object.
+Saved scenarios and trip-level planning history now persist underneath that same trip container, so later comparison and workspace slices should consume those records instead of reintroducing fixture-only storage.
 
 ## Key Docs
 

--- a/frontend/src/api/trips.ts
+++ b/frontend/src/api/trips.ts
@@ -35,6 +35,36 @@ export type TripRecord = {
   };
 };
 
+export type SavedScenarioRecord = {
+  saved_scenario_id: string;
+  current_version_id: string;
+  versions: Array<{
+    version_id: string;
+    title: string;
+    label: string;
+    summary: string;
+  }>;
+  comparisons: Array<{
+    comparison_id: string;
+    summary: string;
+    outcome: string;
+  }>;
+};
+
+export type PlanningHistoryEntry = {
+  activity_event_id: string;
+  occurred_at: string;
+  event_kind: string;
+  summary: string;
+  actor: string;
+  saved_scenario_id: string | null;
+};
+
+export type TripScenarioHistoryData = {
+  saved_scenarios: SavedScenarioRecord[];
+  planning_history: PlanningHistoryEntry[];
+};
+
 export type CreateTripPayload = {
   title: string;
   summary: string;
@@ -56,6 +86,15 @@ export async function fetchTrip(tripId: string): Promise<TripRecord> {
     credentials: "include",
   });
   return response.trip;
+}
+
+export async function fetchTripScenarioHistory(
+  tripId: string,
+): Promise<TripScenarioHistoryData> {
+  return fetchJson<TripScenarioHistoryData>({
+    path: `/api/trips/${tripId}/scenario-history`,
+    credentials: "include",
+  });
 }
 
 export async function createTrip(payload: CreateTripPayload): Promise<TripRecord> {

--- a/frontend/src/router.test.ts
+++ b/frontend/src/router.test.ts
@@ -14,6 +14,10 @@ vi.mock("./api/auth", () => ({
 
 vi.mock("./api/trips", () => ({
   fetchTrip: vi.fn().mockResolvedValue({ trip_id: "trip-1" }),
+  fetchTripScenarioHistory: vi.fn().mockResolvedValue({
+    saved_scenarios: [],
+    planning_history: [],
+  }),
   fetchTrips: vi.fn().mockResolvedValue([{ trip_id: "trip-1" }]),
 }));
 
@@ -164,7 +168,7 @@ describe("router auth loaders", () => {
 
   it("loads a persisted trip detail for signed-in users", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
-    const { fetchTrip } = await import("./api/trips");
+    const { fetchTrip, fetchTripScenarioHistory } = await import("./api/trips");
     vi.mocked(fetchCurrentSession).mockResolvedValueOnce({
       user: {
         user_id: "user:test",
@@ -180,6 +184,13 @@ describe("router auth loaders", () => {
     });
 
     expect(fetchTrip).toHaveBeenCalledWith("trip-1");
-    await expect(result.trip).resolves.toEqual({ trip_id: "trip-1" });
+    expect(fetchTripScenarioHistory).toHaveBeenCalledWith("trip-1");
+    await expect(result.tripDetail).resolves.toEqual({
+      trip: { trip_id: "trip-1" },
+      scenarioHistory: {
+        saved_scenarios: [],
+        planning_history: [],
+      },
+    });
   });
 });

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,7 +6,11 @@ import {
 } from "react-router-dom";
 
 import { fetchCurrentSession } from "./api/auth";
-import { fetchTrip, fetchTrips } from "./api/trips";
+import {
+  fetchTrip,
+  fetchTripScenarioHistory,
+  fetchTrips,
+} from "./api/trips";
 import { fetchWorkspace } from "./api/workspace";
 import App from "./App";
 import { ApiClientError } from "./lib/api/errors";
@@ -104,7 +108,13 @@ export async function protectedTripDetailLoader({
   }
 
   return {
-    trip: fetchTrip(params.tripId ?? ""),
+    tripDetail: Promise.all([
+      fetchTrip(params.tripId ?? ""),
+      fetchTripScenarioHistory(params.tripId ?? ""),
+    ]).then(([trip, scenarioHistory]) => ({
+      trip,
+      scenarioHistory,
+    })),
   };
 }
 

--- a/frontend/src/routes/TripDetailPage.test.tsx
+++ b/frontend/src/routes/TripDetailPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -16,6 +16,8 @@ const mockedUseLoaderData = vi.mocked(useLoaderData);
 
 describe("TripDetailPage", () => {
   afterEach(() => {
+    cleanup();
+    mockedUseLoaderData.mockReset();
     vi.clearAllMocks();
   });
 

--- a/frontend/src/routes/TripDetailPage.test.tsx
+++ b/frontend/src/routes/TripDetailPage.test.tsx
@@ -95,4 +95,63 @@ describe("TripDetailPage", () => {
       screen.getByText("Saved the Kyoto baseline after the first planning pass.")
     ).toBeInTheDocument();
   });
+
+  it("renders a defensive fallback when a saved scenario has no versions", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      tripDetail: Promise.resolve({
+        trip: {
+          trip_id: "trip-kyoto-123abc",
+          user_id: "user:test",
+          title: "Kyoto Spring",
+          summary: "Food and gardens",
+          mode: "leisure",
+          status: "draft",
+          trip_frame: {
+            start_date: "2026-04-20",
+            end_date: "2026-04-26",
+            duration_days: 7,
+            primary_regions: ["Kyoto"],
+            traveler_party: { kind: "solo", traveler_count: 1, notes: "" },
+          },
+          profile_refs: {
+            leisure_profile_id: "profile:trip-kyoto-123abc:leisure",
+            business_profile_id: null,
+          },
+          artifacts: {
+            objective_id: null,
+            option_set_ids: [],
+            itinerary_state_id: null,
+            budget_state_id: null,
+            policy_state_id: null,
+          },
+        },
+        scenarioHistory: {
+          saved_scenarios: [
+            {
+              saved_scenario_id: "saved-scenario:kyoto-empty",
+              current_version_id: "saved-scenario:kyoto-empty-v1",
+              versions: [],
+              comparisons: [],
+            },
+          ],
+          planning_history: [],
+        },
+      }),
+    });
+
+    render(
+      <MemoryRouter>
+        <TripDetailPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Kyoto Spring" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText("This saved scenario is missing version details.")
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/routes/TripDetailPage.test.tsx
+++ b/frontend/src/routes/TripDetailPage.test.tsx
@@ -21,30 +21,59 @@ describe("TripDetailPage", () => {
 
   it("renders persisted trip metadata from the loader payload", async () => {
     mockedUseLoaderData.mockReturnValue({
-      trip: Promise.resolve({
-        trip_id: "trip-kyoto-123abc",
-        user_id: "user:test",
-        title: "Kyoto Spring",
-        summary: "Food and gardens",
-        mode: "leisure",
-        status: "draft",
-        trip_frame: {
-          start_date: "2026-04-20",
-          end_date: "2026-04-26",
-          duration_days: 7,
-          primary_regions: ["Kyoto", "Osaka"],
-          traveler_party: { kind: "solo", traveler_count: 1, notes: "Window seat preferred" },
+      tripDetail: Promise.resolve({
+        trip: {
+          trip_id: "trip-kyoto-123abc",
+          user_id: "user:test",
+          title: "Kyoto Spring",
+          summary: "Food and gardens",
+          mode: "leisure",
+          status: "draft",
+          trip_frame: {
+            start_date: "2026-04-20",
+            end_date: "2026-04-26",
+            duration_days: 7,
+            primary_regions: ["Kyoto", "Osaka"],
+            traveler_party: { kind: "solo", traveler_count: 1, notes: "Window seat preferred" },
+          },
+          profile_refs: {
+            leisure_profile_id: "profile:trip-kyoto-123abc:leisure",
+            business_profile_id: null,
+          },
+          artifacts: {
+            objective_id: null,
+            option_set_ids: [],
+            itinerary_state_id: null,
+            budget_state_id: null,
+            policy_state_id: null,
+          },
         },
-        profile_refs: {
-          leisure_profile_id: "profile:trip-kyoto-123abc:leisure",
-          business_profile_id: null,
-        },
-        artifacts: {
-          objective_id: null,
-          option_set_ids: [],
-          itinerary_state_id: null,
-          budget_state_id: null,
-          policy_state_id: null,
+        scenarioHistory: {
+          saved_scenarios: [
+            {
+              saved_scenario_id: "saved-scenario:kyoto-baseline",
+              current_version_id: "saved-scenario:kyoto-baseline-v1",
+              versions: [
+                {
+                  version_id: "saved-scenario:kyoto-baseline-v1",
+                  title: "Kyoto baseline",
+                  label: "baseline",
+                  summary: "Keeps the calm Kyoto-first route on hand for later refinement.",
+                },
+              ],
+              comparisons: [],
+            },
+          ],
+          planning_history: [
+            {
+              activity_event_id: "activity:scenario-saved-1",
+              occurred_at: "2026-04-10T15:30:00Z",
+              event_kind: "scenario_saved",
+              summary: "Saved the Kyoto baseline after the first planning pass.",
+              actor: "planner",
+              saved_scenario_id: "saved-scenario:kyoto-baseline",
+            },
+          ],
         },
       }),
     });
@@ -61,5 +90,9 @@ describe("TripDetailPage", () => {
 
     expect(screen.getByText("trip-kyoto-123abc")).toBeInTheDocument();
     expect(screen.getByText("Window seat preferred")).toBeInTheDocument();
+    expect(screen.getByText("Kyoto baseline")).toBeInTheDocument();
+    expect(
+      screen.getByText("Saved the Kyoto baseline after the first planning pass.")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/routes/TripDetailPage.tsx
+++ b/frontend/src/routes/TripDetailPage.tsx
@@ -1,10 +1,18 @@
 import { useLoaderData } from "react-router-dom";
 
-import type { TripRecord } from "../api/trips";
+import type {
+  PlanningHistoryEntry,
+  SavedScenarioRecord,
+  TripRecord,
+  TripScenarioHistoryData,
+} from "../api/trips";
 import { AsyncRouteContent } from "../lib/routes/AsyncRouteContent";
 
 type LoaderData = {
-  trip: Promise<TripRecord>;
+  tripDetail: Promise<{
+    trip: TripRecord;
+    scenarioHistory: TripScenarioHistoryData;
+  }>;
 };
 
 function formatValue(value: string | null): string {
@@ -12,15 +20,15 @@ function formatValue(value: string | null): string {
 }
 
 export function TripDetailPage() {
-  const { trip } = useLoaderData() as LoaderData;
+  const { tripDetail } = useLoaderData() as LoaderData;
 
   return (
     <AsyncRouteContent
-      resolve={trip}
+      resolve={tripDetail}
       loading={{
         label: "Trip detail",
         title: "Loading saved trip",
-        message: "Restoring the persisted trip payload and ownership-aware metadata.",
+        message: "Restoring the persisted trip, saved-scenario history, and ownership-aware metadata.",
       }}
       error={{
         label: "Trip detail",
@@ -28,12 +36,36 @@ export function TripDetailPage() {
         message: "The app could not load this trip record.",
       }}
     >
-      {(resolvedTrip) => <TripDetailContent trip={resolvedTrip} />}
+      {({ trip, scenarioHistory }) => (
+        <TripDetailContent trip={trip} scenarioHistory={scenarioHistory} />
+      )}
     </AsyncRouteContent>
   );
 }
 
-function TripDetailContent({ trip }: { trip: TripRecord }) {
+function formatScenarioLabel(label: string): string {
+  return label.replaceAll("_", " ");
+}
+
+function renderCurrentVersion(savedScenario: SavedScenarioRecord) {
+  return (
+    savedScenario.versions.find(
+      (version) => version.version_id === savedScenario.current_version_id
+    ) ?? savedScenario.versions[0]
+  );
+}
+
+function summarizeHistory(entry: PlanningHistoryEntry): string {
+  return entry.event_kind.replaceAll("_", " ");
+}
+
+function TripDetailContent({
+  trip,
+  scenarioHistory,
+}: {
+  trip: TripRecord;
+  scenarioHistory: TripScenarioHistoryData;
+}) {
   return (
     <section className="workspace-layout">
       <article className="status-card workspace-hero">
@@ -93,6 +125,69 @@ function TripDetailContent({ trip }: { trip: TripRecord }) {
               <dd>{trip.trip_frame.traveler_party.notes || "No extra notes yet."}</dd>
             </div>
           </dl>
+        </section>
+
+        <section className="status-card">
+          <p className="status-label">Saved scenarios</p>
+          <h2>Persisted scenario shelf</h2>
+          {scenarioHistory.saved_scenarios.length === 0 ? (
+            <p className="muted-copy">
+              No saved scenarios have been persisted for this trip yet.
+            </p>
+          ) : (
+            <div className="scenario-stack">
+              {scenarioHistory.saved_scenarios.map((savedScenario) => {
+                const currentVersion = renderCurrentVersion(savedScenario);
+                return (
+                  <article
+                    key={savedScenario.saved_scenario_id}
+                    className="scenario-card scenario-card-active"
+                  >
+                    <p className="scenario-kicker">
+                      {formatScenarioLabel(currentVersion.label)}
+                    </p>
+                    <h3>{currentVersion.title}</h3>
+                    <p>{currentVersion.summary || "No scenario summary captured yet."}</p>
+                    <dl className="workspace-meta">
+                      <div>
+                        <dt>Versions</dt>
+                        <dd>{savedScenario.versions.length}</dd>
+                      </div>
+                      <div>
+                        <dt>Scenario ID</dt>
+                        <dd>{savedScenario.saved_scenario_id}</dd>
+                      </div>
+                    </dl>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <section className="status-card">
+          <p className="status-label">Planning history</p>
+          <h2>Trip-level activity timeline</h2>
+          {scenarioHistory.planning_history.length === 0 ? (
+            <p className="muted-copy">
+              No planning-history entries have been recorded for this trip yet.
+            </p>
+          ) : (
+            <div className="decision-stack">
+              {scenarioHistory.planning_history.map((entry) => (
+                <article
+                  key={entry.activity_event_id}
+                  className="decision-card"
+                >
+                  <p className="scenario-kicker">{summarizeHistory(entry)}</p>
+                  <h3>{entry.summary}</h3>
+                  <p>
+                    {entry.actor} at {entry.occurred_at}
+                  </p>
+                </article>
+              ))}
+            </div>
+          )}
         </section>
       </div>
     </section>

--- a/frontend/src/routes/TripDetailPage.tsx
+++ b/frontend/src/routes/TripDetailPage.tsx
@@ -48,11 +48,21 @@ function formatScenarioLabel(label: string): string {
 }
 
 function renderCurrentVersion(savedScenario: SavedScenarioRecord) {
-  return (
+  const currentVersion =
     savedScenario.versions.find(
       (version) => version.version_id === savedScenario.current_version_id
-    ) ?? savedScenario.versions[0]
-  );
+    ) ?? savedScenario.versions[0];
+
+  if (currentVersion) {
+    return currentVersion;
+  }
+
+  return {
+    version_id: savedScenario.current_version_id,
+    label: "unavailable",
+    title: "Unavailable",
+    summary: "This saved scenario is missing version details.",
+  };
 }
 
 function summarizeHistory(entry: PlanningHistoryEntry): string {

--- a/frontend/src/routes/TripDetailPage.tsx
+++ b/frontend/src/routes/TripDetailPage.tsx
@@ -44,7 +44,7 @@ export function TripDetailPage() {
 }
 
 function formatScenarioLabel(label: string): string {
-  return label.replaceAll("_", " ");
+  return label.split("_").join(" ");
 }
 
 function renderCurrentVersion(savedScenario: SavedScenarioRecord) {
@@ -66,7 +66,7 @@ function renderCurrentVersion(savedScenario: SavedScenarioRecord) {
 }
 
 function summarizeHistory(entry: PlanningHistoryEntry): string {
-  return entry.event_kind.replaceAll("_", " ");
+  return entry.event_kind.split("_").join(" ");
 }
 
 function TripDetailContent({

--- a/tests/app/test_trip_routes.py
+++ b/tests/app/test_trip_routes.py
@@ -223,6 +223,75 @@ def test_trip_scenario_history_create_list_and_reload_flow(client: TestClient) -
     assert repeat_listing.json() == payload
 
 
+def test_trip_scenario_history_create_truncates_generated_ids_to_model_limits(
+    client: TestClient,
+) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+    create_trip = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "Food and gardens",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+    trip_id = create_trip.json()["trip"]["trip_id"]
+
+    create_scenario = client.post(
+        f"/api/trips/{trip_id}/saved-scenarios",
+        json={
+            "title": "a" * 160,
+            "label": "baseline",
+            "snapshot_refs": {
+                "itinerary_scenario_id": f"scenario:{trip_id}:1",
+            },
+        },
+    )
+
+    assert create_scenario.status_code == 201
+    payload = create_scenario.json()["saved_scenario"]
+    assert len(payload["saved_scenario_id"]) <= 93
+    assert len(payload["current_version_id"]) <= 96
+
+
+def test_trip_scenario_history_rejects_invalid_domain_payloads_with_422(
+    client: TestClient,
+) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+    create_trip = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "Food and gardens",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+    trip_id = create_trip.json()["trip"]["trip_id"]
+
+    invalid_scenario = client.post(
+        f"/api/trips/{trip_id}/saved-scenarios",
+        json={
+            "title": "Kyoto baseline",
+            "label": "invalid",
+            "snapshot_refs": {
+                "itinerary_scenario_id": f"scenario:{trip_id}:1",
+            },
+        },
+    )
+    assert invalid_scenario.status_code == 422
+
+    invalid_history = client.post(
+        f"/api/trips/{trip_id}/planning-history",
+        json={
+            "event_kind": "invalid_kind",
+            "summary": "Bad payload",
+        },
+    )
+    assert invalid_history.status_code == 422
+
+
 def test_trip_scenario_history_routes_hide_other_users_records(client: TestClient) -> None:
     signup(client, email="owner@example.com", display_name="Owner")
     create_trip = client.post(

--- a/tests/app/test_trip_routes.py
+++ b/tests/app/test_trip_routes.py
@@ -167,3 +167,115 @@ def test_trip_create_rejects_invalid_traveler_party_kind(client: TestClient) -> 
     )
 
     assert response.status_code == 422
+
+
+def test_trip_scenario_history_create_list_and_reload_flow(client: TestClient) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+    create_trip = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "Food and gardens",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+    trip_id = create_trip.json()["trip"]["trip_id"]
+
+    create_scenario = client.post(
+        f"/api/trips/{trip_id}/saved-scenarios",
+        json={
+            "title": "Kyoto baseline",
+            "label": "baseline",
+            "summary": "Persist the calm Kyoto-first route for future comparison.",
+            "snapshot_refs": {
+                "scenario_search_id": "scenario-search:kyoto-spring",
+                "itinerary_scenario_id": f"scenario:{trip_id}:1",
+                "leisure_profile_id": f"profile:{trip_id}:leisure",
+            },
+        },
+    )
+    assert create_scenario.status_code == 201
+    saved_scenario = create_scenario.json()["saved_scenario"]
+
+    create_history = client.post(
+        f"/api/trips/{trip_id}/planning-history",
+        json={
+            "event_kind": "scenario_saved",
+            "summary": "Saved the Kyoto baseline after the first ranking pass.",
+            "actor": "planner",
+            "saved_scenario_id": saved_scenario["saved_scenario_id"],
+            "metadata": {"surface": "trip-detail"},
+        },
+    )
+    assert create_history.status_code == 201
+
+    listing = client.get(f"/api/trips/{trip_id}/scenario-history")
+    assert listing.status_code == 200
+    payload = listing.json()
+    assert payload["saved_scenarios"][0]["saved_scenario_id"] == saved_scenario["saved_scenario_id"]
+    assert payload["saved_scenarios"][0]["versions"][0]["title"] == "Kyoto baseline"
+    assert payload["planning_history"][0]["event_kind"] == "scenario_saved"
+    assert payload["planning_history"][0]["saved_scenario_id"] == saved_scenario["saved_scenario_id"]
+
+    repeat_listing = client.get(f"/api/trips/{trip_id}/scenario-history")
+    assert repeat_listing.status_code == 200
+    assert repeat_listing.json() == payload
+
+
+def test_trip_scenario_history_routes_hide_other_users_records(client: TestClient) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+    create_trip = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "Food and gardens",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+    trip_id = create_trip.json()["trip"]["trip_id"]
+
+    scenario = client.post(
+        f"/api/trips/{trip_id}/saved-scenarios",
+        json={
+            "title": "Kyoto baseline",
+            "label": "baseline",
+            "snapshot_refs": {
+                "scenario_search_id": "scenario-search:kyoto-spring",
+                "itinerary_scenario_id": f"scenario:{trip_id}:1",
+                "leisure_profile_id": f"profile:{trip_id}:leisure",
+            },
+        },
+    )
+    assert scenario.status_code == 201
+
+    client.post("/api/auth/logout")
+    signup(client, email="other@example.com", display_name="Other")
+
+    assert client.get(f"/api/trips/{trip_id}/scenario-history").status_code == 404
+    assert (
+        client.post(
+            f"/api/trips/{trip_id}/saved-scenarios",
+            json={
+                "title": "Other user scenario",
+                "label": "baseline",
+                "snapshot_refs": {
+                    "scenario_search_id": "scenario-search:kyoto-spring",
+                    "itinerary_scenario_id": f"scenario:{trip_id}:1",
+                    "leisure_profile_id": f"profile:{trip_id}:leisure",
+                },
+            },
+        ).status_code
+        == 404
+    )
+    assert (
+        client.post(
+            f"/api/trips/{trip_id}/planning-history",
+            json={
+                "event_kind": "scenario_saved",
+                "summary": "Blocked by ownership guard.",
+            },
+        ).status_code
+        == 404
+    )

--- a/trip_planner/app/main.py
+++ b/trip_planner/app/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from trip_planner.app import APP_VERSION
 from trip_planner.app.routes.auth import router as auth_router
 from trip_planner.app.routes.health import router as health_router
+from trip_planner.app.routes.scenario_history import router as scenario_history_router
 from trip_planner.app.routes.trips import router as trips_router
 from trip_planner.app.routes.workspace import router as workspace_router
 from trip_planner.persistence.db import ensure_database_ready
@@ -36,6 +37,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router, prefix="/api")
     app.include_router(auth_router, prefix="/api")
     app.include_router(trips_router, prefix="/api")
+    app.include_router(scenario_history_router, prefix="/api")
     app.include_router(workspace_router, prefix="/api")
 
     @app.get("/")

--- a/trip_planner/app/routes/scenario_history.py
+++ b/trip_planner/app/routes/scenario_history.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from trip_planner.app.schemas.scenario_history import (
+    CreatePlanningHistoryRequest,
+    CreateSavedScenarioRequest,
+    PlanningHistoryResponse,
+    SavedScenarioResponse,
+    TripScenarioHistoryResponse,
+)
+from trip_planner.app.services.auth import AuthenticatedUser, require_authenticated_user
+from trip_planner.app.services.scenario_history import (
+    create_planning_history_entry,
+    create_saved_scenario,
+    list_trip_scenario_history,
+)
+from trip_planner.persistence.db import get_db_session
+
+router = APIRouter(tags=["trip-scenarios"])
+
+
+@router.get("/trips/{trip_id}/scenario-history", response_model=TripScenarioHistoryResponse)
+def read_trip_scenario_history(
+    trip_id: str,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> TripScenarioHistoryResponse:
+    return TripScenarioHistoryResponse.model_validate(
+        list_trip_scenario_history(db_session, user=user, trip_id=trip_id)
+    )
+
+
+@router.post(
+    "/trips/{trip_id}/saved-scenarios",
+    response_model=SavedScenarioResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_trip_saved_scenario(
+    trip_id: str,
+    payload: CreateSavedScenarioRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> SavedScenarioResponse:
+    return SavedScenarioResponse(
+        saved_scenario=create_saved_scenario(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            payload=payload.model_dump(),
+        )
+    )
+
+
+@router.post(
+    "/trips/{trip_id}/planning-history",
+    response_model=PlanningHistoryResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_trip_planning_history(
+    trip_id: str,
+    payload: CreatePlanningHistoryRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> PlanningHistoryResponse:
+    return PlanningHistoryResponse(
+        planning_history_entry=create_planning_history_entry(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            payload=payload.model_dump(),
+        )
+    )

--- a/trip_planner/app/schemas/scenario_history.py
+++ b/trip_planner/app/schemas/scenario_history.py
@@ -1,0 +1,54 @@
+"""Schemas for persisted saved-scenario and planning-history routes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CreateSavedScenarioRequest(BaseModel):
+    saved_scenario_id: str | None = Field(default=None, max_length=96)
+    version_id: str | None = Field(default=None, max_length=96)
+    title: str = Field(min_length=1, max_length=160)
+    label: str = Field(min_length=1, max_length=64)
+    summary: str = Field(default="", max_length=600)
+    created_at: str | None = Field(default=None, max_length=64)
+    created_by: str = Field(default="system", min_length=1, max_length=64)
+    scope: str = Field(default="route", min_length=1, max_length=64)
+    based_on_version_id: str | None = Field(default=None, max_length=96)
+    snapshot_refs: dict[str, Any] = Field(default_factory=dict)
+    comparisons: list[dict[str, Any]] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class CreatePlanningHistoryRequest(BaseModel):
+    activity_event_id: str | None = Field(default=None, max_length=96)
+    session_state_id: str | None = Field(default=None, max_length=96)
+    occurred_at: str | None = Field(default=None, max_length=64)
+    event_kind: str = Field(min_length=1, max_length=64)
+    summary: str = Field(min_length=1, max_length=600)
+    actor: str = Field(default="system", min_length=1, max_length=64)
+    related_decision_id: str | None = Field(default=None, max_length=96)
+    related_option_set_id: str | None = Field(default=None, max_length=96)
+    saved_scenario_id: str | None = Field(default=None, max_length=96)
+    budget_plan_id: str | None = Field(default=None, max_length=96)
+    scenario_budget_id: str | None = Field(default=None, max_length=96)
+    checkpoint_id: str | None = Field(default=None, max_length=96)
+    metadata: dict[str, str] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class SavedScenarioResponse(BaseModel):
+    saved_scenario: dict[str, Any]
+
+
+class PlanningHistoryResponse(BaseModel):
+    planning_history_entry: dict[str, Any]
+
+
+class TripScenarioHistoryResponse(BaseModel):
+    saved_scenarios: list[dict[str, Any]]
+    planning_history: list[dict[str, Any]]

--- a/trip_planner/app/schemas/scenario_history.py
+++ b/trip_planner/app/schemas/scenario_history.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from trip_planner._option_contracts import OPTION_SET_SCOPES
+from trip_planner.state import ACTIVITY_LOG_EVENT_KINDS, SAVED_SCENARIO_LABELS
 
 
 class CreateSavedScenarioRequest(BaseModel):
@@ -21,6 +24,27 @@ class CreateSavedScenarioRequest(BaseModel):
     comparisons: list[dict[str, Any]] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
+
+    @field_validator("label")
+    @classmethod
+    def validate_label(cls, value: str) -> str:
+        if value not in SAVED_SCENARIO_LABELS:
+            raise ValueError(f"label must be one of {SAVED_SCENARIO_LABELS}")
+        return value
+
+    @field_validator("scope")
+    @classmethod
+    def validate_scope(cls, value: str) -> str:
+        if value not in OPTION_SET_SCOPES:
+            raise ValueError(f"scope must be one of {OPTION_SET_SCOPES}")
+        return value
+
+    @field_validator("snapshot_refs")
+    @classmethod
+    def validate_snapshot_refs(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if not value:
+            raise ValueError("snapshot_refs must capture at least one saved reference")
+        return value
 
 
 class CreatePlanningHistoryRequest(BaseModel):
@@ -39,6 +63,13 @@ class CreatePlanningHistoryRequest(BaseModel):
     metadata: dict[str, str] = Field(default_factory=dict)
     tags: list[str] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
+
+    @field_validator("event_kind")
+    @classmethod
+    def validate_event_kind(cls, value: str) -> str:
+        if value not in ACTIVITY_LOG_EVENT_KINDS:
+            raise ValueError(f"event_kind must be one of {ACTIVITY_LOG_EVENT_KINDS}")
+        return value
 
 
 class SavedScenarioResponse(BaseModel):

--- a/trip_planner/app/services/scenario_history.py
+++ b/trip_planner/app/services/scenario_history.py
@@ -19,6 +19,14 @@ from trip_planner.persistence.models.trip import PersistedTrip
 from trip_planner.state import ActivityLogEvent, SavedScenarioRecord
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
+_SAVED_SCENARIO_ID_PREFIX = "saved-scenario:"
+_SAVED_SCENARIO_ID_SUFFIX_LENGTH = 7
+_SAVED_SCENARIO_ID_MAX_LENGTH = 93
+_SAVED_SCENARIO_SLUG_MAX_LENGTH = (
+    _SAVED_SCENARIO_ID_MAX_LENGTH
+    - len(_SAVED_SCENARIO_ID_PREFIX)
+    - _SAVED_SCENARIO_ID_SUFFIX_LENGTH
+)
 
 
 def _utcnow() -> datetime:
@@ -34,12 +42,27 @@ def _slugify(seed: str) -> str:
     return slug or "entry"
 
 
+def _slugify_with_limit(seed: str, *, max_length: int) -> str:
+    slug = _slugify(seed)
+    if len(slug) <= max_length:
+        return slug
+    return slug[:max_length].rstrip("-") or "entry"
+
+
 def _not_found(trip_id: str) -> HTTPException:
     return HTTPException(status_code=404, detail=f"Trip '{trip_id}' was not found.")
 
 
 def _bad_request(detail: str) -> HTTPException:
     return HTTPException(status_code=400, detail=detail)
+
+
+def _unprocessable(detail: str) -> HTTPException:
+    return HTTPException(status_code=422, detail=detail)
+
+
+def _domain_payload_error(error: ValueError) -> HTTPException:
+    return _unprocessable(str(error))
 
 
 def _get_owned_trip(
@@ -135,7 +158,9 @@ def create_saved_scenario(
 ) -> dict:
     trip = _get_owned_trip(db_session, user=user, trip_id=trip_id)
     saved_scenario_id = payload.get("saved_scenario_id") or (
-        f"saved-scenario:{_slugify(payload['title'])}-{secrets.token_hex(3)}"
+        f"{_SAVED_SCENARIO_ID_PREFIX}"
+        f"{_slugify_with_limit(payload['title'], max_length=_SAVED_SCENARIO_SLUG_MAX_LENGTH)}"
+        f"-{secrets.token_hex(3)}"
     )
     version_id = payload.get("version_id") or f"{saved_scenario_id}-v1"
     created_at = payload.get("created_at") or _timestamp()
@@ -144,33 +169,36 @@ def create_saved_scenario(
     if existing is not None:
         raise _bad_request(f"Saved scenario '{saved_scenario_id}' already exists.")
 
-    scenario_record = SavedScenarioRecord.from_dict(
-        {
-            "saved_scenario_id": saved_scenario_id,
-            "trip_id": trip_id,
-            "current_version_id": version_id,
-            "versions": [
-                {
-                    "version_id": version_id,
-                    "saved_scenario_id": saved_scenario_id,
-                    "trip_id": trip_id,
-                    "title": payload["title"],
-                    "label": payload["label"],
-                    "created_at": created_at,
-                    "snapshot_refs": payload.get("snapshot_refs", {}),
-                    "created_by": payload.get("created_by", "system"),
-                    "scope": payload.get("scope", "route"),
-                    "based_on_version_id": payload.get("based_on_version_id"),
-                    "summary": payload.get("summary", ""),
-                    "tags": payload.get("tags", []),
-                    "notes": payload.get("notes", []),
-                }
-            ],
-            "comparisons": payload.get("comparisons", []),
-            "tags": payload.get("tags", []),
-            "notes": payload.get("notes", []),
-        }
-    )
+    try:
+        scenario_record = SavedScenarioRecord.from_dict(
+            {
+                "saved_scenario_id": saved_scenario_id,
+                "trip_id": trip_id,
+                "current_version_id": version_id,
+                "versions": [
+                    {
+                        "version_id": version_id,
+                        "saved_scenario_id": saved_scenario_id,
+                        "trip_id": trip_id,
+                        "title": payload["title"],
+                        "label": payload["label"],
+                        "created_at": created_at,
+                        "snapshot_refs": payload.get("snapshot_refs", {}),
+                        "created_by": payload.get("created_by", "system"),
+                        "scope": payload.get("scope", "route"),
+                        "based_on_version_id": payload.get("based_on_version_id"),
+                        "summary": payload.get("summary", ""),
+                        "tags": payload.get("tags", []),
+                        "notes": payload.get("notes", []),
+                    }
+                ],
+                "comparisons": payload.get("comparisons", []),
+                "tags": payload.get("tags", []),
+                "notes": payload.get("notes", []),
+            }
+        )
+    except ValueError as error:
+        raise _domain_payload_error(error) from error
 
     record = PersistedSavedScenario(
         saved_scenario_id=scenario_record.saved_scenario_id,
@@ -203,26 +231,29 @@ def create_planning_history_entry(
     if existing is not None:
         raise _bad_request(f"Planning history entry '{activity_event_id}' already exists.")
 
-    entry = ActivityLogEvent.from_dict(
-        {
-            "activity_event_id": activity_event_id,
-            "trip_id": trip_id,
-            "session_state_id": payload.get("session_state_id") or f"session:{trip_id}",
-            "occurred_at": payload.get("occurred_at") or _timestamp(),
-            "event_kind": payload["event_kind"],
-            "summary": payload["summary"],
-            "actor": payload.get("actor", "system"),
-            "related_decision_id": payload.get("related_decision_id"),
-            "related_option_set_id": payload.get("related_option_set_id"),
-            "saved_scenario_id": payload.get("saved_scenario_id"),
-            "budget_plan_id": payload.get("budget_plan_id"),
-            "scenario_budget_id": payload.get("scenario_budget_id"),
-            "checkpoint_id": payload.get("checkpoint_id"),
-            "metadata": payload.get("metadata", {}),
-            "tags": payload.get("tags", []),
-            "notes": payload.get("notes", []),
-        }
-    )
+    try:
+        entry = ActivityLogEvent.from_dict(
+            {
+                "activity_event_id": activity_event_id,
+                "trip_id": trip_id,
+                "session_state_id": payload.get("session_state_id") or f"session:{trip_id}",
+                "occurred_at": payload.get("occurred_at") or _timestamp(),
+                "event_kind": payload["event_kind"],
+                "summary": payload["summary"],
+                "actor": payload.get("actor", "system"),
+                "related_decision_id": payload.get("related_decision_id"),
+                "related_option_set_id": payload.get("related_option_set_id"),
+                "saved_scenario_id": payload.get("saved_scenario_id"),
+                "budget_plan_id": payload.get("budget_plan_id"),
+                "scenario_budget_id": payload.get("scenario_budget_id"),
+                "checkpoint_id": payload.get("checkpoint_id"),
+                "metadata": payload.get("metadata", {}),
+                "tags": payload.get("tags", []),
+                "notes": payload.get("notes", []),
+            }
+        )
+    except ValueError as error:
+        raise _domain_payload_error(error) from error
 
     record = PersistedActivityLogEvent(
         activity_event_id=entry.activity_event_id,

--- a/trip_planner/app/services/scenario_history.py
+++ b/trip_planner/app/services/scenario_history.py
@@ -1,0 +1,249 @@
+"""Services for persisted trip-level scenario and planning-history state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import re
+import secrets
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.persistence.models.scenario import (
+    PersistedActivityLogEvent,
+    PersistedSavedScenario,
+)
+from trip_planner.persistence.models.trip import PersistedTrip
+from trip_planner.state import ActivityLogEvent, SavedScenarioRecord
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _timestamp() -> str:
+    return _utcnow().isoformat().replace("+00:00", "Z")
+
+
+def _slugify(seed: str) -> str:
+    slug = _SLUG_RE.sub("-", seed.strip().lower()).strip("-")
+    return slug or "entry"
+
+
+def _not_found(trip_id: str) -> HTTPException:
+    return HTTPException(status_code=404, detail=f"Trip '{trip_id}' was not found.")
+
+
+def _bad_request(detail: str) -> HTTPException:
+    return HTTPException(status_code=400, detail=detail)
+
+
+def _get_owned_trip(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> PersistedTrip:
+    trip = db_session.scalar(
+        select(PersistedTrip)
+        .where(PersistedTrip.trip_id == trip_id)
+        .where(PersistedTrip.user_id == user.user_id)
+    )
+    if trip is None:
+        raise _not_found(trip_id)
+    return trip
+
+
+def _serialize_saved_scenario(record: PersistedSavedScenario) -> dict:
+    return SavedScenarioRecord.from_dict(
+        {
+            "saved_scenario_id": record.saved_scenario_id,
+            "trip_id": record.trip_id,
+            "current_version_id": record.current_version_id,
+            "versions": list(record.versions),
+            "comparisons": list(record.comparisons),
+            "tags": list(record.tags),
+            "notes": list(record.notes),
+        }
+    ).to_dict()
+
+
+def _serialize_activity_entry(record: PersistedActivityLogEvent) -> dict:
+    return ActivityLogEvent.from_dict(
+        {
+            "activity_event_id": record.activity_event_id,
+            "trip_id": record.trip_id,
+            "session_state_id": record.session_state_id,
+            "occurred_at": record.occurred_at,
+            "event_kind": record.event_kind,
+            "summary": record.summary,
+            "actor": record.actor,
+            "related_decision_id": record.related_decision_id,
+            "related_option_set_id": record.related_option_set_id,
+            "saved_scenario_id": record.saved_scenario_id,
+            "budget_plan_id": record.budget_plan_id,
+            "scenario_budget_id": record.scenario_budget_id,
+            "checkpoint_id": record.checkpoint_id,
+            "metadata": dict(record.metadata_payload),
+            "tags": list(record.tags),
+            "notes": list(record.notes),
+        }
+    ).to_dict()
+
+
+def list_trip_scenario_history(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> dict[str, list[dict]]:
+    _get_owned_trip(db_session, user=user, trip_id=trip_id)
+
+    saved_scenarios = db_session.scalars(
+        select(PersistedSavedScenario)
+        .where(PersistedSavedScenario.trip_id == trip_id)
+        .order_by(
+            PersistedSavedScenario.updated_at.desc(),
+            PersistedSavedScenario.saved_scenario_id.asc(),
+        )
+    ).all()
+    planning_history = db_session.scalars(
+        select(PersistedActivityLogEvent)
+        .where(PersistedActivityLogEvent.trip_id == trip_id)
+        .order_by(
+            PersistedActivityLogEvent.occurred_at.desc(),
+            PersistedActivityLogEvent.activity_event_id.asc(),
+        )
+    ).all()
+
+    return {
+        "saved_scenarios": [_serialize_saved_scenario(record) for record in saved_scenarios],
+        "planning_history": [_serialize_activity_entry(record) for record in planning_history],
+    }
+
+
+def create_saved_scenario(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    payload: dict,
+) -> dict:
+    trip = _get_owned_trip(db_session, user=user, trip_id=trip_id)
+    saved_scenario_id = payload.get("saved_scenario_id") or (
+        f"saved-scenario:{_slugify(payload['title'])}-{secrets.token_hex(3)}"
+    )
+    version_id = payload.get("version_id") or f"{saved_scenario_id}-v1"
+    created_at = payload.get("created_at") or _timestamp()
+
+    existing = db_session.get(PersistedSavedScenario, saved_scenario_id)
+    if existing is not None:
+        raise _bad_request(f"Saved scenario '{saved_scenario_id}' already exists.")
+
+    scenario_record = SavedScenarioRecord.from_dict(
+        {
+            "saved_scenario_id": saved_scenario_id,
+            "trip_id": trip_id,
+            "current_version_id": version_id,
+            "versions": [
+                {
+                    "version_id": version_id,
+                    "saved_scenario_id": saved_scenario_id,
+                    "trip_id": trip_id,
+                    "title": payload["title"],
+                    "label": payload["label"],
+                    "created_at": created_at,
+                    "snapshot_refs": payload.get("snapshot_refs", {}),
+                    "created_by": payload.get("created_by", "system"),
+                    "scope": payload.get("scope", "route"),
+                    "based_on_version_id": payload.get("based_on_version_id"),
+                    "summary": payload.get("summary", ""),
+                    "tags": payload.get("tags", []),
+                    "notes": payload.get("notes", []),
+                }
+            ],
+            "comparisons": payload.get("comparisons", []),
+            "tags": payload.get("tags", []),
+            "notes": payload.get("notes", []),
+        }
+    )
+
+    record = PersistedSavedScenario(
+        saved_scenario_id=scenario_record.saved_scenario_id,
+        trip_id=trip_id,
+        current_version_id=scenario_record.current_version_id,
+        versions=[item.to_dict() for item in scenario_record.versions],
+        comparisons=[item.to_dict() for item in scenario_record.comparisons],
+        tags=list(scenario_record.tags),
+        notes=list(scenario_record.notes),
+    )
+    trip.updated_at = _utcnow()
+    db_session.add(record)
+    db_session.commit()
+    db_session.refresh(record)
+    return _serialize_saved_scenario(record)
+
+
+def create_planning_history_entry(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    payload: dict,
+) -> dict:
+    trip = _get_owned_trip(db_session, user=user, trip_id=trip_id)
+    activity_event_id = payload.get("activity_event_id") or (
+        f"activity:{_slugify(payload['event_kind'])}-{secrets.token_hex(3)}"
+    )
+    existing = db_session.get(PersistedActivityLogEvent, activity_event_id)
+    if existing is not None:
+        raise _bad_request(f"Planning history entry '{activity_event_id}' already exists.")
+
+    entry = ActivityLogEvent.from_dict(
+        {
+            "activity_event_id": activity_event_id,
+            "trip_id": trip_id,
+            "session_state_id": payload.get("session_state_id") or f"session:{trip_id}",
+            "occurred_at": payload.get("occurred_at") or _timestamp(),
+            "event_kind": payload["event_kind"],
+            "summary": payload["summary"],
+            "actor": payload.get("actor", "system"),
+            "related_decision_id": payload.get("related_decision_id"),
+            "related_option_set_id": payload.get("related_option_set_id"),
+            "saved_scenario_id": payload.get("saved_scenario_id"),
+            "budget_plan_id": payload.get("budget_plan_id"),
+            "scenario_budget_id": payload.get("scenario_budget_id"),
+            "checkpoint_id": payload.get("checkpoint_id"),
+            "metadata": payload.get("metadata", {}),
+            "tags": payload.get("tags", []),
+            "notes": payload.get("notes", []),
+        }
+    )
+
+    record = PersistedActivityLogEvent(
+        activity_event_id=entry.activity_event_id,
+        trip_id=trip_id,
+        session_state_id=entry.session_state_id,
+        occurred_at=entry.occurred_at,
+        event_kind=entry.event_kind,
+        summary=entry.summary,
+        actor=entry.actor,
+        related_decision_id=entry.related_decision_id,
+        related_option_set_id=entry.related_option_set_id,
+        saved_scenario_id=entry.saved_scenario_id,
+        budget_plan_id=entry.budget_plan_id,
+        scenario_budget_id=entry.scenario_budget_id,
+        checkpoint_id=entry.checkpoint_id,
+        metadata_payload=dict(entry.metadata),
+        tags=list(entry.tags),
+        notes=list(entry.notes),
+    )
+    trip.updated_at = _utcnow()
+    db_session.add(record)
+    db_session.commit()
+    db_session.refresh(record)
+    return _serialize_activity_entry(record)

--- a/trip_planner/persistence/alembic/versions/20260407_03_scenario_history_state.py
+++ b/trip_planner/persistence/alembic/versions/20260407_03_scenario_history_state.py
@@ -1,0 +1,90 @@
+"""Create persisted saved-scenario and activity-history tables."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260407_03"
+down_revision = "20260407_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "persisted_saved_scenarios",
+        sa.Column("saved_scenario_id", sa.String(length=96), nullable=False),
+        sa.Column("trip_id", sa.String(length=96), nullable=False),
+        sa.Column("current_version_id", sa.String(length=96), nullable=False),
+        sa.Column("versions", sa.JSON(), nullable=False),
+        sa.Column("comparisons", sa.JSON(), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("notes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["trip_id"], ["persisted_trips.trip_id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("saved_scenario_id"),
+    )
+    op.create_index(
+        op.f("ix_persisted_saved_scenarios_trip_id"),
+        "persisted_saved_scenarios",
+        ["trip_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "persisted_activity_log_events",
+        sa.Column("activity_event_id", sa.String(length=96), nullable=False),
+        sa.Column("trip_id", sa.String(length=96), nullable=False),
+        sa.Column("session_state_id", sa.String(length=96), nullable=False),
+        sa.Column("occurred_at", sa.String(length=64), nullable=False),
+        sa.Column("event_kind", sa.String(length=64), nullable=False),
+        sa.Column("summary", sa.String(length=600), nullable=False),
+        sa.Column("actor", sa.String(length=64), nullable=False, server_default="system"),
+        sa.Column("related_decision_id", sa.String(length=96), nullable=True),
+        sa.Column("related_option_set_id", sa.String(length=96), nullable=True),
+        sa.Column("saved_scenario_id", sa.String(length=96), nullable=True),
+        sa.Column("budget_plan_id", sa.String(length=96), nullable=True),
+        sa.Column("scenario_budget_id", sa.String(length=96), nullable=True),
+        sa.Column("checkpoint_id", sa.String(length=96), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("notes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["trip_id"], ["persisted_trips.trip_id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("activity_event_id"),
+    )
+    op.create_index(
+        op.f("ix_persisted_activity_log_events_trip_id"),
+        "persisted_activity_log_events",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_activity_log_events_occurred_at"),
+        "persisted_activity_log_events",
+        ["occurred_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_persisted_activity_log_events_occurred_at"),
+        table_name="persisted_activity_log_events",
+    )
+    op.drop_index(
+        op.f("ix_persisted_activity_log_events_trip_id"),
+        table_name="persisted_activity_log_events",
+    )
+    op.drop_table("persisted_activity_log_events")
+    op.drop_index(
+        op.f("ix_persisted_saved_scenarios_trip_id"),
+        table_name="persisted_saved_scenarios",
+    )
+    op.drop_table("persisted_saved_scenarios")

--- a/trip_planner/persistence/db.py
+++ b/trip_planner/persistence/db.py
@@ -89,7 +89,7 @@ def ensure_database_ready(url: str | None = None) -> None:
     if resolved_url in _MIGRATED_URLS:
         return
 
-    from trip_planner.persistence.models import account, session, trip  # noqa: F401
+    from trip_planner.persistence.models import account, scenario, session, trip  # noqa: F401
 
     _ensure_sqlite_parent_dir(resolved_url)
 

--- a/trip_planner/persistence/models/__init__.py
+++ b/trip_planner/persistence/models/__init__.py
@@ -1,7 +1,17 @@
 """Persistence models for runtime-backed storage."""
 
 from trip_planner.persistence.models.account import UserAccount
+from trip_planner.persistence.models.scenario import (
+    PersistedActivityLogEvent,
+    PersistedSavedScenario,
+)
 from trip_planner.persistence.models.session import AuthSession
 from trip_planner.persistence.models.trip import PersistedTrip
 
-__all__ = ["AuthSession", "PersistedTrip", "UserAccount"]
+__all__ = [
+    "AuthSession",
+    "PersistedActivityLogEvent",
+    "PersistedSavedScenario",
+    "PersistedTrip",
+    "UserAccount",
+]

--- a/trip_planner/persistence/models/scenario.py
+++ b/trip_planner/persistence/models/scenario.py
@@ -1,0 +1,60 @@
+"""SQLAlchemy models for persisted saved-scenario and planning-history state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from trip_planner.persistence.db import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class PersistedSavedScenario(Base):
+    __tablename__ = "persisted_saved_scenarios"
+
+    saved_scenario_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    current_version_id: Mapped[str] = mapped_column(String(96))
+    versions: Mapped[list[dict]] = mapped_column(JSON, default=list)
+    comparisons: Mapped[list[dict]] = mapped_column(JSON, default=list)
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    notes: Mapped[list[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+    )
+
+
+class PersistedActivityLogEvent(Base):
+    __tablename__ = "persisted_activity_log_events"
+
+    activity_event_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    session_state_id: Mapped[str] = mapped_column(String(96))
+    occurred_at: Mapped[str] = mapped_column(String(64), index=True)
+    event_kind: Mapped[str] = mapped_column(String(64))
+    summary: Mapped[str] = mapped_column(String(600))
+    actor: Mapped[str] = mapped_column(String(64), default="system")
+    related_decision_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    related_option_set_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    saved_scenario_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    budget_plan_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    scenario_budget_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    checkpoint_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    metadata_payload: Mapped[dict[str, str]] = mapped_column("metadata", JSON, default=dict)
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    notes: Mapped[list[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #685

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner is designed for iterative planning, comparison, and memory over time. Persisted scenarios and planning history are required if the app is going to support that behavior instead of losing state on every refresh.

Parent epic: #675

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#675](https://github.com/stranske/trip-planner/issues/675)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add persistence models and migrations for saved scenarios and planning-history entries.
- [x] Add backend routes for listing and creating scenario/history records for a trip.
- [x] Add frontend UI that shows saved scenarios and planning history for a trip.
- [x] Ensure the backend enforces trip ownership boundaries for scenario/history access.
- [x] Add tests for persisted history retrieval and UI rendering.
- [x] Document how later comparison and workspace issues should consume scenario/history state.

#### Acceptance criteria
- [x] A trip can display persisted saved-scenario and planning-history entries in the app UI.
- [x] Scenario/history entries survive reload and later re-entry.
- [x] Backend access is scoped to the owning user/trip.
- [x] Automated tests cover both persistence and UI rendering for the scenario/history surface.

**Head SHA:** 5c9a9c851047a5e6daa97f4a5d279b20e196407f
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24119421397) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24119421367) |
<!-- auto-status-summary:end -->
