### PR TITLE
Issue #692: surface ranked workspace scenarios

### DIFF
--- a/docs/contracts/scenario-ranking-workspace.md
+++ b/docs/contracts/scenario-ranking-workspace.md
@@ -1,0 +1,27 @@
+# Scenario Ranking Workspace Contract
+
+This contract defines the handoff between runtime ranking inputs, scenario-generation outputs, and later comparison UX.
+
+## Ranking Inputs
+
+- `InventoryBundle` records remain the normalized runtime input surface.
+- Leisure ranking consumes resolved leisure profile evidence plus derived `ItineraryObjectives`.
+- Business ranking consumes `BusinessTravelProfile`, derived `BusinessPlanningObjectives`, and policy constraint context.
+- Feasibility outputs stay attached to bundle ids so ranking and scenario assembly reuse the same travel-friction and blocking signals.
+
+## Scenario Outputs
+
+- Ranking produces ordered bundle recommendations.
+- Workspace scenario generation converts those ranked bundle results into `ScenarioSearchResult.scenarios`.
+- Each scenario must keep:
+  - the source `bundle_id`
+  - explicit route sequence
+  - score and explanation records
+  - unresolved tradeoffs carried forward from feasibility or policy posture
+- Workspace planner outputs summarize the ranked set and expose per-rank scenario cards for the side-panel UI.
+
+## Comparison Boundary
+
+- Ranking chooses explainable candidate ordering.
+- Scenario generation turns ranked bundles into reusable scenario records.
+- Later comparison UX should consume those scenario records directly instead of recomputing ranking scores or collapsing the route explanation into a single opaque recommendation.

--- a/frontend/src/smoke/runtime.smoke.test.ts
+++ b/frontend/src/smoke/runtime.smoke.test.ts
@@ -50,9 +50,8 @@ describe("runtime smoke", () => {
     });
     expect(workspace.trip_record.trip.trip_id).toBe("trip-leisure-kyoto-draft");
     expect(workspace.scenario_search.scenarios[0]?.scenario_summary.route_sequence).toEqual([
-      "kyoto",
-      "uji",
-      "kyoto",
+      "dest-city-osaka",
+      "dest-city-kyoto",
     ]);
   });
 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,11 @@ build-backend = "setuptools.build_meta"
 include = ["scripts*", "trip_planner*"]
 
 [tool.setuptools.package-data]
-trip_planner = ["resources/options/bundles/*.json"]
+trip_planner = [
+    "resources/business/*.json",
+    "resources/options/bundles/*.json",
+    "resources/preferences/*.json",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -59,8 +59,11 @@ def test_workspace_endpoint_returns_trip_scenario_payload(client: TestClient) ->
         ":feasibility-summary"
     )
     assert payload["planner_panel_state"]["outputs"][0]["tags"][0] == "feasibility"
-    assert payload["planner_panel_state"]["outputs"][3]["title"] == "Scenario ranking summary"
-    assert payload["planner_panel_state"]["outputs"][4]["title"].startswith("Rank #1 ")
+    output_titles = [
+        output["title"] for output in payload["planner_panel_state"]["outputs"]
+    ]
+    assert "Scenario ranking summary" in output_titles
+    assert any(title.startswith("Rank #1 ") for title in output_titles)
     assert payload["planner_panel_state"]["trip"]["trip_id"] == "trip-leisure-kyoto-draft"
     assert payload["planner_panel_state"]["option_set"]["options"][0]["option_id"].startswith(
         "scenario:"
@@ -75,8 +78,11 @@ def test_workspace_endpoint_surfaces_business_ranked_scenarios(client: TestClien
     payload = response.json()
     assert payload["scenario_search"]["title"] == "Client summit ranked scenarios"
     assert payload["scenario_search"]["scenarios"][0]["title"] == "Airport arrival bundle"
-    assert payload["planner_panel_state"]["outputs"][2]["title"] == "Scenario ranking summary"
-    assert payload["planner_panel_state"]["outputs"][3]["title"] == "Rank #1 Airport arrival bundle"
+    output_titles = [
+        output["title"] for output in payload["planner_panel_state"]["outputs"]
+    ]
+    assert "Scenario ranking summary" in output_titles
+    assert "Rank #1 Airport arrival bundle" in output_titles
     assert payload["planner_panel_state"]["option_set"]["options"][0]["label"] == "Airport arrival bundle"
 
 

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -46,13 +46,11 @@ def test_workspace_endpoint_returns_trip_scenario_payload(client: TestClient) ->
         payload["session"]["current_saved_scenario_id"]
         == "saved-scenario:kyoto-baseline"
     )
+    assert payload["scenario_search"]["title"] == "Kyoto ranked scenario workspace"
+    assert payload["scenario_search"]["scenarios"][0]["title"] == "Kyoto cultural anchor"
     assert payload["scenario_search"]["scenarios"][0]["scenario_summary"][
         "route_sequence"
-    ] == [
-        "kyoto",
-        "uji",
-        "kyoto",
-    ]
+    ] == ["dest-city-osaka", "dest-city-kyoto"]
     assert payload["inventory_summary"]["bundle_count"] == 2
     assert payload["inventory_summary"]["bundles"][0]["title"] == "Osaka arrival buffer"
     assert payload["feasibility_summary"]["assessment_count"] == 2
@@ -61,11 +59,25 @@ def test_workspace_endpoint_returns_trip_scenario_payload(client: TestClient) ->
         ":feasibility-summary"
     )
     assert payload["planner_panel_state"]["outputs"][0]["tags"][0] == "feasibility"
+    assert payload["planner_panel_state"]["outputs"][3]["title"] == "Scenario ranking summary"
+    assert payload["planner_panel_state"]["outputs"][4]["title"].startswith("Rank #1 ")
     assert payload["planner_panel_state"]["trip"]["trip_id"] == "trip-leisure-kyoto-draft"
     assert payload["planner_panel_state"]["option_set"]["options"][0]["option_id"].startswith(
         "scenario:"
     )
     assert payload["activity_log"] == []
+
+
+def test_workspace_endpoint_surfaces_business_ranked_scenarios(client: TestClient) -> None:
+    response = client.get("/api/workspace/trip-business-client-summit")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["scenario_search"]["title"] == "Client summit ranked scenarios"
+    assert payload["scenario_search"]["scenarios"][0]["title"] == "Airport arrival bundle"
+    assert payload["planner_panel_state"]["outputs"][2]["title"] == "Scenario ranking summary"
+    assert payload["planner_panel_state"]["outputs"][3]["title"] == "Rank #1 Airport arrival bundle"
+    assert payload["planner_panel_state"]["option_set"]["options"][0]["label"] == "Airport arrival bundle"
 
 
 def test_workspace_endpoint_returns_not_found_for_unknown_trip(

--- a/trip_planner/app/services/scenarios.py
+++ b/trip_planner/app/services/scenarios.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from pathlib import Path
+from importlib import resources
 from typing import Any
 
 from trip_planner.business import (
@@ -17,13 +17,15 @@ from trip_planner.itinerary import (
 )
 from trip_planner.options import InventoryBundle
 from trip_planner.preferences import resolve_leisure_profile
+from trip_planner.preferences.fixture_corpus import load_fixture_map
 from trip_planner.ranking import (
     BusinessRankingEngine,
     LeisureRankingEngine,
     RankedResult,
     RankedResultSet,
 )
-from tests.preferences.fixture_corpus import load_fixture_map
+
+_BUSINESS_RESOURCE_PACKAGE = "trip_planner.resources.business"
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,17 +51,10 @@ _SCENARIO_FIXTURE_SEEDS: dict[str, ScenarioFixtureSeed] = {
     ),
 }
 
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[3]
-
-
-def _load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _business_fixture_dir() -> Path:
-    return _repo_root() / "tests" / "fixtures" / "business"
+def _load_business_fixture(name: str) -> dict[str, Any]:
+    return json.loads(
+        resources.files(_BUSINESS_RESOURCE_PACKAGE).joinpath(name).read_text(encoding="utf-8")
+    )
 
 
 def _bundle_ranked_results(
@@ -148,10 +143,10 @@ def build_workspace_scenario_search(
         )
     else:
         profile = BusinessTravelProfile.from_dict(
-            _load_json(_business_fixture_dir() / (fixture_seed.business_profile_fixture or ""))
+            _load_business_fixture(fixture_seed.business_profile_fixture or "")
         )
-        constraint_payload = _load_json(
-            _business_fixture_dir() / (fixture_seed.business_constraint_fixture or "")
+        constraint_payload = _load_business_fixture(
+            fixture_seed.business_constraint_fixture or ""
         )
         constraint_set = PolicyConstraintSet(**constraint_payload["constraint_set"])
         objectives = derive_business_planning_objectives(

--- a/trip_planner/app/services/scenarios.py
+++ b/trip_planner/app/services/scenarios.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from trip_planner.business import (
+    BusinessTravelProfile,
+    PolicyConstraintSet,
+    derive_business_planning_objectives,
+)
+from trip_planner.itinerary import (
+    assemble_itinerary_scenarios,
+    derive_itinerary_objectives,
+    evaluate_bundle_feasibility,
+)
+from trip_planner.options import InventoryBundle
+from trip_planner.preferences import resolve_leisure_profile
+from trip_planner.ranking import (
+    BusinessRankingEngine,
+    LeisureRankingEngine,
+    RankedResult,
+    RankedResultSet,
+)
+from tests.preferences.fixture_corpus import load_fixture_map
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioFixtureSeed:
+    trip_mode: str
+    title: str
+    leisure_fixture_id: str | None = None
+    business_profile_fixture: str | None = None
+    business_constraint_fixture: str | None = None
+
+
+_SCENARIO_FIXTURE_SEEDS: dict[str, ScenarioFixtureSeed] = {
+    "trip-leisure-kyoto-draft": ScenarioFixtureSeed(
+        trip_mode="leisure",
+        title="Kyoto ranked scenario workspace",
+        leisure_fixture_id="urban-historian",
+    ),
+    "trip-business-client-summit": ScenarioFixtureSeed(
+        trip_mode="business",
+        title="Client summit ranked scenarios",
+        business_profile_fixture="client_meeting_profile.json",
+        business_constraint_fixture="policy_round_trip_exception.json",
+    ),
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _business_fixture_dir() -> Path:
+    return _repo_root() / "tests" / "fixtures" / "business"
+
+
+def _bundle_ranked_results(
+    ranked_results: RankedResultSet,
+    bundles: list[InventoryBundle],
+) -> RankedResultSet:
+    bundle_map = {bundle.bundle_id: bundle for bundle in bundles}
+
+    return RankedResultSet(
+        result_set_id=ranked_results.result_set_id,
+        trip_id=ranked_results.trip_id,
+        purpose=ranked_results.purpose,
+        scope=ranked_results.scope,
+        title=ranked_results.title,
+        explanation=list(ranked_results.explanation),
+        source_refs=list(ranked_results.source_refs),
+        schema_version=ranked_results.schema_version,
+        results=[
+            RankedResult(
+                result_id=result.result_id.replace("ranked:item:", "ranked:bundle:", 1),
+                result_kind="bundle",
+                rank=result.rank,
+                score=result.score,
+                target_bundle_id=(
+                    result.target_option.option_id
+                    if result.target_option is not None
+                    else result.explanation_records[0].target_id
+                ),
+                supporting_option_ids=list(result.supporting_option_ids),
+                supporting_destination_ids=list(result.supporting_destination_ids),
+                route_sequence=list(
+                    result.route_sequence
+                    or bundle_map[
+                        result.target_option.option_id
+                        if result.target_option is not None
+                        else result.explanation_records[0].target_id
+                    ].destination_ids
+                ),
+                score_breakdown=result.score_breakdown,
+                confidence_summary=result.confidence_summary,
+                explanation_records=list(result.explanation_records),
+                unresolved_risks=list(result.unresolved_risks),
+                source_refs=list(result.source_refs),
+                notes=list(result.notes),
+            )
+            for result in ranked_results.results
+        ],
+    )
+
+
+def build_workspace_scenario_search(
+    *,
+    trip_id: str,
+    trip_mode: str,
+    bundles: list[InventoryBundle],
+):
+    fixture_seed = _SCENARIO_FIXTURE_SEEDS.get(trip_id)
+    if fixture_seed is None or fixture_seed.trip_mode != trip_mode:
+        raise KeyError(f"Unsupported scenario fixture trip: {trip_id}")
+    if not bundles:
+        raise ValueError("Workspace scenario search requires at least one inventory bundle")
+
+    feasibility_outputs = {
+        bundle.bundle_id: evaluate_bundle_feasibility(bundle) for bundle in bundles
+    }
+
+    if trip_mode == "leisure":
+        traveler_fixture = load_fixture_map()[fixture_seed.leisure_fixture_id or ""]
+        resolved_profile = resolve_leisure_profile(
+            traveler_fixture.profile,
+            traveler_fixture.evidence,
+        )
+        objectives = derive_itinerary_objectives(
+            resolved_profile,
+            trip_id=trip_id,
+            objective_id=f"objective:{trip_id}:ranking",
+        )
+        ranked_results = LeisureRankingEngine().rank_bundles(
+            traveler_fixture.profile,
+            objectives,
+            bundles,
+            trip_id=trip_id,
+            title=fixture_seed.title,
+            feasibility_outputs=feasibility_outputs,
+        )
+    else:
+        profile = BusinessTravelProfile.from_dict(
+            _load_json(_business_fixture_dir() / (fixture_seed.business_profile_fixture or ""))
+        )
+        constraint_payload = _load_json(
+            _business_fixture_dir() / (fixture_seed.business_constraint_fixture or "")
+        )
+        constraint_set = PolicyConstraintSet(**constraint_payload["constraint_set"])
+        objectives = derive_business_planning_objectives(
+            profile,
+            trip_id=trip_id,
+            constraint_set=constraint_set,
+        )
+        ranked_results = BusinessRankingEngine().rank_bundles(
+            profile,
+            objectives,
+            bundles,
+            trip_id=trip_id,
+            title=fixture_seed.title,
+            constraint_set=constraint_set,
+            feasibility_outputs=feasibility_outputs,
+        )
+
+    return assemble_itinerary_scenarios(
+        _bundle_ranked_results(ranked_results, bundles),
+        bundles=bundles,
+        objectives=objectives,
+        feasibility_outputs=feasibility_outputs,
+        title=fixture_seed.title,
+    )
+
+
+def _scenario_output_status(scenario: dict[str, Any]) -> str:
+    if not scenario["scenario_summary"]["feasible"]:
+        return "critical"
+    if scenario["scenario_summary"]["recommended_for_selection"]:
+        return "positive"
+    return "caution"
+
+
+def build_scenario_ranking_outputs(
+    *,
+    trip_id: str,
+    scenario_search: dict[str, Any],
+) -> list[dict[str, Any]]:
+    scenarios = list(scenario_search.get("scenarios", []))
+    if not scenarios:
+        return []
+
+    lead = scenarios[0]
+    outputs: list[dict[str, Any]] = [
+        {
+            "output_id": f"output:{trip_id}:scenario-ranking-summary",
+            "title": "Scenario ranking summary",
+            "body": (
+                f"{len(scenarios)} ranked scenario(s) are ready for workspace review. "
+                f"Top scenario: {lead['title']}."
+            ),
+            "tags": ["scenario-ranking", "workspace-runtime"],
+            "status": _scenario_output_status(lead),
+            "highlights": [
+                scenario_search.get("title") or "Scenario ranking is active.",
+                f"Primary route: {' -> '.join(lead['scenario_summary'].get('route_sequence', [])) or 'not surfaced yet'}.",
+                f"Generated from {scenario_search.get('source_result_set_id', 'ranked workspace scenarios')}.",
+            ],
+        }
+    ]
+
+    for scenario in scenarios[:3]:
+        outputs.append(
+            {
+                "output_id": f"output:{trip_id}:scenario-rank:{scenario['rank']}",
+                "title": f"Rank #{scenario['rank']} {scenario['title']}",
+                "body": (
+                    f"{scenario['scenario_summary']['headline']} "
+                    f"Score {scenario['score']:.2f} with "
+                    f"{scenario['scenario_summary']['total_travel_minutes']} travel minutes and "
+                    f"{scenario['scenario_summary']['total_transfer_count']} transfer(s)."
+                ),
+                "tags": [
+                    "scenario-ranking",
+                    scenario["scenario_summary"]["scenario_kind"],
+                    "recommended"
+                    if scenario["scenario_summary"]["recommended_for_selection"]
+                    else "fallback",
+                ],
+                "status": _scenario_output_status(scenario),
+                "highlights": [
+                    f"Route: {' -> '.join(scenario['scenario_summary'].get('route_sequence', [])) or 'not surfaced yet'}.",
+                    *[
+                        tradeoff["summary"]
+                        for tradeoff in scenario.get("unresolved_tradeoffs", [])[:2]
+                    ],
+                ]
+                or ["No unresolved tradeoffs are currently surfaced."],
+            }
+        )
+
+    return outputs

--- a/trip_planner/app/services/scenarios.py
+++ b/trip_planner/app/services/scenarios.py
@@ -125,6 +125,7 @@ def build_workspace_scenario_search(
     feasibility_outputs = {
         bundle.bundle_id: evaluate_bundle_feasibility(bundle) for bundle in bundles
     }
+    objectives: object
 
     if trip_mode == "leisure":
         traveler_fixture = load_fixture_map()[fixture_seed.leisure_fixture_id or ""]

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -19,6 +19,10 @@ from trip_planner.app.services.inventory import (
     assemble_inventory_bundles_for_trip,
     build_inventory_summary_payload,
 )
+from trip_planner.app.services.scenarios import (
+    build_scenario_ranking_outputs,
+    build_workspace_scenario_search,
+)
 from trip_planner.contracts.trip import Trip
 from trip_planner.contracts import MoneyRange
 from trip_planner.itinerary import (
@@ -322,12 +326,17 @@ def _business_search_result(trip_id: str) -> ScenarioSearchResult:
     )
 
 
-def _build_scenario_search(trip_id: str, variant: str) -> ScenarioSearchResult:
-    if variant == "leisure":
-        return _leisure_search_result(trip_id)
-    if variant == "business":
-        return _business_search_result(trip_id)
-    raise KeyError(f"Unsupported scenario search variant: {variant}")
+def _build_scenario_search(
+    *,
+    trip_id: str,
+    trip_mode: str,
+    bundles: list[Any],
+) -> ScenarioSearchResult:
+    return build_workspace_scenario_search(
+        trip_id=trip_id,
+        trip_mode=trip_mode,
+        bundles=bundles,
+    )
 
 
 def _isoformat(value: datetime) -> str:
@@ -737,6 +746,10 @@ def _build_planner_panel_state(
             trip_id=trip["trip_id"],
             feasibility_summary=feasibility_summary,
         )
+        + build_scenario_ranking_outputs(
+            trip_id=trip["trip_id"],
+            scenario_search=scenario_search,
+        )
         + outputs
     )
 
@@ -812,10 +825,14 @@ def get_workspace_payload(
         saved_scenarios, scenario_comparison = _load_saved_scenarios(fixture.scenarios_fixture)
         session = _load_session(fixture.session_fixture)
         _canonicalize_saved_scenario_ids(session, saved_scenarios)
-        scenario_search = _build_scenario_search(trip_id, fixture.scenario_search_variant)
         inventory_bundles = assemble_inventory_bundles_for_trip(
             trip_id=trip_id,
             trip_mode=trip_record.trip.mode,
+        )
+        scenario_search = _build_scenario_search(
+            trip_id=trip_id,
+            trip_mode=trip_record.trip.mode,
+            bundles=inventory_bundles,
         )
         feasibility_summary = build_feasibility_summary_payload(inventory_bundles)
 

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -24,20 +24,14 @@ from trip_planner.app.services.scenarios import (
     build_workspace_scenario_search,
 )
 from trip_planner.contracts.trip import Trip
-from trip_planner.contracts import MoneyRange
-from trip_planner.itinerary import (
-    ItineraryScenario,
-    ScenarioSearchResult,
-    ScenarioSummary,
-    ScenarioTradeoff,
-)
+from trip_planner.itinerary import ScenarioSearchResult
+from trip_planner.options import InventoryBundle
 from trip_planner.persistence.models.scenario import (
     PersistedActivityLogEvent,
     PersistedSavedScenario,
 )
 from trip_planner.persistence.models.session import PersistedPlanningSessionState
 from trip_planner.persistence.models.trip import PersistedTrip
-from trip_planner.ranking import ExplanationRecord
 from trip_planner.state import (
     ActivityLogEvent,
     OptionPresentationRecord,
@@ -56,7 +50,6 @@ class WorkspaceFixture:
     trip_fixture: str
     scenarios_fixture: str
     session_fixture: str
-    scenario_search_variant: str
 
 
 WORKSPACE_ACTIVITY_LOG_LIMIT = 50
@@ -71,13 +64,11 @@ _FIXTURES: dict[str, WorkspaceFixture] = {
         trip_fixture="leisure_draft_trip.json",
         scenarios_fixture="leisure_baseline_vs_fallback.json",
         session_fixture="active_leisure_session.json",
-        scenario_search_variant="leisure",
     ),
     "trip-business-client-summit": WorkspaceFixture(
         trip_fixture="business_active_trip.json",
         scenarios_fixture="business_compliant_vs_exception.json",
         session_fixture="business_review_session.json",
-        scenario_search_variant="business",
     ),
 }
 
@@ -135,202 +126,11 @@ def _canonicalize_saved_scenario_ids(
         decision.related_saved_scenario_id = normalize(decision.related_saved_scenario_id)
 
 
-def _leisure_search_result(trip_id: str) -> ScenarioSearchResult:
-    return ScenarioSearchResult(
-        search_id="scenario-search:kyoto-spring",
-        trip_id=trip_id,
-        purpose="final_selection",
-        title="Kyoto leisure scenario comparison",
-        source_result_set_id="ranked-results:kyoto-spring",
-        scenarios=[
-            ItineraryScenario(
-                scenario_id=f"scenario:{trip_id}:1",
-                title="Kyoto base with Uji day trip",
-                rank=1,
-                bundle_id="bundle:urban-culture",
-                source_result_id=f"ranked-result:{trip_id}:1",
-                score=0.93,
-                scenario_summary=ScenarioSummary(
-                    headline="Balanced Kyoto culture baseline",
-                    scenario_kind="primary",
-                    feasible=True,
-                    recommended_for_selection=True,
-                    coherence_passed=True,
-                    estimated_total=MoneyRange(currency="USD", typical_amount=3400.0),
-                    total_travel_minutes=265,
-                    total_transfer_count=4,
-                    route_sequence=["kyoto", "uji", "kyoto"],
-                    notes=["baseline"],
-                ),
-                supporting_option_ids=["option:kyoto-central", "option:uji-daytrip"],
-                objective_refs=["objective:kyoto-spring"],
-                explanation_records=[
-                    ExplanationRecord(
-                        explanation_id=f"explanation:{trip_id}:1",
-                        target_kind="route",
-                        target_id=f"scenario:{trip_id}:1",
-                        headline="Best overall cultural balance",
-                        summary="The baseline preserves depth in Kyoto with one lighter excursion day.",
-                        factor_keys=["cultural_depth", "moderate_pace"],
-                        machine_context={"planner_mode": "leisure"},
-                        human_summary=[
-                            "Moderate travel friction with a clear cultural center of gravity."
-                        ],
-                        source_refs=["ranked-results:kyoto-spring"],
-                    )
-                ],
-                unresolved_tradeoffs=[
-                    ScenarioTradeoff(
-                        tradeoff_id=f"tradeoff:{trip_id}:1",
-                        code="limited_nightlife",
-                        summary="Evening variety is lower than the Osaka-heavy fallback.",
-                        severity="info",
-                    )
-                ],
-            ),
-            ItineraryScenario(
-                scenario_id=f"scenario:{trip_id}:2",
-                title="Kyoto plus Osaka fallback",
-                rank=2,
-                bundle_id="bundle:scenic-wanderer",
-                source_result_id=f"ranked-result:{trip_id}:2",
-                score=0.88,
-                scenario_summary=ScenarioSummary(
-                    headline="Higher-energy fallback with extra transfers",
-                    scenario_kind="alternative",
-                    feasible=True,
-                    recommended_for_selection=False,
-                    coherence_passed=True,
-                    estimated_total=MoneyRange(currency="USD", typical_amount=3250.0),
-                    total_travel_minutes=360,
-                    total_transfer_count=7,
-                    route_sequence=["kyoto", "osaka", "kyoto"],
-                    notes=["higher movement"],
-                ),
-                supporting_option_ids=["option:kyoto-central", "option:osaka-daytrip"],
-                objective_refs=["objective:kyoto-spring"],
-                explanation_records=[
-                    ExplanationRecord(
-                        explanation_id=f"explanation:{trip_id}:2",
-                        target_kind="route",
-                        target_id=f"scenario:{trip_id}:2",
-                        headline="Fallback with broader city coverage",
-                        summary="The fallback opens more nightlife at the cost of extra transfers.",
-                        factor_keys=["breadth", "transfer_cost"],
-                        machine_context={"planner_mode": "leisure"},
-                        human_summary=["Broader exploration, slightly more travel fatigue."],
-                        source_refs=["ranked-results:kyoto-spring"],
-                    )
-                ],
-            ),
-        ],
-        explanation=[
-            "Workspace timeline derives from the ordered scenario route sequence plus persisted trip dates."
-        ],
-        source_refs=["ranked-results:kyoto-spring", "objective:kyoto-spring"],
-    )
-
-
-def _business_search_result(trip_id: str) -> ScenarioSearchResult:
-    return ScenarioSearchResult(
-        search_id="scenario-search:client-summit",
-        trip_id=trip_id,
-        purpose="final_selection",
-        title="Client summit scenario comparison",
-        source_result_set_id="ranked-results:client-summit",
-        scenarios=[
-            ItineraryScenario(
-                scenario_id=f"scenario:{trip_id}:1",
-                title="Compliant first rail plan",
-                rank=1,
-                bundle_id="bundle:approved-business",
-                source_result_id=f"ranked-result:{trip_id}:1",
-                score=0.97,
-                scenario_summary=ScenarioSummary(
-                    headline="Primary path preserves compliant vendors and arrival buffers",
-                    scenario_kind="primary",
-                    feasible=True,
-                    recommended_for_selection=True,
-                    coherence_passed=True,
-                    estimated_total=MoneyRange(currency="USD", typical_amount=2280.0),
-                    total_travel_minutes=315,
-                    total_transfer_count=3,
-                    route_sequence=["home", "client-site", "conference-hotel"],
-                    notes=["compliant-first"],
-                ),
-                supporting_option_ids=["option:approved-rail", "option:conference-hotel"],
-                objective_refs=["objective:client-summit"],
-                explanation_records=[
-                    ExplanationRecord(
-                        explanation_id=f"explanation:{trip_id}:1",
-                        target_kind="route",
-                        target_id=f"scenario:{trip_id}:1",
-                        headline="Best approval-ready route",
-                        summary="Keeps policy-safe vendors and preserves the buffer before the client visit.",
-                        factor_keys=["policy_alignment", "schedule_protection"],
-                        machine_context={"planner_mode": "business"},
-                        human_summary=["Approved route keeps arrival risk low."],
-                        source_refs=["ranked-results:client-summit"],
-                    )
-                ],
-            ),
-            ItineraryScenario(
-                scenario_id=f"scenario:{trip_id}:2",
-                title="Exception-nearest direct option",
-                rank=2,
-                bundle_id="bundle:exception-business",
-                source_result_id=f"ranked-result:{trip_id}:2",
-                score=0.89,
-                scenario_summary=ScenarioSummary(
-                    headline="Direct path reduces travel time but requires exception handling",
-                    scenario_kind="fallback",
-                    feasible=True,
-                    recommended_for_selection=False,
-                    coherence_passed=True,
-                    estimated_total=MoneyRange(currency="USD", typical_amount=2410.0),
-                    total_travel_minutes=255,
-                    total_transfer_count=2,
-                    route_sequence=["home", "client-site", "airport-hotel"],
-                    notes=["exception-nearest"],
-                ),
-                supporting_option_ids=["option:direct-flight", "option:airport-hotel"],
-                objective_refs=["objective:client-summit"],
-                explanation_records=[
-                    ExplanationRecord(
-                        explanation_id=f"explanation:{trip_id}:2",
-                        target_kind="route",
-                        target_id=f"scenario:{trip_id}:2",
-                        headline="Faster route with approval debt",
-                        summary="Shorter travel time comes with a policy exception path and higher approval burden.",
-                        factor_keys=["travel_time", "policy_exception"],
-                        machine_context={"planner_mode": "business"},
-                        human_summary=["Faster movement, weaker compliance posture."],
-                        source_refs=["ranked-results:client-summit"],
-                    )
-                ],
-                unresolved_tradeoffs=[
-                    ScenarioTradeoff(
-                        tradeoff_id=f"tradeoff:{trip_id}:2a",
-                        code="policy_exception_path",
-                        summary="Requires exception approval before booking.",
-                        severity="critical",
-                        blocking=True,
-                    )
-                ],
-            ),
-        ],
-        explanation=[
-            "Business timeline still derives from route order; policy posture is communicated via scenario tradeoffs."
-        ],
-        source_refs=["ranked-results:client-summit", "objective:client-summit"],
-    )
-
-
 def _build_scenario_search(
     *,
     trip_id: str,
     trip_mode: str,
-    bundles: list[Any],
+    bundles: list[InventoryBundle],
 ) -> ScenarioSearchResult:
     return build_workspace_scenario_search(
         trip_id=trip_id,

--- a/trip_planner/preferences/fixture_corpus.py
+++ b/trip_planner/preferences/fixture_corpus.py
@@ -1,0 +1,333 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from importlib import resources
+from typing import Any
+
+from trip_planner.preferences.evidence import (
+    ContradictionMarker,
+    OptionEvidence,
+    PreferenceEvidence,
+)
+from trip_planner.preferences.models import (
+    Anchor,
+    BudgetModel,
+    DateWindow,
+    DurationBounds,
+    EvidenceSummary,
+    HardConstraints,
+    HybridFactor,
+    InteractionRule,
+    LeisurePreferenceProfile,
+    TensionFlag,
+    TradeoffDimension,
+    TripFrame,
+)
+from trip_planner.preferences.schema import (
+    ANCHOR_GROUPS,
+    HYBRID_FACTOR_KEYS,
+    SCHEMA_VERSION,
+    TRADEOFF_DIMENSION_KEYS,
+)
+
+_FIXTURE_RESOURCE_PACKAGE = "trip_planner.resources.preferences"
+_FIXTURE_RESOURCE_NAME = "leisure_fixture_corpus.json"
+
+
+@dataclass(slots=True)
+class IntendedInterpretation:
+    qualitative_summary: str
+    dominant_dimensions: list[str]
+    expected_tensions: list[str]
+    planning_implications: list[str]
+
+
+@dataclass(slots=True)
+class TravelerFixture:
+    id: str
+    fixture_kind: str
+    summary: str
+    tags: list[str]
+    raw_inputs: dict[str, Any]
+    intended_interpretation: IntendedInterpretation
+    profile: LeisurePreferenceProfile
+    evidence: list[PreferenceEvidence]
+
+
+def load_fixture_corpus() -> list[TravelerFixture]:
+    payload = json.loads(
+        resources.files(_FIXTURE_RESOURCE_PACKAGE)
+        .joinpath(_FIXTURE_RESOURCE_NAME)
+        .read_text(encoding="utf-8")
+    )
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(
+            "fixture corpus schema_version must match trip_planner.preferences.schema.SCHEMA_VERSION"
+        )
+    fixtures = payload.get("fixtures", [])
+    if not isinstance(fixtures, list):
+        raise ValueError("fixtures must be a list")
+    fixture_objects = [_build_fixture(index, entry) for index, entry in enumerate(fixtures)]
+    fixture_ids = [fixture.id for fixture in fixture_objects]
+    if len(set(fixture_ids)) != len(fixture_ids):
+        raise ValueError("fixture corpus ids must be unique")
+    return fixture_objects
+
+
+def load_fixture_map() -> dict[str, TravelerFixture]:
+    return {fixture.id: fixture for fixture in load_fixture_corpus()}
+
+
+def _build_fixture(index: int, payload: Any) -> TravelerFixture:
+    if not isinstance(payload, dict):
+        raise ValueError(f"fixture at index {index} must be an object")
+    fixture_id = payload.get("id", f"<fixture {index}>")
+    for required_field in ("id", "fixture_kind", "summary"):
+        if not payload.get(required_field):
+            raise ValueError(f"fixture {fixture_id!r} must define {required_field}")
+    intended = payload.get("intended_interpretation", {})
+    if not isinstance(intended, dict):
+        raise ValueError(f"fixture {fixture_id!r} intended_interpretation must be an object")
+    raw_inputs = payload.get("raw_inputs", {})
+    if not isinstance(raw_inputs, dict):
+        raise ValueError(f"fixture {fixture_id!r} raw_inputs must be an object")
+    profile = build_profile_from_overrides(payload.get("profile_overrides", {}))
+    evidence = [build_evidence_record(item) for item in payload.get("evidence", [])]
+    if not intended.get("qualitative_summary"):
+        raise ValueError(
+            f"fixture {fixture_id!r} must define intended_interpretation.qualitative_summary"
+        )
+    return TravelerFixture(
+        id=payload["id"],
+        fixture_kind=payload["fixture_kind"],
+        summary=payload["summary"],
+        tags=list(payload.get("tags", [])),
+        raw_inputs=dict(raw_inputs),
+        intended_interpretation=IntendedInterpretation(
+            qualitative_summary=intended["qualitative_summary"],
+            dominant_dimensions=list(intended.get("dominant_dimensions", [])),
+            expected_tensions=list(intended.get("expected_tensions", [])),
+            planning_implications=list(intended.get("planning_implications", [])),
+        ),
+        profile=profile,
+        evidence=evidence,
+    )
+
+
+def build_profile_from_overrides(overrides: dict[str, Any]) -> LeisurePreferenceProfile:
+    profile_payload = _default_profile_payload()
+
+    trip_frame_overrides = overrides.get("trip_frame", {})
+    profile_payload["trip_frame"] = {
+        **profile_payload["trip_frame"],
+        **trip_frame_overrides,
+    }
+
+    hard_constraint_overrides = overrides.get("hard_constraints", {})
+    allowed_constraint_keys = {
+        "date_window",
+        "duration_bounds",
+        "budget_ceiling",
+        "must_include_places",
+        "must_protect_experiences",
+        "mobility_constraints",
+        "lodging_constraints",
+        "visa_border_constraints",
+    }
+    unknown_constraint_keys = set(hard_constraint_overrides) - allowed_constraint_keys
+    if unknown_constraint_keys:
+        raise ValueError(
+            "unsupported hard constraint override keys: " f"{sorted(unknown_constraint_keys)}"
+        )
+    date_window = {
+        **profile_payload["hard_constraints"]["date_window"],
+        **hard_constraint_overrides.get("date_window", {}),
+    }
+    unknown_date_window_keys = set(date_window) - {"start", "end"}
+    if unknown_date_window_keys:
+        raise ValueError(
+            f"unsupported date_window override keys: {sorted(unknown_date_window_keys)}"
+        )
+    duration_bounds = {
+        **profile_payload["hard_constraints"]["duration_bounds"],
+        **hard_constraint_overrides.get("duration_bounds", {}),
+    }
+    unknown_duration_keys = set(duration_bounds) - {"min_days", "max_days"}
+    if unknown_duration_keys:
+        raise ValueError(
+            "unsupported duration_bounds override keys: " f"{sorted(unknown_duration_keys)}"
+        )
+    merged_constraints = {
+        **profile_payload["hard_constraints"],
+        **hard_constraint_overrides,
+        "date_window": date_window,
+        "duration_bounds": duration_bounds,
+    }
+    profile_payload["hard_constraints"] = merged_constraints
+
+    budget_overrides = overrides.get("budget_model", {})
+    profile_payload["budget_model"] = {
+        **profile_payload["budget_model"],
+        **budget_overrides,
+    }
+
+    for key, values in overrides.get("tradeoff_dimensions", {}).items():
+        if key not in profile_payload["tradeoff_dimensions"]:
+            raise ValueError(f"unsupported tradeoff dimension override: {key}")
+        profile_payload["tradeoff_dimensions"][key] = {
+            **profile_payload["tradeoff_dimensions"][key],
+            **values,
+        }
+
+    for key, values in overrides.get("hybrid_factors", {}).items():
+        if key not in profile_payload["hybrid_factors"]:
+            raise ValueError(f"unsupported hybrid factor override: {key}")
+        profile_payload["hybrid_factors"][key] = {
+            **profile_payload["hybrid_factors"][key],
+            **values,
+        }
+
+    anchor_overrides = overrides.get("anchors", {})
+    for group, values in anchor_overrides.items():
+        if group not in profile_payload["anchors"]:
+            raise ValueError(f"unsupported anchor group override: {group}")
+        profile_payload["anchors"][group] = list(values)
+
+    for key in ("interaction_rules", "tension_flags", "conditional_overrides"):
+        if key in overrides:
+            profile_payload[key] = deepcopy(overrides[key])
+    if "evidence_summary" in overrides:
+        profile_payload["evidence_summary"] = {
+            **profile_payload["evidence_summary"],
+            **overrides["evidence_summary"],
+        }
+
+    return LeisurePreferenceProfile(
+        trip_frame=TripFrame(**profile_payload["trip_frame"]),
+        hard_constraints=HardConstraints(
+            date_window=DateWindow(**profile_payload["hard_constraints"]["date_window"]),
+            duration_bounds=DurationBounds(
+                **profile_payload["hard_constraints"]["duration_bounds"]
+            ),
+            budget_ceiling=profile_payload["hard_constraints"].get("budget_ceiling"),
+            must_include_places=list(
+                profile_payload["hard_constraints"].get("must_include_places", [])
+            ),
+            must_protect_experiences=list(
+                profile_payload["hard_constraints"].get("must_protect_experiences", [])
+            ),
+            mobility_constraints=list(
+                profile_payload["hard_constraints"].get("mobility_constraints", [])
+            ),
+            lodging_constraints=list(
+                profile_payload["hard_constraints"].get("lodging_constraints", [])
+            ),
+            visa_border_constraints=list(
+                profile_payload["hard_constraints"].get("visa_border_constraints", [])
+            ),
+        ),
+        anchors={
+            group: [Anchor(**anchor) for anchor in anchors]
+            for group, anchors in profile_payload["anchors"].items()
+        },
+        budget_model=BudgetModel(**profile_payload["budget_model"]),
+        tradeoff_dimensions={
+            key: TradeoffDimension(**values)
+            for key, values in profile_payload["tradeoff_dimensions"].items()
+        },
+        hybrid_factors={
+            key: HybridFactor(**values) for key, values in profile_payload["hybrid_factors"].items()
+        },
+        conditional_overrides=list(profile_payload["conditional_overrides"]),
+        interaction_rules=[
+            InteractionRule(**rule) for rule in profile_payload["interaction_rules"]
+        ],
+        tension_flags=[TensionFlag(**flag) for flag in profile_payload["tension_flags"]],
+        evidence_summary=EvidenceSummary(**profile_payload["evidence_summary"]),
+    )
+
+
+def build_evidence_record(payload: dict[str, Any]) -> PreferenceEvidence:
+    option_evidence = payload.get("option_evidence")
+    contradictions = payload.get("contradictions", [])
+    return PreferenceEvidence(
+        id=payload["id"],
+        evidence_type=payload["evidence_type"],
+        source_type=payload["source_type"],
+        affected_dimensions=list(payload.get("affected_dimensions", [])),
+        affected_hybrid_factors=list(payload.get("affected_hybrid_factors", [])),
+        anchor_groups=list(payload.get("anchor_groups", [])),
+        signal_direction=payload.get("signal_direction", "positive"),
+        confidence_hint=payload.get("confidence_hint", 0.5),
+        salience_hint=payload.get("salience_hint", 0.5),
+        observed_at=payload.get("observed_at"),
+        sequence=payload.get("sequence"),
+        note=payload.get("note", ""),
+        option_evidence=OptionEvidence(**option_evidence) if option_evidence else None,
+        contradictions=[ContradictionMarker(**item) for item in contradictions],
+    )
+
+
+def _default_profile_payload() -> dict[str, Any]:
+    return {
+        "trip_frame": {
+            "duration_days": 28,
+            "traveler_party": "solo",
+            "season_window": [],
+            "trip_stage": "mixed",
+            "regions_in_scope": [],
+            "special_themes": [],
+        },
+        "hard_constraints": {
+            "date_window": {"start": None, "end": None},
+            "duration_bounds": {"min_days": 14, "max_days": 42},
+            "budget_ceiling": None,
+            "must_include_places": [],
+            "must_protect_experiences": [],
+            "mobility_constraints": [],
+            "lodging_constraints": [],
+            "visa_border_constraints": [],
+        },
+        "budget_model": {
+            "total_budget_sensitivity": 0.5,
+            "spending_priorities": {},
+            "quality_floors": {},
+            "splurge_allowed": False,
+            "splurge_style": None,
+        },
+        "anchors": {group: [] for group in ANCHOR_GROUPS},
+        "tradeoff_dimensions": {
+            key: {
+                "value": 0.0,
+                "confidence": 0.4,
+                "salience": 0.4,
+                "stability": 0.4,
+                "trip_stage_sensitivity": {
+                    "initial_design": 0.3,
+                    "inventory_selection": 0.3,
+                    "daily_activity_design": 0.3,
+                    "in_trip_adjustment": 0.3,
+                },
+                "scope": "global",
+                "notes": "",
+            }
+            for key in TRADEOFF_DIMENSION_KEYS
+        },
+        "hybrid_factors": {
+            key: {
+                "mode": "tradeoff",
+                "salience": 0.2,
+                "anchor_strength": 0.0,
+                "tradeoff_role": "none",
+                "notes": "",
+                "preferences": {},
+            }
+            for key in HYBRID_FACTOR_KEYS
+        },
+        "conditional_overrides": [],
+        "interaction_rules": [],
+        "tension_flags": [],
+        "evidence_summary": {"sources": {}, "confidence_notes": []},
+    }

--- a/trip_planner/resources/business/__init__.py
+++ b/trip_planner/resources/business/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged business fixtures used by runtime scenario services."""

--- a/trip_planner/resources/business/client_meeting_profile.json
+++ b/trip_planner/resources/business/client_meeting_profile.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "0.1.0",
+  "profile_kind": "business",
+  "traveler_context": {
+    "employee_type": "employee",
+    "traveler_experience": "frequent",
+    "home_airport": "DFW",
+    "loyalty_programs": ["American AAdvantage", "Hilton Honors"],
+    "mobility_or_access_needs": []
+  },
+  "trip_purpose": {
+    "purpose_type": "client_meeting",
+    "business_justification": "Lead in-person contract renewal meetings with a major client account.",
+    "required_presence_windows": [
+      {
+        "start": "2026-05-11T09:00:00-04:00",
+        "end": "2026-05-11T17:00:00-04:00",
+        "label": "Client negotiation day"
+      }
+    ],
+    "trip_criticality": "high"
+  },
+  "policy_constraints": {
+    "required_booking_channels": ["Navan", "Concur"],
+    "airfare_rules": {
+      "cabin": "economy",
+      "nonstop_priority": true
+    },
+    "lodging_rules": {
+      "max_nightly_rate_usd": 350,
+      "distance_to_meeting_max_miles": 3
+    },
+    "ground_transport_rules": {
+      "black_car_requires_approval": true,
+      "rideshare_allowed": true
+    },
+    "per_diem_or_meal_rules": {
+      "client_meal_documentation_required": true
+    },
+    "approval_triggers": ["business_class_request", "black_car_request"],
+    "documentation_rules": ["capture client-attendance justification"]
+  },
+  "vendor_constraints": {
+    "preferred_vendors": ["American", "Hilton"],
+    "approved_vendors": ["American", "Delta", "United", "Hilton", "Marriott"],
+    "disallowed_vendors": ["Spirit"],
+    "comparison_requirements": {
+      "airfare": 2,
+      "lodging": 2,
+      "ground_transport": 1
+    }
+  },
+  "schedule_requirements": {
+    "arrival_buffer_preference": "conservative",
+    "meeting_protection_priority": 0.98,
+    "same_day_return_tolerance": 0.25,
+    "red_eye_tolerance": 0.0
+  },
+  "cost_controls": {
+    "overall_cost_priority": 0.62,
+    "policy_compliance_priority": 0.94,
+    "employee_convenience_priority": 0.78,
+    "splurge_requires_justification": true
+  },
+  "comfort_floors": {
+    "lodging_needs": ["quiet room near client office"],
+    "transport_needs": ["low-risk arrival timing", "backup ground transport option"],
+    "arrival_readiness_needs": ["same-day meeting readiness"],
+    "work_enablers": ["early check-in option", "reliable wifi"]
+  },
+  "documentation_requirements": {
+    "required_receipt_categories": ["airfare", "lodging", "ground_transport", "client_meals"],
+    "justification_fields": ["client importance", "need for in-person presence"],
+    "comparable_capture_required": true,
+    "booking_link_retention_required": true
+  },
+  "approval_targets": {
+    "needs_manager_approval": true,
+    "needs_finance_review": false,
+    "needs_exception_preclearance": true,
+    "approval_roles": ["manager", "travel_admin"]
+  },
+  "exception_strategy": {
+    "fallback_mode": "document_exception_candidate",
+    "require_additional_comparables": true,
+    "notes": ["If nonstop options exceed policy, prepare a documented client-readiness exception."]
+  }
+}

--- a/trip_planner/resources/business/policy_round_trip_exception.json
+++ b/trip_planner/resources/business/policy_round_trip_exception.json
@@ -1,0 +1,91 @@
+{
+  "constraint_set": {
+    "policy_id": "policy-003",
+    "organization_id": "org-001",
+    "policy_version": "2026.1",
+    "required_booking_channels": ["Concur"],
+    "airfare_rules": {"cabin": "economy", "nonstop_priority": true},
+    "lodging_rules": {"max_nightly_rate_usd": 240},
+    "ground_transport_rules": {"rental_car_default": true},
+    "meal_rules": {"per_diem": "standard"},
+    "approval_rules": ["manager review", "finance review for approved exceptions"],
+    "documentation_rules": ["retain comparables", "retain site agenda"],
+    "allowed_exception_types": ["fatigue_management", "fare_cap", "lodging_cap"]
+  },
+  "proposal": {
+    "proposal_id": "proposal-003",
+    "trip_id": "trip-business-003",
+    "mode": "business",
+    "constraint_set_id": "policy-003",
+    "traveler_context": {
+      "employee_type": "contractor",
+      "traveler_experience": "occasional",
+      "home_airport": "MSP",
+      "loyalty_programs": [],
+      "mobility_or_access_needs": ["avoid unsafe overnight routing"]
+    },
+    "selected_options": [
+      {
+        "category": "lodging",
+        "option_id": "hotel-201",
+        "label": "Extra night near site",
+        "vendor": "Hilton Garden Inn",
+        "booking_channel": "Concur",
+        "estimated_cost": {"currency": "USD", "typical_amount": 310.0},
+        "justification_refs": ["just-201"]
+      }
+    ],
+    "cost_summary": {
+      "currency": "USD",
+      "total_estimated_cost": 1460.0,
+      "category_estimates": {"lodging": 310.0, "airfare": 560.0, "car_rental": 420.0},
+      "notes": ["Adds an extra lodging night to avoid fatigued driving before the audit."]
+    },
+    "comparables": [
+      {
+        "category": "lodging",
+        "label": "Within-cap motel",
+        "vendor": "Budget Inn",
+        "booking_channel": "Concur",
+        "estimated_cost": {"currency": "USD", "typical_amount": 185.0},
+        "notes": ["Requires late-night arrival and pre-dawn site transfer."]
+      }
+    ],
+    "justifications": [
+      {
+        "category": "lodging",
+        "summary": "Extra night protects safe arrival and audit readiness.",
+        "evidence": ["site access begins at 07:30", "same-day routing would require overnight drive"]
+      }
+    ],
+    "booking_channel_summaries": [
+      {"category": "lodging", "selected_channel": "Concur", "approved": true, "rationale": "Policy-required booking tool."}
+    ],
+    "approval_notes": ["Exception requested for fatigue-management lodging overage."],
+    "requested_exception": {
+      "exception_type": "fatigue_management",
+      "reason": "Extra lodging night is needed to avoid unsafe routing and preserve site-visit readiness.",
+      "requested_approval_roles": ["manager", "finance"],
+      "notes": ["Comparable lower-cost option remains attached for review."]
+    }
+  },
+  "evaluation_result": {
+    "evaluation_id": "eval-003",
+    "proposal_id": "proposal-003",
+    "status": "exception_required",
+    "approval_requirements": [
+      {"role": "manager", "reason": "Operational exception requires manager approval", "mandatory": true},
+      {"role": "finance", "reason": "Lodging cap exception requires finance review", "mandatory": true}
+    ],
+    "failure_reasons": [
+      {"code": "lodging_rate_cap", "message": "Selected lodging exceeds the nightly cap but includes an operational-safety justification.", "severity": "warning", "related_category": "lodging"}
+    ],
+    "preferred_alternatives": [],
+    "exception_guidance": [
+      "Retain the lower-cost comparable in the approval packet.",
+      "Document the operational-safety rationale in the manager approval request."
+    ],
+    "notes": ["Proposal is exception-eligible if the fatigue-management rationale is approved."],
+    "compliance_score": 0.68
+  }
+}

--- a/trip_planner/resources/preferences/__init__.py
+++ b/trip_planner/resources/preferences/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged leisure preference fixtures used by runtime scenario services."""

--- a/trip_planner/resources/preferences/leisure_fixture_corpus.json
+++ b/trip_planner/resources/preferences/leisure_fixture_corpus.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": "0.1.0",
+  "fixtures": [
+    {
+      "id": "urban-historian",
+      "fixture_kind": "archetype",
+      "summary": "Depth-oriented city traveler who values historic layers, museums, and urban walking more than broad destination coverage.",
+      "tags": ["history", "cities", "depth", "culture"],
+      "raw_inputs": {
+        "trip_brief": "I would rather spend five dense days in one great city than race through four capitals. I care about museums, neighborhoods, and historic texture.",
+        "stated_constraints": ["trip length around 21 days"],
+        "planning_style_notes": [
+          "comfortable with transit-rich cities",
+          "prefers a researched daily structure"
+        ]
+      },
+      "profile_overrides": {
+        "trip_frame": {
+          "duration_days": 21,
+          "traveler_party": "pair",
+          "season_window": ["April", "May"],
+          "trip_stage": "first_visit",
+          "regions_in_scope": ["Italy", "Austria", "Czech Republic"],
+          "special_themes": ["urban history", "museums", "historic neighborhoods"]
+        },
+        "anchors": {
+          "place_anchors": [
+            {
+              "type": "place",
+              "label": "Rome",
+              "strength": 0.95,
+              "flexibility": 0.1,
+              "notes": "Major anchor city."
+            }
+          ],
+          "experience_anchors": [
+            {
+              "type": "experience",
+              "label": "Museum and old-city days",
+              "strength": 0.82,
+              "flexibility": 0.3,
+              "notes": "Historic urban immersion matters more than countryside exposure."
+            }
+          ]
+        },
+        "tradeoff_dimensions": {
+          "movement_vs_friction": {"value": 0.46, "confidence": 0.7, "salience": 0.68, "stability": 0.72},
+          "nature_vs_culture": {"value": 0.86, "confidence": 0.9, "salience": 0.92, "stability": 0.86},
+          "structure_vs_elasticity": {"value": -0.58, "confidence": 0.72, "salience": 0.74, "stability": 0.78},
+          "breadth_vs_depth": {"value": 0.84, "confidence": 0.9, "salience": 0.94, "stability": 0.88},
+          "historic_vs_contemporary": {"value": -0.88, "confidence": 0.94, "salience": 0.9, "stability": 0.86},
+          "iconic_vs_discovery": {"value": -0.38, "confidence": 0.68, "salience": 0.58, "stability": 0.64}
+        },
+        "hybrid_factors": {
+          "food": {
+            "mode": "tradeoff",
+            "salience": 0.52,
+            "tradeoff_role": "cost",
+            "preferences": {"destination_meals": 0.64}
+          }
+        },
+        "interaction_rules": [
+          {
+            "id": "urban_historian_depth_x_history",
+            "dimensions": ["breadth_vs_depth", "historic_vs_contemporary"],
+            "activation": {
+              "all_of": [
+                {"dimension": "breadth_vs_depth", "min_value": 0.65},
+                {"dimension": "historic_vs_contemporary", "max_value": -0.6}
+              ]
+            },
+            "effect": {
+              "prioritize": [
+                "longer stays in heritage-rich cities",
+                "walkable districts",
+                "museum clusters"
+              ]
+            },
+            "strength": 0.86,
+            "priority": 0.84
+          }
+        ]
+      },
+      "evidence": [
+        {
+          "id": "urban-historian-ev-1",
+          "evidence_type": "direct_statement",
+          "source_type": "user_message",
+          "affected_dimensions": [
+            "breadth_vs_depth",
+            "nature_vs_culture",
+            "historic_vs_contemporary"
+          ],
+          "sequence": 1,
+          "confidence_hint": 0.9,
+          "salience_hint": 0.94,
+          "note": "Traveler explicitly rejects fast multi-city hopping in favor of depth."
+        },
+        {
+          "id": "urban-historian-ev-2",
+          "evidence_type": "scenario_reaction",
+          "source_type": "scenario_prompt",
+          "affected_dimensions": ["structure_vs_elasticity"],
+          "sequence": 2,
+          "confidence_hint": 0.74,
+          "salience_hint": 0.7,
+          "note": "Traveler reacts positively to a museum district day with preselected targets."
+        }
+      ],
+      "intended_interpretation": {
+        "qualitative_summary": "Depth and cultural-historic attention dominate this profile, so route sprawl should be penalized early.",
+        "dominant_dimensions": [
+          "breadth_vs_depth",
+          "nature_vs_culture",
+          "historic_vs_contemporary"
+        ],
+        "expected_tensions": [
+          "Iconic sites matter, but they are acceptable mainly when they fit a deeper urban immersion plan."
+        ],
+        "planning_implications": [
+          "Use fewer bases with denser local cultural menus.",
+          "Prefer neighborhood and museum clustering over broader regional coverage."
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #692

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This merged PR added the runtime ranking layer that turns objectives and assembled inventory into reusable ranked scenarios, exposed those scenarios through the workspace/backend surface, and documented the contract for later comparison UX.

Parent epic: #677

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#677](https://github.com/stranske/trip-planner/issues/677)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks completed in this PR
- [x] Added ranking services over objectives and assembled inventory bundles.
- [x] Added scenario-generation outputs suitable for workspace display.
- [x] Exposed ranked scenarios through backend APIs.
- [x] Added workspace views for ranked scenario summaries.
- [x] Added tests for one leisure and one business ranking path.
- [x] Documented the boundary between ranking inputs, scenario outputs, and later comparison UX.

#### Acceptance evidence for this PR
- [x] The workspace displays ranked scenarios rather than only raw options.
- [x] Ranking inputs use trip objectives and normalized/assembled runtime data.
- [x] Automated tests cover one leisure and one business ranking case.
- [x] Scenario outputs are explicit and reusable by later comparison UI.

**Head SHA:** f51556d70fc133960e37c742307b37f0714d53d2
<!-- auto-status-summary:end -->
