### PR TITLE
Issue #688 follow-up: scope planner bundle integration

### DIFF
--- a/frontend/src/components/planner/PlannerSidePanelSurface.tsx
+++ b/frontend/src/components/planner/PlannerSidePanelSurface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { PlannerPanelState } from "../../../../bundle/planner/orchestration-contracts";
 
@@ -19,6 +19,8 @@ type PlannerResponseEvent = CustomEvent<{
   decision_id: string | null;
 }>;
 
+const plannerStylesheetHref = new URL("../../../../bundle/style.css", import.meta.url).href;
+
 export function PlannerSidePanelSurface({
   state,
   onDecisionAnswer,
@@ -30,14 +32,27 @@ export function PlannerSidePanelSurface({
 }) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const controllerRef = useRef<PlannerSidePanelController | null>(null);
+  const [plannerMountNode, setPlannerMountNode] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
     let isCancelled = false;
 
     async function mountPlannerPanel() {
-      if (!mountRef.current) {
+      const host = mountRef.current;
+      if (!host) {
         return;
       }
+
+      const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: "open" });
+      shadowRoot.replaceChildren();
+
+      const stylesheet = document.createElement("link");
+      stylesheet.rel = "stylesheet";
+      stylesheet.href = plannerStylesheetHref;
+
+      const plannerMount = document.createElement("div");
+      shadowRoot.append(stylesheet, plannerMount);
+      setPlannerMountNode(plannerMount);
 
       // @ts-expect-error The planner bundle ships as plain JS outside the frontend package.
       const plannerModule = await import("../../../../bundle/planner/side-panel.js");
@@ -46,7 +61,7 @@ export function PlannerSidePanelSurface({
         return;
       }
 
-      controllerRef.current = plannerModule.renderPlannerSidePanel(mountRef.current, state);
+      controllerRef.current = plannerModule.renderPlannerSidePanel(plannerMount, state);
     }
 
     void mountPlannerPanel();
@@ -55,6 +70,8 @@ export function PlannerSidePanelSurface({
       isCancelled = true;
       controllerRef.current?.destroy();
       controllerRef.current = null;
+      setPlannerMountNode(null);
+      mountRef.current?.shadowRoot?.replaceChildren();
     };
   }, []);
 
@@ -63,7 +80,7 @@ export function PlannerSidePanelSurface({
   }, [state]);
 
   useEffect(() => {
-    const mountNode = mountRef.current;
+    const mountNode = plannerMountNode;
     if (!mountNode) {
       return;
     }
@@ -108,7 +125,7 @@ export function PlannerSidePanelSurface({
         handlePlannerResponse as EventListener
       );
     };
-  }, [onDecisionAnswer, onOptionFeedback]);
+  }, [onDecisionAnswer, onOptionFeedback, plannerMountNode]);
 
   return <div ref={mountRef} className="planner-panel-host" />;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
 import { router } from "./router";
-import "../../bundle/style.css";
 import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -231,6 +231,12 @@ function renderWorkspacePage() {
   );
 }
 
+function getPlannerHost() {
+  const plannerHost = document.querySelector(".planner-panel-host");
+  expect(plannerHost).toBeTruthy();
+  return plannerHost as HTMLDivElement;
+}
+
 describe("WorkspacePage", () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -256,7 +262,10 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Osaka arrival buffer")).toBeInTheDocument();
     expect(screen.getByText("Kyoto cultural anchor")).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.getByLabelText("Planner side panel")).toBeInTheDocument();
+      const plannerPanel = getPlannerHost().shadowRoot?.querySelector(
+        '[aria-label="Planner side panel"]'
+      );
+      expect(plannerPanel).toBeTruthy();
     });
   });
 
@@ -309,7 +318,9 @@ describe("WorkspacePage", () => {
         "Trip context is ready now, so the next planning pass can attach saved scenarios and timeline stops."
       )
     ).toBeInTheDocument();
-    expect(screen.getByText("Workspace bootstrap is ready")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getPlannerHost().shadowRoot?.querySelector('[aria-label="Planner side panel"]')).toBeTruthy();
+    });
   });
 
   it("shows created-trip metadata even when the workspace has no seeded scenario state yet", async () => {
@@ -389,8 +400,10 @@ describe("WorkspacePage", () => {
 
     expect(screen.getByText("Dates not set yet")).toBeInTheDocument();
     expect(screen.getByText("Duration not set yet")).toBeInTheDocument();
-    expect(screen.getAllByText("Planner workspace bootstrap").length).toBeGreaterThan(0);
     expect(screen.getByText("Bundle assembly has not started yet for this trip.")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getPlannerHost().shadowRoot?.querySelector('[aria-label="Planner side panel"]')).toBeTruthy();
+    });
   });
 
   it("renders the shared route error card when the workspace loader rejects", async () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,19 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+function fileUrlToFsPath(relativePath: string): string {
+  const fileUrl = new URL(relativePath, import.meta.url);
+  const pathname = decodeURI(fileUrl.pathname);
+  return pathname.replace(/^\/([A-Za-z]:\/)/, "$1");
+}
+
+const bundleDirectory = fileUrlToFsPath("../bundle");
+
 export default defineConfig({
   plugins: [react()],
   server: {
     fs: {
-      allow: [decodeURIComponent(new URL("..", import.meta.url).pathname)],
+      allow: [bundleDirectory],
     },
     port: 5173,
     proxy: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,9 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
+    fs: {
+      allow: [decodeURIComponent(new URL("..", import.meta.url).pathname)],
+    },
     port: 5173,
     proxy: {
       "/api": {

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -74,6 +74,10 @@ def test_workspace_endpoint_returns_trip_scenario_payload(client: TestClient) ->
         "scenario:"
     )
     assert payload["activity_log"] == []
+    assert payload["planner_panel_state"]["pending_decisions"][0]["choices"] == [
+        "save baseline",
+        "keep exploring",
+    ]
 
 
 def test_workspace_endpoint_surfaces_business_ranked_scenarios(client: TestClient) -> None:

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -932,7 +932,7 @@ def _build_planner_panel_state(
             "prompt": decision["prompt"],
             "choices": (
                 list(decision["choices"])
-                if isinstance(decision.get("choices"), list) and decision["choices"]
+                if isinstance(decision.get("choices"), (list, tuple)) and decision["choices"]
                 else [
                     "Keep the current direction.",
                     "Compare another planner-backed option first.",


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #688

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo already has a tested planner side-panel component surface, but it still lives outside a real application workspace. Until it is mounted in the app with trip-scoped state, the planner experience is still mostly a component demo.

Parent epic: #676

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#676](https://github.com/stranske/trip-planner/issues/676)
- [#690](https://github.com/stranske/trip-planner/issues/690)
- [#693](https://github.com/stranske/trip-planner/issues/693)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Wrap, port, or otherwise integrate the planner side panel into the frontend app component tree.
- [ ] Load planner-panel state through backend APIs for a real trip.
- [ ] Render workspace-level trip context around the planner panel.
- [ ] Retain the existing contract alignment between Python contracts and the planner UI mirror.
- [ ] Add tests for planner-panel rendering and data loading inside the app workspace.
- [ ] Document how future planner UI issues should build on the app-integrated panel.

#### Acceptance criteria
- [ ] A real trip workspace renders the planner panel inside the app shell.
- [ ] Planner-panel data loads through the app API rather than only through fixture HTML/examples.
- [ ] The workspace shows trip context alongside planner state.
- [ ] Automated tests cover planner-panel mounting and data loading in the app runtime.

**Head SHA:** 003661c1d32d403c53d45eb0309b4faa56865680
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24159383037) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24159383006) |
<!-- auto-status-summary:end -->