### PR TITLE
Issue #695: add persisted workspace policy sync state

### DIFF
--- a/docs/contracts/tpp-policy-sync.md
+++ b/docs/contracts/tpp-policy-sync.md
@@ -22,6 +22,12 @@ This scaffold imports policy constraints and organization context from `Travel-P
 - Imported policy data must stay advisory inside `trip-planner`; final compliance decisions still belong to `Travel-Plan-Permission`.
 - When a snapshot is stale or invalidated, the planner should treat it as unsuitable for final business recommendations and request a fresh import rather than silently trusting it.
 
+## Persisted Workspace Boundary
+
+- Persisted workspace policy state stores imported constraint sets, organization context, freshness metadata, and approval-readiness guidance for the current business trip.
+- That storage is intentionally not the proposal-submission system of record. It exists so the workspace can load real policy posture and required constraints before submission APIs are wired.
+- Proposal submission, final policy evaluation, and exception-resolution workflows remain later execution stages and should consume the stored constraint-state as input rather than overwrite its boundary.
+
 ## Issue Boundary
 
 - issue `#551` owns import and normalization only

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -19,7 +20,7 @@ def _load_fixture(name: str) -> dict:
 
 
 @pytest.fixture
-def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'policy.db'}")
     reset_database_state()
     app = create_app()

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -1,0 +1,107 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trip_planner.app.main import create_app
+from trip_planner.persistence.db import reset_database_state
+
+
+def _fixture_path(name: str) -> Path:
+    return (
+        Path(__file__).resolve().parents[1] / "fixtures" / "integrations" / "tpp" / "policy" / name
+    )
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'policy.db'}")
+    reset_database_state()
+    app = create_app()
+
+    with TestClient(app) as test_client:
+        test_client.post(
+            "/api/auth/signup",
+            json={
+                "email": "policy@example.com",
+                "password": "password123",
+                "display_name": "Policy Owner",
+            },
+        )
+        yield test_client
+
+    reset_database_state()
+
+
+def test_workspace_policy_import_persists_constraint_set_and_readiness(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Client policy sync",
+            "summary": "Import policy inputs for the workspace.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = _load_fixture("standard_policy_sync.json")
+
+    imported = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={
+            "request": fixture["request"],
+            "response": fixture["response"],
+            "source_kind": "tpp_sync",
+            "tags": ["business-policy"],
+            "notes": ["Imported from TPP fixture for workspace readiness."],
+        },
+    )
+
+    assert imported.status_code == 200
+    payload = imported.json()
+    assert payload["policy_state"]["trip_id"] == trip_id
+    assert payload["policy_state"]["policy_id"] == "policy-standard-2026-02"
+    assert payload["summary"]["required_booking_channels"] == ["Navan", "Concur"]
+    assert payload["policy_evaluation"]["status"] == "compliant"
+    assert payload["proposal"]["constraint_set_id"] == "policy-standard-2026-02"
+
+    reloaded = client.get(f"/api/workspace/{trip_id}/policy")
+    assert reloaded.status_code == 200
+    reloaded_payload = reloaded.json()
+    assert reloaded_payload["policy_state"]["policy_state_id"] == f"policy-state:{trip_id}"
+    assert "Persisted policy storage is limited" in reloaded_payload["policy_state"]["notes"][-2]
+
+
+def test_workspace_policy_import_rejects_leisure_trip(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Leisure trip",
+            "summary": "Should not accept policy imports.",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 2, "primary_regions": ["Kyoto"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = _load_fixture("standard_policy_sync.json")
+
+    response = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={
+            "request": fixture["request"],
+            "response": fixture["response"],
+        },
+    )
+
+    assert response.status_code == 400
+    assert "business trips" in response.json()["detail"]

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -171,6 +171,57 @@ def test_workspace_endpoint_returns_minimal_payload_for_persisted_trip(
     assert payload["budget_state"]["summary"]["has_budget_plan"] is False
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
     assert payload["planner_panel_state"]["option_set"]["purpose"] == "workspace_bootstrap"
+    assert payload["policy_state"] is None
+
+
+def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_trip(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Policy-backed workspace",
+            "summary": "Business workspace should load stored policy posture.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "fixtures"
+            / "integrations"
+            / "tpp"
+            / "policy"
+            / "standard_policy_sync.json"
+        ).read_text(encoding="utf-8")
+    )
+    imported = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={
+            "request": fixture["request"],
+            "response": fixture["response"],
+            "notes": ["Policy-backed workspace test import."],
+        },
+    )
+    assert imported.status_code == 200
+
+    response = client.get(f"/api/workspace/{trip_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["policy_state"]["policy_id"] == "policy-standard-2026-02"
+    assert payload["planner_panel_state"]["policy_evaluation"]["status"] == "compliant"
+    assert payload["planner_panel_state"]["proposal"]["constraint_set_id"] == "policy-standard-2026-02"
+    assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Policy posture loaded"
+    assert payload["planner_panel_state"]["next_step_actions"][0]["target_section"] == "approval"
+    assert "Navan" in payload["planner_panel_state"]["policy_evaluation"]["notes"][-2]
 
 
 def test_workspace_planner_decision_answer_persists_across_reload(client: TestClient) -> None:

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -59,6 +59,7 @@ trip_planner/app/routes/auth.py
 trip_planner/app/routes/budget.py
 trip_planner/app/routes/health.py
 trip_planner/app/routes/inventory.py
+trip_planner/app/routes/policy.py
 trip_planner/app/routes/scenario_history.py
 trip_planner/app/routes/trips.py
 trip_planner/app/routes/workspace.py
@@ -67,6 +68,7 @@ trip_planner/app/schemas/auth.py
 trip_planner/app/schemas/budget.py
 trip_planner/app/schemas/health.py
 trip_planner/app/schemas/inventory.py
+trip_planner/app/schemas/policy.py
 trip_planner/app/schemas/scenario_history.py
 trip_planner/app/schemas/trips.py
 trip_planner/app/schemas/workspace.py
@@ -74,6 +76,7 @@ trip_planner/app/services/auth.py
 trip_planner/app/services/budget.py
 trip_planner/app/services/feasibility.py
 trip_planner/app/services/inventory.py
+trip_planner/app/services/policy.py
 trip_planner/app/services/scenario_history.py
 trip_planner/app/services/scenarios.py
 trip_planner/app/services/trips.py
@@ -139,9 +142,11 @@ trip_planner/persistence/alembic/versions/20260407_02_persisted_trips.py
 trip_planner/persistence/alembic/versions/20260407_03_scenario_history_state.py
 trip_planner/persistence/alembic/versions/20260408_01_planning_session_state.py
 trip_planner/persistence/alembic/versions/20260408_02_budget_state.py
+trip_planner/persistence/alembic/versions/20260408_03_policy_state.py
 trip_planner/persistence/models/__init__.py
 trip_planner/persistence/models/account.py
 trip_planner/persistence/models/budget.py
+trip_planner/persistence/models/policy.py
 trip_planner/persistence/models/scenario.py
 trip_planner/persistence/models/session.py
 trip_planner/persistence/models/trip.py

--- a/trip_planner/app/main.py
+++ b/trip_planner/app/main.py
@@ -8,6 +8,7 @@ from trip_planner.app.routes.auth import router as auth_router
 from trip_planner.app.routes.budget import router as budget_router
 from trip_planner.app.routes.health import router as health_router
 from trip_planner.app.routes.inventory import router as inventory_router
+from trip_planner.app.routes.policy import router as policy_router
 from trip_planner.app.routes.scenario_history import router as scenario_history_router
 from trip_planner.app.routes.trips import router as trips_router
 from trip_planner.app.routes.workspace import router as workspace_router
@@ -40,6 +41,7 @@ def create_app() -> FastAPI:
     app.include_router(auth_router, prefix="/api")
     app.include_router(trips_router, prefix="/api")
     app.include_router(inventory_router, prefix="/api")
+    app.include_router(policy_router, prefix="/api")
     app.include_router(scenario_history_router, prefix="/api")
     app.include_router(workspace_router, prefix="/api")
     app.include_router(budget_router, prefix="/api")

--- a/trip_planner/app/routes/policy.py
+++ b/trip_planner/app/routes/policy.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from trip_planner.app.schemas.policy import (
+    PolicySyncImportRequest,
+    WorkspacePolicyResponse,
+)
+from trip_planner.app.services.auth import AuthenticatedUser, require_authenticated_user
+from trip_planner.app.services.policy import (
+    WorkspacePolicyNotFoundError,
+    get_workspace_policy_payload,
+    import_workspace_policy_constraints,
+)
+from trip_planner.persistence.db import get_db_session
+
+router = APIRouter(tags=["policy"])
+
+
+@router.get("/workspace/{trip_id}/policy", response_model=WorkspacePolicyResponse)
+def read_workspace_policy(
+    trip_id: str,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> WorkspacePolicyResponse:
+    try:
+        payload = get_workspace_policy_payload(db_session, user=user, trip_id=trip_id)
+    except WorkspacePolicyNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    return WorkspacePolicyResponse.model_validate(payload)
+
+
+@router.put("/workspace/{trip_id}/policy", response_model=WorkspacePolicyResponse)
+def save_workspace_policy(
+    trip_id: str,
+    payload: PolicySyncImportRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> WorkspacePolicyResponse:
+    try:
+        result = import_workspace_policy_constraints(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            request_payload=payload.request,
+            response_payload=payload.response,
+            source_kind=payload.source_kind,
+            tags=payload.tags,
+            notes=payload.notes,
+        )
+    except WorkspacePolicyNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return WorkspacePolicyResponse.model_validate(result)

--- a/trip_planner/app/schemas/policy.py
+++ b/trip_planner/app/schemas/policy.py
@@ -1,0 +1,22 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class PolicySyncImportRequest(BaseModel):
+    request: dict[str, Any] = Field(
+        description="Serialized TPPRequestEnvelope payload used to fetch policy constraints."
+    )
+    response: dict[str, Any] = Field(
+        description="Serialized TPPResponseEnvelope payload returned by the policy sync source."
+    )
+    source_kind: Literal["tpp_sync", "manual_import"] = "tpp_sync"
+    tags: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class WorkspacePolicyResponse(BaseModel):
+    policy_state: dict[str, Any] | None = None
+    proposal: dict[str, Any] | None = None
+    policy_evaluation: dict[str, Any] | None = None
+    summary: dict[str, Any] = Field(default_factory=dict)

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -40,6 +40,10 @@ class WorkspaceResponse(BaseModel):
         default_factory=dict,
         description="Persisted budget plan, actual spend entries, and budget-vs-actual summary for the workspace.",
     )
+    policy_state: dict[str, Any] | None = Field(
+        default=None,
+        description="Persisted policy constraint import and readiness summary for business-workspace flows.",
+    )
 
 
 class ScenarioComparisonSurfaceResponse(BaseModel):

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.business import (
+    ApprovalRequirement,
+    PolicyConstraintSet,
+    PolicyEvaluationResult,
+    PolicyFailureReason,
+    ProposalCostSummary,
+    SelectedOptionSummary,
+    TravelerContext,
+    TripPlanProposal,
+)
+from trip_planner.integrations.tpp import (
+    OrganizationContextSnapshot,
+    PolicyConstraintImport,
+    PolicyFreshness,
+    TPPPolicySyncService,
+    TPPRequestEnvelope,
+    TPPResponseEnvelope,
+)
+from trip_planner.persistence.models.policy import PersistedPolicyState
+from trip_planner.persistence.models.trip import PersistedTrip
+
+
+class WorkspacePolicyNotFoundError(ValueError):
+    """Raised when workspace policy state or trip ownership is missing."""
+
+
+def _isoformat(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _owner_profile_id(record: PersistedTrip) -> str:
+    if record.mode == "business" and record.business_profile_id:
+        return record.business_profile_id
+    if record.leisure_profile_id:
+        return record.leisure_profile_id
+    return f"profile:{record.trip_id}:{record.mode}"
+
+
+def _get_owned_trip_record(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> PersistedTrip:
+    record = db_session.scalar(
+        select(PersistedTrip)
+        .where(PersistedTrip.trip_id == trip_id)
+        .where(PersistedTrip.user_id == user.user_id)
+    )
+    if record is None:
+        raise WorkspacePolicyNotFoundError(f"Trip '{trip_id}' was not found.")
+    return record
+
+
+def _get_latest_policy_state(
+    db_session: Session,
+    *,
+    trip_id: str,
+    user_id: str,
+) -> PersistedPolicyState | None:
+    return db_session.scalar(
+        select(PersistedPolicyState)
+        .where(PersistedPolicyState.trip_id == trip_id)
+        .where(PersistedPolicyState.user_id == user_id)
+        .order_by(PersistedPolicyState.updated_at.desc())
+    )
+
+
+class _PassiveTPPClient:
+    def __init__(self, response: TPPResponseEnvelope) -> None:
+        self.response = response
+
+    def fetch_policy_constraints(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        return self.response
+
+
+def _is_effectively_stale(imported: PolicyConstraintImport) -> bool:
+    return imported.freshness.status != "current" or imported.freshness.invalidated_at is not None
+
+
+def _summarize_policy_import(imported: PolicyConstraintImport) -> dict[str, Any]:
+    constraint_set = imported.constraint_set
+    org = imported.organization_context
+    freshness = imported.freshness
+    stale = _is_effectively_stale(imported)
+    return {
+        "policy_id": constraint_set.policy_id,
+        "organization_id": constraint_set.organization_id,
+        "policy_version": constraint_set.policy_version,
+        "sync_status": freshness.status,
+        "is_stale": stale,
+        "required_booking_channels": list(constraint_set.required_booking_channels),
+        "approval_triggers": list(org.approval_triggers),
+        "documentation_rules": list(constraint_set.documentation_rules),
+        "allowed_exception_types": list(constraint_set.allowed_exception_types),
+        "fresh_until": freshness.fresh_until,
+        "captured_at": freshness.captured_at,
+    }
+
+
+def _proposal_from_import(record: PersistedTrip, imported: PolicyConstraintImport) -> TripPlanProposal:
+    notes = [
+        f"Imported policy {imported.constraint_set.policy_id} v{imported.constraint_set.policy_version}.",
+        (
+            "Final proposal submission remains out of scope for this stored-policy slice; "
+            "workspace approval-readiness is advisory until submission work lands."
+        ),
+    ]
+    if imported.constraint_set.documentation_rules:
+        notes.append(
+            "Required documentation: " + ", ".join(imported.constraint_set.documentation_rules)
+        )
+    return TripPlanProposal(
+        proposal_id=f"proposal-preview:{record.trip_id}",
+        trip_id=record.trip_id,
+        mode="business",
+        traveler_context=TravelerContext(
+            employee_type="employee",
+            traveler_experience="occasional",
+            home_airport="policy-import",
+            loyalty_programs=[],
+            mobility_or_access_needs=[],
+        ),
+        selected_options=[
+            SelectedOptionSummary(
+                category="policy_constraints",
+                option_id=f"policy-preview:{record.trip_id}",
+                label="Imported policy constraint set",
+                vendor=imported.organization_id,
+                booking_channel=(
+                    imported.constraint_set.required_booking_channels[0]
+                    if imported.constraint_set.required_booking_channels
+                    else "policy-sync"
+                ),
+                estimated_cost=None,
+                justification_refs=[f"policy-state:{record.trip_id}"],
+            )
+        ],
+        cost_summary=ProposalCostSummary(
+            currency="USD",
+            total_estimated_cost=0.0,
+            category_estimates={},
+            notes=["Cost summary not available until proposal submission wiring lands."],
+        ),
+        approval_notes=notes,
+        constraint_set_id=imported.constraint_set.policy_id,
+    )
+
+
+def _policy_evaluation_from_import(
+    record: PersistedTrip,
+    imported: PolicyConstraintImport,
+) -> PolicyEvaluationResult:
+    approval_requirements = [
+        ApprovalRequirement(role="manager", reason=f"Review trigger: {trigger}", mandatory=True)
+        for trigger in imported.organization_context.approval_triggers
+    ]
+    failure_reasons: list[PolicyFailureReason] = []
+    notes = [
+        f"Imported {imported.constraint_set.policy_id} for organization {imported.organization_id}.",
+        "Constraint storage is local to planning; final compliance decisions remain external.",
+    ]
+    compliance_score = 1.0
+    status = "compliant"
+
+    if _is_effectively_stale(imported):
+        status = "non_compliant"
+        compliance_score = 0.35
+        failure_reasons.append(
+            PolicyFailureReason(
+                code="stale_policy_snapshot",
+                message="Stored policy inputs are stale or invalidated and should be refreshed before submission.",
+                severity="blocking",
+                related_category="policy_sync",
+            )
+        )
+    elif approval_requirements:
+        compliance_score = 0.82
+        notes.append(
+            "Approval-readiness remains active because the imported policy defines approval triggers."
+        )
+
+    if not record.start_date or not record.end_date:
+        compliance_score = min(compliance_score, 0.65)
+        failure_reasons.append(
+            PolicyFailureReason(
+                code="trip_window_incomplete",
+                message="Trip dates should be finalized before the approval packet is treated as complete.",
+                severity="warning",
+                related_category="trip_frame",
+            )
+        )
+    if not record.primary_regions:
+        compliance_score = min(compliance_score, 0.65)
+        failure_reasons.append(
+            PolicyFailureReason(
+                code="trip_region_missing",
+                message="Primary travel regions are missing from the persisted trip frame.",
+                severity="warning",
+                related_category="trip_frame",
+            )
+        )
+
+    if imported.constraint_set.required_booking_channels:
+        notes.append(
+            "Approved booking channels: "
+            + ", ".join(imported.constraint_set.required_booking_channels)
+        )
+    if imported.constraint_set.documentation_rules:
+        notes.append(
+            "Documentation rules: " + ", ".join(imported.constraint_set.documentation_rules)
+        )
+
+    return PolicyEvaluationResult(
+        evaluation_id=f"policy-eval:{record.trip_id}:{imported.constraint_set.policy_id}",
+        proposal_id=f"proposal-preview:{record.trip_id}",
+        status=status,
+        approval_requirements=approval_requirements,
+        failure_reasons=failure_reasons,
+        preferred_alternatives=[],
+        exception_guidance=(
+            [
+                "Refresh the policy import before preparing a final approval packet."
+            ]
+            if _is_effectively_stale(imported)
+            else [
+                "Use the stored constraint set as planning guidance until proposal submission is wired."
+            ]
+        ),
+        notes=notes,
+        compliance_score=compliance_score,
+    )
+
+
+def _serialize_policy_state(record: PersistedPolicyState) -> dict[str, Any]:
+    return {
+        "policy_state_id": record.policy_state_id,
+        "trip_id": record.trip_id,
+        "owner_profile_id": record.owner_profile_id,
+        "source_kind": record.source_kind,
+        "source_request_id": record.source_request_id,
+        "source_correlation_id": record.source_correlation_id,
+        "policy_id": record.policy_id,
+        "organization_id": record.organization_id,
+        "policy_version": record.policy_version,
+        "sync_status": record.sync_status,
+        "imported_at": record.imported_at,
+        "constraint_set": dict(record.constraint_set),
+        "organization_context": dict(record.organization_context),
+        "freshness": dict(record.freshness),
+        "raw_payload": dict(record.raw_payload),
+        "tags": list(record.tags),
+        "notes": list(record.notes),
+    }
+
+
+def _build_workspace_policy_payload(
+    *,
+    trip_record: PersistedTrip,
+    policy_record: PersistedPolicyState,
+) -> dict[str, Any]:
+    imported = PolicyConstraintImport(
+        constraint_set=PolicyConstraintSet(**policy_record.constraint_set),
+        organization_context=OrganizationContextSnapshot(**policy_record.organization_context),
+        freshness=PolicyFreshness(**policy_record.freshness),
+        source_request_id=policy_record.source_request_id,
+        source_correlation_id=policy_record.source_correlation_id,
+        raw_payload=dict(policy_record.raw_payload),
+    )
+    proposal = _proposal_from_import(trip_record, imported)
+    policy_evaluation = _policy_evaluation_from_import(trip_record, imported)
+    return {
+        "policy_state": _serialize_policy_state(policy_record),
+        "proposal": proposal.to_dict(),
+        "policy_evaluation": policy_evaluation.to_dict(),
+        "summary": _summarize_policy_import(imported),
+    }
+
+
+def get_workspace_policy_payload(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> dict[str, Any]:
+    trip_record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    policy_record = _get_latest_policy_state(
+        db_session,
+        trip_id=trip_id,
+        user_id=user.user_id,
+    )
+    if policy_record is None:
+        return {
+            "policy_state": None,
+            "proposal": None,
+            "policy_evaluation": None,
+            "summary": {"trip_id": trip_id, "status": "missing"},
+        }
+    return _build_workspace_policy_payload(
+        trip_record=trip_record,
+        policy_record=policy_record,
+    )
+
+
+def import_workspace_policy_constraints(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    request_payload: dict[str, Any],
+    response_payload: dict[str, Any],
+    source_kind: str,
+    tags: list[str],
+    notes: list[str],
+) -> dict[str, Any]:
+    trip_record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    if trip_record.mode != "business":
+        raise ValueError("Only business trips can import workspace policy constraints.")
+
+    request = TPPRequestEnvelope.from_dict(request_payload)
+    response = TPPResponseEnvelope.from_dict(response_payload)
+    imported = TPPPolicySyncService(_PassiveTPPClient(response)).import_policy_constraints(request)
+    imported_at = _isoformat(datetime.now(UTC))
+    existing = _get_latest_policy_state(
+        db_session,
+        trip_id=trip_id,
+        user_id=user.user_id,
+    )
+    policy_state_id = existing.policy_state_id if existing is not None else f"policy-state:{trip_id}"
+
+    record = existing or PersistedPolicyState(
+        policy_state_id=policy_state_id,
+        trip_id=trip_id,
+        user_id=user.user_id,
+        owner_profile_id=_owner_profile_id(trip_record),
+        source_kind=source_kind,
+        source_request_id=imported.source_request_id,
+        source_correlation_id=imported.source_correlation_id,
+        policy_id=imported.constraint_set.policy_id,
+        organization_id=imported.organization_id,
+        policy_version=imported.constraint_set.policy_version,
+        sync_status=imported.freshness.status,
+        imported_at=imported_at,
+        constraint_set=imported.constraint_set.to_dict(),
+        organization_context=imported.organization_context.to_dict(),
+        freshness=imported.freshness.to_dict(),
+        raw_payload=imported.raw_payload,
+        tags=[],
+        notes=[],
+    )
+    record.owner_profile_id = _owner_profile_id(trip_record)
+    record.source_kind = source_kind
+    record.source_request_id = imported.source_request_id
+    record.source_correlation_id = imported.source_correlation_id
+    record.policy_id = imported.constraint_set.policy_id
+    record.organization_id = imported.organization_id
+    record.policy_version = imported.constraint_set.policy_version
+    record.sync_status = imported.freshness.status
+    record.imported_at = imported_at
+    record.constraint_set = imported.constraint_set.to_dict()
+    record.organization_context = imported.organization_context.to_dict()
+    record.freshness = imported.freshness.to_dict()
+    record.raw_payload = imported.raw_payload
+    record.tags = list(dict.fromkeys([*record.tags, *tags]))
+    record.notes = list(
+        dict.fromkeys(
+            [
+                *record.notes,
+                *notes,
+                "Persisted policy storage is limited to imported constraint sets and readiness context.",
+                "Proposal submission and final policy evaluation remain separate later workflow stages.",
+            ]
+        )
+    )
+
+    if existing is None:
+        db_session.add(record)
+
+    trip_record.policy_state_id = policy_state_id
+    trip_record.updated_at = datetime.now(UTC)
+    db_session.commit()
+    db_session.refresh(record)
+    return _build_workspace_policy_payload(
+        trip_record=trip_record,
+        policy_record=record,
+    )

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -1,6 +1,4 @@
 from __future__ import annotations
-
-import secrets
 from datetime import UTC, datetime
 from typing import Any
 

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -81,6 +81,17 @@ class _PassiveTPPClient:
     def fetch_policy_constraints(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         return self.response
 
+    def submit_proposal(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        raise NotImplementedError("Passive policy import client does not submit proposals.")
+
+    def fetch_evaluation_result(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        raise NotImplementedError(
+            "Passive policy import client does not fetch evaluation results."
+        )
+
+    def poll_execution_status(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        raise NotImplementedError("Passive policy import client does not poll execution status.")
+
 
 def _is_effectively_stale(imported: PolicyConstraintImport) -> bool:
     return imported.freshness.status != "current" or imported.freshness.invalidated_at is not None

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -23,6 +23,7 @@ from trip_planner.app.services.inventory import (
     assemble_inventory_bundles_for_trip,
     build_inventory_summary_payload,
 )
+from trip_planner.app.services.policy import get_workspace_policy_payload
 from trip_planner.app.services.scenarios import (
     build_scenario_ranking_outputs,
     build_workspace_scenario_search,
@@ -701,6 +702,7 @@ def _build_persisted_trip_workspace(
     saved_scenarios: list[dict[str, Any]] | None = None,
     activity_log: list[dict[str, Any]] | None = None,
     budget_state: dict[str, Any] | None = None,
+    policy_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     resolved_session = session or _default_workspace_session(record).to_dict()
     trip_record = _serialize_persisted_trip_record(record)
@@ -751,10 +753,12 @@ def _build_persisted_trip_workspace(
             session=resolved_session,
             activity_log=resolved_activity_log,
             feasibility_summary=feasibility_summary,
+            policy_context=policy_context,
         ),
         "feasibility_summary": feasibility_summary,
         "inventory_summary": build_inventory_summary_payload(inventory_bundles),
         "budget_state": resolved_budget_state,
+        "policy_state": (policy_context or {}).get("policy_state"),
     }
 
 
@@ -813,6 +817,7 @@ def _build_planner_panel_state(
     session: dict[str, Any],
     activity_log: list[dict[str, Any]],
     feasibility_summary: dict[str, Any],
+    policy_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     scenarios = list(scenario_search.get("scenarios", []))
     primary_regions = list(trip["trip_frame"].get("primary_regions") or [])
@@ -1011,11 +1016,46 @@ def _build_planner_panel_state(
             },
         )
 
+    policy_evaluation = (
+        dict(policy_context["policy_evaluation"])
+        if policy_context is not None and policy_context.get("policy_evaluation") is not None
+        else None
+    )
+    proposal = (
+        dict(policy_context["proposal"])
+        if policy_context is not None and policy_context.get("proposal") is not None
+        else None
+    )
+    if policy_evaluation is not None:
+        outputs.append(
+            {
+                "output_id": f"output:{trip['trip_id']}:policy-ready",
+                "title": "Policy posture loaded",
+                "body": "The workspace is using persisted policy inputs instead of mock approval-readiness state.",
+                "tags": ["policy", "workspace", trip["mode"]],
+                "status": "positive"
+                if policy_evaluation["status"] == "compliant"
+                else ("critical" if policy_evaluation["status"] == "non_compliant" else "caution"),
+                "highlights": list(policy_evaluation.get("notes") or [])[:3],
+            }
+        )
+        next_step_actions.insert(
+            0,
+            {
+                "action_id": f"action:{trip['trip_id']}:review-policy",
+                "action_kind": "prepare_approval",
+                "label": "Review policy posture",
+                "description": "Inspect imported policy constraints and approval-readiness before moving to submission work.",
+                "emphasis": "primary",
+                "target_section": "approval",
+            },
+        )
+
     return {
         "trip": trip,
         "option_set": option_set,
-        "proposal": None,
-        "policy_evaluation": None,
+        "proposal": proposal,
+        "policy_evaluation": policy_evaluation,
         "pending_decisions": mapped_decisions,
         "outputs": outputs,
         "planner_behavior": {
@@ -1082,6 +1122,7 @@ def get_workspace_payload(
                 session=session.to_dict(),
                 activity_log=[],
                 feasibility_summary=feasibility_summary,
+                policy_context=None,
             ),
             "feasibility_summary": feasibility_summary,
             "inventory_summary": build_inventory_summary_payload(inventory_bundles),
@@ -1089,6 +1130,7 @@ def get_workspace_payload(
                 trip_id=trip_id,
                 trip_mode=trip_record.trip.mode,
             ),
+            "policy_state": None,
         }
 
     record = db_session.scalar(
@@ -1131,6 +1173,11 @@ def get_workspace_payload(
         ],
         activity_log=[_serialize_activity_record(item) for item in activity_records],
         budget_state=load_budget_payload_for_workspace(db_session, record=record),
+        policy_context=(
+            get_workspace_policy_payload(db_session, user=user, trip_id=trip_id)
+            if record.mode == "business"
+            else None
+        ),
     )
 
 

--- a/trip_planner/persistence/alembic/versions/20260408_03_policy_state.py
+++ b/trip_planner/persistence/alembic/versions/20260408_03_policy_state.py
@@ -1,0 +1,117 @@
+"""add persisted policy import state
+
+Revision ID: 20260408_03
+Revises: 20260408_02
+Create Date: 2026-04-08 22:05:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260408_03"
+down_revision = "20260408_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "persisted_policy_states",
+        sa.Column("policy_state_id", sa.String(length=96), primary_key=True),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.String(length=96),
+            sa.ForeignKey("user_accounts.user_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("owner_profile_id", sa.String(length=96), nullable=False),
+        sa.Column("source_kind", sa.String(length=32), nullable=False),
+        sa.Column("source_request_id", sa.String(length=96), nullable=False),
+        sa.Column("source_correlation_id", sa.String(length=96), nullable=False),
+        sa.Column("policy_id", sa.String(length=96), nullable=False),
+        sa.Column("organization_id", sa.String(length=96), nullable=False),
+        sa.Column("policy_version", sa.String(length=48), nullable=False),
+        sa.Column("sync_status", sa.String(length=32), nullable=False),
+        sa.Column("imported_at", sa.String(length=64), nullable=False),
+        sa.Column("constraint_set", sa.JSON(), nullable=False),
+        sa.Column("organization_context", sa.JSON(), nullable=False),
+        sa.Column("freshness", sa.JSON(), nullable=False),
+        sa.Column("raw_payload", sa.JSON(), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("notes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_persisted_policy_states_trip_id"),
+        "persisted_policy_states",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_policy_states_user_id"),
+        "persisted_policy_states",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_policy_states_policy_id"),
+        "persisted_policy_states",
+        ["policy_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_policy_states_organization_id"),
+        "persisted_policy_states",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_policy_states_sync_status"),
+        "persisted_policy_states",
+        ["sync_status"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_policy_states_imported_at"),
+        "persisted_policy_states",
+        ["imported_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_persisted_policy_states_imported_at"),
+        table_name="persisted_policy_states",
+    )
+    op.drop_index(
+        op.f("ix_persisted_policy_states_sync_status"),
+        table_name="persisted_policy_states",
+    )
+    op.drop_index(
+        op.f("ix_persisted_policy_states_organization_id"),
+        table_name="persisted_policy_states",
+    )
+    op.drop_index(
+        op.f("ix_persisted_policy_states_policy_id"),
+        table_name="persisted_policy_states",
+    )
+    op.drop_index(
+        op.f("ix_persisted_policy_states_user_id"),
+        table_name="persisted_policy_states",
+    )
+    op.drop_index(
+        op.f("ix_persisted_policy_states_trip_id"),
+        table_name="persisted_policy_states",
+    )
+    op.drop_table("persisted_policy_states")

--- a/trip_planner/persistence/db.py
+++ b/trip_planner/persistence/db.py
@@ -90,7 +90,13 @@ def ensure_database_ready(url: str | None = None) -> None:
         return
 
     from trip_planner.persistence.models import budget  # noqa: F401
-    from trip_planner.persistence.models import account, scenario, session, trip  # noqa: F401
+    from trip_planner.persistence.models import (  # noqa: F401
+        account,
+        policy,
+        scenario,
+        session,
+        trip,
+    )
 
     _ensure_sqlite_parent_dir(resolved_url)
 

--- a/trip_planner/persistence/models/__init__.py
+++ b/trip_planner/persistence/models/__init__.py
@@ -6,6 +6,7 @@ from trip_planner.persistence.models.budget import (
     PersistedBudgetPlan,
     PersistedBudgetPlanVersion,
 )
+from trip_planner.persistence.models.policy import PersistedPolicyState
 from trip_planner.persistence.models.scenario import (
     PersistedActivityLogEvent,
     PersistedSavedScenario,
@@ -23,6 +24,7 @@ __all__ = [
     "PersistedBudgetPlan",
     "PersistedBudgetPlanVersion",
     "PersistedPlanningSessionState",
+    "PersistedPolicyState",
     "PersistedSavedScenario",
     "PersistedTrip",
     "UserAccount",

--- a/trip_planner/persistence/models/policy.py
+++ b/trip_planner/persistence/models/policy.py
@@ -1,0 +1,49 @@
+"""SQLAlchemy model for persisted business policy imports."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from trip_planner.persistence.db import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class PersistedPolicyState(Base):
+    __tablename__ = "persisted_policy_states"
+
+    policy_state_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("user_accounts.user_id", ondelete="CASCADE"),
+        index=True,
+    )
+    owner_profile_id: Mapped[str] = mapped_column(String(96))
+    source_kind: Mapped[str] = mapped_column(String(32), default="tpp_sync")
+    source_request_id: Mapped[str] = mapped_column(String(96))
+    source_correlation_id: Mapped[str] = mapped_column(String(96))
+    policy_id: Mapped[str] = mapped_column(String(96), index=True)
+    organization_id: Mapped[str] = mapped_column(String(96), index=True)
+    policy_version: Mapped[str] = mapped_column(String(48))
+    sync_status: Mapped[str] = mapped_column(String(32), default="current", index=True)
+    imported_at: Mapped[str] = mapped_column(String(64), index=True)
+    constraint_set: Mapped[dict] = mapped_column(JSON, default=dict)
+    organization_context: Mapped[dict] = mapped_column(JSON, default=dict)
+    freshness: Mapped[dict] = mapped_column(JSON, default=dict)
+    raw_payload: Mapped[dict] = mapped_column(JSON, default=dict)
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    notes: Mapped[list[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #695

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Business mode is not complete until the app can load policy constraints and show approval-readiness state from real stored policy inputs. Right now those concepts exist mostly as contracts and component surfaces.

Parent epic: #678

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#678](https://github.com/stranske/trip-planner/issues/678)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add persistence and API routes for policy constraint sets.
- [x] Add import or sync behavior for business-trip policy inputs.
- [x] Add workspace UI that displays current policy posture and required constraints.
- [x] Connect policy-readiness display to persisted policy data rather than static mock state.
- [x] Add tests for policy loading and approval-readiness display.
- [x] Document the boundary between policy constraint storage and later proposal submission work.

#### Acceptance criteria
- [x] Business trips can load a policy constraint set through the app runtime.
- [x] The workspace displays approval-readiness state from persisted policy data.
- [x] Automated tests cover policy import/load and the resulting workspace display.
- [x] The policy-readiness UI is backed by runtime data, not only fixtures.

<!-- auto-status-summary:end -->
