### PR TITLE
Fix workspace date-only rendering for issue 687

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -474,6 +474,36 @@ describe("WorkspacePage", () => {
     });
   });
 
+  it("formats single persisted trip dates without shifting date-only values across time zones", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        trip_record: {
+          ...workspacePayload.trip_record,
+          trip: {
+            ...workspacePayload.trip_record.trip,
+            trip_id: "trip-chicago-arrival",
+            title: "Chicago arrival",
+            trip_frame: {
+              ...workspacePayload.trip_record.trip.trip_frame,
+              start_date: "2026-05-04",
+              end_date: null,
+            },
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Chicago arrival" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("May 4")).toBeInTheDocument();
+    expect(screen.queryByText("2026-05-04")).not.toBeInTheDocument();
+  });
+
   it("saves a budget plan and refreshes the workspace totals", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve(workspacePayload),

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -475,6 +475,8 @@ describe("WorkspacePage", () => {
   });
 
   it("formats single persisted trip dates without shifting date-only values across time zones", async () => {
+    expect(process.env.TZ).toBe("America/Los_Angeles");
+
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({
         ...workspacePayload,

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -475,7 +475,9 @@ describe("WorkspacePage", () => {
   });
 
   it("formats single persisted trip dates without shifting date-only values across time zones", async () => {
-    expect(process.env.TZ).toBe("America/Los_Angeles");
+    expect(new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(new Date("2026-05-04"))).toBe(
+      "May 3",
+    );
 
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -99,6 +99,16 @@ function buildTimelineStops(workspace: WorkspaceData): TimelineStop[] {
 }
 
 function formatDate(value: string): string {
+  const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (dateOnlyMatch) {
+    const [, year, month, day] = dateOnlyMatch;
+    return new Intl.DateTimeFormat("en-US", {
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    }).format(new Date(Date.UTC(Number(year), Number(month) - 1, Number(day))));
+  }
+
   return new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" }).format(new Date(value));
 }
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,5 +1,8 @@
 import "@testing-library/jest-dom/vitest";
 
+// Keep frontend tests off UTC so date-only regressions reproduce in CI.
+process.env.TZ = "America/Los_Angeles";
+
 Object.assign(globalThis, {
   Request,
   Response,

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,7 +1,14 @@
 import "@testing-library/jest-dom/vitest";
 
+type TestProcess = {
+  env: Record<string, string | undefined>;
+};
+
 // Keep frontend tests off UTC so date-only regressions reproduce in CI.
-process.env.TZ = "America/Los_Angeles";
+const testProcess = (globalThis as typeof globalThis & { process?: TestProcess }).process;
+if (testProcess) {
+  testProcess.env.TZ = "America/Los_Angeles";
+}
 
 Object.assign(globalThis, {
   Request,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #687

<!-- pr-preamble:end -->

## Summary
- format date-only trip frame values in UTC so single-date workspace metadata does not shift by timezone
- add a WorkspacePage regression test that covers a persisted single-date trip
- own the unresolved PR #733 review thread through a bounded follow-up lane

## Testing
- npm test -- --run src/routes/WorkspacePage.test.tsx

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Users need a first-run path from account state into an actual planning workspace. Without a trip-entry flow, the app still requires synthetic or manually seeded trip records to reach the planner.

Parent epic: #676

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#676](https://github.com/stranske/trip-planner/issues/676)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a frontend trip-entry flow for mode, dates, regions, and traveler-party basics.
- [ ] Persist the created trip through backend APIs rather than local-only UI state.
- [ ] Route the user into the correct workspace after trip creation.
- [ ] Show the created trip context in the workspace shell on first load.
- [ ] Add tests for the create-trip-to-workspace path.
- [ ] Document the minimum trip data required to open a workspace.

#### Acceptance criteria
- [ ] A signed-in user can create a trip from the app UI and land in the workspace.
- [ ] The workspace shows the created trip context after redirect.
- [ ] Created trip data survives refresh and reload.
- [ ] Automated tests cover the create-trip-to-workspace flow.

**Head SHA:** 2d9bae8a6e31abdfaa3d576149b8acdab5eff251
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24182791806) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24182791838) |
<!-- auto-status-summary:end -->