### PR TITLE
Issue #684: harden trip creation validation

### DIFF
--- a/tests/app/test_trip_routes.py
+++ b/tests/app/test_trip_routes.py
@@ -467,3 +467,42 @@ def test_trip_scenario_history_routes_hide_other_users_records(client: TestClien
         ).status_code
         == 404
     )
+
+
+def test_trip_create_truncates_generated_trip_id_to_model_limit(client: TestClient) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+
+    response = client.post(
+        "/api/trips",
+        json={
+            "title": "a" * 160,
+            "summary": "",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+
+    assert response.status_code == 201
+    assert len(response.json()["trip"]["trip_id"]) <= 96
+
+
+def test_trip_create_rejects_invalid_traveler_party_kind_with_422(client: TestClient) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+
+    response = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "",
+            "mode": "leisure",
+            "trip_frame": {
+                "traveler_party": {
+                    "kind": "unsupported",
+                    "traveler_count": 2,
+                    "notes": "",
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 422

--- a/tests/app/test_trip_routes.py
+++ b/tests/app/test_trip_routes.py
@@ -167,6 +167,12 @@ def test_trip_create_rejects_invalid_traveler_party_kind(client: TestClient) -> 
     )
 
     assert response.status_code == 422
+    detail = response.json()["detail"]
+    assert any(
+        error["loc"][-3:] == ["trip_frame", "traveler_party", "kind"]
+        and error["type"] == "literal_error"
+        for error in detail
+    )
 
 
 def test_trip_scenario_history_create_list_and_reload_flow(client: TestClient) -> None:
@@ -467,42 +473,3 @@ def test_trip_scenario_history_routes_hide_other_users_records(client: TestClien
         ).status_code
         == 404
     )
-
-
-def test_trip_create_truncates_generated_trip_id_to_model_limit(client: TestClient) -> None:
-    signup(client, email="owner@example.com", display_name="Owner")
-
-    response = client.post(
-        "/api/trips",
-        json={
-            "title": "a" * 160,
-            "summary": "",
-            "mode": "leisure",
-            "trip_frame": {"duration_days": 7},
-        },
-    )
-
-    assert response.status_code == 201
-    assert len(response.json()["trip"]["trip_id"]) <= 96
-
-
-def test_trip_create_rejects_invalid_traveler_party_kind_with_422(client: TestClient) -> None:
-    signup(client, email="owner@example.com", display_name="Owner")
-
-    response = client.post(
-        "/api/trips",
-        json={
-            "title": "Kyoto Spring",
-            "summary": "",
-            "mode": "leisure",
-            "trip_frame": {
-                "traveler_party": {
-                    "kind": "unsupported",
-                    "traveler_count": 2,
-                    "notes": "",
-                }
-            },
-        },
-    )
-
-    assert response.status_code == 422

--- a/trip_planner/app/schemas/trips.py
+++ b/trip_planner/app/schemas/trips.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from typing import Literal
 
 from pydantic import BaseModel, Field
-
+from trip_planner.contracts.trip import TRAVELER_PARTY_KINDS
 TravelerPartyKind = Literal["solo", "pair", "family", "friends", "team"]
 
 
 class TravelerPartyRequest(BaseModel):
-    kind: TravelerPartyKind = Field(default="solo")
+    kind: TravelerPartyKind = Field(default=TRAVELER_PARTY_KINDS[0])
     traveler_count: int = Field(default=1, ge=1, le=50)
     notes: str = Field(default="", max_length=240)
 

--- a/trip_planner/app/schemas/trips.py
+++ b/trip_planner/app/schemas/trips.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel, Field
 from trip_planner.contracts.trip import TRAVELER_PARTY_KINDS
 
 TravelerPartyKind = Literal["solo", "pair", "family", "friends", "team"]
+DEFAULT_TRAVELER_PARTY_KIND = cast(TravelerPartyKind, TRAVELER_PARTY_KINDS[0])
 
 
 class TravelerPartyRequest(BaseModel):
-    kind: TravelerPartyKind = Field(default=TRAVELER_PARTY_KINDS[0])
+    kind: TravelerPartyKind = Field(default=DEFAULT_TRAVELER_PARTY_KIND)
     traveler_count: int = Field(default=1, ge=1, le=50)
     notes: str = Field(default="", max_length=240)
 

--- a/trip_planner/app/schemas/trips.py
+++ b/trip_planner/app/schemas/trips.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 from trip_planner.contracts.trip import TRAVELER_PARTY_KINDS
+
 TravelerPartyKind = Literal["solo", "pair", "family", "friends", "team"]
 
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #684
>
> **Lane:** bounded verify/review follow-up after the original implementation merged
<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Finish the remaining completion work for issue #684 after the original persistence PR merged by hardening trip creation validation to match the canonical trip contract and preserving regression coverage for the verifier-flagged edge cases.

Parent epic: #675

#### Tasks
- [x] Align trip creation request defaults with the canonical traveler-party contract.
- [x] Preserve regression coverage for generated trip-id length handling.
- [x] Preserve regression coverage for invalid traveler-party kind validation details.
- [x] Resolve the bounded review/disposition debt called out on the prior merged lane.

#### Acceptance criteria
- [x] Trip creation defaults continue to use a valid canonical traveler-party kind.
- [x] Validation coverage still guards generated trip-id length behavior.
- [x] Validation coverage still proves invalid traveler-party kinds fail with targeted detail.
- [x] The follow-up lane leaves issue #684 ready for fresh `verify:compare` review.

**Disposition:** Merged bounded follow-up for issue-completion cleanup; final issue closure depends on fresh verifier output after merge.
<!-- auto-status-summary:end -->
