### PR TITLE
Follow up issue #696 review fixes

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -677,6 +677,37 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Seoul gallery weekend is stored as a leisure trip with 1 traveler(s).")).toBeInTheDocument();
   });
 
+  it("falls back to plain number formatting when comparable currency codes are invalid", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          proposal: {
+            ...workspacePayload.proposal_state.proposal,
+            comparables: [
+              {
+                ...workspacePayload.proposal_state.proposal.comparables[0],
+                estimated_cost: {
+                  ...workspacePayload.proposal_state.proposal.comparables[0].estimated_cost,
+                  currency: "INVALID",
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Comparables and readiness signals" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Marriott via Navan · 245/)).toBeInTheDocument();
+  });
+
   it("shows an empty-state message when no route sequence is available", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -126,11 +126,17 @@ function formatDate(value: string): string {
 }
 
 function formatCurrency(amount: number, currency: string): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency,
-    maximumFractionDigits: 0,
-  }).format(amount);
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return new Intl.NumberFormat("en-US", {
+      maximumFractionDigits: 0,
+    }).format(amount);
+  }
 }
 
 function ScenarioSummaryCard({

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -223,6 +223,140 @@ def test_workspace_proposal_evaluation_derives_reoptimization_follow_up(client: 
     assert follow_up["alternatives"][0]["category"] == "lodging"
 
 
+def test_workspace_proposal_submission_clears_stale_evaluation_state(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Proposal resubmission workspace",
+            "summary": "New proposal submissions should reset evaluation state.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    first_submission = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v1",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert first_submission.status_code == 200
+
+    evaluation_fixture = _load_fixture("results", "approved_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["proposal_version"] = "proposal-v1"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+
+    evaluated = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v1",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert evaluated.status_code == 200
+    assert evaluated.json()["proposal_state"]["summary"]["approval_ready"] is True
+
+    resubmitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v2",
+            "scenario_id": "scenario-b",
+        },
+    )
+    assert resubmitted.status_code == 200
+    proposal_state = resubmitted.json()["proposal_state"]
+    assert proposal_state["proposal_version"] == "proposal-v2"
+    assert proposal_state["evaluation"] == {}
+    assert proposal_state["evaluation_status"] is None
+    assert proposal_state["summary"]["approval_ready"] is False
+    assert proposal_state["summary"]["evaluation_result_status"] is None
+
+
+def test_workspace_proposal_evaluation_rejects_mismatched_submission_linkage(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Proposal evaluation linkage",
+            "summary": "Evaluation linkage must match the stored submission.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+
+    evaluation_fixture = _load_fixture("results", "approved_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = "proposal:other-trip"
+    evaluation_fixture["response"]["result_payload"]["proposal_version"] = "proposal-v3"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        "proposal:other-trip"
+    )
+
+    evaluated = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert evaluated.status_code == 400
+    assert "persisted proposal" in evaluated.json()["detail"]
+
+
 def test_workspace_proposal_follow_up_patch_persists_exception_request(client: TestClient) -> None:
     created = client.post(
         "/api/trips",

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -357,6 +357,89 @@ def test_workspace_proposal_evaluation_rejects_mismatched_submission_linkage(
     assert "persisted proposal" in evaluated.json()["detail"]
 
 
+def test_workspace_proposal_evaluation_rejects_mismatched_scenario_and_organization(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Proposal evaluation linkage",
+            "summary": "Evaluation scenario and organization must match the stored submission.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+
+    scenario_fixture = _load_fixture("results", "approved_evaluation.json")
+    scenario_fixture["request"]["trip_id"] = trip_id
+    scenario_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    scenario_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    scenario_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    scenario_fixture["response"]["result_payload"]["proposal_version"] = "proposal-v3"
+    scenario_fixture["response"]["result_payload"]["scenario_id"] = "scenario-b"
+    scenario_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+
+    scenario_response = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": scenario_fixture["request"],
+            "response": scenario_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert scenario_response.status_code == 400
+    assert "scenario_id" in scenario_response.json()["detail"]
+
+    organization_fixture = _load_fixture("results", "approved_evaluation.json")
+    organization_fixture["request"]["trip_id"] = trip_id
+    organization_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    organization_fixture["request"]["organization_id"] = "org-other"
+    organization_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    organization_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    organization_fixture["response"]["result_payload"]["proposal_version"] = "proposal-v3"
+    organization_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+
+    organization_response = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": organization_fixture["request"],
+            "response": organization_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert organization_response.status_code == 400
+    assert "organization_id" in organization_response.json()["detail"]
+
+
 def test_workspace_proposal_follow_up_patch_persists_exception_request(client: TestClient) -> None:
     created = client.post(
         "/api/trips",

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -359,6 +359,118 @@ def test_workspace_endpoint_prefers_persisted_proposal_lifecycle_for_business_tr
     assert payload["proposal_state"]["follow_up"]["status"] == "resolved"
 
 
+def test_workspace_endpoint_does_not_mix_policy_preview_with_pending_proposal_state(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Pending proposal workspace",
+            "summary": "Workspace should not mix policy preview artifacts with persisted proposals.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    policy_fixture = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "fixtures"
+            / "integrations"
+            / "tpp"
+            / "policy"
+            / "standard_policy_sync.json"
+        ).read_text(encoding="utf-8")
+    )
+    imported = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={
+            "request": policy_fixture["request"],
+            "response": policy_fixture["response"],
+            "notes": ["Policy-backed workspace test import."],
+        },
+    )
+    assert imported.status_code == 200
+
+    submission_fixture = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "fixtures"
+            / "integrations"
+            / "tpp"
+            / "proposal_submit_deferred.json"
+        ).read_text(encoding="utf-8")
+    )
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    proposal_payload = {
+        "proposal_id": f"proposal:{trip_id}",
+        "trip_id": trip_id,
+        "mode": "business",
+        "traveler_context": {
+            "employee_type": "employee",
+            "traveler_experience": "frequent",
+            "home_airport": "ORD",
+            "loyalty_programs": ["United"],
+            "mobility_or_access_needs": [],
+        },
+        "selected_options": [
+            {
+                "category": "airfare",
+                "option_id": "flight-1",
+                "label": "United 123",
+                "vendor": "United",
+                "booking_channel": "Navan",
+                "estimated_cost": {
+                    "currency": "USD",
+                    "typical_amount": 620.0,
+                    "min_amount": 620.0,
+                    "max_amount": 620.0,
+                },
+                "justification_refs": ["fare-policy"],
+            }
+        ],
+        "cost_summary": {
+            "currency": "USD",
+            "total_estimated_cost": 620.0,
+            "category_estimates": {"airfare": 620.0},
+            "notes": ["Costs include taxes."],
+        },
+        "comparables": [],
+        "approval_notes": ["Manager review required before booking."],
+        "constraint_set_id": "policy-standard-2026-02",
+    }
+
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": proposal_payload,
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+
+    response = client.get(f"/api/workspace/{trip_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["planner_panel_state"]["proposal"]["proposal_id"] == f"proposal:{trip_id}"
+    assert payload["planner_panel_state"]["policy_evaluation"] is None
+    assert "Policy posture loaded" not in [
+        item["title"] for item in payload["planner_panel_state"]["outputs"]
+    ]
+
+
 def test_workspace_endpoint_surfaces_reoptimization_follow_up_for_non_compliant_results(
     client: TestClient,
 ) -> None:

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -330,7 +330,6 @@ def save_workspace_proposal_submission(
     proposal_state_id = (
         existing.proposal_state_id if existing is not None else f"proposal-state:{trip_id}"
     )
-    evaluation_record = dict(existing.evaluation_record) if existing is not None else {}
     record = existing or PersistedProposalState(
         proposal_state_id=proposal_state_id,
         trip_id=trip_id,
@@ -345,7 +344,7 @@ def save_workspace_proposal_submission(
         evaluation_status=None,
         proposal_payload=proposal.to_dict(),
         submission_record=submission.to_dict(),
-        evaluation_record=evaluation_record,
+        evaluation_record={},
         summary={},
     )
     record.owner_profile_id = _owner_profile_id(trip_record)
@@ -357,9 +356,10 @@ def save_workspace_proposal_submission(
     record.submission_status = submission.execution_status.state
     record.proposal_payload = proposal.to_dict()
     record.submission_record = submission.to_dict()
+    _reset_evaluation_state(record)
     record.summary = _build_summary(
         submission_record=record.submission_record,
-        evaluation_record=evaluation_record,
+        evaluation_record={},
         proposal_payload=record.proposal_payload,
         persisted_follow_up=dict(existing.summary.get("follow_up") or {}) if existing else None,
     )
@@ -405,6 +405,14 @@ def save_workspace_proposal_evaluation(
     )
     if request.trip_id is not None and request.trip_id != trip_id:
         raise ValueError("evaluation request.trip_id must match the workspace trip.")
+    if evaluation.linkage.trip_id != trip_id:
+        raise ValueError("evaluation linkage.trip_id must match the workspace trip.")
+    if evaluation.linkage.proposal_id != existing.proposal_id:
+        raise ValueError("evaluation linkage.proposal_id must match the persisted proposal.")
+    if evaluation.linkage.proposal_version != existing.proposal_version:
+        raise ValueError(
+            "evaluation linkage.proposal_version must match the persisted proposal version."
+        )
 
     existing.proposal_version = evaluation.linkage.proposal_version
     existing.scenario_id = evaluation.linkage.scenario_id

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -253,6 +253,11 @@ def _resolve_manual_follow_up_path(
     raise ValueError(f"Unsupported workspace proposal follow-up status: {status}")
 
 
+def _reset_evaluation_state(record: PersistedProposalState) -> None:
+    record.evaluation_status = None
+    record.evaluation_record = {}
+
+
 def _serialize_proposal_state(record: PersistedProposalState) -> dict[str, Any]:
     follow_up = _resolved_follow_up_payload(record)
     return {

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -413,6 +413,18 @@ def save_workspace_proposal_evaluation(
         raise ValueError(
             "evaluation linkage.proposal_version must match the persisted proposal version."
         )
+    if (
+        existing.scenario_id is not None
+        and evaluation.linkage.scenario_id is not None
+        and evaluation.linkage.scenario_id != existing.scenario_id
+    ):
+        raise ValueError("evaluation linkage.scenario_id must match the persisted proposal.")
+    if (
+        existing.organization_id is not None
+        and evaluation.linkage.organization_id is not None
+        and evaluation.linkage.organization_id != existing.organization_id
+    ):
+        raise ValueError("evaluation linkage.organization_id must match the persisted proposal.")
 
     existing.proposal_version = evaluation.linkage.proposal_version
     existing.scenario_id = evaluation.linkage.scenario_id

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1026,26 +1026,29 @@ def _build_planner_panel_state(
         if proposal_context is not None and proposal_context.get("proposal_state") is not None
         else None
     )
-    policy_evaluation = (
-        dict(proposal_state["evaluation"].get("evaluation_result"))
-        if proposal_state is not None
-        and proposal_state.get("evaluation") is not None
-        and proposal_state["evaluation"].get("evaluation_result") is not None
-        else (
+    if proposal_state is not None:
+        policy_evaluation = (
+            dict(proposal_state["evaluation"].get("evaluation_result"))
+            if proposal_state.get("evaluation") is not None
+            and proposal_state["evaluation"].get("evaluation_result") is not None
+            else None
+        )
+        proposal = (
+            dict(proposal_state["proposal"])
+            if proposal_state.get("proposal") is not None
+            else None
+        )
+    else:
+        policy_evaluation = (
             dict(policy_context["policy_evaluation"])
             if policy_context is not None and policy_context.get("policy_evaluation") is not None
             else None
         )
-    )
-    proposal = (
-        dict(proposal_state["proposal"])
-        if proposal_state is not None and proposal_state.get("proposal") is not None
-        else (
+        proposal = (
             dict(policy_context["proposal"])
             if policy_context is not None and policy_context.get("proposal") is not None
             else None
         )
-    )
     if policy_evaluation is not None:
         outputs.append(
             {


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #696

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The business planner is supposed to produce approval-ready plans and react to evaluation results. Until proposal submission and evaluation-result ingestion are real app behaviors, the business side remains structurally incomplete.

Parent epic: #678

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#678](https://github.com/stranske/trip-planner/issues/678)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add APIs for proposal submission and evaluation-result ingestion.
- [x] Persist proposal and evaluation state per trip.
- [x] Add workspace UI for proposal status, comparables, and approval-packet readiness.
- [x] Add tests for proposal lifecycle persistence and UI display.
- [x] Document how later reoptimization work should consume proposal and evaluation records.

#### Acceptance criteria
- [x] A business trip can surface a proposal submission/result lifecycle in the app UI.
- [x] Proposal and evaluation state persist and reload correctly.
- [x] The workspace shows a real approval-packet/readiness surface backed by runtime data.
- [x] Automated tests cover both backend lifecycle behavior and UI rendering.

**Head SHA:** b6b6b4856c7fc2d827b20ec773fa3cb209d8de74
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24203842910) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24203842918) |
<!-- auto-status-summary:end -->
