### PR TITLE
Issue #697: add policy follow-up flows

### DIFF
--- a/docs/contracts/tpp-proposal-lifecycle.md
+++ b/docs/contracts/tpp-proposal-lifecycle.md
@@ -1,21 +1,23 @@
 # TPP Proposal Lifecycle Boundary
 
-The workspace now persists two bounded proposal-lifecycle artifacts per business trip:
+The workspace now persists three bounded proposal-lifecycle artifacts per business trip:
 
 - proposal submission transport state, including the normalized `TripPlanProposal`
 - evaluation-result transport state, including the latest normalized `PolicyEvaluationResult`
+- a persisted follow-up lane derived from the latest policy result and any explicit workspace updates
 
-This slice is intentionally limited to submission/evaluation persistence and workspace display.
-Later reoptimization work should treat these records as inputs, not as a replacement for re-ranking or exception handling.
+This slice remains intentionally bounded: it does not auto-rerank scenarios or take ownership of enterprise approvals.
+It does make the next step concrete inside the workspace so non-compliant and exception-required results are no longer a dead end.
 
 Downstream work should consume:
 
 - `proposal_state.proposal` as the last submitted approval packet snapshot
 - `proposal_state.submission` for execution metadata such as `execution_id`, retry posture, and transport summaries
 - `proposal_state.evaluation` for the latest policy verdict and approval/failure details
+- `proposal_state.follow_up` for the current reoptimization or exception path, including selected alternatives, guidance, and any drafted exception request
 
 Out of scope for this slice:
 
 - automatic resubmission after non-compliant evaluations
 - creating replacement scenarios from preferred alternatives
-- approval-routing ownership beyond showing the required approvals in the workspace
+- approval-routing ownership beyond showing the required approvals and exception path in the workspace

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -248,6 +248,34 @@ export type WorkspaceData = {
         compliance_score: number;
       };
     };
+    follow_up: {
+      status: string;
+      path: string;
+      title: string;
+      summary: string;
+      recommended_action?: string;
+      recommended_label?: string;
+      alternatives?: Array<{
+        category: string;
+        summary: string;
+        rationale: string;
+        comparable_ref?: string | null;
+      }>;
+      guidance?: string[];
+      notes?: string[];
+      selected_alternative?: {
+        category?: string;
+        summary?: string;
+        rationale?: string;
+        comparable_ref?: string | null;
+      } | null;
+      requested_exception?: {
+        exception_type: string;
+        reason: string;
+        requested_approval_roles: string[];
+        notes: string[];
+      } | null;
+    };
     summary: {
       submission_status?: string;
       submission_summary?: string;
@@ -255,6 +283,9 @@ export type WorkspaceData = {
       approval_ready?: boolean;
       comparable_count?: number;
       highlights?: string[];
+      follow_up_status?: string;
+      follow_up_title?: string;
+      follow_up_summary?: string;
     };
   } | null;
 };

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -275,7 +275,7 @@ export type WorkspaceData = {
         requested_approval_roles: string[];
         notes: string[];
       } | null;
-    };
+    } | null;
     summary: {
       submission_status?: string;
       submission_summary?: string;

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -242,6 +242,19 @@ const workspacePayload = {
         compliance_score: 0.98,
       },
     },
+    follow_up: {
+      status: "resolved",
+      path: "approval",
+      title: "Approval-ready proposal",
+      summary: "Policy evaluation passed. Move the workspace packet into final approval handling.",
+      recommended_action: "prepare_approval",
+      recommended_label: "Advance to approval",
+      alternatives: [],
+      guidance: [],
+      notes: [],
+      selected_alternative: null,
+      requested_exception: null,
+    },
     summary: {
       submission_status: "succeeded",
       submission_summary: "Proposal submitted to the policy engine.",
@@ -249,6 +262,10 @@ const workspacePayload = {
       approval_ready: true,
       comparable_count: 1,
       highlights: ["Policy constraints satisfied."],
+      follow_up_status: "resolved",
+      follow_up_title: "Approval-ready proposal",
+      follow_up_summary:
+        "Policy evaluation passed. Move the workspace packet into final approval handling.",
     },
   },
   planner_panel_state: {
@@ -379,6 +396,7 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Osaka arrival buffer")).toBeInTheDocument();
     expect(screen.getByText("Kyoto cultural anchor")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();
+    expect(screen.getByText("Approval-ready proposal")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Comparables and readiness signals" })).toBeInTheDocument();
     expect(screen.getByText("Conference Hotel")).toBeInTheDocument();
     await waitFor(() => {
@@ -560,6 +578,98 @@ describe("WorkspacePage", () => {
 
     expect(screen.getByText("May 4")).toBeInTheDocument();
     expect(screen.queryByText("2026-05-04")).not.toBeInTheDocument();
+  });
+
+  it("surfaces reoptimization follow-up guidance for non-compliant policy results", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          follow_up: {
+            status: "reoptimization_required",
+            path: "reoptimization",
+            title: "Reoptimization path required",
+            summary: "Use a compliant downtown property before resubmitting the approval packet.",
+            recommended_action: "reoptimize",
+            recommended_label: "Reoptimize plan",
+            alternatives: [
+              {
+                category: "lodging",
+                summary: "Use a compliant downtown property",
+                rationale: "Alternative meets nightly cap and booking-channel requirements.",
+                comparable_ref: "lodging-alt-2",
+              },
+            ],
+            guidance: ["Keep the policy-safe lodging alternative attached to the next submission."],
+            notes: [],
+            selected_alternative: {
+              category: "lodging",
+              summary: "Use a compliant downtown property",
+              rationale: "Alternative meets nightly cap and booking-channel requirements.",
+              comparable_ref: "lodging-alt-2",
+            },
+            requested_exception: null,
+          },
+          evaluation: {
+            evaluation_result: {
+              ...workspacePayload.proposal_state.evaluation.evaluation_result,
+              status: "non_compliant",
+              failure_reasons: [
+                {
+                  code: "lodging_cap_exceeded",
+                  message: "Nightly lodging exceeds the allowed cap.",
+                  severity: "blocking",
+                  related_category: "lodging",
+                },
+              ],
+              notes: ["Proposal requires lodging changes before submission can pass."],
+              compliance_score: 0.42,
+            },
+          },
+          summary: {
+            ...workspacePayload.proposal_state.summary,
+            approval_ready: false,
+            evaluation_result_status: "non_compliant",
+            follow_up_status: "reoptimization_required",
+            follow_up_title: "Reoptimization path required",
+            follow_up_summary:
+              "Use a compliant downtown property before resubmitting the approval packet.",
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Reoptimization path required")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Reoptimize plan")).toBeInTheDocument();
+    expect(screen.getByText("Use a compliant downtown property")).toBeInTheDocument();
+    expect(screen.getByText("Nightly lodging exceeds the allowed cap.")).toBeInTheDocument();
+  });
+
+  it("skips the follow-up card when legacy records expose an empty follow-up object", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          follow_up: {} as typeof workspacePayload.proposal_state.follow_up,
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("heading", { name: "Approval-ready proposal" })).not.toBeInTheDocument();
+    expect(screen.getByText("resolved")).toBeInTheDocument();
+    expect(screen.queryByText("undefined")).not.toBeInTheDocument();
   });
 
   it("saves a budget plan and refreshes the workspace totals", async () => {

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -138,6 +138,19 @@ function ScenarioSummaryCard({
   );
 }
 
+function formatFollowUpStatus(status: string | undefined): string {
+  if (!status) {
+    return "pending";
+  }
+  return status.replace(/_/g, " ");
+}
+
+function hasRenderableFollowUp(
+  followUp: NonNullable<WorkspaceData["proposal_state"]>["follow_up"]
+): followUp is NonNullable<NonNullable<WorkspaceData["proposal_state"]>["follow_up"]> {
+  return Boolean(followUp?.status && followUp?.title && followUp?.summary);
+}
+
 function mergeWorkspaceBudgetState(
   workspace: WorkspaceData,
   budgetState: BudgetWorkspaceState
@@ -196,6 +209,10 @@ function WorkspacePageContent({ workspace }: { workspace: WorkspaceData }) {
   const timelineStops = buildTimelineStops(currentWorkspace);
   const { trip } = currentWorkspace.trip_record;
   const activeScenario = resolveActiveScenario(currentWorkspace);
+  const proposalFollowUp = currentWorkspace.proposal_state?.follow_up ?? null;
+  const renderableProposalFollowUp = hasRenderableFollowUp(proposalFollowUp)
+    ? proposalFollowUp
+    : null;
 
   async function handleDecisionAnswer(decisionId: string, choice: string) {
     setPlannerError(null);
@@ -356,8 +373,27 @@ function WorkspacePageContent({ workspace }: { workspace: WorkspaceData }) {
                   <dt>Proposal version</dt>
                   <dd>{currentWorkspace.proposal_state.proposal_version}</dd>
                 </div>
+                <div>
+                  <dt>Next step</dt>
+                  <dd>
+                    {formatFollowUpStatus(
+                      renderableProposalFollowUp?.status ??
+                        currentWorkspace.proposal_state.summary.follow_up_status
+                    )}
+                  </dd>
+                </div>
               </dl>
               <p>{currentWorkspace.proposal_state.summary.submission_summary ?? "Submission stored for later review."}</p>
+              {renderableProposalFollowUp ? (
+                <article className="decision-card">
+                  <h3>{renderableProposalFollowUp.title}</h3>
+                  <p>{renderableProposalFollowUp.summary}</p>
+                  {renderableProposalFollowUp.guidance &&
+                  renderableProposalFollowUp.guidance.length > 0 ? (
+                    <p className="muted-copy">{renderableProposalFollowUp.guidance[0]}</p>
+                  ) : null}
+                </article>
+              ) : null}
               <div className="decision-stack">
                 {(currentWorkspace.proposal_state.summary.highlights ?? []).map((highlight) => (
                   <article key={highlight} className="decision-card">
@@ -516,6 +552,31 @@ function WorkspacePageContent({ workspace }: { workspace: WorkspaceData }) {
             <p className="muted-copy">Approval-packet details will render here once a proposal is submitted.</p>
           ) : (
             <div className="decision-stack">
+              {proposalFollowUp ? (
+                <article className="decision-card">
+                  <h3>{proposalFollowUp.recommended_label ?? proposalFollowUp.title}</h3>
+                  <p>{proposalFollowUp.summary}</p>
+                  {proposalFollowUp.selected_alternative?.summary ? (
+                    <p className="muted-copy">
+                      Selected alternative: {proposalFollowUp.selected_alternative.summary}
+                    </p>
+                  ) : null}
+                  {proposalFollowUp.requested_exception?.reason ? (
+                    <p className="muted-copy">
+                      Exception rationale: {proposalFollowUp.requested_exception.reason}
+                    </p>
+                  ) : null}
+                </article>
+              ) : null}
+              {(proposalFollowUp?.alternatives ?? []).map((alternative) => (
+                <article
+                  key={`${alternative.category}-${alternative.summary}`}
+                  className="decision-card"
+                >
+                  <h3>{alternative.summary}</h3>
+                  <p>{alternative.rationale}</p>
+                </article>
+              ))}
               {(currentWorkspace.proposal_state.proposal.comparables ?? []).map((comparable) => (
                 <article
                   key={`${comparable.category}-${comparable.label}`}

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -6,7 +6,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from trip_planner.app.main import create_app
-from trip_planner.persistence.db import reset_database_state
+from trip_planner.persistence.db import get_session_factory, reset_database_state
+from trip_planner.persistence.models.proposal import PersistedProposalState
 
 
 def _fixture_path(*parts: str) -> Path:
@@ -275,6 +276,201 @@ def test_workspace_proposal_follow_up_patch_persists_exception_request(client: T
     assert payload["follow_up"]["status"] == "exception_requested"
     assert payload["follow_up"]["requested_exception"]["exception_type"] == "schedule_protection"
     assert payload["proposal"]["requested_exception"]["requested_approval_roles"] == ["manager"]
+
+
+def test_workspace_proposal_follow_up_patch_rejects_malformed_exception_payload(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Malformed exception workspace",
+            "summary": "Reject invalid exception payload containers.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    updated = client.patch(
+        f"/api/workspace/{trip_id}/proposal/follow-up",
+        json={
+            "status": "exception_requested",
+            "title": "Exception packet drafted",
+            "summary": "Preserve the faster arrival path and route the packet for manager review.",
+            "requested_exception": {
+                "exception_type": "schedule_protection",
+                "reason": "Preserve the faster arrival path and route the packet for manager review.",
+                "requested_approval_roles": "manager",
+                "notes": ["Attach the compliant comparable for review."],
+            },
+        },
+    )
+
+    assert updated.status_code == 422
+
+
+def test_workspace_proposal_follow_up_patch_preserves_existing_path_for_resolved_status(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Resolved reoptimization workspace",
+            "summary": "Resolve the active reoptimization lane without losing the path.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    evaluation_fixture = _load_fixture("results", "non_compliant_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+    client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    updated = client.patch(
+        f"/api/workspace/{trip_id}/proposal/follow-up",
+        json={
+            "status": "resolved",
+            "title": "Reoptimization finished",
+            "summary": "The compliant alternative is now ready for the next approval handoff.",
+            "selected_alternative": {
+                "category": "lodging",
+                "summary": "Use a compliant downtown property",
+                "rationale": "Alternative meets nightly cap and booking-channel requirements.",
+                "comparable_ref": "lodging-alt-2",
+            },
+        },
+    )
+
+    assert updated.status_code == 200
+    payload = updated.json()["proposal_state"]
+    assert payload["follow_up"]["status"] == "resolved"
+    assert payload["follow_up"]["path"] == "reoptimization"
+
+
+def test_workspace_proposal_get_derives_follow_up_when_legacy_summary_is_missing(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Legacy proposal workspace",
+            "summary": "Backfill a follow-up response for older persisted records.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    evaluation_fixture = _load_fixture("results", "approved_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+    client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    session = get_session_factory()()
+    try:
+        record = session.query(PersistedProposalState).filter_by(trip_id=trip_id).one()
+        summary = dict(record.summary)
+        summary.pop("follow_up", None)
+        record.summary = summary
+        session.commit()
+    finally:
+        session.close()
+
+    reloaded = client.get(f"/api/workspace/{trip_id}/proposal")
+
+    assert reloaded.status_code == 200
+    payload = reloaded.json()["proposal_state"]
+    assert payload["follow_up"]["status"] == "resolved"
+    assert payload["follow_up"]["path"] == "approval"
 
 
 def test_workspace_proposal_submission_rejects_leisure_trip(client: TestClient) -> None:

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -153,6 +153,7 @@ def test_workspace_proposal_submission_and_evaluation_persist(client: TestClient
         == "compliant"
     )
     assert evaluated_payload["proposal_state"]["summary"]["approval_ready"] is True
+    assert evaluated_payload["proposal_state"]["follow_up"]["status"] == "resolved"
 
     reloaded = client.get(f"/api/workspace/{trip_id}/proposal")
     assert reloaded.status_code == 200
@@ -162,6 +163,118 @@ def test_workspace_proposal_submission_and_evaluation_persist(client: TestClient
         reloaded_payload["proposal_state"]["evaluation"]["evaluation_result"]["evaluation_id"]
         == "eval-approved-001"
     )
+
+
+def test_workspace_proposal_evaluation_derives_reoptimization_follow_up(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Reoptimization workspace",
+            "summary": "Persist follow-up state for non-compliant policy results.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    evaluation_fixture = _load_fixture("results", "non_compliant_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+
+    evaluated = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert evaluated.status_code == 200
+    follow_up = evaluated.json()["proposal_state"]["follow_up"]
+    assert follow_up["status"] == "reoptimization_required"
+    assert follow_up["recommended_action"] == "reoptimize"
+    assert follow_up["alternatives"][0]["category"] == "lodging"
+
+
+def test_workspace_proposal_follow_up_patch_persists_exception_request(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Exception follow-up workspace",
+            "summary": "Persist exception request follow-up after policy review.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    updated = client.patch(
+        f"/api/workspace/{trip_id}/proposal/follow-up",
+        json={
+            "status": "exception_requested",
+            "title": "Exception packet drafted",
+            "summary": "Preserve the faster arrival path and route the packet for manager review.",
+            "notes": ["Traveler needs the earlier arrival buffer for the client meeting."],
+            "requested_exception": {
+                "exception_type": "schedule_protection",
+                "reason": "Preserve the faster arrival path and route the packet for manager review.",
+                "requested_approval_roles": ["manager"],
+                "notes": ["Attach the compliant comparable for review."],
+            },
+        },
+    )
+
+    assert updated.status_code == 200
+    payload = updated.json()["proposal_state"]
+    assert payload["follow_up"]["status"] == "exception_requested"
+    assert payload["follow_up"]["requested_exception"]["exception_type"] == "schedule_protection"
+    assert payload["proposal"]["requested_exception"]["requested_approval_roles"] == ["manager"]
 
 
 def test_workspace_proposal_submission_rejects_leisure_trip(client: TestClient) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -353,7 +353,138 @@ def test_workspace_endpoint_prefers_persisted_proposal_lifecycle_for_business_tr
     assert payload["proposal_state"]["summary"]["approval_ready"] is True
     assert payload["planner_panel_state"]["proposal"]["proposal_id"] == f"proposal:{trip_id}"
     assert payload["planner_panel_state"]["policy_evaluation"]["evaluation_id"] == "eval-approved-001"
-    assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Proposal lifecycle loaded"
+    titles = [item["title"] for item in payload["planner_panel_state"]["outputs"]]
+    assert "Proposal lifecycle loaded" in titles
+    assert "Approval-ready proposal" in titles
+    assert payload["proposal_state"]["follow_up"]["status"] == "resolved"
+
+
+def test_workspace_endpoint_surfaces_reoptimization_follow_up_for_non_compliant_results(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Non-compliant workspace",
+            "summary": "Workspace should expose the next follow-up action.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "fixtures"
+            / "integrations"
+            / "tpp"
+            / "proposal_submit_deferred.json"
+        ).read_text(encoding="utf-8")
+    )
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    evaluation_fixture = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "fixtures"
+            / "integrations"
+            / "tpp"
+            / "results"
+            / "non_compliant_evaluation.json"
+        ).read_text(encoding="utf-8")
+    )
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+    proposal_payload = {
+        "proposal_id": f"proposal:{trip_id}",
+        "trip_id": trip_id,
+        "mode": "business",
+        "traveler_context": {
+            "employee_type": "employee",
+            "traveler_experience": "frequent",
+            "home_airport": "ORD",
+            "loyalty_programs": ["United"],
+            "mobility_or_access_needs": [],
+        },
+        "selected_options": [
+            {
+                "category": "airfare",
+                "option_id": "flight-1",
+                "label": "United 123",
+                "vendor": "United",
+                "booking_channel": "Navan",
+                "estimated_cost": {
+                    "currency": "USD",
+                    "typical_amount": 620.0,
+                    "min_amount": 620.0,
+                    "max_amount": 620.0,
+                },
+                "justification_refs": ["fare-policy"],
+            }
+        ],
+        "cost_summary": {
+            "currency": "USD",
+            "total_estimated_cost": 620.0,
+            "category_estimates": {"airfare": 620.0},
+            "notes": ["Costs include taxes."],
+        },
+        "comparables": [
+            {
+                "category": "lodging",
+                "label": "Downtown compliant hotel",
+                "vendor": "Hilton",
+                "booking_channel": "Navan",
+                "estimated_cost": {
+                    "currency": "USD",
+                    "typical_amount": 245.0,
+                    "min_amount": 245.0,
+                    "max_amount": 245.0,
+                },
+                "notes": ["Compliant alternative for resubmission."],
+            }
+        ],
+        "approval_notes": ["Manager review required before booking."],
+        "constraint_set_id": "policy-standard-2026-02",
+    }
+
+    client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": proposal_payload,
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    response = client.get(f"/api/workspace/{trip_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["proposal_state"]["follow_up"]["status"] == "reoptimization_required"
+    assert payload["planner_panel_state"]["next_step_actions"][0]["action_kind"] == "reoptimize"
+    assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Reoptimization path required"
 
 
 def test_workspace_planner_decision_answer_persists_across_reload(client: TestClient) -> None:

--- a/trip_planner/app/routes/proposal.py
+++ b/trip_planner/app/routes/proposal.py
@@ -98,8 +98,16 @@ def save_workspace_proposal_follow_up_state(
             summary=payload.summary,
             title=payload.title,
             notes=payload.notes,
-            selected_alternative=payload.selected_alternative,
-            requested_exception=payload.requested_exception,
+            selected_alternative=(
+                payload.selected_alternative.model_dump(mode="python")
+                if payload.selected_alternative is not None
+                else None
+            ),
+            requested_exception=(
+                payload.requested_exception.model_dump(mode="python")
+                if payload.requested_exception is not None
+                else None
+            ),
         )
     except WorkspaceProposalNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error

--- a/trip_planner/app/routes/proposal.py
+++ b/trip_planner/app/routes/proposal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from trip_planner.app.schemas.proposal import (
+    WorkspaceProposalFollowUpRequest,
     WorkspaceProposalEvaluationRequest,
     WorkspaceProposalResponse,
     WorkspaceProposalSubmissionRequest,
@@ -10,6 +11,7 @@ from trip_planner.app.services.auth import AuthenticatedUser, require_authentica
 from trip_planner.app.services.proposal import (
     WorkspaceProposalNotFoundError,
     get_workspace_proposal_payload,
+    save_workspace_proposal_follow_up,
     save_workspace_proposal_evaluation,
     save_workspace_proposal_submission,
 )
@@ -72,6 +74,32 @@ def save_workspace_proposal_result(
             response_payload=payload.response,
             proposal_version=payload.proposal_version,
             scenario_id=payload.scenario_id,
+        )
+    except WorkspaceProposalNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return WorkspaceProposalResponse.model_validate(result)
+
+
+@router.patch("/workspace/{trip_id}/proposal/follow-up", response_model=WorkspaceProposalResponse)
+def save_workspace_proposal_follow_up_state(
+    trip_id: str,
+    payload: WorkspaceProposalFollowUpRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> WorkspaceProposalResponse:
+    try:
+        result = save_workspace_proposal_follow_up(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            status=payload.status,
+            summary=payload.summary,
+            title=payload.title,
+            notes=payload.notes,
+            selected_alternative=payload.selected_alternative,
+            requested_exception=payload.requested_exception,
         )
     except WorkspaceProposalNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error

--- a/trip_planner/app/schemas/proposal.py
+++ b/trip_planner/app/schemas/proposal.py
@@ -28,6 +28,20 @@ class WorkspaceProposalEvaluationRequest(BaseModel):
     scenario_id: str | None = Field(default=None, max_length=96)
 
 
+class WorkspaceProposalSelectedAlternative(BaseModel):
+    category: str | None = Field(default=None, min_length=1, max_length=64)
+    summary: str | None = Field(default=None, min_length=1, max_length=280)
+    rationale: str | None = Field(default=None, min_length=1, max_length=280)
+    comparable_ref: str | None = Field(default=None, min_length=1, max_length=96)
+
+
+class WorkspaceProposalExceptionRequest(BaseModel):
+    exception_type: str = Field(min_length=1, max_length=64)
+    reason: str = Field(min_length=1, max_length=280)
+    requested_approval_roles: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
 class WorkspaceProposalFollowUpRequest(BaseModel):
     status: Literal[
         "reoptimization_required",
@@ -40,8 +54,8 @@ class WorkspaceProposalFollowUpRequest(BaseModel):
     summary: str = Field(min_length=1, max_length=280)
     title: str | None = Field(default=None, min_length=1, max_length=120)
     notes: list[str] = Field(default_factory=list)
-    selected_alternative: dict[str, Any] | None = None
-    requested_exception: dict[str, Any] | None = None
+    selected_alternative: WorkspaceProposalSelectedAlternative | None = None
+    requested_exception: WorkspaceProposalExceptionRequest | None = None
 
 
 class WorkspaceProposalResponse(BaseModel):

--- a/trip_planner/app/schemas/proposal.py
+++ b/trip_planner/app/schemas/proposal.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -26,6 +26,22 @@ class WorkspaceProposalEvaluationRequest(BaseModel):
     )
     proposal_version: str = Field(min_length=1, max_length=96)
     scenario_id: str | None = Field(default=None, max_length=96)
+
+
+class WorkspaceProposalFollowUpRequest(BaseModel):
+    status: Literal[
+        "reoptimization_required",
+        "reoptimized",
+        "exception_required",
+        "exception_requested",
+        "approval_pending",
+        "resolved",
+    ]
+    summary: str = Field(min_length=1, max_length=280)
+    title: str | None = Field(default=None, min_length=1, max_length=120)
+    notes: list[str] = Field(default_factory=list)
+    selected_alternative: dict[str, Any] | None = None
+    requested_exception: dict[str, Any] | None = None
 
 
 class WorkspaceProposalResponse(BaseModel):

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -88,6 +88,8 @@ def _derive_follow_up_state(
     requested_exception = proposal_payload.get("requested_exception")
     status = evaluation_result.get("status")
 
+    follow_up: dict[str, Any]
+
     if status == "compliant":
         follow_up = {
             "status": "resolved",

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from trip_planner.app.services.auth import AuthenticatedUser
-from trip_planner.business import TripPlanProposal
+from trip_planner.business import ExceptionRequest, TripPlanProposal
 from trip_planner.integrations.tpp import (
     BaseTPPIntegrationClient,
     TPPEvaluationResultIngestionService,
@@ -69,16 +69,130 @@ class _PassiveTPPClient(BaseTPPIntegrationClient):
         return self.response
 
 
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _derive_follow_up_state(
+    *,
+    proposal_payload: dict[str, Any],
+    evaluation_record: dict[str, Any],
+    persisted_follow_up: dict[str, Any] | None = None,
+    submission_record: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    evaluation_result = dict(evaluation_record.get("evaluation_result") or {})
+    preferred_alternatives = list(evaluation_result.get("preferred_alternatives") or [])
+    approval_requirements = list(evaluation_result.get("approval_requirements") or [])
+    failure_reasons = list(evaluation_result.get("failure_reasons") or [])
+    exception_guidance = list(evaluation_result.get("exception_guidance") or [])
+    requested_exception = proposal_payload.get("requested_exception")
+    status = evaluation_result.get("status")
+
+    if status == "compliant":
+        follow_up = {
+            "status": "resolved",
+            "path": "approval",
+            "title": "Approval-ready proposal",
+            "summary": "Policy evaluation passed. Move the workspace packet into final approval handling.",
+            "recommended_action": "prepare_approval",
+            "recommended_label": "Advance to approval",
+        }
+    elif status == "non_compliant":
+        alternative = preferred_alternatives[0] if preferred_alternatives else None
+        follow_up = {
+            "status": "reoptimization_required",
+            "path": "reoptimization",
+            "title": "Reoptimization path required",
+            "summary": (
+                alternative.get("summary")
+                if isinstance(alternative, dict) and alternative.get("summary")
+                else "The current proposal is non-compliant. Rebuild it around a policy-safe alternative."
+            ),
+            "recommended_action": "reoptimize",
+            "recommended_label": "Reoptimize plan",
+        }
+    elif status == "exception_required":
+        follow_up = {
+            "status": "exception_requested" if requested_exception else "exception_required",
+            "path": "exception",
+            "title": "Exception path required",
+            "summary": (
+                requested_exception.get("reason")
+                if isinstance(requested_exception, dict) and requested_exception.get("reason")
+                else "The workspace needs an exception-oriented next step before booking can proceed."
+            ),
+            "recommended_action": (
+                "await_approval" if requested_exception else "request_exception"
+            ),
+            "recommended_label": (
+                "Review drafted exception" if requested_exception else "Prepare exception request"
+            ),
+        }
+    else:
+        follow_up = {
+            "status": "awaiting_evaluation",
+            "path": "pending",
+            "title": "Awaiting policy verdict",
+            "summary": (
+                dict(submission_record or {}).get("execution_status", {}).get("summary")
+                or "Proposal transport is stored. Wait for the policy result before choosing a follow-up path."
+            ),
+            "recommended_action": "monitor_submission",
+            "recommended_label": "Monitor evaluation",
+        }
+
+    follow_up["alternatives"] = preferred_alternatives
+    follow_up["approval_requirements"] = approval_requirements
+    follow_up["failure_reasons"] = failure_reasons
+    follow_up["guidance"] = exception_guidance
+    follow_up["requested_exception"] = requested_exception
+    follow_up["selected_alternative"] = None
+    follow_up["notes"] = []
+
+    if persisted_follow_up and persisted_follow_up.get("manual"):
+        for key in (
+            "status",
+            "path",
+            "title",
+            "summary",
+            "recommended_action",
+            "recommended_label",
+            "selected_alternative",
+            "notes",
+            "updated_at",
+        ):
+            if key in persisted_follow_up and persisted_follow_up[key] not in (None, ""):
+                follow_up[key] = persisted_follow_up[key]
+        if persisted_follow_up.get("requested_exception") is not None:
+            follow_up["requested_exception"] = persisted_follow_up["requested_exception"]
+
+    return follow_up
+
+
 def _build_summary(
     *,
     submission_record: dict[str, Any],
     evaluation_record: dict[str, Any],
     proposal_payload: dict[str, Any],
+    persisted_follow_up: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     execution_status = dict(submission_record.get("execution_status") or {})
     evaluation_transport = dict(evaluation_record.get("execution_status") or {})
     evaluation_result = dict(evaluation_record.get("evaluation_result") or {})
     failure_reasons = list(evaluation_result.get("failure_reasons") or [])
+    follow_up = _derive_follow_up_state(
+        proposal_payload=proposal_payload,
+        evaluation_record=evaluation_record,
+        persisted_follow_up=persisted_follow_up,
+        submission_record=submission_record,
+    )
+    highlights = (
+        list(evaluation_result.get("notes") or [])[:2]
+        if evaluation_result
+        else list(proposal_payload.get("approval_notes") or [])[:2]
+    )
+    if follow_up.get("summary"):
+        highlights = [str(follow_up["summary"]), *highlights][:3]
     return {
         "trip_id": proposal_payload.get("trip_id"),
         "proposal_id": proposal_payload.get("proposal_id"),
@@ -94,11 +208,11 @@ def _build_summary(
         "blocking_failure_count": len(
             [item for item in failure_reasons if item.get("severity") == "blocking"]
         ),
-        "highlights": (
-            list(evaluation_result.get("notes") or [])[:2]
-            if evaluation_result
-            else list(proposal_payload.get("approval_notes") or [])[:2]
-        ),
+        "highlights": highlights,
+        "follow_up_status": follow_up.get("status"),
+        "follow_up_title": follow_up.get("title"),
+        "follow_up_summary": follow_up.get("summary"),
+        "follow_up": follow_up,
     }
 
 
@@ -118,6 +232,7 @@ def _serialize_proposal_state(record: PersistedProposalState) -> dict[str, Any]:
         "submission": dict(record.submission_record),
         "evaluation": dict(record.evaluation_record),
         "summary": dict(record.summary),
+        "follow_up": dict(record.summary.get("follow_up") or {}),
     }
 
 
@@ -203,6 +318,7 @@ def save_workspace_proposal_submission(
         submission_record=record.submission_record,
         evaluation_record=evaluation_record,
         proposal_payload=record.proposal_payload,
+        persisted_follow_up=dict(existing.summary.get("follow_up") or {}) if existing else None,
     )
 
     if existing is None:
@@ -257,6 +373,65 @@ def save_workspace_proposal_evaluation(
         submission_record=dict(existing.submission_record),
         evaluation_record=existing.evaluation_record,
         proposal_payload=dict(existing.proposal_payload),
+        persisted_follow_up=dict(existing.summary.get("follow_up") or {}),
+    )
+
+    trip_record.updated_at = datetime.now(UTC)
+    db_session.commit()
+    db_session.refresh(existing)
+    return {
+        "proposal_state": _serialize_proposal_state(existing),
+        "summary": dict(existing.summary),
+    }
+
+
+def save_workspace_proposal_follow_up(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    status: str,
+    summary: str,
+    title: str | None,
+    notes: list[str],
+    selected_alternative: dict[str, Any] | None,
+    requested_exception: dict[str, Any] | None,
+) -> dict[str, Any]:
+    trip_record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    if trip_record.mode != "business":
+        raise ValueError("Only business trips can persist proposal lifecycle state.")
+
+    existing = _get_latest_proposal_state(db_session, trip_id=trip_id, user_id=user.user_id)
+    if existing is None:
+        raise WorkspaceProposalNotFoundError(
+            "Proposal follow-up cannot be stored before a proposal submission exists."
+        )
+
+    proposal_payload = dict(existing.proposal_payload)
+    serialized_exception: dict[str, Any] | None = None
+    if requested_exception is not None:
+        serialized_exception = ExceptionRequest(**requested_exception).to_dict()
+        proposal_payload["requested_exception"] = serialized_exception
+
+    manual_follow_up = {
+        "manual": True,
+        "status": status,
+        "path": "exception" if "exception" in status else "reoptimization",
+        "title": title or existing.summary.get("follow_up_title") or "Workspace follow-up updated",
+        "summary": summary,
+        "notes": list(notes),
+        "selected_alternative": dict(selected_alternative) if selected_alternative else None,
+        "updated_at": _now_iso(),
+    }
+    if serialized_exception is not None:
+        manual_follow_up["requested_exception"] = serialized_exception
+
+    existing.proposal_payload = proposal_payload
+    existing.summary = _build_summary(
+        submission_record=dict(existing.submission_record),
+        evaluation_record=dict(existing.evaluation_record),
+        proposal_payload=proposal_payload,
+        persisted_follow_up=manual_follow_up,
     )
 
     trip_record.updated_at = datetime.now(UTC)

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -216,7 +216,43 @@ def _build_summary(
     }
 
 
+_FOLLOW_UP_PATH_BY_STATUS: dict[str, str] = {
+    "reoptimization_required": "reoptimization",
+    "reoptimized": "reoptimization",
+    "exception_required": "exception",
+    "exception_requested": "exception",
+}
+_FOLLOW_UP_STATUSES_USING_EXISTING_PATH = {"approval_pending", "resolved"}
+
+
+def _resolved_follow_up_payload(record: PersistedProposalState) -> dict[str, Any]:
+    follow_up = dict(record.summary.get("follow_up") or {})
+    if follow_up:
+        return follow_up
+    return _derive_follow_up_state(
+        proposal_payload=dict(record.proposal_payload),
+        evaluation_record=dict(record.evaluation_record),
+        submission_record=dict(record.submission_record),
+    )
+
+
+def _resolve_manual_follow_up_path(
+    *, existing_follow_up: dict[str, Any], status: str
+) -> str:
+    if status in _FOLLOW_UP_PATH_BY_STATUS:
+        return _FOLLOW_UP_PATH_BY_STATUS[status]
+    if status in _FOLLOW_UP_STATUSES_USING_EXISTING_PATH:
+        existing_path = existing_follow_up.get("path")
+        if existing_path in {"approval", "exception", "reoptimization"}:
+            return str(existing_path)
+        raise ValueError(
+            f"Cannot store follow-up status '{status}' without an existing follow-up path."
+        )
+    raise ValueError(f"Unsupported workspace proposal follow-up status: {status}")
+
+
 def _serialize_proposal_state(record: PersistedProposalState) -> dict[str, Any]:
+    follow_up = _resolved_follow_up_payload(record)
     return {
         "proposal_state_id": record.proposal_state_id,
         "trip_id": record.trip_id,
@@ -232,7 +268,7 @@ def _serialize_proposal_state(record: PersistedProposalState) -> dict[str, Any]:
         "submission": dict(record.submission_record),
         "evaluation": dict(record.evaluation_record),
         "summary": dict(record.summary),
-        "follow_up": dict(record.summary.get("follow_up") or {}),
+        "follow_up": follow_up,
     }
 
 
@@ -407,6 +443,7 @@ def save_workspace_proposal_follow_up(
             "Proposal follow-up cannot be stored before a proposal submission exists."
         )
 
+    existing_follow_up = _resolved_follow_up_payload(existing)
     proposal_payload = dict(existing.proposal_payload)
     serialized_exception: dict[str, Any] | None = None
     if requested_exception is not None:
@@ -416,7 +453,10 @@ def save_workspace_proposal_follow_up(
     manual_follow_up = {
         "manual": True,
         "status": status,
-        "path": "exception" if "exception" in status else "reoptimization",
+        "path": _resolve_manual_follow_up_path(
+            existing_follow_up=existing_follow_up,
+            status=status,
+        ),
         "title": title or existing.summary.get("follow_up_title") or "Workspace follow-up updated",
         "summary": summary,
         "notes": list(notes),

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1072,6 +1072,7 @@ def _build_planner_panel_state(
         )
     if proposal_state is not None:
         summary = dict(proposal_state.get("summary") or {})
+        follow_up = dict(proposal_state.get("follow_up") or {})
         outputs.append(
             {
                 "output_id": f"output:{trip['trip_id']}:proposal-lifecycle",
@@ -1086,6 +1087,34 @@ def _build_planner_panel_state(
                 "highlights": list(summary.get("highlights") or [])[:3],
             }
         )
+        if follow_up:
+            outputs.append(
+                {
+                    "output_id": f"output:{trip['trip_id']}:proposal-follow-up",
+                    "title": follow_up.get("title") or "Proposal follow-up",
+                    "body": follow_up.get("summary")
+                    or "The workspace has a persisted follow-up path after policy evaluation.",
+                    "tags": ["proposal", "follow-up", trip["mode"]],
+                    "status": (
+                        "positive"
+                        if follow_up.get("status") in {"resolved", "approval_pending"}
+                        else ("critical" if follow_up.get("status") == "reoptimization_required" else "caution")
+                    ),
+                    "highlights": list(follow_up.get("guidance") or [])[:2],
+                }
+            )
+            next_step_actions.insert(
+                0,
+                {
+                    "action_id": f"action:{trip['trip_id']}:proposal-follow-up",
+                    "action_kind": follow_up.get("recommended_action") or "review_follow_up",
+                    "label": follow_up.get("recommended_label") or "Review proposal follow-up",
+                    "description": follow_up.get("summary")
+                    or "Inspect the persisted follow-up lane for the latest policy result.",
+                    "emphasis": "primary",
+                    "target_section": "approval",
+                },
+            )
 
     return {
         "trip": trip,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #697

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The business workflow is incomplete until the planner can respond to non-compliant or exception-required evaluation results. The app needs a visible and persistent path for reoptimization and exception handling.

Parent epic: #678

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#678](https://github.com/stranske/trip-planner/issues/678)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add reoptimization behavior for non-compliant or exception-required results.
- [ ] Add exception-request persistence or update flows.
- [ ] Add workspace UI that explains the reoptimized plan or exception path.
- [ ] Persist the resulting reoptimized or exception state.
- [ ] Add tests for non-compliant and exception-required result handling.
- [ ] Document the relationship between policy outcomes, reoptimization, and later approval actions.

#### Acceptance criteria
- [ ] Business trips can surface a reoptimized or exception-oriented next step after policy results.
- [ ] Reoptimization or exception outcomes persist and reload correctly.
- [ ] Automated tests cover at least one non-compliant and one exception-required path.
- [ ] The workspace presents a visible next action rather than leaving the trip in an ambiguous blocked state.

**Head SHA:** 217bc3796be0483941a3e8b49adf96baa9eb1b54
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24187512392) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24187512330) |
<!-- auto-status-summary:end -->