### PR TITLE
Issue #686: persist planning session state and audit trail

### DIFF
--- a/docs/state-session-persistence.md
+++ b/docs/state-session-persistence.md
@@ -33,4 +33,28 @@ Repository implementations should treat:
 - option-presentation history as a bounded recent-history slice on the session record
 - activity-log events as append-only records that can be filtered by trip, session, decision, or option set
 
+## Event Writing Guidance
+
+Later workspace, orchestration, and policy features should append `ActivityLogEvent`
+records whenever they create user-visible planning state transitions. The event trail is
+the durable explanation surface for why a trip changed, so later issues should reuse it
+instead of creating side-channel audit notes.
+
+The first pass expects new writers to:
+
+- attach every event to the owning `trip_id`
+- include `session_state_id` whenever the action came from an active planning session
+- keep `event_kind` stable and specific enough for filtering, such as
+  `scenario_saved`, `policy_review_requested`, or `budget_recomputed`
+- write a concise `summary` that is suitable for direct UI rendering in the trip activity
+  timeline
+- populate related ids like `saved_scenario_id`, `related_decision_id`, or
+  `related_option_set_id` when that context exists instead of burying it only in metadata
+- treat `metadata` as optional supporting detail, not the only place the core event meaning
+  lives
+
+Future policy and workspace issues should prefer appending a new event over mutating prior
+history. Session state may evolve in place, but the audit trail should remain chronological
+and additive so reload, verification, and later incident review can explain what happened.
+
 The first pass stays backend-neutral. The goal is to lock the persistence contract before later UI, orchestration, and notification work depends on it.

--- a/frontend/src/api/trips.ts
+++ b/frontend/src/api/trips.ts
@@ -57,12 +57,38 @@ export type PlanningHistoryEntry = {
   event_kind: string;
   summary: string;
   actor: string;
+  session_state_id: string;
   saved_scenario_id: string | null;
+};
+
+export type PlanningSessionRecord = {
+  session_state_id: string;
+  owner_profile_id: string;
+  mode: string;
+  started_at: string;
+  updated_at: string;
+  status: string;
+  current_saved_scenario_id: string | null;
+  activity_log_id: string | null;
+  interaction_state: {
+    initiative_level: string;
+    summary_granularity: string;
+    checkpoint_frequency: string;
+  };
+  pending_decisions: Array<{
+    decision_id: string;
+    prompt: string;
+  }>;
+  recent_option_presentations: Array<{
+    presentation_id: string;
+    option_set_id: string;
+  }>;
 };
 
 export type TripScenarioHistoryData = {
   saved_scenarios: SavedScenarioRecord[];
   planning_history: PlanningHistoryEntry[];
+  planning_sessions: PlanningSessionRecord[];
 };
 
 export type CreateTripPayload = {

--- a/frontend/src/router.test.ts
+++ b/frontend/src/router.test.ts
@@ -17,6 +17,7 @@ vi.mock("./api/trips", () => ({
   fetchTripScenarioHistory: vi.fn().mockResolvedValue({
     saved_scenarios: [],
     planning_history: [],
+    planning_sessions: [],
   }),
   fetchTrips: vi.fn().mockResolvedValue([{ trip_id: "trip-1" }]),
 }));
@@ -190,6 +191,7 @@ describe("router auth loaders", () => {
       scenarioHistory: {
         saved_scenarios: [],
         planning_history: [],
+        planning_sessions: [],
       },
     });
   });

--- a/frontend/src/routes/TripDetailPage.test.tsx
+++ b/frontend/src/routes/TripDetailPage.test.tsx
@@ -51,6 +51,35 @@ describe("TripDetailPage", () => {
           },
         },
         scenarioHistory: {
+          planning_sessions: [
+            {
+              session_state_id: "session-state:kyoto-spring-abc123",
+              owner_profile_id: "profile:trip-kyoto-123abc:leisure",
+              mode: "leisure",
+              started_at: "2026-04-10T15:00:00Z",
+              updated_at: "2026-04-10T15:35:00Z",
+              status: "active",
+              current_saved_scenario_id: "saved-scenario:kyoto-baseline",
+              activity_log_id: "activity-log:kyoto-spring",
+              interaction_state: {
+                initiative_level: "balanced",
+                summary_granularity: "balanced",
+                checkpoint_frequency: "milestone",
+              },
+              pending_decisions: [
+                {
+                  decision_id: "decision:lodging",
+                  prompt: "Choose the Kyoto base neighborhood.",
+                },
+              ],
+              recent_option_presentations: [
+                {
+                  presentation_id: "presentation:kyoto-1",
+                  option_set_id: "option-set:kyoto-1",
+                },
+              ],
+            },
+          ],
           saved_scenarios: [
             {
               saved_scenario_id: "saved-scenario:kyoto-baseline",
@@ -73,6 +102,7 @@ describe("TripDetailPage", () => {
               event_kind: "scenario_saved",
               summary: "Saved the Kyoto baseline after the first planning pass.",
               actor: "planner",
+              session_state_id: "session-state:kyoto-spring-abc123",
               saved_scenario_id: "saved-scenario:kyoto-baseline",
             },
           ],
@@ -93,6 +123,8 @@ describe("TripDetailPage", () => {
     expect(screen.getByText("trip-kyoto-123abc")).toBeInTheDocument();
     expect(screen.getByText("Window seat preferred")).toBeInTheDocument();
     expect(screen.getByText("Kyoto baseline")).toBeInTheDocument();
+    expect(screen.getByText("session-state:kyoto-spring-abc123")).toBeInTheDocument();
+    expect(screen.getByText("activity-log:kyoto-spring")).toBeInTheDocument();
     expect(
       screen.getByText("Saved the Kyoto baseline after the first planning pass.")
     ).toBeInTheDocument();
@@ -128,6 +160,7 @@ describe("TripDetailPage", () => {
           },
         },
         scenarioHistory: {
+          planning_sessions: [],
           saved_scenarios: [
             {
               saved_scenario_id: "saved-scenario:kyoto-empty",
@@ -154,6 +187,9 @@ describe("TripDetailPage", () => {
     expect(screen.getByText("Unavailable")).toBeInTheDocument();
     expect(
       screen.getByText("This saved scenario is missing version details.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No planning session has been persisted for this trip yet.")
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/routes/TripDetailPage.tsx
+++ b/frontend/src/routes/TripDetailPage.tsx
@@ -2,6 +2,7 @@ import { useLoaderData } from "react-router-dom";
 
 import type {
   PlanningHistoryEntry,
+  PlanningSessionRecord,
   SavedScenarioRecord,
   TripRecord,
   TripScenarioHistoryData,
@@ -28,7 +29,8 @@ export function TripDetailPage() {
       loading={{
         label: "Trip detail",
         title: "Loading saved trip",
-        message: "Restoring the persisted trip, saved-scenario history, and ownership-aware metadata.",
+        message:
+          "Restoring the persisted trip, planning-session context, and trip-level audit trail.",
       }}
       error={{
         label: "Trip detail",
@@ -67,6 +69,10 @@ function renderCurrentVersion(savedScenario: SavedScenarioRecord) {
 
 function summarizeHistory(entry: PlanningHistoryEntry): string {
   return entry.event_kind.split("_").join(" ");
+}
+
+function summarizeSession(session: PlanningSessionRecord): string {
+  return session.status.split("_").join(" ");
 }
 
 function TripDetailContent({
@@ -176,6 +182,40 @@ function TripDetailContent({
         </section>
 
         <section className="status-card">
+          <p className="status-label">Planning session</p>
+          <h2>Active workflow memory</h2>
+          {scenarioHistory.planning_sessions.length === 0 ? (
+            <p className="muted-copy">
+              No planning session has been persisted for this trip yet.
+            </p>
+          ) : (
+            <div className="decision-stack">
+              {scenarioHistory.planning_sessions.map((session) => (
+                <article key={session.session_state_id} className="decision-card">
+                  <p className="scenario-kicker">{summarizeSession(session)}</p>
+                  <h3>{session.session_state_id}</h3>
+                  <p>
+                    Initiative {session.interaction_state.initiative_level} with{" "}
+                    {session.pending_decisions.length} pending decisions and{" "}
+                    {session.recent_option_presentations.length} recent option surfaces.
+                  </p>
+                  <dl className="workspace-meta">
+                    <div>
+                      <dt>Updated</dt>
+                      <dd>{session.updated_at}</dd>
+                    </div>
+                    <div>
+                      <dt>Activity log</dt>
+                      <dd>{session.activity_log_id || "Not linked yet"}</dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="status-card">
           <p className="status-label">Planning history</p>
           <h2>Trip-level activity timeline</h2>
           {scenarioHistory.planning_history.length === 0 ? (
@@ -194,6 +234,7 @@ function TripDetailContent({
                   <p>
                     {entry.actor} at {entry.occurred_at}
                   </p>
+                  <p>Session {entry.session_state_id}</p>
                 </article>
               ))}
             </div>

--- a/tests/app/test_trip_routes.py
+++ b/tests/app/test_trip_routes.py
@@ -252,6 +252,81 @@ def test_trip_scenario_history_create_list_and_reload_flow(client: TestClient) -
     assert repeat_listing.json() == payload
 
 
+def test_trip_scenario_history_orders_planning_sessions_by_payload_updated_at(
+    client: TestClient,
+) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+    create_trip = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "Food and gardens",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+    trip_id = create_trip.json()["trip"]["trip_id"]
+
+    older = client.post(
+        f"/api/trips/{trip_id}/planning-sessions",
+        json={
+            "session_state_id": "session-state:older",
+            "started_at": "2026-04-10T15:00:00Z",
+            "updated_at": "2026-04-10T15:05:00Z",
+        },
+    )
+    assert older.status_code == 201
+
+    newer = client.post(
+        f"/api/trips/{trip_id}/planning-sessions",
+        json={
+            "session_state_id": "session-state:newer",
+            "started_at": "2026-04-10T14:00:00Z",
+            "updated_at": "2026-04-10T16:05:00Z",
+        },
+    )
+    assert newer.status_code == 201
+
+    listing = client.get(f"/api/trips/{trip_id}/scenario-history")
+    assert listing.status_code == 200
+    assert [item["session_state_id"] for item in listing.json()["planning_sessions"]] == [
+        "session-state:newer",
+        "session-state:older",
+    ]
+
+
+def test_trip_planning_session_create_rejects_malformed_nested_payloads(
+    client: TestClient,
+) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+    create_trip = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "Food and gardens",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+    trip_id = create_trip.json()["trip"]["trip_id"]
+
+    response = client.post(
+        f"/api/trips/{trip_id}/planning-sessions",
+        json={
+            "recent_option_presentations": [
+                {
+                    "presentation_id": "presentation:kyoto-1",
+                    "option_set_id": "option-set:kyoto-1",
+                    "surfaced_option_ids": ["lodging:gion", "lodging:downtown"],
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "shown_at is required"
+
+
 def test_trip_scenario_history_create_truncates_generated_ids_to_model_limits(
     client: TestClient,
 ) -> None:

--- a/tests/app/test_trip_routes.py
+++ b/tests/app/test_trip_routes.py
@@ -210,9 +210,38 @@ def test_trip_scenario_history_create_list_and_reload_flow(client: TestClient) -
     )
     assert create_history.status_code == 201
 
+    create_session = client.post(
+        f"/api/trips/{trip_id}/planning-sessions",
+        json={
+            "activity_log_id": "activity-log:kyoto-spring",
+            "current_saved_scenario_id": saved_scenario["saved_scenario_id"],
+            "pending_decisions": [
+                {
+                    "decision_id": "decision:lodging",
+                    "prompt": "Choose the Kyoto base neighborhood.",
+                    "created_at": "2026-04-10T15:15:00Z",
+                    "choices": ["Gion", "Downtown"],
+                }
+            ],
+            "recent_option_presentations": [
+                {
+                    "presentation_id": "presentation:kyoto-1",
+                    "option_set_id": "option-set:kyoto-1",
+                    "shown_at": "2026-04-10T15:10:00Z",
+                    "surfaced_option_ids": ["lodging:gion", "lodging:downtown"],
+                }
+            ],
+        },
+    )
+    assert create_session.status_code == 201
+
     listing = client.get(f"/api/trips/{trip_id}/scenario-history")
     assert listing.status_code == 200
     payload = listing.json()
+    assert payload["planning_sessions"][0]["activity_log_id"] == "activity-log:kyoto-spring"
+    assert payload["planning_sessions"][0]["current_saved_scenario_id"] == (
+        saved_scenario["saved_scenario_id"]
+    )
     assert payload["saved_scenarios"][0]["saved_scenario_id"] == saved_scenario["saved_scenario_id"]
     assert payload["saved_scenarios"][0]["versions"][0]["title"] == "Kyoto baseline"
     assert payload["planning_history"][0]["event_kind"] == "scenario_saved"
@@ -291,6 +320,14 @@ def test_trip_scenario_history_rejects_invalid_domain_payloads_with_422(
     )
     assert invalid_history.status_code == 422
 
+    invalid_session = client.post(
+        f"/api/trips/{trip_id}/planning-sessions",
+        json={
+            "status": "invalid",
+        },
+    )
+    assert invalid_session.status_code == 422
+
 
 def test_trip_scenario_history_routes_hide_other_users_records(client: TestClient) -> None:
     signup(client, email="owner@example.com", display_name="Owner")
@@ -345,6 +382,13 @@ def test_trip_scenario_history_routes_hide_other_users_records(client: TestClien
                 "event_kind": "scenario_saved",
                 "summary": "Blocked by ownership guard.",
             },
+        ).status_code
+        == 404
+    )
+    assert (
+        client.post(
+            f"/api/trips/{trip_id}/planning-sessions",
+            json={},
         ).status_code
         == 404
     )

--- a/trip_planner/app/routes/scenario_history.py
+++ b/trip_planner/app/routes/scenario_history.py
@@ -3,14 +3,17 @@ from sqlalchemy.orm import Session
 
 from trip_planner.app.schemas.scenario_history import (
     CreatePlanningHistoryRequest,
+    CreatePlanningSessionRequest,
     CreateSavedScenarioRequest,
     PlanningHistoryResponse,
+    PlanningSessionResponse,
     SavedScenarioResponse,
     TripScenarioHistoryResponse,
 )
 from trip_planner.app.services.auth import AuthenticatedUser, require_authenticated_user
 from trip_planner.app.services.scenario_history import (
     create_planning_history_entry,
+    create_planning_session,
     create_saved_scenario,
     list_trip_scenario_history,
 )
@@ -64,6 +67,27 @@ def create_trip_planning_history(
 ) -> PlanningHistoryResponse:
     return PlanningHistoryResponse(
         planning_history_entry=create_planning_history_entry(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            payload=payload.model_dump(),
+        )
+    )
+
+
+@router.post(
+    "/trips/{trip_id}/planning-sessions",
+    response_model=PlanningSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_trip_planning_session(
+    trip_id: str,
+    payload: CreatePlanningSessionRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> PlanningSessionResponse:
+    return PlanningSessionResponse(
+        planning_session=create_planning_session(
             db_session,
             user=user,
             trip_id=trip_id,

--- a/trip_planner/app/schemas/scenario_history.py
+++ b/trip_planner/app/schemas/scenario_history.py
@@ -72,6 +72,25 @@ class CreatePlanningHistoryRequest(BaseModel):
         return value
 
 
+class CreatePlanningSessionRequest(BaseModel):
+    session_state_id: str | None = Field(default=None, max_length=96)
+    owner_profile_id: str | None = Field(default=None, max_length=96)
+    mode: str | None = Field(default=None, min_length=1, max_length=32)
+    started_at: str | None = Field(default=None, max_length=64)
+    updated_at: str | None = Field(default=None, max_length=64)
+    interaction_state: dict[str, Any] = Field(default_factory=dict)
+    recent_option_presentations: list[dict[str, Any]] = Field(default_factory=list)
+    pending_decisions: list[dict[str, Any]] = Field(default_factory=list)
+    status: str = Field(default="active", min_length=1, max_length=32)
+    current_checkpoint_id: str | None = Field(default=None, max_length=96)
+    current_saved_scenario_id: str | None = Field(default=None, max_length=96)
+    active_budget_plan_id: str | None = Field(default=None, max_length=96)
+    activity_log_id: str | None = Field(default=None, max_length=96)
+    schema_version: str | None = Field(default=None, max_length=16)
+    tags: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
 class SavedScenarioResponse(BaseModel):
     saved_scenario: dict[str, Any]
 
@@ -80,6 +99,11 @@ class PlanningHistoryResponse(BaseModel):
     planning_history_entry: dict[str, Any]
 
 
+class PlanningSessionResponse(BaseModel):
+    planning_session: dict[str, Any]
+
+
 class TripScenarioHistoryResponse(BaseModel):
     saved_scenarios: list[dict[str, Any]]
     planning_history: list[dict[str, Any]]
+    planning_sessions: list[dict[str, Any]]

--- a/trip_planner/app/services/scenario_history.py
+++ b/trip_planner/app/services/scenario_history.py
@@ -79,6 +79,16 @@ def _domain_payload_error(error: ValueError) -> HTTPException:
     return _unprocessable(str(error))
 
 
+def _domain_payload_exception(error: Exception) -> HTTPException:
+    if isinstance(error, KeyError) and error.args:
+        return _unprocessable(f"{error.args[0]} is required")
+    if isinstance(error, TypeError):
+        return _unprocessable(str(error))
+    if isinstance(error, ValueError):
+        return _domain_payload_error(error)
+    raise TypeError(f"Unsupported domain payload exception: {type(error)!r}")
+
+
 def _get_owned_trip(
     db_session: Session,
     *,
@@ -193,7 +203,7 @@ def list_trip_scenario_history(
         select(PersistedPlanningSessionState)
         .where(PersistedPlanningSessionState.trip_id == trip_id)
         .order_by(
-            PersistedPlanningSessionState.updated_at.desc(),
+            PersistedPlanningSessionState.last_updated_at.desc(),
             PersistedPlanningSessionState.session_state_id.asc(),
         )
     ).all()
@@ -384,8 +394,8 @@ def create_planning_session(
                 "notes": payload.get("notes", []),
             }
         )
-    except ValueError as error:
-        raise _domain_payload_error(error) from error
+    except (KeyError, TypeError, ValueError) as error:
+        raise _domain_payload_exception(error) from error
 
     record = PersistedPlanningSessionState(
         session_state_id=session_state.session_state_id,

--- a/trip_planner/app/services/scenario_history.py
+++ b/trip_planner/app/services/scenario_history.py
@@ -15,8 +15,14 @@ from trip_planner.persistence.models.scenario import (
     PersistedActivityLogEvent,
     PersistedSavedScenario,
 )
+from trip_planner.persistence.models.session import PersistedPlanningSessionState
 from trip_planner.persistence.models.trip import PersistedTrip
-from trip_planner.state import ActivityLogEvent, SavedScenarioRecord
+from trip_planner.state import (
+    ActivityLogEvent,
+    PlanningSessionState,
+    SESSION_STATE_SCHEMA_VERSION,
+    SavedScenarioRecord,
+)
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 _SAVED_SCENARIO_ID_PREFIX = "saved-scenario:"
@@ -26,6 +32,14 @@ _SAVED_SCENARIO_SLUG_MAX_LENGTH = (
     _SAVED_SCENARIO_ID_MAX_LENGTH
     - len(_SAVED_SCENARIO_ID_PREFIX)
     - _SAVED_SCENARIO_ID_SUFFIX_LENGTH
+)
+_SESSION_STATE_ID_PREFIX = "session-state:"
+_SESSION_STATE_ID_SUFFIX_LENGTH = 7
+_SESSION_STATE_ID_MAX_LENGTH = 96
+_SESSION_STATE_SLUG_MAX_LENGTH = (
+    _SESSION_STATE_ID_MAX_LENGTH
+    - len(_SESSION_STATE_ID_PREFIX)
+    - _SESSION_STATE_ID_SUFFIX_LENGTH
 )
 
 
@@ -118,6 +132,39 @@ def _serialize_activity_entry(record: PersistedActivityLogEvent) -> dict:
     ).to_dict()
 
 
+def _serialize_planning_session(record: PersistedPlanningSessionState) -> dict:
+    return PlanningSessionState.from_dict(
+        {
+            "session_state_id": record.session_state_id,
+            "trip_id": record.trip_id,
+            "user_id": record.user_id,
+            "owner_profile_id": record.owner_profile_id,
+            "mode": record.mode,
+            "started_at": record.started_at,
+            "updated_at": record.last_updated_at,
+            "interaction_state": dict(record.interaction_state),
+            "recent_option_presentations": list(record.recent_option_presentations),
+            "pending_decisions": list(record.pending_decisions),
+            "status": record.status,
+            "current_checkpoint_id": record.current_checkpoint_id,
+            "current_saved_scenario_id": record.current_saved_scenario_id,
+            "active_budget_plan_id": record.active_budget_plan_id,
+            "activity_log_id": record.activity_log_id,
+            "schema_version": record.schema_version,
+            "tags": list(record.tags),
+            "notes": list(record.notes),
+        }
+    ).to_dict()
+
+
+def _owner_profile_id_for_trip(trip: PersistedTrip) -> str:
+    if trip.mode == "business" and trip.business_profile_id:
+        return trip.business_profile_id
+    if trip.leisure_profile_id:
+        return trip.leisure_profile_id
+    return f"profile:{trip.trip_id}:{trip.mode}"
+
+
 def list_trip_scenario_history(
     db_session: Session,
     *,
@@ -142,10 +189,21 @@ def list_trip_scenario_history(
             PersistedActivityLogEvent.activity_event_id.asc(),
         )
     ).all()
+    planning_sessions = db_session.scalars(
+        select(PersistedPlanningSessionState)
+        .where(PersistedPlanningSessionState.trip_id == trip_id)
+        .order_by(
+            PersistedPlanningSessionState.updated_at.desc(),
+            PersistedPlanningSessionState.session_state_id.asc(),
+        )
+    ).all()
 
     return {
         "saved_scenarios": [_serialize_saved_scenario(record) for record in saved_scenarios],
         "planning_history": [_serialize_activity_entry(record) for record in planning_history],
+        "planning_sessions": [
+            _serialize_planning_session(record) for record in planning_sessions
+        ],
     }
 
 
@@ -278,3 +336,81 @@ def create_planning_history_entry(
     db_session.commit()
     db_session.refresh(record)
     return _serialize_activity_entry(record)
+
+
+def create_planning_session(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    payload: dict,
+) -> dict:
+    trip = _get_owned_trip(db_session, user=user, trip_id=trip_id)
+    session_state_id = payload.get("session_state_id") or (
+        f"{_SESSION_STATE_ID_PREFIX}"
+        f"{_slugify_with_limit(trip.title, max_length=_SESSION_STATE_SLUG_MAX_LENGTH)}"
+        f"-{secrets.token_hex(3)}"
+    )
+    started_at = payload.get("started_at") or _timestamp()
+    updated_at = payload.get("updated_at") or started_at
+    existing = db_session.get(PersistedPlanningSessionState, session_state_id)
+    if existing is not None:
+        raise _bad_request(f"Planning session '{session_state_id}' already exists.")
+
+    try:
+        session_state = PlanningSessionState.from_dict(
+            {
+                "session_state_id": session_state_id,
+                "trip_id": trip_id,
+                "user_id": user.user_id,
+                "owner_profile_id": payload.get("owner_profile_id")
+                or _owner_profile_id_for_trip(trip),
+                "mode": payload.get("mode") or trip.mode,
+                "started_at": started_at,
+                "updated_at": updated_at,
+                "interaction_state": payload.get("interaction_state", {}),
+                "recent_option_presentations": payload.get(
+                    "recent_option_presentations", []
+                ),
+                "pending_decisions": payload.get("pending_decisions", []),
+                "status": payload.get("status", "active"),
+                "current_checkpoint_id": payload.get("current_checkpoint_id"),
+                "current_saved_scenario_id": payload.get("current_saved_scenario_id"),
+                "active_budget_plan_id": payload.get("active_budget_plan_id"),
+                "activity_log_id": payload.get("activity_log_id"),
+                "schema_version": payload.get("schema_version")
+                or SESSION_STATE_SCHEMA_VERSION,
+                "tags": payload.get("tags", []),
+                "notes": payload.get("notes", []),
+            }
+        )
+    except ValueError as error:
+        raise _domain_payload_error(error) from error
+
+    record = PersistedPlanningSessionState(
+        session_state_id=session_state.session_state_id,
+        trip_id=session_state.trip_id,
+        user_id=session_state.user_id,
+        owner_profile_id=session_state.owner_profile_id,
+        mode=session_state.mode,
+        started_at=session_state.started_at,
+        last_updated_at=session_state.updated_at,
+        interaction_state=session_state.interaction_state.to_dict(),
+        recent_option_presentations=[
+            item.to_dict() for item in session_state.recent_option_presentations
+        ],
+        pending_decisions=[item.to_dict() for item in session_state.pending_decisions],
+        status=session_state.status,
+        current_checkpoint_id=session_state.current_checkpoint_id,
+        current_saved_scenario_id=session_state.current_saved_scenario_id,
+        active_budget_plan_id=session_state.active_budget_plan_id,
+        activity_log_id=session_state.activity_log_id,
+        schema_version=session_state.schema_version,
+        tags=list(session_state.tags),
+        notes=list(session_state.notes),
+    )
+    trip.updated_at = _utcnow()
+    db_session.add(record)
+    db_session.commit()
+    db_session.refresh(record)
+    return _serialize_planning_session(record)

--- a/trip_planner/persistence/alembic/versions/20260408_01_planning_session_state.py
+++ b/trip_planner/persistence/alembic/versions/20260408_01_planning_session_state.py
@@ -52,33 +52,36 @@ def upgrade() -> None:
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
     )
     op.create_index(
-        "ix_persisted_planning_session_states_trip_id",
+        op.f("ix_persisted_planning_session_states_trip_id"),
         "persisted_planning_session_states",
         ["trip_id"],
+        unique=False,
     )
     op.create_index(
-        "ix_persisted_planning_session_states_user_id",
+        op.f("ix_persisted_planning_session_states_user_id"),
         "persisted_planning_session_states",
         ["user_id"],
+        unique=False,
     )
     op.create_index(
-        "ix_persisted_planning_session_states_last_updated_at",
+        op.f("ix_persisted_planning_session_states_last_updated_at"),
         "persisted_planning_session_states",
         ["last_updated_at"],
+        unique=False,
     )
 
 
 def downgrade() -> None:
     op.drop_index(
-        "ix_persisted_planning_session_states_last_updated_at",
+        op.f("ix_persisted_planning_session_states_last_updated_at"),
         table_name="persisted_planning_session_states",
     )
     op.drop_index(
-        "ix_persisted_planning_session_states_user_id",
+        op.f("ix_persisted_planning_session_states_user_id"),
         table_name="persisted_planning_session_states",
     )
     op.drop_index(
-        "ix_persisted_planning_session_states_trip_id",
+        op.f("ix_persisted_planning_session_states_trip_id"),
         table_name="persisted_planning_session_states",
     )
     op.drop_table("persisted_planning_session_states")

--- a/trip_planner/persistence/alembic/versions/20260408_01_planning_session_state.py
+++ b/trip_planner/persistence/alembic/versions/20260408_01_planning_session_state.py
@@ -1,0 +1,84 @@
+"""add persisted planning session state
+
+Revision ID: 20260408_01
+Revises: 20260407_03
+Create Date: 2026-04-08 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260408_01"
+down_revision = "20260407_03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "persisted_planning_session_states",
+        sa.Column("session_state_id", sa.String(length=96), primary_key=True),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            sa.String(length=96),
+            sa.ForeignKey("user_accounts.user_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("owner_profile_id", sa.String(length=96), nullable=False),
+        sa.Column("mode", sa.String(length=32), nullable=False),
+        sa.Column("started_at", sa.String(length=64), nullable=False),
+        sa.Column("last_updated_at", sa.String(length=64), nullable=False),
+        sa.Column("interaction_state", sa.JSON(), nullable=False),
+        sa.Column("recent_option_presentations", sa.JSON(), nullable=False),
+        sa.Column("pending_decisions", sa.JSON(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("current_checkpoint_id", sa.String(length=96), nullable=True),
+        sa.Column("current_saved_scenario_id", sa.String(length=96), nullable=True),
+        sa.Column("active_budget_plan_id", sa.String(length=96), nullable=True),
+        sa.Column("activity_log_id", sa.String(length=96), nullable=True),
+        sa.Column("schema_version", sa.String(length=16), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("notes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_persisted_planning_session_states_trip_id",
+        "persisted_planning_session_states",
+        ["trip_id"],
+    )
+    op.create_index(
+        "ix_persisted_planning_session_states_user_id",
+        "persisted_planning_session_states",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_persisted_planning_session_states_last_updated_at",
+        "persisted_planning_session_states",
+        ["last_updated_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_persisted_planning_session_states_last_updated_at",
+        table_name="persisted_planning_session_states",
+    )
+    op.drop_index(
+        "ix_persisted_planning_session_states_user_id",
+        table_name="persisted_planning_session_states",
+    )
+    op.drop_index(
+        "ix_persisted_planning_session_states_trip_id",
+        table_name="persisted_planning_session_states",
+    )
+    op.drop_table("persisted_planning_session_states")

--- a/trip_planner/persistence/models/__init__.py
+++ b/trip_planner/persistence/models/__init__.py
@@ -5,12 +5,16 @@ from trip_planner.persistence.models.scenario import (
     PersistedActivityLogEvent,
     PersistedSavedScenario,
 )
-from trip_planner.persistence.models.session import AuthSession
+from trip_planner.persistence.models.session import (
+    AuthSession,
+    PersistedPlanningSessionState,
+)
 from trip_planner.persistence.models.trip import PersistedTrip
 
 __all__ = [
     "AuthSession",
     "PersistedActivityLogEvent",
+    "PersistedPlanningSessionState",
     "PersistedSavedScenario",
     "PersistedTrip",
     "UserAccount",

--- a/trip_planner/persistence/models/session.py
+++ b/trip_planner/persistence/models/session.py
@@ -1,10 +1,10 @@
-"""SQLAlchemy model for cookie-backed application sessions."""
+"""SQLAlchemy models for auth and persisted planning sessions."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy import JSON, DateTime, ForeignKey, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from trip_planner.persistence.db import Base
@@ -31,3 +31,38 @@ class AuthSession(Base):
         DateTime(timezone=True), nullable=True
     )
     user = relationship("UserAccount", back_populates="sessions")
+
+
+class PersistedPlanningSessionState(Base):
+    __tablename__ = "persisted_planning_session_states"
+
+    session_state_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("user_accounts.user_id", ondelete="CASCADE"),
+        index=True,
+    )
+    owner_profile_id: Mapped[str] = mapped_column(String(96))
+    mode: Mapped[str] = mapped_column(String(32))
+    started_at: Mapped[str] = mapped_column(String(64))
+    last_updated_at: Mapped[str] = mapped_column(String(64), index=True)
+    interaction_state: Mapped[dict] = mapped_column(JSON, default=dict)
+    recent_option_presentations: Mapped[list[dict]] = mapped_column(JSON, default=list)
+    pending_decisions: Mapped[list[dict]] = mapped_column(JSON, default=list)
+    status: Mapped[str] = mapped_column(String(32), default="active")
+    current_checkpoint_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    current_saved_scenario_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    active_budget_plan_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    activity_log_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    schema_version: Mapped[str] = mapped_column(String(16), default="0.1.0")
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    notes: Mapped[list[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+    )


### PR DESCRIPTION
Closes #686

## Summary
- add persisted planning-session storage and a matching migration
- extend the trip scenario-history API with planning-session create/list support
- surface planning-session workflow memory beside the trip audit timeline in the UI

## Validation
- pytest tests/app/test_trip_routes.py -q
- NPM_CONFIG_CACHE=/tmp/trip-planner-npm-cache npm --prefix frontend test -- --run src/routes/TripDetailPage.test.tsx src/router.test.ts