### PR TITLE
Issue #694: add workspace budget persistence APIs

### DIFF
--- a/docs/frontend-trip-workspace.md
+++ b/docs/frontend-trip-workspace.md
@@ -24,6 +24,22 @@ The workspace intentionally composes existing backend-facing seams instead of in
 
 The practical rule is that the workspace may summarize scenario, checkpoint, and budget state, but it should not redefine canonical trip, planner, ranking, or budget contracts.
 
+## Budget Reasoning Handoff
+
+Issue `#694` adds the first workspace UI that can mutate persisted budget state instead of only rendering a summary. That UI should remain a thin editor over the canonical budget records:
+
+- category allocations and caps stay in the persisted budget plan
+- actual-spend entries append durable spend events instead of mutating planner outputs
+- workspace totals and variance labels are derived views over the saved budget state
+
+Later planner and policy issues should consume that saved state rather than reading transient form state from the page:
+
+1. scenario comparison and budget-variant work should read `budget_state_id`, `current_scenario_budget_id`, and the saved category totals to explain which scenario remains within the intended budget posture
+2. in-trip adjustment flows should treat actual-spend drift as an explicit trigger for replanning instead of recalculating against ad hoc UI-only numbers
+3. policy and approval surfaces should reuse the same persisted budget categories and variance signals so readiness checks, proposal payloads, and exception handling stay aligned with the planner workspace
+
+The boundary matters because the workspace owns capture and display, while later planner reasoning owns interpretation. If a later issue needs richer budget heuristics, it should build on the persisted plan and spend ledgers produced here instead of introducing a second budget model inside the frontend.
+
 ## Representative Fixtures
 
 Issue `#558` extends the shell fixtures with three route-ready workspace contexts:

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -21,11 +21,13 @@ export type TripRecord = {
     saved_scenario_ids: string[];
     scenario_search_id: string | null;
     session_state_id: string | null;
+    budget_state_id: string | null;
   };
 };
 
 export type SessionState = {
   current_saved_scenario_id: string | null;
+  active_budget_plan_id: string | null;
   pending_decisions: Array<{
     decision_id: string;
     title: string;
@@ -42,6 +44,96 @@ export type SessionState = {
     summary: string;
     surfaced_option_ids: string[];
   }>;
+};
+
+export type BudgetCategorySummary = {
+  category_key: string;
+  label: string;
+  currency: string;
+  planned_amount: number;
+  actual_amount: number;
+  remaining_amount: number;
+  flexibility: string;
+};
+
+export type BudgetCategoryAllocation = {
+  category_key: string;
+  label: string;
+  planned_amount: number;
+  currency: string;
+  flexibility: string;
+  notes: string[];
+};
+
+export type BudgetScenario = {
+  scenario_budget_id: string;
+  saved_scenario_id: string | null;
+  title: string;
+  summary: string;
+  tags: string[];
+  notes: string[];
+  allocations: BudgetCategoryAllocation[];
+};
+
+export type BudgetPlan = {
+  budget_plan_id: string;
+  trip_id: string;
+  owner_profile_id: string;
+  title: string;
+  mode: string;
+  created_at: string;
+  updated_at: string;
+  scenario_budgets: BudgetScenario[];
+  current_scenario_budget_id: string | null;
+  currency: string;
+  schema_version: string;
+  tags: string[];
+  notes: string[];
+};
+
+export type BudgetVersion = {
+  version_id: string;
+  budget_plan_id: string;
+  recorded_at: string;
+  summary: string;
+};
+
+export type ActualSpendEvent = {
+  spend_event_id: string;
+  trip_id: string;
+  budget_plan_id: string;
+  category_key: string;
+  amount: number;
+  currency: string;
+  occurred_at: string;
+  source_kind: string;
+  source_context: string;
+  scenario_budget_id: string | null;
+  saved_scenario_id: string | null;
+  merchant_name: string;
+  source_ref: string | null;
+  notes: string[];
+};
+
+export type BudgetSummary = {
+  currency: string;
+  has_budget_plan: boolean;
+  current_scenario_budget_id: string | null;
+  current_scenario_title: string | null;
+  planned_total: number;
+  actual_total: number;
+  remaining_total: number;
+  spend_event_count: number;
+  version_count: number;
+  suggested_categories: string[];
+  category_summaries: BudgetCategorySummary[];
+};
+
+export type BudgetWorkspaceState = {
+  budget_plan: BudgetPlan | null;
+  versions: BudgetVersion[];
+  spend_events: ActualSpendEvent[];
+  summary: BudgetSummary;
 };
 
 export type SavedScenarioRecord = {
@@ -112,6 +204,46 @@ export type WorkspaceData = {
     }>;
     notes: string[];
   };
+  budget_state: BudgetWorkspaceState;
+};
+
+export type BudgetPlanUpsertPayload = {
+  title: string;
+  currency: string;
+  current_scenario_budget_id?: string | null;
+  tags?: string[];
+  notes?: string[];
+  scenario_budgets: Array<{
+    scenario_budget_id?: string | null;
+    saved_scenario_id?: string | null;
+    title: string;
+    summary?: string;
+    tags?: string[];
+    notes?: string[];
+    allocations: Array<{
+      category_key: string;
+      label: string;
+      planned_amount: number;
+      currency?: string;
+      flexibility?: string;
+      notes?: string[];
+    }>;
+  }>;
+  summary?: string;
+};
+
+export type ActualSpendEventUpsertPayload = {
+  category_key: string;
+  amount: number;
+  currency?: string | null;
+  occurred_at?: string | null;
+  source_kind: string;
+  source_context: string;
+  scenario_budget_id?: string | null;
+  saved_scenario_id?: string | null;
+  merchant_name?: string;
+  source_ref?: string | null;
+  notes?: string[];
 };
 
 export async function fetchWorkspace(tripId: string): Promise<WorkspaceData> {
@@ -154,5 +286,35 @@ export async function submitPlannerOptionFeedback(
       action_type: actionType,
       decision_id: decisionId,
     }),
+  });
+}
+
+export async function saveWorkspaceBudget(
+  tripId: string,
+  payload: BudgetPlanUpsertPayload
+): Promise<BudgetWorkspaceState> {
+  return fetchJson<BudgetWorkspaceState>({
+    path: `/api/workspace/${tripId}/budget`,
+    method: "PUT",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function recordWorkspaceSpendEvent(
+  tripId: string,
+  payload: ActualSpendEventUpsertPayload
+): Promise<BudgetWorkspaceState> {
+  return fetchJson<BudgetWorkspaceState>({
+    path: `/api/workspace/${tripId}/budget/spend-events`,
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
   });
 }

--- a/frontend/src/components/budget/WorkspaceBudgetPanel.tsx
+++ b/frontend/src/components/budget/WorkspaceBudgetPanel.tsx
@@ -1,0 +1,434 @@
+import { useEffect, useState, type FormEvent } from "react";
+
+import type {
+  ActualSpendEventUpsertPayload,
+  BudgetCategoryAllocation,
+  BudgetPlanUpsertPayload,
+  BudgetWorkspaceState,
+} from "../../api/workspace";
+
+type BudgetAllocationDraft = {
+  category_key: string;
+  label: string;
+  planned_amount: string;
+};
+
+type BudgetFormState = {
+  title: string;
+  currency: string;
+  scenarioTitle: string;
+  summary: string;
+  allocations: BudgetAllocationDraft[];
+};
+
+type SpendFormState = {
+  category_key: string;
+  amount: string;
+  source_context: string;
+  merchant_name: string;
+};
+
+function titleCaseCategory(categoryKey: string): string {
+  return categoryKey
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatCurrency(amount: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
+function getActiveScenario(budgetState: BudgetWorkspaceState) {
+  const plan = budgetState.budget_plan;
+  if (!plan) {
+    return null;
+  }
+  return (
+    plan.scenario_budgets.find(
+      (scenario) => scenario.scenario_budget_id === plan.current_scenario_budget_id
+    ) ??
+    plan.scenario_budgets[0] ??
+    null
+  );
+}
+
+function buildAllocationDrafts(budgetState: BudgetWorkspaceState): BudgetAllocationDraft[] {
+  const activeScenario = getActiveScenario(budgetState);
+  const allocationMap = new Map<string, BudgetCategoryAllocation>();
+
+  for (const allocation of activeScenario?.allocations ?? []) {
+    allocationMap.set(allocation.category_key, allocation);
+  }
+
+  const orderedKeys = [
+    ...budgetState.summary.category_summaries.map((item) => item.category_key),
+    ...budgetState.summary.suggested_categories,
+  ].filter((value, index, items) => items.indexOf(value) === index);
+
+  return orderedKeys.map((categoryKey) => {
+    const summary =
+      budgetState.summary.category_summaries.find(
+        (item) => item.category_key === categoryKey
+      ) ?? null;
+    const allocation = allocationMap.get(categoryKey);
+
+    return {
+      category_key: categoryKey,
+      label: allocation?.label ?? summary?.label ?? titleCaseCategory(categoryKey),
+      planned_amount:
+        allocation?.planned_amount != null && allocation.planned_amount > 0
+          ? allocation.planned_amount.toString()
+          : "",
+    };
+  });
+}
+
+function buildBudgetFormState(budgetState: BudgetWorkspaceState, tripMode: string): BudgetFormState {
+  const plan = budgetState.budget_plan;
+  const activeScenario = getActiveScenario(budgetState);
+
+  return {
+    title: plan?.title ?? `${titleCaseCategory(tripMode)} trip budget`,
+    currency: plan?.currency ?? budgetState.summary.currency ?? "USD",
+    scenarioTitle: activeScenario?.title ?? "Current working budget",
+    summary:
+      budgetState.versions[0]?.summary ??
+      (plan ? "Updated workspace budget" : "Initial workspace budget"),
+    allocations: buildAllocationDrafts(budgetState),
+  };
+}
+
+function buildSpendFormState(budgetState: BudgetWorkspaceState): SpendFormState {
+  return {
+    category_key:
+      budgetState.summary.category_summaries[0]?.category_key ??
+      budgetState.summary.suggested_categories[0] ??
+      "lodging",
+    amount: "",
+    source_context: "",
+    merchant_name: "",
+  };
+}
+
+export function WorkspaceBudgetPanel({
+  budgetState,
+  tripMode,
+  busyLabel,
+  errorMessage,
+  onSaveBudget,
+  onRecordSpend,
+}: {
+  budgetState: BudgetWorkspaceState;
+  tripMode: string;
+  busyLabel: string | null;
+  errorMessage: string | null;
+  onSaveBudget: (payload: BudgetPlanUpsertPayload) => Promise<void>;
+  onRecordSpend: (payload: ActualSpendEventUpsertPayload) => Promise<void>;
+}) {
+  const [budgetForm, setBudgetForm] = useState<BudgetFormState>(() =>
+    buildBudgetFormState(budgetState, tripMode)
+  );
+  const [spendForm, setSpendForm] = useState<SpendFormState>(() =>
+    buildSpendFormState(budgetState)
+  );
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+  const activeScenario = getActiveScenario(budgetState);
+
+  useEffect(() => {
+    setBudgetForm(buildBudgetFormState(budgetState, tripMode));
+    setSpendForm(buildSpendFormState(budgetState));
+    setValidationMessage(null);
+  }, [budgetState, tripMode]);
+
+  async function handleBudgetSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setValidationMessage(null);
+
+    const allocations = budgetForm.allocations
+      .map((item) => ({
+        category_key: item.category_key,
+        label: item.label,
+        planned_amount: Number(item.planned_amount),
+        currency: budgetForm.currency,
+        flexibility:
+          budgetState.summary.category_summaries.find(
+            (summary) => summary.category_key === item.category_key
+          )?.flexibility ?? "flexible",
+        notes: [] as string[],
+      }))
+      .filter((item) => Number.isFinite(item.planned_amount) && item.planned_amount > 0);
+
+    if (allocations.length === 0) {
+      setValidationMessage("Add at least one positive category cap before saving the budget.");
+      return;
+    }
+
+    await onSaveBudget({
+      title: budgetForm.title.trim(),
+      currency: budgetForm.currency.trim().toUpperCase(),
+      current_scenario_budget_id: activeScenario?.scenario_budget_id ?? null,
+      tags: budgetState.budget_plan?.tags ?? [],
+      notes: budgetState.budget_plan?.notes ?? [],
+      scenario_budgets: [
+        {
+          scenario_budget_id: activeScenario?.scenario_budget_id ?? null,
+          saved_scenario_id: activeScenario?.saved_scenario_id ?? null,
+          title: budgetForm.scenarioTitle.trim(),
+          summary: "",
+          tags: activeScenario?.tags ?? [],
+          notes: activeScenario?.notes ?? [],
+          allocations,
+        },
+      ],
+      summary: budgetForm.summary.trim(),
+    });
+  }
+
+  async function handleSpendSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setValidationMessage(null);
+
+    const amount = Number(spendForm.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setValidationMessage("Spend amount must be greater than zero.");
+      return;
+    }
+    if (spendForm.source_context.trim().length === 0) {
+      setValidationMessage("Add a short spend context so the event can be understood later.");
+      return;
+    }
+
+    await onRecordSpend({
+      category_key: spendForm.category_key,
+      amount,
+      currency: budgetForm.currency.trim().toUpperCase(),
+      source_kind: "manual",
+      source_context: spendForm.source_context.trim(),
+      scenario_budget_id: budgetState.summary.current_scenario_budget_id,
+      merchant_name: spendForm.merchant_name.trim(),
+      notes: [],
+    });
+  }
+
+  return (
+    <section className="status-card budget-panel-card">
+      <p className="status-label">Budget state</p>
+      <h2>Budget vs actual</h2>
+      <p className="muted-copy">
+        Planned caps, actual spend drift, and remaining category headroom should feed later planner tradeoff
+        reasoning and in-trip replans.
+      </p>
+      {busyLabel ? <p className="muted-copy">{busyLabel}</p> : null}
+      {errorMessage ? <p className="planner-inline-error">{errorMessage}</p> : null}
+      {validationMessage ? <p className="planner-inline-error">{validationMessage}</p> : null}
+
+      <dl className="budget-summary-grid">
+        <div>
+          <dt>Planned total</dt>
+          <dd>{formatCurrency(budgetState.summary.planned_total, budgetState.summary.currency)}</dd>
+        </div>
+        <div>
+          <dt>Actual total</dt>
+          <dd>{formatCurrency(budgetState.summary.actual_total, budgetState.summary.currency)}</dd>
+        </div>
+        <div>
+          <dt>Remaining</dt>
+          <dd>{formatCurrency(budgetState.summary.remaining_total, budgetState.summary.currency)}</dd>
+        </div>
+        <div>
+          <dt>Spend events</dt>
+          <dd>{budgetState.summary.spend_event_count}</dd>
+        </div>
+      </dl>
+
+      <div className="budget-layout">
+        <form className="budget-form" onSubmit={handleBudgetSubmit}>
+          <div className="budget-form-header">
+            <label className="budget-field">
+              <span>Budget title</span>
+              <input
+                aria-label="Budget title"
+                value={budgetForm.title}
+                onChange={(event) =>
+                  setBudgetForm((current) => ({ ...current, title: event.target.value }))
+                }
+              />
+            </label>
+
+            <label className="budget-field">
+              <span>Currency</span>
+              <input
+                aria-label="Currency"
+                maxLength={3}
+                value={budgetForm.currency}
+                onChange={(event) =>
+                  setBudgetForm((current) => ({ ...current, currency: event.target.value.toUpperCase() }))
+                }
+              />
+            </label>
+          </div>
+
+          <label className="budget-field">
+            <span>Scenario label</span>
+            <input
+              aria-label="Scenario label"
+              value={budgetForm.scenarioTitle}
+              onChange={(event) =>
+                setBudgetForm((current) => ({ ...current, scenarioTitle: event.target.value }))
+              }
+            />
+          </label>
+
+          <label className="budget-field">
+            <span>Update summary</span>
+            <input
+              aria-label="Update summary"
+              value={budgetForm.summary}
+              onChange={(event) =>
+                setBudgetForm((current) => ({ ...current, summary: event.target.value }))
+              }
+            />
+          </label>
+
+          <div className="budget-allocation-grid">
+            {budgetForm.allocations.map((allocation) => (
+              <label key={allocation.category_key} className="budget-field">
+                <span>{allocation.label} cap</span>
+                <input
+                  aria-label={`${allocation.label} cap`}
+                  inputMode="decimal"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={allocation.planned_amount}
+                  onChange={(event) =>
+                    setBudgetForm((current) => ({
+                      ...current,
+                      allocations: current.allocations.map((item) =>
+                        item.category_key === allocation.category_key
+                          ? { ...item, planned_amount: event.target.value }
+                          : item
+                      ),
+                    }))
+                  }
+                />
+              </label>
+            ))}
+          </div>
+
+          <button className="budget-action-button" disabled={busyLabel !== null} type="submit">
+            Save budget plan
+          </button>
+        </form>
+
+        <form className="budget-form" onSubmit={handleSpendSubmit}>
+          <label className="budget-field">
+            <span>Spend category</span>
+            <select
+              aria-label="Spend category"
+              value={spendForm.category_key}
+              onChange={(event) =>
+                setSpendForm((current) => ({ ...current, category_key: event.target.value }))
+              }
+            >
+              {budgetState.summary.category_summaries.map((summary) => (
+                <option key={summary.category_key} value={summary.category_key}>
+                  {summary.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="budget-field">
+            <span>Amount</span>
+            <input
+              aria-label="Amount"
+              inputMode="decimal"
+              type="number"
+              min="0"
+              step="0.01"
+              value={spendForm.amount}
+              onChange={(event) =>
+                setSpendForm((current) => ({ ...current, amount: event.target.value }))
+              }
+            />
+          </label>
+
+          <label className="budget-field">
+            <span>Spend context</span>
+            <input
+              aria-label="Spend context"
+              value={spendForm.source_context}
+              onChange={(event) =>
+                setSpendForm((current) => ({ ...current, source_context: event.target.value }))
+              }
+            />
+          </label>
+
+          <label className="budget-field">
+            <span>Merchant</span>
+            <input
+              aria-label="Merchant"
+              value={spendForm.merchant_name}
+              onChange={(event) =>
+                setSpendForm((current) => ({ ...current, merchant_name: event.target.value }))
+              }
+            />
+          </label>
+
+          <button className="budget-action-button" disabled={busyLabel !== null} type="submit">
+            Record spend event
+          </button>
+        </form>
+      </div>
+
+      <div className="budget-category-list">
+        {budgetState.summary.category_summaries.map((summary) => (
+          <article key={summary.category_key} className="budget-category-row">
+            <div>
+              <h3>{summary.label}</h3>
+              <p className="muted-copy">{summary.flexibility.replace("_", " ")}</p>
+            </div>
+            <dl>
+              <div>
+                <dt>Plan</dt>
+                <dd>{formatCurrency(summary.planned_amount, summary.currency)}</dd>
+              </div>
+              <div>
+                <dt>Actual</dt>
+                <dd>{formatCurrency(summary.actual_amount, summary.currency)}</dd>
+              </div>
+              <div>
+                <dt>Remaining</dt>
+                <dd>{formatCurrency(summary.remaining_amount, summary.currency)}</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </div>
+
+      <div className="decision-stack">
+        {budgetState.spend_events.length === 0 ? (
+          <p className="muted-copy">No actual spend has been recorded yet for this trip.</p>
+        ) : (
+          budgetState.spend_events.slice(0, 4).map((event) => (
+            <article key={event.spend_event_id} className="decision-card">
+              <h3>{event.source_context}</h3>
+              <p>
+                {formatCurrency(event.amount, event.currency)} in {titleCaseCategory(event.category_key)}
+              </p>
+              <p>{event.merchant_name || "Manual entry"}</p>
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1,8 +1,15 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ApiClientError } from "../lib/api/errors";
+import {
+  answerPlannerDecision,
+  recordWorkspaceSpendEvent,
+  saveWorkspaceBudget,
+  submitPlannerOptionFeedback,
+} from "../api/workspace";
 import { WorkspacePage } from "./WorkspacePage";
 
 vi.mock("react-router-dom", async () => {
@@ -13,7 +20,22 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+vi.mock("../api/workspace", async () => {
+  const actual = await vi.importActual<typeof import("../api/workspace")>("../api/workspace");
+  return {
+    ...actual,
+    answerPlannerDecision: vi.fn(),
+    submitPlannerOptionFeedback: vi.fn(),
+    saveWorkspaceBudget: vi.fn(),
+    recordWorkspaceSpendEvent: vi.fn(),
+  };
+});
+
 const mockedUseLoaderData = vi.mocked(useLoaderData);
+const mockedAnswerPlannerDecision = vi.mocked(answerPlannerDecision);
+const mockedSubmitPlannerOptionFeedback = vi.mocked(submitPlannerOptionFeedback);
+const mockedSaveWorkspaceBudget = vi.mocked(saveWorkspaceBudget);
+const mockedRecordWorkspaceSpendEvent = vi.mocked(recordWorkspaceSpendEvent);
 
 const workspacePayload = {
   trip_record: {
@@ -34,10 +56,12 @@ const workspacePayload = {
       saved_scenario_ids: ["saved-scenario:kyoto-baseline", "saved-scenario:osaka-fallback"],
       scenario_search_id: "scenario-search:kyoto-spring",
       session_state_id: "session-state:kyoto-spring",
+      budget_state_id: null,
     },
   },
   session: {
     current_saved_scenario_id: "saved-scenario:kyoto-baseline",
+    active_budget_plan_id: null,
     pending_decisions: [
       {
         decision_id: "decision:save-baseline",
@@ -139,6 +163,43 @@ const workspacePayload = {
       "Bundle summaries are assembled from normalized destination, lodging, transport, and activity records.",
     ],
   },
+  budget_state: {
+    budget_plan: null,
+    versions: [],
+    spend_events: [],
+    summary: {
+      currency: "USD",
+      has_budget_plan: false,
+      current_scenario_budget_id: null,
+      current_scenario_title: null,
+      planned_total: 0,
+      actual_total: 0,
+      remaining_total: 0,
+      spend_event_count: 0,
+      version_count: 0,
+      suggested_categories: ["lodging", "food", "activities", "local_mobility"],
+      category_summaries: [
+        {
+          category_key: "lodging",
+          label: "Lodging",
+          currency: "USD",
+          planned_amount: 0,
+          actual_amount: 0,
+          remaining_amount: 0,
+          flexibility: "guardrail",
+        },
+        {
+          category_key: "food",
+          label: "Food",
+          currency: "USD",
+          planned_amount: 0,
+          actual_amount: 0,
+          remaining_amount: 0,
+          flexibility: "flexible",
+        },
+      ],
+    },
+  },
   planner_panel_state: {
     trip: {
       trip_id: "trip-leisure-kyoto-draft",
@@ -239,7 +300,12 @@ function getPlannerHost() {
 
 describe("WorkspacePage", () => {
   afterEach(() => {
+    cleanup();
     vi.clearAllMocks();
+    mockedAnswerPlannerDecision.mockReset();
+    mockedSubmitPlannerOptionFeedback.mockReset();
+    mockedSaveWorkspaceBudget.mockReset();
+    mockedRecordWorkspaceSpendEvent.mockReset();
   });
 
   it("renders timeline structure from persisted trip and scenario state", async () => {
@@ -345,11 +411,13 @@ describe("WorkspacePage", () => {
             saved_scenario_ids: [],
             scenario_search_id: null,
             session_state_id: "session:trip-chicago-kickoff",
+            budget_state_id: null,
           },
         },
         session: {
           ...workspacePayload.session,
           current_saved_scenario_id: null,
+          active_budget_plan_id: null,
           pending_decisions: [],
         },
         saved_scenarios: [],
@@ -404,6 +472,297 @@ describe("WorkspacePage", () => {
     await waitFor(() => {
       expect(getPlannerHost().shadowRoot?.querySelector('[aria-label="Planner side panel"]')).toBeTruthy();
     });
+  });
+
+  it("saves a budget plan and refreshes the workspace totals", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(workspacePayload),
+    });
+    mockedSaveWorkspaceBudget.mockResolvedValue({
+      budget_plan: {
+        budget_plan_id: "budget-plan:trip-leisure-kyoto-draft",
+        trip_id: "trip-leisure-kyoto-draft",
+        owner_profile_id: "profile:kyoto",
+        title: "Kyoto spring guardrails",
+        mode: "leisure",
+        created_at: "2026-04-10T15:00:00Z",
+        updated_at: "2026-04-10T15:10:00Z",
+        scenario_budgets: [
+          {
+            scenario_budget_id: "budget-scenario:kyoto-baseline",
+            saved_scenario_id: null,
+            title: "Baseline budget",
+            summary: "",
+            tags: [],
+            notes: [],
+            allocations: [
+              {
+                category_key: "lodging",
+                label: "Lodging",
+                planned_amount: 600,
+                currency: "USD",
+                flexibility: "guardrail",
+                notes: [],
+              },
+              {
+                category_key: "food",
+                label: "Food",
+                planned_amount: 180,
+                currency: "USD",
+                flexibility: "flexible",
+                notes: [],
+              },
+            ],
+          },
+        ],
+        current_scenario_budget_id: "budget-scenario:kyoto-baseline",
+        currency: "USD",
+        schema_version: "v1",
+        tags: [],
+        notes: [],
+      },
+      versions: [
+        {
+          version_id: "budget-plan:trip-leisure-kyoto-draft-v1",
+          budget_plan_id: "budget-plan:trip-leisure-kyoto-draft",
+          recorded_at: "2026-04-10T15:10:00Z",
+          summary: "Initial workspace budget",
+        },
+      ],
+      spend_events: [],
+      summary: {
+        currency: "USD",
+        has_budget_plan: true,
+        current_scenario_budget_id: "budget-scenario:kyoto-baseline",
+        current_scenario_title: "Baseline budget",
+        planned_total: 780,
+        actual_total: 0,
+        remaining_total: 780,
+        spend_event_count: 0,
+        version_count: 1,
+        suggested_categories: ["lodging", "food", "activities", "local_mobility"],
+        category_summaries: [
+          {
+            category_key: "lodging",
+            label: "Lodging",
+            currency: "USD",
+            planned_amount: 600,
+            actual_amount: 0,
+            remaining_amount: 600,
+            flexibility: "guardrail",
+          },
+          {
+            category_key: "food",
+            label: "Food",
+            currency: "USD",
+            planned_amount: 180,
+            actual_amount: 0,
+            remaining_amount: 180,
+            flexibility: "flexible",
+          },
+        ],
+      },
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Budget vs actual" })).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.clear(screen.getByLabelText("Budget title"));
+    await user.type(screen.getByLabelText("Budget title"), "Kyoto spring guardrails");
+    await user.clear(screen.getByLabelText("Lodging cap"));
+    await user.type(screen.getByLabelText("Lodging cap"), "600");
+    await user.clear(screen.getByLabelText("Food cap"));
+    await user.type(screen.getByLabelText("Food cap"), "180");
+    await user.click(screen.getByRole("button", { name: "Save budget plan" }));
+
+    await waitFor(() => {
+      expect(mockedSaveWorkspaceBudget).toHaveBeenCalledWith(
+        "trip-leisure-kyoto-draft",
+        expect.objectContaining({
+          title: "Kyoto spring guardrails",
+        })
+      );
+    });
+
+    expect(screen.getAllByText("$780.00").length).toBeGreaterThan(0);
+    expect(screen.getByDisplayValue("Baseline budget")).toBeInTheDocument();
+  });
+
+  it("records a spend event and surfaces the updated merchant entry", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        budget_state: {
+          budget_plan: {
+            budget_plan_id: "budget-plan:trip-leisure-kyoto-draft",
+            trip_id: "trip-leisure-kyoto-draft",
+            owner_profile_id: "profile:kyoto",
+            title: "Kyoto spring guardrails",
+            mode: "leisure",
+            created_at: "2026-04-10T15:00:00Z",
+            updated_at: "2026-04-10T15:10:00Z",
+            scenario_budgets: [
+              {
+                scenario_budget_id: "budget-scenario:kyoto-baseline",
+                saved_scenario_id: null,
+                title: "Baseline budget",
+                summary: "",
+                tags: [],
+                notes: [],
+                allocations: [
+                  {
+                    category_key: "food",
+                    label: "Food",
+                    planned_amount: 180,
+                    currency: "USD",
+                    flexibility: "flexible",
+                    notes: [],
+                  },
+                ],
+              },
+            ],
+            current_scenario_budget_id: "budget-scenario:kyoto-baseline",
+            currency: "USD",
+            schema_version: "v1",
+            tags: [],
+            notes: [],
+          },
+          versions: [],
+          spend_events: [],
+          summary: {
+            currency: "USD",
+            has_budget_plan: true,
+            current_scenario_budget_id: "budget-scenario:kyoto-baseline",
+            current_scenario_title: "Baseline budget",
+            planned_total: 180,
+            actual_total: 0,
+            remaining_total: 180,
+            spend_event_count: 0,
+            version_count: 1,
+            suggested_categories: ["food"],
+            category_summaries: [
+              {
+                category_key: "food",
+                label: "Food",
+                currency: "USD",
+                planned_amount: 180,
+                actual_amount: 0,
+                remaining_amount: 180,
+                flexibility: "flexible",
+              },
+            ],
+          },
+        },
+      }),
+    });
+    mockedRecordWorkspaceSpendEvent.mockResolvedValue({
+      budget_plan: {
+        budget_plan_id: "budget-plan:trip-leisure-kyoto-draft",
+        trip_id: "trip-leisure-kyoto-draft",
+        owner_profile_id: "profile:kyoto",
+        title: "Kyoto spring guardrails",
+        mode: "leisure",
+        created_at: "2026-04-10T15:00:00Z",
+        updated_at: "2026-04-10T15:10:00Z",
+        scenario_budgets: [
+          {
+            scenario_budget_id: "budget-scenario:kyoto-baseline",
+            saved_scenario_id: null,
+            title: "Baseline budget",
+            summary: "",
+            tags: [],
+            notes: [],
+            allocations: [
+              {
+                category_key: "food",
+                label: "Food",
+                planned_amount: 180,
+                currency: "USD",
+                flexibility: "flexible",
+                notes: [],
+              },
+            ],
+          },
+        ],
+        current_scenario_budget_id: "budget-scenario:kyoto-baseline",
+        currency: "USD",
+        schema_version: "v1",
+        tags: [],
+        notes: [],
+      },
+      versions: [],
+      spend_events: [
+        {
+          spend_event_id: "spend:trip-leisure-kyoto-draft:1",
+          trip_id: "trip-leisure-kyoto-draft",
+          budget_plan_id: "budget-plan:trip-leisure-kyoto-draft",
+          category_key: "food",
+          amount: 42.5,
+          currency: "USD",
+          occurred_at: "2026-04-10T16:00:00Z",
+          source_kind: "manual",
+          source_context: "Dinner near Gion",
+          scenario_budget_id: "budget-scenario:kyoto-baseline",
+          saved_scenario_id: null,
+          merchant_name: "Kyoto Kitchen",
+          source_ref: null,
+          notes: [],
+        },
+      ],
+      summary: {
+        currency: "USD",
+        has_budget_plan: true,
+        current_scenario_budget_id: "budget-scenario:kyoto-baseline",
+        current_scenario_title: "Baseline budget",
+        planned_total: 180,
+        actual_total: 42.5,
+        remaining_total: 137.5,
+        spend_event_count: 1,
+        version_count: 1,
+        suggested_categories: ["food"],
+        category_summaries: [
+          {
+            category_key: "food",
+            label: "Food",
+            currency: "USD",
+            planned_amount: 180,
+            actual_amount: 42.5,
+            remaining_amount: 137.5,
+            flexibility: "flexible",
+          },
+        ],
+      },
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Record spend event" })).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("Amount"), "42.5");
+    await user.type(screen.getByLabelText("Spend context"), "Dinner near Gion");
+    await user.type(screen.getByLabelText("Merchant"), "Kyoto Kitchen");
+    await user.click(screen.getByRole("button", { name: "Record spend event" }));
+
+    await waitFor(() => {
+      expect(mockedRecordWorkspaceSpendEvent).toHaveBeenCalledWith(
+        "trip-leisure-kyoto-draft",
+        expect.objectContaining({
+          amount: 42.5,
+          source_context: "Dinner near Gion",
+          merchant_name: "Kyoto Kitchen",
+        })
+      );
+    });
+
+    expect(screen.getByText("Kyoto Kitchen")).toBeInTheDocument();
+    expect(screen.getAllByText("$137.50").length).toBeGreaterThan(0);
   });
 
   it("renders the shared route error card when the workspace loader rejects", async () => {

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -3,10 +3,16 @@ import { useLoaderData } from "react-router-dom";
 
 import {
   answerPlannerDecision,
+  recordWorkspaceSpendEvent,
+  saveWorkspaceBudget,
+  type ActualSpendEventUpsertPayload,
+  type BudgetPlanUpsertPayload,
+  type BudgetWorkspaceState,
   submitPlannerOptionFeedback,
   type SavedScenarioRecord,
   type WorkspaceData,
 } from "../api/workspace";
+import { WorkspaceBudgetPanel } from "../components/budget/WorkspaceBudgetPanel";
 import { PlannerSidePanelSurface } from "../components/planner/PlannerSidePanelSurface";
 import { AsyncRouteContent } from "../lib/routes/AsyncRouteContent";
 
@@ -114,6 +120,29 @@ function ScenarioSummaryCard({
   );
 }
 
+function mergeWorkspaceBudgetState(
+  workspace: WorkspaceData,
+  budgetState: BudgetWorkspaceState
+): WorkspaceData {
+  const budgetPlanId = budgetState.budget_plan?.budget_plan_id ?? null;
+
+  return {
+    ...workspace,
+    budget_state: budgetState,
+    trip_record: {
+      ...workspace.trip_record,
+      artifact_refs: {
+        ...workspace.trip_record.artifact_refs,
+        budget_state_id: budgetPlanId,
+      },
+    },
+    session: {
+      ...workspace.session,
+      active_budget_plan_id: budgetPlanId,
+    },
+  };
+}
+
 export function WorkspacePage() {
   const { workspace } = useLoaderData() as LoaderData;
 
@@ -140,6 +169,8 @@ function WorkspacePageContent({ workspace }: { workspace: WorkspaceData }) {
   const [currentWorkspace, setCurrentWorkspace] = useState(workspace);
   const [plannerError, setPlannerError] = useState<string | null>(null);
   const [plannerBusyLabel, setPlannerBusyLabel] = useState<string | null>(null);
+  const [budgetError, setBudgetError] = useState<string | null>(null);
+  const [budgetBusyLabel, setBudgetBusyLabel] = useState<string | null>(null);
   useEffect(() => {
     setCurrentWorkspace(workspace);
   }, [workspace]);
@@ -192,6 +223,36 @@ function WorkspacePageContent({ workspace }: { workspace: WorkspaceData }) {
     }
   }
 
+  async function handleBudgetSave(payload: BudgetPlanUpsertPayload) {
+    setBudgetError(null);
+    setBudgetBusyLabel("Saving workspace budget...");
+    try {
+      const nextBudgetState = await saveWorkspaceBudget(trip.trip_id, payload);
+      startTransition(() => {
+        setCurrentWorkspace((current) => mergeWorkspaceBudgetState(current, nextBudgetState));
+      });
+    } catch (error) {
+      setBudgetError(error instanceof Error ? error.message : "Budget plan update failed.");
+    } finally {
+      setBudgetBusyLabel(null);
+    }
+  }
+
+  async function handleSpendRecord(payload: ActualSpendEventUpsertPayload) {
+    setBudgetError(null);
+    setBudgetBusyLabel("Recording actual spend...");
+    try {
+      const nextBudgetState = await recordWorkspaceSpendEvent(trip.trip_id, payload);
+      startTransition(() => {
+        setCurrentWorkspace((current) => mergeWorkspaceBudgetState(current, nextBudgetState));
+      });
+    } catch (error) {
+      setBudgetError(error instanceof Error ? error.message : "Spend entry failed.");
+    } finally {
+      setBudgetBusyLabel(null);
+    }
+  }
+
   return (
     <section className="workspace-layout">
       <div className="workspace-hero status-card">
@@ -237,6 +298,15 @@ function WorkspacePageContent({ workspace }: { workspace: WorkspaceData }) {
             onOptionFeedback={handleOptionFeedback}
           />
         </section>
+
+        <WorkspaceBudgetPanel
+          budgetState={currentWorkspace.budget_state}
+          tripMode={trip.mode}
+          busyLabel={budgetBusyLabel}
+          errorMessage={budgetError}
+          onSaveBudget={handleBudgetSave}
+          onRecordSpend={handleSpendRecord}
+        />
 
         <section className="status-card">
           <p className="status-label">Inventory bundles</p>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -260,6 +260,127 @@ a {
   min-height: 100%;
 }
 
+.budget-panel-card {
+  grid-column: 1 / -1;
+}
+
+.budget-summary-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin: 1.25rem 0 0;
+}
+
+.budget-summary-grid div,
+.budget-category-row,
+.budget-form {
+  border-radius: 20px;
+  background: rgba(19, 33, 44, 0.04);
+}
+
+.budget-summary-grid div {
+  padding: 0.9rem 1rem;
+}
+
+.budget-summary-grid dt,
+.budget-category-row dt {
+  font-size: 0.82rem;
+  color: #577186;
+}
+
+.budget-summary-grid dd,
+.budget-category-row dd {
+  margin: 0.25rem 0 0;
+  font-weight: 600;
+}
+
+.budget-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin-top: 1.25rem;
+}
+
+.budget-form {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+}
+
+.budget-form-header,
+.budget-allocation-grid {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.budget-field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  color: #365063;
+}
+
+.budget-field input,
+.budget-field select {
+  width: 100%;
+  border: 1px solid rgba(19, 33, 44, 0.12);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.76);
+  padding: 0.75rem 0.85rem;
+  font: inherit;
+  color: #13212c;
+}
+
+.budget-field input:focus,
+.budget-field select:focus {
+  outline: 2px solid rgba(56, 117, 107, 0.35);
+  outline-offset: 1px;
+}
+
+.budget-action-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.85rem 1.1rem;
+  font: inherit;
+  font-weight: 600;
+  color: #f7f1e5;
+  background: linear-gradient(135deg, #38756b, #234f48);
+  cursor: pointer;
+}
+
+.budget-action-button:disabled {
+  cursor: progress;
+  opacity: 0.75;
+}
+
+.budget-category-list {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1.25rem;
+}
+
+.budget-category-row {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+.budget-category-row h3 {
+  margin: 0;
+}
+
+.budget-category-row p {
+  margin: 0.2rem 0 0;
+}
+
+.budget-category-row dl {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  margin: 0;
+}
+
 .auth-layout {
   display: grid;
   place-items: center;

--- a/tests/app/test_budget_routes.py
+++ b/tests/app/test_budget_routes.py
@@ -176,3 +176,116 @@ def test_workspace_budget_spend_event_can_be_updated(client: TestClient) -> None
         if item["category_key"] == "client_hospitality"
     )
     assert hospitality_row["remaining_amount"] == 55
+
+
+def test_workspace_budget_spend_event_rejects_currency_drift(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Budget guardrails",
+            "summary": "Reject cross-currency spend capture.",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 3, "primary_regions": ["Lisbon"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    client.put(
+        f"/api/workspace/{trip_id}/budget",
+        json={
+            "title": "Lisbon budget",
+            "currency": "USD",
+            "scenario_budgets": [
+                {
+                    "title": "Baseline",
+                    "allocations": [
+                        {
+                            "category_key": "food",
+                            "label": "Food",
+                            "planned_amount": 150,
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+    recorded = client.post(
+        f"/api/workspace/{trip_id}/budget/spend-events",
+        json={
+            "category_key": "food",
+            "amount": 30,
+            "currency": "eur",
+            "source_kind": "manual",
+            "source_context": "Lunch",
+        },
+    )
+
+    assert recorded.status_code == 400
+    assert recorded.json()["detail"] == "currency must match the persisted budget plan currency"
+
+
+def test_workspace_budget_spend_event_updates_session_timestamp(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Timestamp guardrails",
+            "summary": "Budget spend updates should refresh workspace session state.",
+            "mode": "business",
+            "trip_frame": {"duration_days": 2, "primary_regions": ["Austin"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    client.put(
+        f"/api/workspace/{trip_id}/budget",
+        json={
+            "title": "Austin budget",
+            "currency": "USD",
+            "scenario_budgets": [
+                {
+                    "title": "Baseline",
+                    "allocations": [
+                        {
+                            "category_key": "workspace",
+                            "label": "Workspace",
+                            "planned_amount": 120,
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+    workspace_before = client.get(f"/api/workspace/{trip_id}").json()
+    before_timestamp = workspace_before["session"]["updated_at"]
+
+    recorded = client.post(
+        f"/api/workspace/{trip_id}/budget/spend-events",
+        json={
+            "category_key": "workspace",
+            "amount": 45,
+            "source_kind": "manual",
+            "source_context": "Coworking day pass",
+        },
+    )
+
+    assert recorded.status_code == 200
+    workspace_after_create = client.get(f"/api/workspace/{trip_id}").json()
+    after_create_timestamp = workspace_after_create["session"]["updated_at"]
+    assert after_create_timestamp > before_timestamp
+
+    spend_event_id = recorded.json()["spend_events"][0]["spend_event_id"]
+    updated = client.patch(
+        f"/api/workspace/{trip_id}/budget/spend-events/{spend_event_id}",
+        json={
+            "category_key": "workspace",
+            "amount": 55,
+            "source_kind": "receipt",
+            "source_context": "Final receipt",
+            "currency": "USD",
+        },
+    )
+
+    assert updated.status_code == 200
+    workspace_after_update = client.get(f"/api/workspace/{trip_id}").json()
+    assert workspace_after_update["session"]["updated_at"] > after_create_timestamp

--- a/tests/app/test_budget_routes.py
+++ b/tests/app/test_budget_routes.py
@@ -1,0 +1,178 @@
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trip_planner.app.main import create_app
+from trip_planner.persistence.db import reset_database_state
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv(
+        "TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'budget.db'}"
+    )
+    reset_database_state()
+    app = create_app()
+
+    with TestClient(app) as test_client:
+        test_client.post(
+            "/api/auth/signup",
+            json={
+                "email": "budget@example.com",
+                "password": "password123",
+                "display_name": "Budget Owner",
+            },
+        )
+        yield test_client
+
+    reset_database_state()
+
+
+def test_workspace_budget_route_persists_plan_and_spend_events(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Budgeted Kyoto",
+            "summary": "Track the spend drift in the workspace.",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 4, "primary_regions": ["Kyoto"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    saved_budget = client.put(
+        f"/api/workspace/{trip_id}/budget",
+        json={
+            "title": "Kyoto spring guardrails",
+            "currency": "USD",
+            "scenario_budgets": [
+                {
+                    "title": "Baseline budget",
+                    "allocations": [
+                        {
+                            "category_key": "lodging",
+                            "label": "Lodging",
+                            "planned_amount": 600,
+                        },
+                        {
+                            "category_key": "food",
+                            "label": "Food",
+                            "planned_amount": 180,
+                        },
+                        {
+                            "category_key": "activities",
+                            "label": "Activities",
+                            "planned_amount": 140,
+                        },
+                    ],
+                }
+            ],
+            "summary": "Initial workspace budget",
+        },
+    )
+
+    assert saved_budget.status_code == 200
+    budget_payload = saved_budget.json()
+    assert budget_payload["budget_plan"]["title"] == "Kyoto spring guardrails"
+    assert budget_payload["summary"]["planned_total"] == 920
+    assert budget_payload["summary"]["actual_total"] == 0
+    assert budget_payload["versions"][0]["summary"] == "Initial workspace budget"
+
+    recorded_spend = client.post(
+        f"/api/workspace/{trip_id}/budget/spend-events",
+        json={
+            "category_key": "food",
+            "amount": 42.5,
+            "source_kind": "manual",
+            "source_context": "Dinner near Gion",
+            "merchant_name": "Kyoto Kitchen",
+        },
+    )
+
+    assert recorded_spend.status_code == 200
+    spend_payload = recorded_spend.json()
+    assert spend_payload["summary"]["actual_total"] == 42.5
+    assert spend_payload["summary"]["remaining_total"] == 877.5
+    assert spend_payload["spend_events"][0]["merchant_name"] == "Kyoto Kitchen"
+
+    workspace = client.get(f"/api/workspace/{trip_id}")
+
+    assert workspace.status_code == 200
+    workspace_payload = workspace.json()
+    assert workspace_payload["budget_state"]["summary"]["planned_total"] == 920
+    assert workspace_payload["budget_state"]["summary"]["actual_total"] == 42.5
+    assert workspace_payload["trip_record"]["artifact_refs"]["budget_state_id"] == "budget-plan:" + trip_id
+    assert workspace_payload["session"]["active_budget_plan_id"] == "budget-plan:" + trip_id
+
+
+def test_workspace_budget_spend_event_can_be_updated(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Client summit",
+            "summary": "Exercise spend-event edits.",
+            "mode": "business",
+            "trip_frame": {"duration_days": 2, "primary_regions": ["Chicago"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    client.put(
+        f"/api/workspace/{trip_id}/budget",
+        json={
+            "title": "Client summit plan",
+            "currency": "USD",
+            "scenario_budgets": [
+                {
+                    "title": "Compliant budget",
+                    "allocations": [
+                        {
+                            "category_key": "workspace",
+                            "label": "Workspace",
+                            "planned_amount": 200,
+                        },
+                        {
+                            "category_key": "client_hospitality",
+                            "label": "Client hospitality",
+                            "planned_amount": 150,
+                        },
+                    ],
+                }
+            ],
+        },
+    )
+    recorded = client.post(
+        f"/api/workspace/{trip_id}/budget/spend-events",
+        json={
+            "category_key": "client_hospitality",
+            "amount": 75,
+            "source_kind": "manual",
+            "source_context": "Team dinner",
+        },
+    )
+    spend_event_id = recorded.json()["spend_events"][0]["spend_event_id"]
+
+    updated = client.patch(
+        f"/api/workspace/{trip_id}/budget/spend-events/{spend_event_id}",
+        json={
+            "category_key": "client_hospitality",
+            "amount": 95,
+            "source_kind": "receipt",
+            "source_context": "Updated dinner receipt",
+            "merchant_name": "The Delegate Room",
+        },
+    )
+
+    assert updated.status_code == 200
+    payload = updated.json()
+    assert payload["spend_events"][0]["amount"] == 95
+    assert payload["spend_events"][0]["source_kind"] == "receipt"
+    assert payload["summary"]["actual_total"] == 95
+    hospitality_row = next(
+        item
+        for item in payload["summary"]["category_summaries"]
+        if item["category_key"] == "client_hospitality"
+    )
+    assert hospitality_row["remaining_amount"] == 55

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -78,6 +78,9 @@ def test_workspace_endpoint_returns_trip_scenario_payload(client: TestClient) ->
         "save baseline",
         "keep exploring",
     ]
+    assert payload["budget_state"]["summary"]["planned_total"] > 0
+    assert payload["budget_state"]["summary"]["actual_total"] > 0
+    assert payload["budget_state"]["summary"]["current_scenario_title"]
 
 
 def test_workspace_endpoint_surfaces_business_ranked_scenarios(client: TestClient) -> None:
@@ -163,6 +166,9 @@ def test_workspace_endpoint_returns_minimal_payload_for_persisted_trip(
     assert payload["inventory_summary"]["bundle_count"] == 0
     assert payload["feasibility_summary"]["assessment_count"] == 0
     assert payload["activity_log"] == []
+    assert payload["budget_state"]["summary"]["planned_total"] == 0
+    assert payload["budget_state"]["summary"]["actual_total"] == 0
+    assert payload["budget_state"]["summary"]["has_budget_plan"] is False
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
     assert payload["planner_panel_state"]["option_set"]["purpose"] == "workspace_bootstrap"
 

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -56,6 +56,7 @@ trip_planner/app/__init__.py
 trip_planner/app/main.py
 trip_planner/app/routes/__init__.py
 trip_planner/app/routes/auth.py
+trip_planner/app/routes/budget.py
 trip_planner/app/routes/health.py
 trip_planner/app/routes/inventory.py
 trip_planner/app/routes/scenario_history.py
@@ -63,12 +64,14 @@ trip_planner/app/routes/trips.py
 trip_planner/app/routes/workspace.py
 trip_planner/app/schemas/__init__.py
 trip_planner/app/schemas/auth.py
+trip_planner/app/schemas/budget.py
 trip_planner/app/schemas/health.py
 trip_planner/app/schemas/inventory.py
 trip_planner/app/schemas/scenario_history.py
 trip_planner/app/schemas/trips.py
 trip_planner/app/schemas/workspace.py
 trip_planner/app/services/auth.py
+trip_planner/app/services/budget.py
 trip_planner/app/services/feasibility.py
 trip_planner/app/services/inventory.py
 trip_planner/app/services/scenario_history.py
@@ -135,8 +138,10 @@ trip_planner/persistence/alembic/versions/20260407_01_accounts_sessions.py
 trip_planner/persistence/alembic/versions/20260407_02_persisted_trips.py
 trip_planner/persistence/alembic/versions/20260407_03_scenario_history_state.py
 trip_planner/persistence/alembic/versions/20260408_01_planning_session_state.py
+trip_planner/persistence/alembic/versions/20260408_02_budget_state.py
 trip_planner/persistence/models/__init__.py
 trip_planner/persistence/models/account.py
+trip_planner/persistence/models/budget.py
 trip_planner/persistence/models/scenario.py
 trip_planner/persistence/models/session.py
 trip_planner/persistence/models/trip.py

--- a/trip_planner/app/main.py
+++ b/trip_planner/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from trip_planner.app import APP_VERSION
 from trip_planner.app.routes.auth import router as auth_router
+from trip_planner.app.routes.budget import router as budget_router
 from trip_planner.app.routes.health import router as health_router
 from trip_planner.app.routes.inventory import router as inventory_router
 from trip_planner.app.routes.scenario_history import router as scenario_history_router
@@ -41,6 +42,7 @@ def create_app() -> FastAPI:
     app.include_router(inventory_router, prefix="/api")
     app.include_router(scenario_history_router, prefix="/api")
     app.include_router(workspace_router, prefix="/api")
+    app.include_router(budget_router, prefix="/api")
 
     @app.get("/")
     def read_root() -> dict[str, str]:

--- a/trip_planner/app/routes/budget.py
+++ b/trip_planner/app/routes/budget.py
@@ -1,0 +1,126 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from trip_planner.app.schemas.budget import (
+    ActualSpendEventUpsertRequest,
+    BudgetPlanUpsertRequest,
+    BudgetWorkspaceResponse,
+)
+from trip_planner.app.services.auth import AuthenticatedUser, require_authenticated_user
+from trip_planner.app.services.budget import (
+    WorkspaceBudgetNotFoundError,
+    get_workspace_budget_payload,
+    record_workspace_spend_event,
+    update_workspace_spend_event,
+    upsert_workspace_budget_plan,
+)
+from trip_planner.persistence.db import get_db_session
+
+router = APIRouter(tags=["budget"])
+
+
+@router.get("/workspace/{trip_id}/budget", response_model=BudgetWorkspaceResponse)
+def read_workspace_budget(
+    trip_id: str,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> BudgetWorkspaceResponse:
+    try:
+        payload = get_workspace_budget_payload(db_session, user=user, trip_id=trip_id)
+    except WorkspaceBudgetNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    return BudgetWorkspaceResponse.model_validate(payload)
+
+
+@router.put("/workspace/{trip_id}/budget", response_model=BudgetWorkspaceResponse)
+def save_workspace_budget(
+    trip_id: str,
+    payload: BudgetPlanUpsertRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> BudgetWorkspaceResponse:
+    try:
+        result = upsert_workspace_budget_plan(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            title=payload.title,
+            currency=payload.currency,
+            current_scenario_budget_id=payload.current_scenario_budget_id,
+            tags=payload.tags,
+            notes=payload.notes,
+            scenario_budgets=[item.model_dump() for item in payload.scenario_budgets],
+            summary=payload.summary,
+        )
+    except WorkspaceBudgetNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return BudgetWorkspaceResponse.model_validate(result)
+
+
+@router.post("/workspace/{trip_id}/budget/spend-events", response_model=BudgetWorkspaceResponse)
+def create_workspace_spend_event(
+    trip_id: str,
+    payload: ActualSpendEventUpsertRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> BudgetWorkspaceResponse:
+    try:
+        result = record_workspace_spend_event(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            category_key=payload.category_key,
+            amount=payload.amount,
+            currency=payload.currency,
+            occurred_at=payload.occurred_at,
+            source_kind=payload.source_kind,
+            source_context=payload.source_context,
+            scenario_budget_id=payload.scenario_budget_id,
+            saved_scenario_id=payload.saved_scenario_id,
+            merchant_name=payload.merchant_name,
+            source_ref=payload.source_ref,
+            notes=payload.notes,
+        )
+    except WorkspaceBudgetNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return BudgetWorkspaceResponse.model_validate(result)
+
+
+@router.patch(
+    "/workspace/{trip_id}/budget/spend-events/{spend_event_id}",
+    response_model=BudgetWorkspaceResponse,
+)
+def patch_workspace_spend_event(
+    trip_id: str,
+    spend_event_id: str,
+    payload: ActualSpendEventUpsertRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> BudgetWorkspaceResponse:
+    try:
+        result = update_workspace_spend_event(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            spend_event_id=spend_event_id,
+            category_key=payload.category_key,
+            amount=payload.amount,
+            currency=payload.currency,
+            occurred_at=payload.occurred_at,
+            source_kind=payload.source_kind,
+            source_context=payload.source_context,
+            scenario_budget_id=payload.scenario_budget_id,
+            saved_scenario_id=payload.saved_scenario_id,
+            merchant_name=payload.merchant_name,
+            source_ref=payload.source_ref,
+            notes=payload.notes,
+        )
+    except WorkspaceBudgetNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return BudgetWorkspaceResponse.model_validate(result)

--- a/trip_planner/app/schemas/budget.py
+++ b/trip_planner/app/schemas/budget.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class BudgetCategoryAllocationRequest(BaseModel):
+    category_key: str = Field(min_length=1, max_length=64)
+    label: str = Field(min_length=1, max_length=80)
+    planned_amount: float = Field(gt=0)
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    flexibility: str = Field(default="flexible", min_length=1, max_length=32)
+    notes: list[str] = Field(default_factory=list)
+
+
+class BudgetScenarioRequest(BaseModel):
+    scenario_budget_id: str | None = Field(default=None, max_length=96)
+    saved_scenario_id: str | None = Field(default=None, max_length=96)
+    title: str = Field(min_length=1, max_length=120)
+    summary: str = Field(default="", max_length=240)
+    tags: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+    allocations: list[BudgetCategoryAllocationRequest] = Field(min_length=1)
+
+
+class BudgetPlanUpsertRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=160)
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    current_scenario_budget_id: str | None = Field(default=None, max_length=96)
+    tags: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+    scenario_budgets: list[BudgetScenarioRequest] = Field(min_length=1)
+    summary: str = Field(default="", max_length=240)
+
+
+class ActualSpendEventUpsertRequest(BaseModel):
+    category_key: str = Field(min_length=1, max_length=64)
+    amount: float = Field(gt=0)
+    currency: str | None = Field(default=None, min_length=3, max_length=3)
+    occurred_at: str | None = Field(default=None, max_length=64)
+    source_kind: str = Field(default="manual", min_length=1, max_length=32)
+    source_context: str = Field(min_length=1, max_length=240)
+    scenario_budget_id: str | None = Field(default=None, max_length=96)
+    saved_scenario_id: str | None = Field(default=None, max_length=96)
+    merchant_name: str = Field(default="", max_length=160)
+    source_ref: str | None = Field(default=None, max_length=160)
+    notes: list[str] = Field(default_factory=list)
+
+
+class BudgetWorkspaceResponse(BaseModel):
+    budget_plan: dict[str, Any] | None = None
+    versions: list[dict[str, Any]] = Field(default_factory=list)
+    spend_events: list[dict[str, Any]] = Field(default_factory=list)
+    summary: dict[str, Any] = Field(default_factory=dict)

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -36,6 +36,10 @@ class WorkspaceResponse(BaseModel):
     inventory_summary: dict[str, Any] = Field(
         description="Bundle summary assembled from normalized option/domain records for the workspace surface."
     )
+    budget_state: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Persisted budget plan, actual spend entries, and budget-vs-actual summary for the workspace.",
+    )
 
 
 class ScenarioComparisonSurfaceResponse(BaseModel):

--- a/trip_planner/app/services/budget.py
+++ b/trip_planner/app/services/budget.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import secrets
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
@@ -48,12 +49,60 @@ def _isoformat(value: datetime) -> str:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
+def _to_currency_amount(value: float | Decimal) -> float:
+    return round(float(value), 2)
+
+
+def _next_session_timestamp(current_value: str | None) -> str:
+    now = datetime.now(UTC)
+    if current_value:
+        current_dt = datetime.fromisoformat(current_value.replace("Z", "+00:00"))
+        if now <= current_dt:
+            now = current_dt + timedelta(microseconds=1)
+    return _isoformat(now)
+
+
 def _owner_profile_id(record: PersistedTrip) -> str:
     if record.mode == "business" and record.business_profile_id:
         return record.business_profile_id
     if record.leisure_profile_id:
         return record.leisure_profile_id
     return f"profile:{record.trip_id}:{record.mode}"
+
+
+def _ensure_session_record(
+    db_session: Session,
+    *,
+    record: PersistedTrip,
+    timestamp: str,
+) -> PersistedPlanningSessionState:
+    session_record = db_session.get(PersistedPlanningSessionState, f"session:{record.trip_id}")
+    if session_record is not None:
+        return session_record
+
+    session_record = PersistedPlanningSessionState(
+        session_state_id=f"session:{record.trip_id}",
+        trip_id=record.trip_id,
+        user_id=record.user_id,
+        owner_profile_id=_owner_profile_id(record),
+        mode=record.mode,
+        started_at=_isoformat(record.created_at),
+        last_updated_at=timestamp,
+        interaction_state={},
+        recent_option_presentations=[],
+        pending_decisions=[],
+        status="active",
+        current_checkpoint_id=None,
+        current_saved_scenario_id=None,
+        active_budget_plan_id=record.budget_state_id,
+        activity_log_id=f"activity-log:{record.trip_id}",
+        schema_version="0.1.0",
+        tags=[],
+        notes=["Workspace budget state initialized before planner session activity."],
+    )
+    db_session.add(session_record)
+    db_session.flush()
+    return session_record
 
 
 def _suggested_categories(mode: str) -> list[str]:
@@ -92,7 +141,7 @@ def _serialize_spend_event(record: PersistedActualSpendEvent) -> dict[str, Any]:
             "trip_id": record.trip_id,
             "budget_plan_id": record.budget_plan_id,
             "category_key": record.category_key,
-            "amount": record.amount,
+            "amount": _to_currency_amount(record.amount),
             "currency": record.currency,
             "occurred_at": record.occurred_at,
             "source_kind": record.source_kind,
@@ -320,7 +369,7 @@ def upsert_workspace_budget_plan(
         .where(PersistedBudgetPlan.trip_id == record.trip_id)
         .where(PersistedBudgetPlan.user_id == record.user_id)
     )
-    now = _isoformat(datetime.now(UTC))
+    now = _next_session_timestamp(None)
     plan_id = existing.budget_plan_id if existing is not None else f"budget-plan:{record.trip_id}"
     normalized_scenarios: list[dict[str, Any]] = []
     for index, scenario_payload in enumerate(scenario_budgets):
@@ -399,10 +448,10 @@ def upsert_workspace_budget_plan(
         existing.updated_at = budget_plan.updated_at
 
     record.budget_state_id = budget_plan.budget_plan_id
-    session_record = db_session.get(PersistedPlanningSessionState, f"session:{record.trip_id}")
-    if session_record is not None:
-        session_record.active_budget_plan_id = budget_plan.budget_plan_id
-        session_record.last_updated_at = now
+    session_record = _ensure_session_record(db_session, record=record, timestamp=now)
+    session_record.active_budget_plan_id = budget_plan.budget_plan_id
+    session_record.last_updated_at = now
+    record.updated_at = datetime.now(UTC)
 
     db_session.add(
         PersistedBudgetPlanVersion(
@@ -445,14 +494,23 @@ def record_workspace_spend_event(
         raise WorkspaceBudgetNotFoundError(
             f"Trip '{trip_id}' does not have a persisted budget plan yet."
         )
+    event_currency = plan_record.currency
+    if currency is not None:
+        normalized_currency = currency.strip().upper()
+        if len(normalized_currency) != 3 or not normalized_currency.isalpha():
+            raise ValueError("currency must be a 3-letter ISO currency code")
+        if normalized_currency != plan_record.currency:
+            raise ValueError("currency must match the persisted budget plan currency")
+        event_currency = normalized_currency
+    now = _isoformat(datetime.now(UTC))
     event = ActualSpendEvent(
         spend_event_id=f"spend:{record.trip_id}:{secrets.token_hex(4)}",
         trip_id=record.trip_id,
         budget_plan_id=plan_record.budget_plan_id,
         category_key=category_key,
         amount=amount,
-        currency=currency or plan_record.currency,
-        occurred_at=occurred_at or _isoformat(datetime.now(UTC)),
+        currency=event_currency,
+        occurred_at=occurred_at or now,
         source_kind=source_kind,
         source_context=source_context,
         scenario_budget_id=scenario_budget_id,
@@ -479,6 +537,10 @@ def record_workspace_spend_event(
             notes=list(event.notes),
         )
     )
+    session_record = _ensure_session_record(db_session, record=record, timestamp=now)
+    session_record.active_budget_plan_id = plan_record.budget_plan_id
+    session_record.last_updated_at = _next_session_timestamp(session_record.last_updated_at)
+    record.updated_at = datetime.now(UTC)
     db_session.commit()
     return _load_budget_payload_for_record(db_session, record=record)
 
@@ -511,9 +573,18 @@ def update_workspace_spend_event(
         raise ValueError(f"source_kind must be one of {ACTUAL_SPEND_SOURCE_KINDS}")
     if category_key not in BUDGET_CATEGORY_KEYS:
         raise ValueError(f"category_key must be one of {BUDGET_CATEGORY_KEYS}")
+    updated_currency = event_record.currency
+    if currency is not None:
+        normalized_currency = currency.strip().upper()
+        if len(normalized_currency) != 3 or not normalized_currency.isalpha():
+            raise ValueError("currency must be a 3-letter ISO currency code")
+        if normalized_currency != event_record.currency:
+            raise ValueError("currency cannot be changed for an existing spend event")
+        updated_currency = normalized_currency
+    now = _next_session_timestamp(None)
     event_record.category_key = category_key
     event_record.amount = amount
-    event_record.currency = currency or event_record.currency
+    event_record.currency = updated_currency
     event_record.occurred_at = occurred_at or event_record.occurred_at
     event_record.source_kind = source_kind
     event_record.source_context = source_context
@@ -522,5 +593,9 @@ def update_workspace_spend_event(
     event_record.merchant_name = merchant_name
     event_record.source_ref = source_ref
     event_record.notes = list(notes)
+    session_record = _ensure_session_record(db_session, record=record, timestamp=now)
+    session_record.active_budget_plan_id = event_record.budget_plan_id
+    session_record.last_updated_at = _next_session_timestamp(session_record.last_updated_at)
+    record.updated_at = datetime.now(UTC)
     db_session.commit()
     return _load_budget_payload_for_record(db_session, record=record)

--- a/trip_planner/app/services/budget.py
+++ b/trip_planner/app/services/budget.py
@@ -53,6 +53,10 @@ def _to_currency_amount(value: float | Decimal) -> float:
     return round(float(value), 2)
 
 
+def _to_decimal_amount(value: float) -> Decimal:
+    return Decimal(f"{value:.2f}")
+
+
 def _next_session_timestamp(current_value: str | None) -> str:
     now = datetime.now(UTC)
     if current_value:
@@ -525,7 +529,7 @@ def record_workspace_spend_event(
             trip_id=event.trip_id,
             budget_plan_id=event.budget_plan_id,
             category_key=event.category_key,
-            amount=event.amount,
+            amount=_to_decimal_amount(event.amount),
             currency=event.currency,
             occurred_at=event.occurred_at,
             source_kind=event.source_kind,
@@ -583,7 +587,7 @@ def update_workspace_spend_event(
         updated_currency = normalized_currency
     now = _next_session_timestamp(None)
     event_record.category_key = category_key
-    event_record.amount = amount
+    event_record.amount = _to_decimal_amount(amount)
     event_record.currency = updated_currency
     event_record.occurred_at = occurred_at or event_record.occurred_at
     event_record.source_kind = source_kind

--- a/trip_planner/app/services/budget.py
+++ b/trip_planner/app/services/budget.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.persistence.models.budget import (
+    PersistedActualSpendEvent,
+    PersistedBudgetPlan,
+    PersistedBudgetPlanVersion,
+)
+from trip_planner.persistence.models.session import PersistedPlanningSessionState
+from trip_planner.persistence.models.trip import PersistedTrip
+from trip_planner.state import (
+    ACTUAL_SPEND_SOURCE_KINDS,
+    ActualSpendEvent,
+    BUDGET_CATEGORY_KEYS,
+    BUSINESS_ONLY_BUDGET_CATEGORIES,
+    BudgetCategoryAllocation,
+    BudgetPlan,
+    BudgetScenario,
+)
+
+
+class WorkspaceBudgetNotFoundError(ValueError):
+    """Raised when a workspace budget or trip does not exist for the user."""
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _state_fixture_dir(kind: str) -> Path:
+    return _repo_root() / "tests" / "fixtures" / "state" / kind
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _isoformat(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _owner_profile_id(record: PersistedTrip) -> str:
+    if record.mode == "business" and record.business_profile_id:
+        return record.business_profile_id
+    if record.leisure_profile_id:
+        return record.leisure_profile_id
+    return f"profile:{record.trip_id}:{record.mode}"
+
+
+def _suggested_categories(mode: str) -> list[str]:
+    business_only = set(BUSINESS_ONLY_BUDGET_CATEGORIES)
+    return [
+        category
+        for category in BUDGET_CATEGORY_KEYS
+        if mode == "business" or category not in business_only
+    ]
+
+
+def _serialize_budget_plan(record: PersistedBudgetPlan) -> dict[str, Any]:
+    return BudgetPlan.from_dict(
+        {
+            "budget_plan_id": record.budget_plan_id,
+            "trip_id": record.trip_id,
+            "owner_profile_id": record.owner_profile_id,
+            "title": record.title,
+            "mode": record.mode,
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+            "scenario_budgets": list(record.scenario_budgets),
+            "current_scenario_budget_id": record.current_scenario_budget_id,
+            "currency": record.currency,
+            "schema_version": record.schema_version,
+            "tags": list(record.tags),
+            "notes": list(record.notes),
+        }
+    ).to_dict()
+
+
+def _serialize_spend_event(record: PersistedActualSpendEvent) -> dict[str, Any]:
+    return ActualSpendEvent.from_dict(
+        {
+            "spend_event_id": record.spend_event_id,
+            "trip_id": record.trip_id,
+            "budget_plan_id": record.budget_plan_id,
+            "category_key": record.category_key,
+            "amount": record.amount,
+            "currency": record.currency,
+            "occurred_at": record.occurred_at,
+            "source_kind": record.source_kind,
+            "source_context": record.source_context,
+            "scenario_budget_id": record.scenario_budget_id,
+            "saved_scenario_id": record.saved_scenario_id,
+            "merchant_name": record.merchant_name,
+            "source_ref": record.source_ref,
+            "notes": list(record.notes),
+        }
+    ).to_dict()
+
+
+def _serialize_version(record: PersistedBudgetPlanVersion) -> dict[str, Any]:
+    return {
+        "version_id": record.version_id,
+        "budget_plan_id": record.budget_plan_id,
+        "recorded_at": record.recorded_at,
+        "summary": record.summary,
+    }
+
+
+def _build_budget_summary(
+    *,
+    trip_mode: str,
+    budget_plan: dict[str, Any] | None,
+    spend_events: list[dict[str, Any]],
+    versions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    current_scenario: dict[str, Any] | None = None
+    allocations: list[dict[str, Any]] = []
+    currency = "USD"
+
+    if budget_plan is not None:
+        currency = budget_plan["currency"]
+        current_scenario = next(
+            (
+                scenario
+                for scenario in budget_plan["scenario_budgets"]
+                if scenario["scenario_budget_id"] == budget_plan["current_scenario_budget_id"]
+            ),
+            budget_plan["scenario_budgets"][0] if budget_plan["scenario_budgets"] else None,
+        )
+        allocations = list(current_scenario["allocations"]) if current_scenario is not None else []
+
+    spend_totals_by_category: dict[str, float] = {}
+    for event in spend_events:
+        spend_totals_by_category[event["category_key"]] = round(
+            spend_totals_by_category.get(event["category_key"], 0.0) + event["amount"],
+            2,
+        )
+
+    category_summaries: list[dict[str, Any]] = []
+    if allocations:
+        for allocation in allocations:
+            actual_amount = round(spend_totals_by_category.get(allocation["category_key"], 0.0), 2)
+            planned_amount = round(allocation["planned_amount"], 2)
+            category_summaries.append(
+                {
+                    "category_key": allocation["category_key"],
+                    "label": allocation["label"],
+                    "currency": allocation["currency"],
+                    "planned_amount": planned_amount,
+                    "actual_amount": actual_amount,
+                    "remaining_amount": round(planned_amount - actual_amount, 2),
+                    "flexibility": allocation["flexibility"],
+                }
+            )
+    else:
+        for category in _suggested_categories(trip_mode):
+            category_summaries.append(
+                {
+                    "category_key": category,
+                    "label": category.replace("_", " ").title(),
+                    "currency": currency,
+                    "planned_amount": 0.0,
+                    "actual_amount": round(spend_totals_by_category.get(category, 0.0), 2),
+                    "remaining_amount": round(-spend_totals_by_category.get(category, 0.0), 2),
+                    "flexibility": "flexible",
+                }
+            )
+
+    planned_total = round(sum(item["planned_amount"] for item in category_summaries), 2)
+    actual_total = round(sum(item["actual_amount"] for item in category_summaries), 2)
+    return {
+        "currency": currency,
+        "has_budget_plan": budget_plan is not None,
+        "current_scenario_budget_id": budget_plan["current_scenario_budget_id"] if budget_plan else None,
+        "current_scenario_title": current_scenario["title"] if current_scenario else None,
+        "planned_total": planned_total,
+        "actual_total": actual_total,
+        "remaining_total": round(planned_total - actual_total, 2),
+        "spend_event_count": len(spend_events),
+        "version_count": len(versions),
+        "suggested_categories": _suggested_categories(trip_mode),
+        "category_summaries": category_summaries,
+    }
+
+
+def _budget_fixture_payload(trip_id: str, trip_mode: str) -> dict[str, Any]:
+    plan_name = "business_budget_plan.json" if trip_mode == "business" else "leisure_budget_plan.json"
+    budget_plan = BudgetPlan.from_dict(_load_json(_state_fixture_dir("budget") / plan_name)).to_dict()
+    event_payload = _load_json(_state_fixture_dir("budget") / "actual_spend_events.json")
+    spend_events = [
+        ActualSpendEvent.from_dict(item).to_dict()
+        for item in event_payload["events"]
+        if item["trip_id"] == trip_id
+    ]
+    versions = [
+        {
+            "version_id": f"{budget_plan['budget_plan_id']}-fixture-v1",
+            "budget_plan_id": budget_plan["budget_plan_id"],
+            "recorded_at": budget_plan["updated_at"],
+            "summary": "Fixture budget baseline",
+        }
+    ]
+    return {
+        "budget_plan": budget_plan,
+        "versions": versions,
+        "spend_events": spend_events,
+        "summary": _build_budget_summary(
+            trip_mode=trip_mode,
+            budget_plan=budget_plan,
+            spend_events=spend_events,
+            versions=versions,
+        ),
+    }
+
+
+def _get_owned_trip_record(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> PersistedTrip:
+    record = db_session.scalar(
+        select(PersistedTrip)
+        .where(PersistedTrip.trip_id == trip_id)
+        .where(PersistedTrip.user_id == user.user_id)
+    )
+    if record is None:
+        raise WorkspaceBudgetNotFoundError(f"Trip '{trip_id}' was not found.")
+    return record
+
+
+def _load_budget_payload_for_record(
+    db_session: Session,
+    *,
+    record: PersistedTrip,
+) -> dict[str, Any]:
+    plan_record = db_session.scalar(
+        select(PersistedBudgetPlan)
+        .where(PersistedBudgetPlan.trip_id == record.trip_id)
+        .where(PersistedBudgetPlan.user_id == record.user_id)
+        .order_by(PersistedBudgetPlan.updated_at.desc())
+    )
+    budget_plan = _serialize_budget_plan(plan_record) if plan_record is not None else None
+    versions = [
+        _serialize_version(item)
+        for item in db_session.scalars(
+            select(PersistedBudgetPlanVersion)
+            .where(PersistedBudgetPlanVersion.trip_id == record.trip_id)
+            .order_by(PersistedBudgetPlanVersion.recorded_at.desc())
+        ).all()
+    ]
+    spend_events = [
+        _serialize_spend_event(item)
+        for item in db_session.scalars(
+            select(PersistedActualSpendEvent)
+            .where(PersistedActualSpendEvent.trip_id == record.trip_id)
+            .order_by(PersistedActualSpendEvent.occurred_at.desc())
+        ).all()
+    ]
+    return {
+        "budget_plan": budget_plan,
+        "versions": versions,
+        "spend_events": spend_events,
+        "summary": _build_budget_summary(
+            trip_mode=record.mode,
+            budget_plan=budget_plan,
+            spend_events=spend_events,
+            versions=versions,
+        ),
+    }
+
+
+def get_workspace_budget_payload(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> dict[str, Any]:
+    record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    return _load_budget_payload_for_record(db_session, record=record)
+
+
+def build_fixture_budget_payload(*, trip_id: str, trip_mode: str) -> dict[str, Any]:
+    return _budget_fixture_payload(trip_id, trip_mode)
+
+
+def load_budget_payload_for_workspace(
+    db_session: Session,
+    *,
+    record: PersistedTrip,
+) -> dict[str, Any]:
+    return _load_budget_payload_for_record(db_session, record=record)
+
+
+def upsert_workspace_budget_plan(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    title: str,
+    currency: str,
+    current_scenario_budget_id: str | None,
+    tags: list[str],
+    notes: list[str],
+    scenario_budgets: list[dict[str, Any]],
+    summary: str = "",
+) -> dict[str, Any]:
+    record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    existing = db_session.scalar(
+        select(PersistedBudgetPlan)
+        .where(PersistedBudgetPlan.trip_id == record.trip_id)
+        .where(PersistedBudgetPlan.user_id == record.user_id)
+    )
+    now = _isoformat(datetime.now(UTC))
+    plan_id = existing.budget_plan_id if existing is not None else f"budget-plan:{record.trip_id}"
+    normalized_scenarios: list[dict[str, Any]] = []
+    for index, scenario_payload in enumerate(scenario_budgets):
+        scenario_id = scenario_payload.get("scenario_budget_id") or f"{plan_id}:scenario-{index + 1}"
+        allocations = [
+            BudgetCategoryAllocation(
+                category_key=item["category_key"],
+                label=item["label"],
+                planned_amount=item["planned_amount"],
+                currency=item.get("currency", currency),
+                flexibility=item.get("flexibility", "flexible"),
+                notes=list(item.get("notes", [])),
+            ).to_dict()
+            for item in scenario_payload["allocations"]
+        ]
+        normalized_scenarios.append(
+            BudgetScenario(
+                scenario_budget_id=scenario_id,
+                trip_id=record.trip_id,
+                title=scenario_payload["title"],
+                created_at=existing.created_at if existing is not None else now,
+                allocations=[BudgetCategoryAllocation.from_dict(item) for item in allocations],
+                currency=currency,
+                saved_scenario_id=scenario_payload.get("saved_scenario_id"),
+                summary=scenario_payload.get("summary", ""),
+                tags=list(scenario_payload.get("tags", [])),
+                notes=list(scenario_payload.get("notes", [])),
+            ).to_dict()
+        )
+    current_id = current_scenario_budget_id or normalized_scenarios[0]["scenario_budget_id"]
+    budget_plan = BudgetPlan.from_dict(
+        {
+            "budget_plan_id": plan_id,
+            "trip_id": record.trip_id,
+            "owner_profile_id": _owner_profile_id(record),
+            "title": title,
+            "mode": record.mode,
+            "created_at": existing.created_at if existing is not None else now,
+            "updated_at": now,
+            "scenario_budgets": normalized_scenarios,
+            "current_scenario_budget_id": current_id,
+            "currency": currency,
+            "tags": tags,
+            "notes": notes,
+        }
+    )
+
+    if existing is None:
+        existing = PersistedBudgetPlan(
+            budget_plan_id=budget_plan.budget_plan_id,
+            trip_id=record.trip_id,
+            user_id=record.user_id,
+            owner_profile_id=budget_plan.owner_profile_id,
+            title=budget_plan.title,
+            mode=budget_plan.mode,
+            current_scenario_budget_id=budget_plan.current_scenario_budget_id,
+            currency=budget_plan.currency,
+            schema_version=budget_plan.schema_version,
+            scenario_budgets=budget_plan.to_dict()["scenario_budgets"],
+            tags=list(budget_plan.tags),
+            notes=list(budget_plan.notes),
+            created_at=budget_plan.created_at,
+            updated_at=budget_plan.updated_at,
+        )
+        db_session.add(existing)
+    else:
+        existing.owner_profile_id = budget_plan.owner_profile_id
+        existing.title = budget_plan.title
+        existing.mode = budget_plan.mode
+        existing.current_scenario_budget_id = budget_plan.current_scenario_budget_id
+        existing.currency = budget_plan.currency
+        existing.schema_version = budget_plan.schema_version
+        existing.scenario_budgets = budget_plan.to_dict()["scenario_budgets"]
+        existing.tags = list(budget_plan.tags)
+        existing.notes = list(budget_plan.notes)
+        existing.updated_at = budget_plan.updated_at
+
+    record.budget_state_id = budget_plan.budget_plan_id
+    session_record = db_session.get(PersistedPlanningSessionState, f"session:{record.trip_id}")
+    if session_record is not None:
+        session_record.active_budget_plan_id = budget_plan.budget_plan_id
+        session_record.last_updated_at = now
+
+    db_session.add(
+        PersistedBudgetPlanVersion(
+            version_id=f"{budget_plan.budget_plan_id}-v{secrets.token_hex(4)}",
+            budget_plan_id=budget_plan.budget_plan_id,
+            trip_id=record.trip_id,
+            recorded_at=budget_plan.updated_at,
+            summary=summary or "Budget plan updated",
+            snapshot=budget_plan.to_dict(),
+        )
+    )
+    db_session.commit()
+    return _load_budget_payload_for_record(db_session, record=record)
+
+
+def record_workspace_spend_event(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    category_key: str,
+    amount: float,
+    currency: str | None,
+    occurred_at: str | None,
+    source_kind: str,
+    source_context: str,
+    scenario_budget_id: str | None,
+    saved_scenario_id: str | None,
+    merchant_name: str,
+    source_ref: str | None,
+    notes: list[str],
+) -> dict[str, Any]:
+    record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    plan_record = db_session.scalar(
+        select(PersistedBudgetPlan)
+        .where(PersistedBudgetPlan.trip_id == record.trip_id)
+        .where(PersistedBudgetPlan.user_id == record.user_id)
+    )
+    if plan_record is None:
+        raise WorkspaceBudgetNotFoundError(
+            f"Trip '{trip_id}' does not have a persisted budget plan yet."
+        )
+    event = ActualSpendEvent(
+        spend_event_id=f"spend:{record.trip_id}:{secrets.token_hex(4)}",
+        trip_id=record.trip_id,
+        budget_plan_id=plan_record.budget_plan_id,
+        category_key=category_key,
+        amount=amount,
+        currency=currency or plan_record.currency,
+        occurred_at=occurred_at or _isoformat(datetime.now(UTC)),
+        source_kind=source_kind,
+        source_context=source_context,
+        scenario_budget_id=scenario_budget_id,
+        saved_scenario_id=saved_scenario_id,
+        merchant_name=merchant_name,
+        source_ref=source_ref,
+        notes=notes,
+    )
+    db_session.add(
+        PersistedActualSpendEvent(
+            spend_event_id=event.spend_event_id,
+            trip_id=event.trip_id,
+            budget_plan_id=event.budget_plan_id,
+            category_key=event.category_key,
+            amount=event.amount,
+            currency=event.currency,
+            occurred_at=event.occurred_at,
+            source_kind=event.source_kind,
+            source_context=event.source_context,
+            scenario_budget_id=event.scenario_budget_id,
+            saved_scenario_id=event.saved_scenario_id,
+            merchant_name=event.merchant_name,
+            source_ref=event.source_ref,
+            notes=list(event.notes),
+        )
+    )
+    db_session.commit()
+    return _load_budget_payload_for_record(db_session, record=record)
+
+
+def update_workspace_spend_event(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    spend_event_id: str,
+    category_key: str,
+    amount: float,
+    currency: str | None,
+    occurred_at: str | None,
+    source_kind: str,
+    source_context: str,
+    scenario_budget_id: str | None,
+    saved_scenario_id: str | None,
+    merchant_name: str,
+    source_ref: str | None,
+    notes: list[str],
+) -> dict[str, Any]:
+    record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    event_record = db_session.get(PersistedActualSpendEvent, spend_event_id)
+    if event_record is None or event_record.trip_id != record.trip_id:
+        raise WorkspaceBudgetNotFoundError(
+            f"Spend event '{spend_event_id}' was not found for trip '{trip_id}'."
+        )
+    if source_kind not in ACTUAL_SPEND_SOURCE_KINDS:
+        raise ValueError(f"source_kind must be one of {ACTUAL_SPEND_SOURCE_KINDS}")
+    if category_key not in BUDGET_CATEGORY_KEYS:
+        raise ValueError(f"category_key must be one of {BUDGET_CATEGORY_KEYS}")
+    event_record.category_key = category_key
+    event_record.amount = amount
+    event_record.currency = currency or event_record.currency
+    event_record.occurred_at = occurred_at or event_record.occurred_at
+    event_record.source_kind = source_kind
+    event_record.source_context = source_context
+    event_record.scenario_budget_id = scenario_budget_id
+    event_record.saved_scenario_id = saved_scenario_id
+    event_record.merchant_name = merchant_name
+    event_record.source_ref = source_ref
+    event_record.notes = list(notes)
+    db_session.commit()
+    return _load_budget_payload_for_record(db_session, record=record)

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -11,6 +11,10 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.app.services.budget import (
+    build_fixture_budget_payload,
+    load_budget_payload_for_workspace,
+)
 from trip_planner.app.services.feasibility import (
     build_feasibility_planner_outputs,
     build_feasibility_summary_payload,
@@ -598,6 +602,7 @@ def _default_workspace_session(record: PersistedTrip) -> PlanningSessionState:
         recent_option_presentations=[_default_workspace_presentation(record.trip_id, timestamp)],
         pending_decisions=_default_workspace_decisions(record.trip_id),
         activity_log_id=f"activity-log:{record.trip_id}",
+        active_budget_plan_id=record.budget_state_id,
         notes=["Workspace opened before any saved scenarios or planner turns existed."],
     )
 
@@ -695,11 +700,30 @@ def _build_persisted_trip_workspace(
     session: dict[str, Any] | None = None,
     saved_scenarios: list[dict[str, Any]] | None = None,
     activity_log: list[dict[str, Any]] | None = None,
+    budget_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     resolved_session = session or _default_workspace_session(record).to_dict()
     trip_record = _serialize_persisted_trip_record(record)
     resolved_saved_scenarios = saved_scenarios or []
     resolved_activity_log = activity_log or []
+    resolved_budget_state = budget_state or {
+        "budget_plan": None,
+        "versions": [],
+        "spend_events": [],
+        "summary": {
+            "currency": "USD",
+            "has_budget_plan": False,
+            "current_scenario_budget_id": None,
+            "current_scenario_title": None,
+            "planned_total": 0.0,
+            "actual_total": 0.0,
+            "remaining_total": 0.0,
+            "spend_event_count": 0,
+            "version_count": 0,
+            "suggested_categories": [],
+            "category_summaries": [],
+        },
+    }
     scenario_search = _empty_workspace_scenario_search()
 
     inventory_bundles = assemble_inventory_bundles_for_trip(
@@ -730,6 +754,7 @@ def _build_persisted_trip_workspace(
         ),
         "feasibility_summary": feasibility_summary,
         "inventory_summary": build_inventory_summary_payload(inventory_bundles),
+        "budget_state": resolved_budget_state,
     }
 
 
@@ -1060,6 +1085,10 @@ def get_workspace_payload(
             ),
             "feasibility_summary": feasibility_summary,
             "inventory_summary": build_inventory_summary_payload(inventory_bundles),
+            "budget_state": build_fixture_budget_payload(
+                trip_id=trip_id,
+                trip_mode=trip_record.trip.mode,
+            ),
         }
 
     record = db_session.scalar(
@@ -1101,6 +1130,7 @@ def get_workspace_payload(
             for scenario in persisted_saved_scenarios
         ],
         activity_log=[_serialize_activity_record(item) for item in activity_records],
+        budget_state=load_budget_payload_for_workspace(db_session, record=record),
     )
 
 

--- a/trip_planner/persistence/alembic/versions/20260408_02_budget_state.py
+++ b/trip_planner/persistence/alembic/versions/20260408_02_budget_state.py
@@ -121,7 +121,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("category_key", sa.String(length=64), nullable=False),
-        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("amount", sa.Numeric(precision=12, scale=2), nullable=False),
         sa.Column("currency", sa.String(length=3), nullable=False),
         sa.Column("occurred_at", sa.String(length=64), nullable=False),
         sa.Column("source_kind", sa.String(length=32), nullable=False),

--- a/trip_planner/persistence/alembic/versions/20260408_02_budget_state.py
+++ b/trip_planner/persistence/alembic/versions/20260408_02_budget_state.py
@@ -1,0 +1,238 @@
+"""add persisted budget plan and actual-spend state
+
+Revision ID: 20260408_02
+Revises: 20260408_01
+Create Date: 2026-04-08 00:30:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260408_02"
+down_revision = "20260408_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "persisted_budget_plans",
+        sa.Column("budget_plan_id", sa.String(length=96), primary_key=True),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.String(length=96),
+            sa.ForeignKey("user_accounts.user_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("owner_profile_id", sa.String(length=96), nullable=False),
+        sa.Column("title", sa.String(length=160), nullable=False),
+        sa.Column("mode", sa.String(length=32), nullable=False),
+        sa.Column("current_scenario_budget_id", sa.String(length=96), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("schema_version", sa.String(length=16), nullable=False),
+        sa.Column("scenario_budgets", sa.JSON(), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("notes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.String(length=64), nullable=False),
+        sa.Column("updated_at", sa.String(length=64), nullable=False),
+        sa.Column("created_at_ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at_ts", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_persisted_budget_plans_trip_id"),
+        "persisted_budget_plans",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_budget_plans_user_id"),
+        "persisted_budget_plans",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_budget_plans_updated_at"),
+        "persisted_budget_plans",
+        ["updated_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "persisted_budget_plan_versions",
+        sa.Column("version_id", sa.String(length=128), primary_key=True),
+        sa.Column(
+            "budget_plan_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_budget_plans.budget_plan_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("recorded_at", sa.String(length=64), nullable=False),
+        sa.Column("summary", sa.String(length=240), nullable=False),
+        sa.Column("snapshot", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_persisted_budget_plan_versions_budget_plan_id"),
+        "persisted_budget_plan_versions",
+        ["budget_plan_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_budget_plan_versions_trip_id"),
+        "persisted_budget_plan_versions",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_budget_plan_versions_recorded_at"),
+        "persisted_budget_plan_versions",
+        ["recorded_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "persisted_actual_spend_events",
+        sa.Column("spend_event_id", sa.String(length=96), primary_key=True),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "budget_plan_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_budget_plans.budget_plan_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("category_key", sa.String(length=64), nullable=False),
+        sa.Column("amount", sa.Float(), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("occurred_at", sa.String(length=64), nullable=False),
+        sa.Column("source_kind", sa.String(length=32), nullable=False),
+        sa.Column("source_context", sa.String(length=240), nullable=False),
+        sa.Column("scenario_budget_id", sa.String(length=96), nullable=True),
+        sa.Column("saved_scenario_id", sa.String(length=96), nullable=True),
+        sa.Column("merchant_name", sa.String(length=160), nullable=False),
+        sa.Column("source_ref", sa.String(length=160), nullable=True),
+        sa.Column("notes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_persisted_actual_spend_events_trip_id"),
+        "persisted_actual_spend_events",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_actual_spend_events_budget_plan_id"),
+        "persisted_actual_spend_events",
+        ["budget_plan_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_actual_spend_events_category_key"),
+        "persisted_actual_spend_events",
+        ["category_key"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_actual_spend_events_occurred_at"),
+        "persisted_actual_spend_events",
+        ["occurred_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_actual_spend_events_source_kind"),
+        "persisted_actual_spend_events",
+        ["source_kind"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_actual_spend_events_scenario_budget_id"),
+        "persisted_actual_spend_events",
+        ["scenario_budget_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_actual_spend_events_saved_scenario_id"),
+        "persisted_actual_spend_events",
+        ["saved_scenario_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_persisted_actual_spend_events_saved_scenario_id"),
+        table_name="persisted_actual_spend_events",
+    )
+    op.drop_index(
+        op.f("ix_persisted_actual_spend_events_scenario_budget_id"),
+        table_name="persisted_actual_spend_events",
+    )
+    op.drop_index(
+        op.f("ix_persisted_actual_spend_events_source_kind"),
+        table_name="persisted_actual_spend_events",
+    )
+    op.drop_index(
+        op.f("ix_persisted_actual_spend_events_occurred_at"),
+        table_name="persisted_actual_spend_events",
+    )
+    op.drop_index(
+        op.f("ix_persisted_actual_spend_events_category_key"),
+        table_name="persisted_actual_spend_events",
+    )
+    op.drop_index(
+        op.f("ix_persisted_actual_spend_events_budget_plan_id"),
+        table_name="persisted_actual_spend_events",
+    )
+    op.drop_index(
+        op.f("ix_persisted_actual_spend_events_trip_id"),
+        table_name="persisted_actual_spend_events",
+    )
+    op.drop_table("persisted_actual_spend_events")
+
+    op.drop_index(
+        op.f("ix_persisted_budget_plan_versions_recorded_at"),
+        table_name="persisted_budget_plan_versions",
+    )
+    op.drop_index(
+        op.f("ix_persisted_budget_plan_versions_trip_id"),
+        table_name="persisted_budget_plan_versions",
+    )
+    op.drop_index(
+        op.f("ix_persisted_budget_plan_versions_budget_plan_id"),
+        table_name="persisted_budget_plan_versions",
+    )
+    op.drop_table("persisted_budget_plan_versions")
+
+    op.drop_index(
+        op.f("ix_persisted_budget_plans_updated_at"),
+        table_name="persisted_budget_plans",
+    )
+    op.drop_index(
+        op.f("ix_persisted_budget_plans_user_id"),
+        table_name="persisted_budget_plans",
+    )
+    op.drop_index(
+        op.f("ix_persisted_budget_plans_trip_id"),
+        table_name="persisted_budget_plans",
+    )
+    op.drop_table("persisted_budget_plans")

--- a/trip_planner/persistence/db.py
+++ b/trip_planner/persistence/db.py
@@ -89,6 +89,7 @@ def ensure_database_ready(url: str | None = None) -> None:
     if resolved_url in _MIGRATED_URLS:
         return
 
+    from trip_planner.persistence.models import budget  # noqa: F401
     from trip_planner.persistence.models import account, scenario, session, trip  # noqa: F401
 
     _ensure_sqlite_parent_dir(resolved_url)

--- a/trip_planner/persistence/models/__init__.py
+++ b/trip_planner/persistence/models/__init__.py
@@ -1,6 +1,11 @@
 """Persistence models for runtime-backed storage."""
 
 from trip_planner.persistence.models.account import UserAccount
+from trip_planner.persistence.models.budget import (
+    PersistedActualSpendEvent,
+    PersistedBudgetPlan,
+    PersistedBudgetPlanVersion,
+)
 from trip_planner.persistence.models.scenario import (
     PersistedActivityLogEvent,
     PersistedSavedScenario,
@@ -14,6 +19,9 @@ from trip_planner.persistence.models.trip import PersistedTrip
 __all__ = [
     "AuthSession",
     "PersistedActivityLogEvent",
+    "PersistedActualSpendEvent",
+    "PersistedBudgetPlan",
+    "PersistedBudgetPlanVersion",
     "PersistedPlanningSessionState",
     "PersistedSavedScenario",
     "PersistedTrip",

--- a/trip_planner/persistence/models/budget.py
+++ b/trip_planner/persistence/models/budget.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from datetime import UTC, datetime
 
-from sqlalchemy import JSON, DateTime, Float, ForeignKey, String
+from sqlalchemy import JSON, DateTime, ForeignKey, Numeric, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from trip_planner.persistence.db import Base
@@ -79,7 +80,7 @@ class PersistedActualSpendEvent(Base):
         index=True,
     )
     category_key: Mapped[str] = mapped_column(String(64), index=True)
-    amount: Mapped[float] = mapped_column(Float)
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2))
     currency: Mapped[str] = mapped_column(String(3))
     occurred_at: Mapped[str] = mapped_column(String(64), index=True)
     source_kind: Mapped[str] = mapped_column(String(32), index=True)

--- a/trip_planner/persistence/models/budget.py
+++ b/trip_planner/persistence/models/budget.py
@@ -1,0 +1,97 @@
+"""SQLAlchemy models for persisted budget plans and actual-spend events."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, Float, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from trip_planner.persistence.db import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class PersistedBudgetPlan(Base):
+    __tablename__ = "persisted_budget_plans"
+
+    budget_plan_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("user_accounts.user_id", ondelete="CASCADE"),
+        index=True,
+    )
+    owner_profile_id: Mapped[str] = mapped_column(String(96))
+    title: Mapped[str] = mapped_column(String(160))
+    mode: Mapped[str] = mapped_column(String(32))
+    current_scenario_budget_id: Mapped[str] = mapped_column(String(96))
+    currency: Mapped[str] = mapped_column(String(3), default="USD")
+    schema_version: Mapped[str] = mapped_column(String(16), default="0.1.0")
+    scenario_budgets: Mapped[list[dict]] = mapped_column(JSON, default=list)
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    notes: Mapped[list[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[str] = mapped_column(String(64))
+    updated_at: Mapped[str] = mapped_column(String(64), index=True)
+    created_at_ts: Mapped[datetime] = mapped_column(
+        "created_at_ts", DateTime(timezone=True), default=_utcnow
+    )
+    updated_at_ts: Mapped[datetime] = mapped_column(
+        "updated_at_ts",
+        DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+    )
+
+
+class PersistedBudgetPlanVersion(Base):
+    __tablename__ = "persisted_budget_plan_versions"
+
+    version_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    budget_plan_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_budget_plans.budget_plan_id", ondelete="CASCADE"),
+        index=True,
+    )
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    recorded_at: Mapped[str] = mapped_column(String(64), index=True)
+    summary: Mapped[str] = mapped_column(String(240), default="")
+    snapshot: Mapped[dict] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+
+class PersistedActualSpendEvent(Base):
+    __tablename__ = "persisted_actual_spend_events"
+
+    spend_event_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    budget_plan_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_budget_plans.budget_plan_id", ondelete="CASCADE"),
+        index=True,
+    )
+    category_key: Mapped[str] = mapped_column(String(64), index=True)
+    amount: Mapped[float] = mapped_column(Float)
+    currency: Mapped[str] = mapped_column(String(3))
+    occurred_at: Mapped[str] = mapped_column(String(64), index=True)
+    source_kind: Mapped[str] = mapped_column(String(32), index=True)
+    source_context: Mapped[str] = mapped_column(String(240))
+    scenario_budget_id: Mapped[str | None] = mapped_column(String(96), nullable=True, index=True)
+    saved_scenario_id: Mapped[str | None] = mapped_column(String(96), nullable=True, index=True)
+    merchant_name: Mapped[str] = mapped_column(String(160), default="")
+    source_ref: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    notes: Mapped[list[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #694

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
This merged PR delivered the first workspace-visible budget workflow for trip planning. It added persisted budget-plan and actual-spend APIs, exposed budget editing and spend capture in the React workspace, surfaced planned-vs-actual totals in the UI, and documented how later planner reasoning should consume the saved budget state.

Parent epic: #678

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#678](https://github.com/stranske/trip-planner/issues/678)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks completed in this PR
- [x] Added budget CRUD and actual-spend persistence APIs.
- [x] Added frontend budget editing UI for category targets and caps.
- [x] Added frontend actual-spend capture UI for simple event entry.
- [x] Displayed budget-vs-actual totals and summaries in the workspace.
- [x] Added tests for persistence and UI state updates.
- [x] Documented how budget state should connect to later planner reasoning.

#### Acceptance evidence for this PR
- [x] Users can edit a trip budget in the app UI.
- [x] Users can record actual spend events in the app UI.
- [x] The workspace shows updated planned-vs-actual budget status after edits.
- [x] Automated tests cover backend persistence and frontend budget/actual-spend behavior.

#### Evidence snapshot
- Added persisted workspace budget endpoints and services for budget plans and spend events.
- Added `WorkspaceBudgetPanel` so the workspace can save category caps, capture actual spend, and render live budget-vs-actual totals.
- Added backend tests for budget persistence, spend capture, spend-event updates, currency-guard rails, and session timestamp refresh.
- Added frontend workspace tests that cover budget saves and actual-spend capture updating rendered totals.
- Documented the budget reasoning handoff in `docs/frontend-trip-workspace.md` so later planner and policy flows build on the persisted budget state from this lane.

**Head SHA:** 5070eaf4d39fb8daa44eadf1854f100890ddb2f1
**Merge Commit:** 6480c836b6c36d649f0db4c959f1ebef7f3111d6
<!-- auto-status-summary:end -->
