### PR TITLE
Issue #699: add workspace route map surface

### DIFF
--- a/docs/frontend-route-visualization.md
+++ b/docs/frontend-route-visualization.md
@@ -18,7 +18,7 @@ Issue `#559` adds visualization-oriented shell surfaces that consume route and f
 ## Current runtime contract
 
 - `frontend/src/components/maps/TripMap.tsx` is the current first-pass route/context map surface for workspace rendering.
-- The component consumes `runtime_scenario_comparison.scenarios[*].route_sequence`, `route_summary`, metric deltas, and `inventory_summary.bundles[*].destination_names`.
+- The component consumes `runtime_scenario_comparison.scenarios[*].route_sequence`, `route_summary`, `metrics`, and `inventory_summary.bundles[*].destination_names`.
 - `feasibility_summary.assessments` remains the source of route-attention and bundle-readiness signals; the map surface may summarize those signals, but it must not recalculate feasibility in the browser.
 - Scenario preview changes are local presentation changes. The selected map preview should start from persisted workspace state and then update the rendered map surface without mutating backend route logic.
 

--- a/docs/frontend-route-visualization.md
+++ b/docs/frontend-route-visualization.md
@@ -15,6 +15,13 @@ Issue `#559` adds visualization-oriented shell surfaces that consume route and f
 - `active_visualization_scenario_id` selects the currently rendered scenario. Switching scenarios in the shell changes presentation only.
 - When map provider output is absent, the shell should degrade to textual route summaries instead of synthesizing route logic locally.
 
+## Current runtime contract
+
+- `frontend/src/components/maps/TripMap.tsx` is the current first-pass route/context map surface for workspace rendering.
+- The component consumes `runtime_scenario_comparison.scenarios[*].route_sequence`, `route_summary`, metric deltas, and `inventory_summary.bundles[*].destination_names`.
+- `feasibility_summary.assessments` remains the source of route-attention and bundle-readiness signals; the map surface may summarize those signals, but it must not recalculate feasibility in the browser.
+- Scenario preview changes are local presentation changes. The selected map preview should start from persisted workspace state and then update the rendered map surface without mutating backend route logic.
+
 ## Representative states
 
 - Leisure regional loop: low-friction base with one regional excursion.

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -173,6 +173,61 @@ export type ScenarioSearchResult = {
   }>;
 };
 
+export type RuntimeScenarioComparison = {
+  title: string;
+  summary: string;
+  lead_scenario_id: string | null;
+  comparison_axes: Array<{
+    key: string;
+    label: string;
+    direction: string;
+  }>;
+  scenarios: Array<{
+    scenario_id: string;
+    title: string;
+    rank: number;
+    status: string;
+    summary: string;
+    comparison_note: string;
+    option_count: number;
+    route_sequence: string[];
+    route_summary: string;
+    recommended_for_selection: boolean;
+    feasible: boolean;
+    metrics: {
+      score: number;
+      travel_minutes: number;
+      transfers: number;
+      estimated_total: number | null;
+    };
+    delta: {
+      score_delta: number;
+      travel_minutes_delta: number;
+      transfers_delta: number;
+      estimated_total_delta: number | null;
+    };
+    highlights: string[];
+  }>;
+  source_refs: string[];
+};
+
+export type FeasibilitySummary = {
+  assessment_count: number;
+  recommended_bundle_count: number;
+  blocking_bundle_count: number;
+  attention_bundle_count: number;
+  notes: string[];
+  assessments: Array<{
+    bundle_id: string;
+    bundle_title: string;
+    bundle_context: string;
+    status: string;
+    total_travel_minutes: number;
+    total_transfer_count: number;
+    friction_penalty_total: number;
+  }>;
+};
+
 export type WorkspaceData = {
   trip_record: TripRecord;
   session: SessionState;
@@ -183,6 +238,7 @@ export type WorkspaceData = {
     focus_areas: string[];
   } | null;
   scenario_search: ScenarioSearchResult;
+  runtime_scenario_comparison: RuntimeScenarioComparison;
   activity_log: Array<{
     activity_event_id: string;
     occurred_at: string;
@@ -190,6 +246,7 @@ export type WorkspaceData = {
     summary: string;
   }>;
   planner_panel_state: PlannerPanelState;
+  feasibility_summary: FeasibilitySummary;
   inventory_summary: {
     bundle_count: number;
     bundles: Array<{

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -180,7 +180,7 @@ export type RuntimeScenarioComparison = {
   comparison_axes: Array<{
     key: string;
     label: string;
-    direction: string;
+    direction: "higher_better" | "lower_better";
   }>;
   scenarios: Array<{
     scenario_id: string;
@@ -198,7 +198,10 @@ export type RuntimeScenarioComparison = {
       score: number;
       travel_minutes: number;
       transfers: number;
-      estimated_total: number | null;
+      estimated_total: {
+        currency: string;
+        typical_amount: number;
+      } | null;
     };
     delta: {
       score_delta: number;

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -18,15 +18,18 @@ function humanizeStop(stop: string): string {
     .join(" ");
 }
 
-function formatEstimatedTotal(value: number | null): string {
+function formatEstimatedTotal(
+  value: RuntimeScenarioComparison["scenarios"][number]["metrics"]["estimated_total"]
+): string {
   if (value == null) {
     return "Pending";
   }
+
   return new Intl.NumberFormat("en-US", {
     style: "currency",
-    currency: "USD",
+    currency: value.currency,
     maximumFractionDigits: 0,
-  }).format(value);
+  }).format(value.typical_amount);
 }
 
 function summarizeFeasibility(

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -1,0 +1,178 @@
+import type {
+  FeasibilitySummary,
+  RuntimeScenarioComparison,
+  WorkspaceData,
+} from "../../api/workspace";
+
+type TripMapScenario = RuntimeScenarioComparison["scenarios"][number];
+type InventoryBundle = WorkspaceData["inventory_summary"]["bundles"][number];
+
+function humanizeStop(stop: string): string {
+  return stop
+    .replace(/^dest-city-/, "")
+    .replace(/^dest-/, "")
+    .replace(/^city-/, "")
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatEstimatedTotal(value: number | null): string {
+  if (value == null) {
+    return "Pending";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function summarizeFeasibility(
+  feasibilitySummary: FeasibilitySummary,
+  bundleDestinations: string[]
+): string {
+  if (feasibilitySummary.assessment_count === 0) {
+    return "No inventory bundles have produced route-feasibility signals yet.";
+  }
+
+  if (bundleDestinations.length === 0) {
+    return `${feasibilitySummary.assessment_count} bundle checks are available, but destination anchors have not been attached yet.`;
+  }
+
+  return `${bundleDestinations.length} destination anchors are backed by ${feasibilitySummary.assessment_count} feasibility assessment(s).`;
+}
+
+export function TripMap({
+  comparison,
+  activeScenarioId,
+  onSelectScenario,
+  bundles,
+  feasibilitySummary,
+}: {
+  comparison: RuntimeScenarioComparison;
+  activeScenarioId: string | null;
+  onSelectScenario: (scenarioId: string) => void;
+  bundles: InventoryBundle[];
+  feasibilitySummary: FeasibilitySummary;
+}) {
+  const activeScenario =
+    comparison.scenarios.find((scenario) => scenario.scenario_id === activeScenarioId) ??
+    comparison.scenarios[0] ??
+    null;
+
+  if (activeScenario == null) {
+    return (
+      <section className="status-card map-card">
+        <p className="status-label">Map surface</p>
+        <h2>Route context is not ready</h2>
+        <p className="muted-copy">
+          The workspace needs ranked scenario output before it can render a route-aware map
+          preview.
+        </p>
+      </section>
+    );
+  }
+
+  const bundleDestinations = Array.from(
+    new Set(
+      bundles
+        .flatMap((bundle) => bundle.destination_names)
+        .map((destination) => destination.trim())
+        .filter(Boolean)
+    )
+  );
+
+  return (
+    <section className="status-card map-card">
+      <p className="status-label">Map surface</p>
+      <h2>Map preview for {activeScenario.title}</h2>
+      <p>{activeScenario.summary}</p>
+      <div className="map-scenario-toggle" aria-label="Map scenario previews">
+        {comparison.scenarios.map((scenario) => (
+          <button
+            key={scenario.scenario_id}
+            type="button"
+            className={`map-toggle-chip${
+              scenario.scenario_id === activeScenario.scenario_id ? " map-toggle-chip-active" : ""
+            }`}
+            aria-pressed={scenario.scenario_id === activeScenario.scenario_id}
+            onClick={() => onSelectScenario(scenario.scenario_id)}
+          >
+            {scenario.rank}. {scenario.title}
+          </button>
+        ))}
+      </div>
+      <div className="map-surface" aria-label="Route context map">
+        <div className="map-route">
+          {activeScenario.route_sequence.map((stop, index) => (
+            <div key={`${activeScenario.scenario_id}-${stop}-${index}`} className="map-stop">
+              <div className="map-stop-marker">
+                <span>{index + 1}</span>
+              </div>
+              <div className="map-stop-copy">
+                <h3>{humanizeStop(stop)}</h3>
+                <p>
+                  {index === 0
+                    ? "Current route origin for the workspace preview."
+                    : index === activeScenario.route_sequence.length - 1
+                      ? "Current route destination anchor."
+                      : "Intermediate route checkpoint preserved in the active scenario."}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="map-sidebar">
+          <dl className="workspace-meta map-metrics">
+            <div>
+              <dt>Travel minutes</dt>
+              <dd>{activeScenario.metrics.travel_minutes}</dd>
+            </div>
+            <div>
+              <dt>Transfers</dt>
+              <dd>{activeScenario.metrics.transfers}</dd>
+            </div>
+            <div>
+              <dt>Options</dt>
+              <dd>{activeScenario.option_count}</dd>
+            </div>
+            <div>
+              <dt>Estimated total</dt>
+              <dd>{formatEstimatedTotal(activeScenario.metrics.estimated_total)}</dd>
+            </div>
+          </dl>
+          <article className="decision-card">
+            <h3>Route summary</h3>
+            <p>{activeScenario.route_summary}</p>
+            <p className="muted-copy">{activeScenario.comparison_note}</p>
+          </article>
+          <article className="decision-card">
+            <h3>Destination anchors</h3>
+            <p>{summarizeFeasibility(feasibilitySummary, bundleDestinations)}</p>
+            <div className="map-anchor-list">
+              {bundleDestinations.length === 0 ? (
+                <span className="map-anchor-chip map-anchor-chip-muted">Awaiting option anchors</span>
+              ) : (
+                bundleDestinations.map((destination) => (
+                  <span key={destination} className="map-anchor-chip">
+                    {destination}
+                  </span>
+                ))
+              )}
+            </div>
+          </article>
+          <article className="decision-card">
+            <h3>Scenario highlights</h3>
+            <ul className="map-highlight-list">
+              {activeScenario.highlights.slice(0, 3).map((highlight) => (
+                <li key={highlight}>{highlight}</li>
+              ))}
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -133,7 +133,93 @@ const workspacePayload = {
         },
         unresolved_tradeoffs: [],
       },
+      {
+        scenario_id: "scenario:trip-leisure-kyoto-draft:2",
+        title: "Kyoto plus Osaka fallback",
+        rank: 2,
+        score: 0.88,
+        scenario_summary: {
+          headline: "Higher-energy fallback with extra transfers",
+          scenario_kind: "alternative",
+          recommended_for_selection: false,
+          total_travel_minutes: 360,
+          total_transfer_count: 7,
+          route_sequence: ["kyoto", "osaka", "kyoto"],
+        },
+        unresolved_tradeoffs: [
+          {
+            tradeoff_id: "tradeoff:osaka-nightlife",
+            summary: "Higher transfer load to preserve nightlife breadth.",
+            severity: "info",
+          },
+        ],
+      },
     ],
+  },
+  runtime_scenario_comparison: {
+    title: "Kyoto leisure scenario comparison",
+    summary: "Two runtime scenarios are available for map-backed comparison.",
+    lead_scenario_id: "scenario:trip-leisure-kyoto-draft:1",
+    comparison_axes: [
+      { key: "score", label: "Planner score", direction: "higher_better" },
+      { key: "travel_minutes", label: "Travel minutes", direction: "lower_better" },
+      { key: "transfers", label: "Transfers", direction: "lower_better" },
+    ],
+    scenarios: [
+      {
+        scenario_id: "scenario:trip-leisure-kyoto-draft:1",
+        title: "Kyoto base with Uji day trip",
+        rank: 1,
+        status: "lead",
+        summary: "Balanced Kyoto culture baseline",
+        comparison_note: "Lead route for the current workspace comparison set.",
+        option_count: 2,
+        route_sequence: ["kyoto", "uji", "kyoto"],
+        route_summary: "kyoto -> uji -> kyoto",
+        recommended_for_selection: true,
+        feasible: true,
+        metrics: {
+          score: 0.93,
+          travel_minutes: 265,
+          transfers: 4,
+          estimated_total: 3400,
+        },
+        delta: {
+          score_delta: 0,
+          travel_minutes_delta: 0,
+          transfers_delta: 0,
+          estimated_total_delta: 0,
+        },
+        highlights: ["Moderate travel friction with a clear cultural center of gravity."],
+      },
+      {
+        scenario_id: "scenario:trip-leisure-kyoto-draft:2",
+        title: "Kyoto plus Osaka fallback",
+        rank: 2,
+        status: "alternative",
+        summary: "Higher-energy fallback with extra transfers",
+        comparison_note: "Alternative route preserved for direct scenario comparison.",
+        option_count: 2,
+        route_sequence: ["kyoto", "osaka", "kyoto"],
+        route_summary: "kyoto -> osaka -> kyoto",
+        recommended_for_selection: false,
+        feasible: true,
+        metrics: {
+          score: 0.88,
+          travel_minutes: 360,
+          transfers: 7,
+          estimated_total: 3250,
+        },
+        delta: {
+          score_delta: -0.05,
+          travel_minutes_delta: 95,
+          transfers_delta: 3,
+          estimated_total_delta: -150,
+        },
+        highlights: ["Higher transfer load to preserve nightlife breadth."],
+      },
+    ],
+    source_refs: ["ranked-results:kyoto-spring"],
   },
   inventory_summary: {
     bundle_count: 2,
@@ -161,6 +247,33 @@ const workspacePayload = {
     ],
     notes: [
       "Bundle summaries are assembled from normalized destination, lodging, transport, and activity records.",
+    ],
+  },
+  feasibility_summary: {
+    assessment_count: 2,
+    recommended_bundle_count: 1,
+    blocking_bundle_count: 0,
+    attention_bundle_count: 1,
+    notes: ["Route feasibility is available for the current workspace bundle set."],
+    assessments: [
+      {
+        bundle_id: "bundle-osaka-gateway",
+        bundle_title: "Osaka arrival buffer",
+        bundle_context: "transport_lodging",
+        status: "positive",
+        total_travel_minutes: 90,
+        total_transfer_count: 1,
+        friction_penalty_total: 0.4,
+      },
+      {
+        bundle_id: "bundle-kyoto-culture-day",
+        bundle_title: "Kyoto cultural anchor",
+        bundle_context: "route_level",
+        status: "caution",
+        total_travel_minutes: 175,
+        total_transfer_count: 3,
+        friction_penalty_total: 1.2,
+      },
     ],
   },
   budget_state: {
@@ -392,6 +505,8 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Uji")).toBeInTheDocument();
     expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
     expect(screen.getByText("Trip-scoped planner surface")).toBeInTheDocument();
+    expect(screen.getByLabelText("Route context map")).toBeInTheDocument();
+    expect(screen.getByText("Destination anchors")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Assembled inventory layer" })).toBeInTheDocument();
     expect(screen.getByText("Osaka arrival buffer")).toBeInTheDocument();
     expect(screen.getByText("Kyoto cultural anchor")).toBeInTheDocument();
@@ -407,6 +522,26 @@ describe("WorkspacePage", () => {
     });
   });
 
+  it("updates the map surface when a different scenario preview is selected", async () => {
+    const user = userEvent.setup();
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(workspacePayload),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Balanced Kyoto culture baseline")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
+
+    expect(screen.getByText("Higher-energy fallback with extra transfers")).toBeInTheDocument();
+    expect(screen.getByText("Osaka")).toBeInTheDocument();
+    expect(screen.getByText("Higher transfer load to preserve nightlife breadth.")).toBeInTheDocument();
+  });
+
   it("shows an empty-state message when no route sequence is available", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({
@@ -414,6 +549,11 @@ describe("WorkspacePage", () => {
         saved_scenarios: [],
         scenario_search: {
           ...workspacePayload.scenario_search,
+          scenarios: [],
+        },
+        runtime_scenario_comparison: {
+          ...workspacePayload.runtime_scenario_comparison,
+          lead_scenario_id: null,
           scenarios: [],
         },
         planner_panel_state: {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -182,7 +182,10 @@ const workspacePayload = {
           score: 0.93,
           travel_minutes: 265,
           transfers: 4,
-          estimated_total: 3400,
+          estimated_total: {
+            currency: "JPY",
+            typical_amount: 3400,
+          },
         },
         delta: {
           score_delta: 0,
@@ -208,7 +211,10 @@ const workspacePayload = {
           score: 0.88,
           travel_minutes: 360,
           transfers: 7,
-          estimated_total: 3250,
+          estimated_total: {
+            currency: "JPY",
+            typical_amount: 3250,
+          },
         },
         delta: {
           score_delta: -0.05,
@@ -500,13 +506,15 @@ describe("WorkspacePage", () => {
       expect(screen.getByRole("heading", { name: "Spring Kyoto anniversary draft" })).toBeInTheDocument();
     });
 
+    const routeContextMap = screen.getByLabelText("Route context map");
+
     expect(screen.getByRole("heading", { name: "Kyoto base with Uji day trip" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Map preview for Kyoto base with Uji day trip" })).toBeInTheDocument();
-    expect(within(screen.getByLabelText("Route context map")).getAllByText("Kyoto")).toHaveLength(2);
-    expect(screen.getByText("Uji")).toBeInTheDocument();
+    expect(within(routeContextMap).getAllByRole("heading", { name: "Kyoto" })).toHaveLength(2);
+    expect(within(routeContextMap).getByRole("heading", { name: "Uji" })).toBeInTheDocument();
     expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
     expect(screen.getByText("Trip-scoped planner surface")).toBeInTheDocument();
-    expect(screen.getByLabelText("Route context map")).toBeInTheDocument();
+    expect(routeContextMap).toBeInTheDocument();
     expect(screen.getByText("Destination anchors")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Assembled inventory layer" })).toBeInTheDocument();
     expect(screen.getByText("Osaka arrival buffer")).toBeInTheDocument();
@@ -543,7 +551,7 @@ describe("WorkspacePage", () => {
     expect(
       screen.getByRole("heading", { name: "Map preview for Kyoto plus Osaka fallback" })
     ).toBeInTheDocument();
-    expect(screen.getByText("Osaka")).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Route context map")).getByRole("heading", { name: "Osaka" })).toBeInTheDocument();
     expect(screen.getByText("Higher transfer load to preserve nightlife breadth.")).toBeInTheDocument();
   });
 

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -501,7 +501,8 @@ describe("WorkspacePage", () => {
     });
 
     expect(screen.getByRole("heading", { name: "Kyoto base with Uji day trip" })).toBeInTheDocument();
-    expect(screen.getAllByText("Kyoto")).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Map preview for Kyoto base with Uji day trip" })).toBeInTheDocument();
+    expect(within(screen.getByLabelText("Route context map")).getAllByText("Kyoto")).toHaveLength(2);
     expect(screen.getByText("Uji")).toBeInTheDocument();
     expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
     expect(screen.getByText("Trip-scoped planner surface")).toBeInTheDocument();
@@ -534,10 +535,14 @@ describe("WorkspacePage", () => {
       expect(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" })).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Balanced Kyoto culture baseline")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Map preview for Kyoto base with Uji day trip" })
+    ).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
 
-    expect(screen.getByText("Higher-energy fallback with extra transfers")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Map preview for Kyoto plus Osaka fallback" })
+    ).toBeInTheDocument();
     expect(screen.getByText("Osaka")).toBeInTheDocument();
     expect(screen.getByText("Higher transfer load to preserve nightlife breadth.")).toBeInTheDocument();
   });

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -13,6 +13,7 @@ import {
   type WorkspaceData,
 } from "../api/workspace";
 import { WorkspaceBudgetPanel } from "../components/budget/WorkspaceBudgetPanel";
+import { TripMap } from "../components/maps/TripMap";
 import { PlannerSidePanelSurface } from "../components/planner/PlannerSidePanelSurface";
 import { AsyncRouteContent } from "../lib/routes/AsyncRouteContent";
 
@@ -66,6 +67,14 @@ function resolveActiveScenario(workspace: WorkspaceData) {
     activeVersion,
     scenario: matchedScenario ?? workspace.scenario_search.scenarios[0] ?? null,
   };
+}
+
+function resolveMapScenarioId(workspace: WorkspaceData): string | null {
+  const activeScenario = resolveActiveScenario(workspace).scenario;
+  if (activeScenario?.scenario_id) {
+    return activeScenario.scenario_id;
+  }
+  return workspace.runtime_scenario_comparison.lead_scenario_id;
 }
 
 function buildTimelineStops(workspace: WorkspaceData): TimelineStop[] {
@@ -198,12 +207,16 @@ export function WorkspacePage() {
 
 function WorkspacePageContent({ workspace }: { workspace: WorkspaceData }) {
   const [currentWorkspace, setCurrentWorkspace] = useState(workspace);
+  const [selectedMapScenarioId, setSelectedMapScenarioId] = useState(() =>
+    resolveMapScenarioId(workspace)
+  );
   const [plannerError, setPlannerError] = useState<string | null>(null);
   const [plannerBusyLabel, setPlannerBusyLabel] = useState<string | null>(null);
   const [budgetError, setBudgetError] = useState<string | null>(null);
   const [budgetBusyLabel, setBudgetBusyLabel] = useState<string | null>(null);
   useEffect(() => {
     setCurrentWorkspace(workspace);
+    setSelectedMapScenarioId(resolveMapScenarioId(workspace));
   }, [workspace]);
 
   const timelineStops = buildTimelineStops(currentWorkspace);
@@ -341,6 +354,14 @@ function WorkspacePageContent({ workspace }: { workspace: WorkspaceData }) {
           errorMessage={budgetError}
           onSaveBudget={handleBudgetSave}
           onRecordSpend={handleSpendRecord}
+        />
+
+        <TripMap
+          comparison={currentWorkspace.runtime_scenario_comparison}
+          activeScenarioId={selectedMapScenarioId}
+          onSelectScenario={setSelectedMapScenarioId}
+          bundles={currentWorkspace.inventory_summary.bundles}
+          feasibilitySummary={currentWorkspace.feasibility_summary}
         />
 
         <section className="status-card">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -264,6 +264,130 @@ a {
   grid-column: 1 / -1;
 }
 
+.map-card {
+  grid-column: 1 / -1;
+}
+
+.map-scenario-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.25rem 0 1rem;
+}
+
+.map-toggle-chip {
+  border: 0;
+  border-radius: 999px;
+  background: rgba(19, 33, 44, 0.08);
+  color: #13212c;
+  cursor: pointer;
+  font: inherit;
+  padding: 0.75rem 1rem;
+}
+
+.map-toggle-chip-active {
+  background: #13212c;
+  color: #f7f1e5;
+}
+
+.map-surface {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 1fr);
+  margin-top: 1rem;
+}
+
+.map-route,
+.map-sidebar {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.map-route {
+  padding: 1rem;
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgba(56, 117, 107, 0.12), rgba(19, 33, 44, 0.03)),
+    rgba(255, 255, 255, 0.72);
+}
+
+.map-stop {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  gap: 1rem;
+  align-items: center;
+}
+
+.map-stop + .map-stop {
+  position: relative;
+}
+
+.map-stop + .map-stop::before {
+  content: "";
+  position: absolute;
+  left: 31px;
+  top: -0.9rem;
+  bottom: calc(100% - 0.2rem);
+  border-left: 2px dashed rgba(19, 33, 44, 0.2);
+}
+
+.map-stop-marker {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  background: #13212c;
+  color: #f7f1e5;
+  font-weight: 700;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.map-stop-copy h3 {
+  margin: 0 0 0.3rem;
+}
+
+.map-stop-copy p {
+  margin: 0;
+  color: #365063;
+}
+
+.map-metrics {
+  margin-top: 0;
+}
+
+.map-anchor-list,
+.map-highlight-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.9rem;
+}
+
+.map-anchor-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(132, 86, 35, 0.12);
+}
+
+.map-anchor-chip-muted {
+  background: rgba(19, 33, 44, 0.08);
+  color: #577186;
+}
+
+.map-highlight-list {
+  padding-left: 1rem;
+  display: grid;
+}
+
+@media (max-width: 820px) {
+  .map-surface {
+    grid-template-columns: 1fr;
+  }
+}
+
 .budget-summary-grid {
   display: grid;
   gap: 0.9rem;


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #699

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The design explicitly calls for map-aware route and option understanding. The app still lacks any map surface that makes destination, route, and option context visible.

Parent epic: #679

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#679](https://github.com/stranske/trip-planner/issues/679)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add a map component and data-loading path in the frontend runtime.
- [x] Display destination and route context for the active trip or scenario.
- [x] Link map state to workspace scenario selection or active trip state.
- [x] Add tests for map data loading and key UI behaviors.
- [x] Document the contract between route/location outputs and the map surface.

#### Acceptance criteria
- [x] The workspace can display map context for the active trip or scenario.
- [x] Map state updates when the active scenario changes.
- [x] Automated tests cover route/location loading and key map UI states.
- [x] The map surface is driven by runtime trip/scenario data rather than static examples.

**Head SHA:** 01b945a05bb04f3e10a21b3e0de6ac7bbb2ab73f
**Latest Runs:** ❔ in progress — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24191619916) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24191619948) |
<!-- auto-status-summary:end -->
