### PR TITLE
Issue #689 follow-up: persist explicit planner actions

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1305,13 +1305,14 @@ describe("WorkspacePage", () => {
     const view = renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Planner side panel")).toBeInTheDocument();
+      expect(getPlannerHost().shadowRoot?.querySelector('[aria-label="Planner side panel"]')).toBeTruthy();
     });
 
     const host = view.container.querySelector(".planner-panel-host");
-    expect(host).not.toBeNull();
+    const plannerMountNode = host?.shadowRoot?.lastElementChild;
+    expect(plannerMountNode).not.toBeNull();
     fireEvent(
-      host as Element,
+      plannerMountNode as Element,
       new CustomEvent("planner-response-save-as-fallback", {
         detail: {
           option_id: "scenario:trip-leisure-kyoto-draft:1",
@@ -1330,7 +1331,9 @@ describe("WorkspacePage", () => {
       );
     });
     await waitFor(() => {
-      expect(screen.getByText("Kyoto base with Uji day trip (fallback)")).toBeInTheDocument();
+      expect(getPlannerHost().shadowRoot?.textContent).toContain(
+        "Kyoto base with Uji day trip (fallback)"
+      );
     });
 
     view.unmount();
@@ -1341,7 +1344,9 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByText("Kyoto base with Uji day trip (fallback)")).toBeInTheDocument();
+      expect(getPlannerHost().shadowRoot?.textContent).toContain(
+        "Kyoto base with Uji day trip (fallback)"
+      );
     });
   });
 

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -13,14 +13,6 @@ import {
 import type { TripRecord } from "../api/trips";
 import { WorkspacePage } from "./WorkspacePage";
 
-vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
-  return {
-    ...actual,
-    useLoaderData: vi.fn(),
-  };
-});
-
 vi.mock("../api/workspace", async () => {
   const actual = await vi.importActual<typeof import("../api/workspace")>("../api/workspace");
   return {
@@ -29,6 +21,14 @@ vi.mock("../api/workspace", async () => {
     submitPlannerOptionFeedback: vi.fn(),
     saveWorkspaceBudget: vi.fn(),
     recordWorkspaceSpendEvent: vi.fn(),
+  };
+});
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useLoaderData: vi.fn(),
   };
 });
 
@@ -1269,6 +1269,80 @@ describe("WorkspacePage", () => {
 
     expect(screen.getByText("Kyoto Kitchen")).toBeInTheDocument();
     expect(screen.getAllByText("$137.50").length).toBeGreaterThan(0);
+  });
+
+  it("restores persisted planner feedback after a workspace reload", async () => {
+    const updatedWorkspace = {
+      ...workspacePayload,
+      activity_log: [
+        {
+          activity_event_id: "activity:trip-leisure-kyoto-draft:1",
+          occurred_at: "2026-04-10T05:40:00Z",
+          event_kind: "decision_recorded",
+          summary:
+            "Traveler saved option 'scenario:trip-leisure-kyoto-draft:1' as a fallback in the workspace planner panel.",
+        },
+      ],
+      planner_panel_state: {
+        ...workspacePayload.planner_panel_state,
+        option_set: {
+          ...workspacePayload.planner_panel_state.option_set,
+          options: [
+            {
+              ...workspacePayload.planner_panel_state.option_set.options[0],
+              label: "Kyoto base with Uji day trip (fallback)",
+              explanation: ["This option was kept as an explicit fallback for later comparison."],
+            },
+          ],
+        },
+      },
+    };
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(workspacePayload),
+    });
+    mockedSubmitPlannerOptionFeedback.mockResolvedValue(updatedWorkspace);
+
+    const view = renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Planner side panel")).toBeInTheDocument();
+    });
+
+    const host = view.container.querySelector(".planner-panel-host");
+    expect(host).not.toBeNull();
+    fireEvent(
+      host as Element,
+      new CustomEvent("planner-response-save-as-fallback", {
+        detail: {
+          option_id: "scenario:trip-leisure-kyoto-draft:1",
+          action_type: "save_as_fallback",
+          decision_id: null,
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockedSubmitPlannerOptionFeedback).toHaveBeenCalledWith(
+        "trip-leisure-kyoto-draft",
+        "scenario:trip-leisure-kyoto-draft:1",
+        "save_as_fallback",
+        null
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Kyoto base with Uji day trip (fallback)")).toBeInTheDocument();
+    });
+
+    view.unmount();
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(updatedWorkspace),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Kyoto base with Uji day trip (fallback)")).toBeInTheDocument();
+    });
   });
 
   it("renders the shared route error card when the workspace loader rejects", async () => {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -9,6 +9,7 @@ import {
   recordWorkspaceSpendEvent,
   saveWorkspaceBudget,
   submitPlannerOptionFeedback,
+  type WorkspaceData,
 } from "../api/workspace";
 import type { TripRecord } from "../api/trips";
 import { WorkspacePage } from "./WorkspacePage";
@@ -562,7 +563,7 @@ const workspacePayload = {
       },
     ],
   },
-};
+} satisfies WorkspaceData;
 
 function renderWorkspacePage() {
   return render(
@@ -1296,7 +1297,7 @@ describe("WorkspacePage", () => {
           ],
         },
       },
-    };
+    } satisfies WorkspaceData;
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve(workspacePayload),
     });

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 
 from trip_planner.app.main import create_app
 from trip_planner.app.services.feasibility import (
@@ -11,7 +12,8 @@ from trip_planner.app.services.feasibility import (
     build_feasibility_summary_payload,
 )
 from trip_planner.options import InventoryBundle
-from trip_planner.persistence.db import reset_database_state
+from trip_planner.persistence.db import get_session_factory, reset_database_state
+from trip_planner.persistence.models.activity import PersistedPlannerAction
 
 
 @pytest.fixture
@@ -631,6 +633,17 @@ def test_workspace_planner_decision_answer_persists_across_reload(client: TestCl
     assert reloaded_payload["session"]["pending_decisions"] == []
     assert reloaded_payload["activity_log"][0]["event_kind"] == "decision_recorded"
 
+    with get_session_factory()() as db_session:
+        actions = db_session.scalars(
+            select(PersistedPlannerAction)
+            .where(PersistedPlannerAction.trip_id == trip_id)
+            .order_by(PersistedPlannerAction.occurred_at.desc())
+        ).all()
+
+    assert actions[0].action_type == "decision_answer"
+    assert actions[0].decision_id == decision["decision_id"]
+    assert actions[0].choice == decision["choices"][0]
+
 
 def test_workspace_planner_decision_answer_returns_not_found_for_unknown_trip(
     client: TestClient,
@@ -677,6 +690,37 @@ def test_workspace_option_feedback_persists_across_reload(client: TestClient) ->
     assert reloaded_payload["planner_panel_state"]["option_set"]["options"][0]["label"].endswith(
         "(fallback)"
     )
+
+    with get_session_factory()() as db_session:
+        actions = db_session.scalars(
+            select(PersistedPlannerAction)
+            .where(PersistedPlannerAction.trip_id == trip_id)
+            .order_by(PersistedPlannerAction.occurred_at.desc())
+        ).all()
+
+    assert actions[0].action_type == "save_as_fallback"
+    assert actions[0].option_id == option_id
+
+
+def test_workspace_option_feedback_rejects_unknown_option_id(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Lisbon revisit",
+            "summary": "Reject invalid option identifiers.",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 4, "primary_regions": ["Lisbon"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    invalid = client.post(
+        f"/api/workspace/{trip_id}/planner/options/option:missing/feedback",
+        json={"action_type": "save_as_fallback", "decision_id": None},
+    )
+
+    assert invalid.status_code == 400
+    assert "not available in the current workspace option set" in invalid.json()["detail"]
 
 
 def test_workspace_activity_log_is_capped_for_persisted_trips(client: TestClient) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -735,11 +735,10 @@ def test_workspace_activity_log_is_capped_for_persisted_trips(client: TestClient
     )
     assert created.status_code == 201
     trip_id = created.json()["trip"]["trip_id"]
-    option_id = client.get(f"/api/workspace/{trip_id}").json()["planner_panel_state"]["option_set"][
-        "options"
-    ][0]["option_id"]
-
     for index in range(55):
+        option_id = client.get(f"/api/workspace/{trip_id}").json()["planner_panel_state"][
+            "option_set"
+        ]["options"][0]["option_id"]
         action_type = "save_as_fallback" if index % 2 == 0 else "reject"
         response = client.post(
             f"/api/workspace/{trip_id}/planner/options/{option_id}/feedback",

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -643,6 +643,8 @@ def test_workspace_planner_decision_answer_persists_across_reload(client: TestCl
     assert actions[0].action_type == "decision_answer"
     assert actions[0].decision_id == decision["decision_id"]
     assert actions[0].choice == decision["choices"][0]
+    assert actions[0].activity_event_id == payload["activity_log"][0]["activity_event_id"]
+    assert actions[0].occurred_at == payload["activity_log"][0]["occurred_at"]
 
 
 def test_workspace_planner_decision_answer_returns_not_found_for_unknown_trip(
@@ -700,6 +702,35 @@ def test_workspace_option_feedback_persists_across_reload(client: TestClient) ->
 
     assert actions[0].action_type == "save_as_fallback"
     assert actions[0].option_id == option_id
+    assert actions[0].activity_event_id == payload["activity_log"][0]["activity_event_id"]
+    assert actions[0].occurred_at == payload["activity_log"][0]["occurred_at"]
+
+
+def test_workspace_option_feedback_reuses_recent_presentation_ids(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto revisit",
+            "summary": "Exercise option feedback persistence.",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 5, "primary_regions": ["Kyoto"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    initial = client.get(f"/api/workspace/{trip_id}")
+    option_id = initial.json()["planner_panel_state"]["option_set"]["options"][1]["option_id"]
+
+    updated = client.post(
+        f"/api/workspace/{trip_id}/planner/options/{option_id}/feedback",
+        json={"action_type": "accept", "decision_id": None},
+    )
+
+    assert updated.status_code == 200
+    payload = updated.json()
+    assert payload["planner_panel_state"]["option_set"]["options"][1]["label"].endswith(
+        "(saved direction)"
+    )
 
 
 def test_workspace_option_feedback_rejects_unknown_option_id(client: TestClient) -> None:

--- a/trip_planner/app/services/scenario_history.py
+++ b/trip_planner/app/services/scenario_history.py
@@ -11,8 +11,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.persistence.models.activity import PersistedActivityLogEvent
 from trip_planner.persistence.models.scenario import (
-    PersistedActivityLogEvent,
     PersistedSavedScenario,
 )
 from trip_planner.persistence.models.session import PersistedPlanningSessionState

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1330,20 +1330,17 @@ def _get_or_create_workspace_session_record(
 
 
 def _current_workspace_option_set(
-    db_session: Session,
+    session: PlanningSessionState,
     *,
-    user: AuthenticatedUser,
     trip_id: str,
 ) -> tuple[str, list[str]]:
-    payload = get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}
-    planner_state = payload.get("planner_panel_state", {})
-    option_set = planner_state.get("option_set", {})
-    option_set_id = option_set.get("option_set_id") or f"option-set:{trip_id}:workspace-bootstrap"
-    option_ids = [
-        option["option_id"]
-        for option in option_set.get("options", [])
-        if isinstance(option, dict) and isinstance(option.get("option_id"), str)
-    ]
+    presentation = (
+        session.recent_option_presentations[0]
+        if session.recent_option_presentations
+        else _default_workspace_presentation(trip_id, session.updated_at)
+    )
+    option_set_id = presentation.option_set_id or f"option-set:{trip_id}:workspace-bootstrap"
+    option_ids = [option_id for option_id in presentation.surfaced_option_ids if option_id]
     return option_set_id, option_ids
 
 
@@ -1353,6 +1350,7 @@ def _append_activity_event(
     activity_event_id: str,
     trip_id: str,
     session_state_id: str,
+    occurred_at: str,
     event_kind: str,
     summary: str,
     related_decision_id: str | None = None,
@@ -1364,7 +1362,7 @@ def _append_activity_event(
             activity_event_id=activity_event_id,
             trip_id=trip_id,
             session_state_id=session_state_id,
-            occurred_at=_isoformat(datetime.now(UTC)),
+            occurred_at=occurred_at,
             event_kind=event_kind,
             summary=summary,
             actor="traveler",
@@ -1383,6 +1381,7 @@ def _record_planner_action(
     trip_id: str,
     session_state_id: str,
     activity_event_id: str,
+    occurred_at: str,
     action_type: str,
     decision_id: str | None = None,
     option_set_id: str | None = None,
@@ -1396,7 +1395,7 @@ def _record_planner_action(
             trip_id=trip_id,
             session_state_id=session_state_id,
             activity_event_id=activity_event_id,
-            occurred_at=_isoformat(datetime.now(UTC)),
+            occurred_at=occurred_at,
             action_type=action_type,
             decision_id=decision_id,
             option_set_id=option_set_id,
@@ -1437,11 +1436,13 @@ def answer_workspace_planner_decision(
     session_record.last_updated_at = session.updated_at
     record.updated_at = datetime.now(UTC)
     activity_event_id = f"activity:{trip_id}:{secrets.token_hex(4)}"
+    occurred_at = _isoformat(datetime.now(UTC))
     _append_activity_event(
         db_session,
         activity_event_id=activity_event_id,
         trip_id=trip_id,
         session_state_id=session.session_state_id,
+        occurred_at=occurred_at,
         event_kind="decision_recorded",
         summary=f"Traveler answered '{matching.title}' with '{choice}'.",
         related_decision_id=decision_id,
@@ -1453,6 +1454,7 @@ def answer_workspace_planner_decision(
         trip_id=trip_id,
         session_state_id=session.session_state_id,
         activity_event_id=activity_event_id,
+        occurred_at=occurred_at,
         action_type="decision_answer",
         decision_id=decision_id,
         option_set_id=matching.related_option_set_id,
@@ -1475,11 +1477,7 @@ def submit_workspace_option_feedback(
     record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
-    option_set_id, valid_option_ids = _current_workspace_option_set(
-        db_session,
-        user=user,
-        trip_id=trip_id,
-    )
+    option_set_id, valid_option_ids = _current_workspace_option_set(session, trip_id=trip_id)
     if option_id not in valid_option_ids:
         raise ValueError(f"Option '{option_id}' is not available in the current workspace option set.")
     presentation = (
@@ -1550,11 +1548,13 @@ def submit_workspace_option_feedback(
     session_record.last_updated_at = session.updated_at
     record.updated_at = datetime.now(UTC)
     activity_event_id = f"activity:{trip_id}:{secrets.token_hex(4)}"
+    occurred_at = _isoformat(datetime.now(UTC))
     _append_activity_event(
         db_session,
         activity_event_id=activity_event_id,
         trip_id=trip_id,
         session_state_id=session.session_state_id,
+        occurred_at=occurred_at,
         event_kind=event_kind,
         summary=summary,
         related_decision_id=decision_id,
@@ -1566,6 +1566,7 @@ def submit_workspace_option_feedback(
         trip_id=trip_id,
         session_state_id=session.session_state_id,
         activity_event_id=activity_event_id,
+        occurred_at=occurred_at,
         action_type=action_type,
         decision_id=decision_id,
         option_set_id=option_set_id,

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1489,6 +1489,13 @@ def submit_workspace_option_feedback(
     )
     presentation.surfaced_option_ids = valid_option_ids
     presentation.option_set_id = option_set_id
+    if presentation.highlighted_option_id not in valid_option_ids:
+        presentation.highlighted_option_id = valid_option_ids[0]
+    if presentation.selected_option_id not in valid_option_ids:
+        presentation.selected_option_id = None
+    presentation.rejected_option_ids = [
+        item for item in presentation.rejected_option_ids if item in valid_option_ids
+    ]
 
     if action_type == "accept":
         presentation.selected_option_id = option_id

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -37,8 +37,11 @@ from trip_planner.itinerary import (
     ScenarioSummary,
     ScenarioTradeoff,
 )
-from trip_planner.persistence.models.scenario import (
+from trip_planner.persistence.models.activity import (
     PersistedActivityLogEvent,
+    PersistedPlannerAction,
+)
+from trip_planner.persistence.models.scenario import (
     PersistedSavedScenario,
 )
 from trip_planner.persistence.models.session import PersistedPlanningSessionState
@@ -1326,9 +1329,28 @@ def _get_or_create_workspace_session_record(
     return persisted
 
 
+def _current_workspace_option_set(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> tuple[str, list[str]]:
+    payload = get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}
+    planner_state = payload.get("planner_panel_state", {})
+    option_set = planner_state.get("option_set", {})
+    option_set_id = option_set.get("option_set_id") or f"option-set:{trip_id}:workspace-bootstrap"
+    option_ids = [
+        option["option_id"]
+        for option in option_set.get("options", [])
+        if isinstance(option, dict) and isinstance(option.get("option_id"), str)
+    ]
+    return option_set_id, option_ids
+
+
 def _append_activity_event(
     db_session: Session,
     *,
+    activity_event_id: str,
     trip_id: str,
     session_state_id: str,
     event_kind: str,
@@ -1339,7 +1361,7 @@ def _append_activity_event(
 ) -> None:
     db_session.add(
         PersistedActivityLogEvent(
-            activity_event_id=f"activity:{trip_id}:{secrets.token_hex(4)}",
+            activity_event_id=activity_event_id,
             trip_id=trip_id,
             session_state_id=session_state_id,
             occurred_at=_isoformat(datetime.now(UTC)),
@@ -1351,6 +1373,36 @@ def _append_activity_event(
             metadata_payload=metadata or {},
             tags=["workspace", "planner-action"],
             notes=[],
+        )
+    )
+
+
+def _record_planner_action(
+    db_session: Session,
+    *,
+    trip_id: str,
+    session_state_id: str,
+    activity_event_id: str,
+    action_type: str,
+    decision_id: str | None = None,
+    option_set_id: str | None = None,
+    option_id: str | None = None,
+    choice: str | None = None,
+    payload: dict[str, str] | None = None,
+) -> None:
+    db_session.add(
+        PersistedPlannerAction(
+            planner_action_id=f"planner-action:{trip_id}:{secrets.token_hex(4)}",
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+            activity_event_id=activity_event_id,
+            occurred_at=_isoformat(datetime.now(UTC)),
+            action_type=action_type,
+            decision_id=decision_id,
+            option_set_id=option_set_id,
+            option_id=option_id,
+            choice=choice,
+            payload=payload or {},
         )
     )
 
@@ -1384,8 +1436,10 @@ def answer_workspace_planner_decision(
     session_record.notes = list(session.notes)
     session_record.last_updated_at = session.updated_at
     record.updated_at = datetime.now(UTC)
+    activity_event_id = f"activity:{trip_id}:{secrets.token_hex(4)}"
     _append_activity_event(
         db_session,
+        activity_event_id=activity_event_id,
         trip_id=trip_id,
         session_state_id=session.session_state_id,
         event_kind="decision_recorded",
@@ -1393,6 +1447,17 @@ def answer_workspace_planner_decision(
         related_decision_id=decision_id,
         related_option_set_id=matching.related_option_set_id,
         metadata={"choice": choice},
+    )
+    _record_planner_action(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        activity_event_id=activity_event_id,
+        action_type="decision_answer",
+        decision_id=decision_id,
+        option_set_id=matching.related_option_set_id,
+        choice=choice,
+        payload={"decision_title": matching.title},
     )
     db_session.commit()
     return get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}
@@ -1410,17 +1475,19 @@ def submit_workspace_option_feedback(
     record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
-    option_set_id = (
-        session.recent_option_presentations[0].option_set_id
-        if session.recent_option_presentations
-        else f"option-set:{trip_id}:workspace-bootstrap"
+    option_set_id, valid_option_ids = _current_workspace_option_set(
+        db_session,
+        user=user,
+        trip_id=trip_id,
     )
+    if option_id not in valid_option_ids:
+        raise ValueError(f"Option '{option_id}' is not available in the current workspace option set.")
     presentation = (
         session.recent_option_presentations[0]
         if session.recent_option_presentations
         else _default_workspace_presentation(trip_id, session.updated_at)
     )
-    presentation.surfaced_option_ids = list(dict.fromkeys(presentation.surfaced_option_ids + [option_id]))
+    presentation.surfaced_option_ids = valid_option_ids
     presentation.option_set_id = option_set_id
 
     if action_type == "accept":
@@ -1475,8 +1542,10 @@ def submit_workspace_option_feedback(
     session_record.notes = list(session.notes)
     session_record.last_updated_at = session.updated_at
     record.updated_at = datetime.now(UTC)
+    activity_event_id = f"activity:{trip_id}:{secrets.token_hex(4)}"
     _append_activity_event(
         db_session,
+        activity_event_id=activity_event_id,
         trip_id=trip_id,
         session_state_id=session.session_state_id,
         event_kind=event_kind,
@@ -1484,6 +1553,17 @@ def submit_workspace_option_feedback(
         related_decision_id=decision_id,
         related_option_set_id=option_set_id,
         metadata={"action_type": action_type, "option_id": option_id},
+    )
+    _record_planner_action(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        activity_event_id=activity_event_id,
+        action_type=action_type,
+        decision_id=decision_id,
+        option_set_id=option_set_id,
+        option_id=option_id,
+        payload={"summary": summary},
     )
     db_session.commit()
     return get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}

--- a/trip_planner/persistence/alembic/versions/20260410_01_planner_actions.py
+++ b/trip_planner/persistence/alembic/versions/20260410_01_planner_actions.py
@@ -1,7 +1,7 @@
 """add persisted planner actions
 
 Revision ID: 20260410_01
-Revises: 20260408_01
+Revises: 20260409_01
 Create Date: 2026-04-10 00:00:00.000000
 """
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 revision = "20260410_01"
-down_revision = "20260408_01"
+down_revision = "20260409_01"
 branch_labels = None
 depends_on = None
 

--- a/trip_planner/persistence/alembic/versions/20260410_01_planner_actions.py
+++ b/trip_planner/persistence/alembic/versions/20260410_01_planner_actions.py
@@ -28,7 +28,12 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("session_state_id", sa.String(length=96), nullable=False),
-        sa.Column("activity_event_id", sa.String(length=96), nullable=True),
+        sa.Column(
+            "activity_event_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_activity_log_events.activity_event_id", ondelete="SET NULL"),
+            nullable=True,
+        ),
         sa.Column("occurred_at", sa.String(length=64), nullable=False),
         sa.Column("action_type", sa.String(length=64), nullable=False),
         sa.Column("decision_id", sa.String(length=96), nullable=True),
@@ -51,6 +56,12 @@ def upgrade() -> None:
         unique=False,
     )
     op.create_index(
+        op.f("ix_persisted_planner_actions_activity_event_id"),
+        "persisted_planner_actions",
+        ["activity_event_id"],
+        unique=False,
+    )
+    op.create_index(
         op.f("ix_persisted_planner_actions_occurred_at"),
         "persisted_planner_actions",
         ["occurred_at"],
@@ -59,6 +70,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_persisted_planner_actions_activity_event_id"),
+        table_name="persisted_planner_actions",
+    )
     op.drop_index(
         op.f("ix_persisted_planner_actions_occurred_at"),
         table_name="persisted_planner_actions",

--- a/trip_planner/persistence/alembic/versions/20260410_01_planner_actions.py
+++ b/trip_planner/persistence/alembic/versions/20260410_01_planner_actions.py
@@ -1,0 +1,74 @@
+"""add persisted planner actions
+
+Revision ID: 20260410_01
+Revises: 20260408_01
+Create Date: 2026-04-10 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260410_01"
+down_revision = "20260408_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "persisted_planner_actions",
+        sa.Column("planner_action_id", sa.String(length=96), primary_key=True),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("session_state_id", sa.String(length=96), nullable=False),
+        sa.Column("activity_event_id", sa.String(length=96), nullable=True),
+        sa.Column("occurred_at", sa.String(length=64), nullable=False),
+        sa.Column("action_type", sa.String(length=64), nullable=False),
+        sa.Column("decision_id", sa.String(length=96), nullable=True),
+        sa.Column("option_set_id", sa.String(length=96), nullable=True),
+        sa.Column("option_id", sa.String(length=96), nullable=True),
+        sa.Column("choice", sa.String(length=160), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_persisted_planner_actions_trip_id"),
+        "persisted_planner_actions",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_planner_actions_session_state_id"),
+        "persisted_planner_actions",
+        ["session_state_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_planner_actions_occurred_at"),
+        "persisted_planner_actions",
+        ["occurred_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_persisted_planner_actions_occurred_at"),
+        table_name="persisted_planner_actions",
+    )
+    op.drop_index(
+        op.f("ix_persisted_planner_actions_session_state_id"),
+        table_name="persisted_planner_actions",
+    )
+    op.drop_index(
+        op.f("ix_persisted_planner_actions_trip_id"),
+        table_name="persisted_planner_actions",
+    )
+    op.drop_table("persisted_planner_actions")

--- a/trip_planner/persistence/db.py
+++ b/trip_planner/persistence/db.py
@@ -91,6 +91,7 @@ def ensure_database_ready(url: str | None = None) -> None:
 
     from trip_planner.persistence.models import budget  # noqa: F401
     from trip_planner.persistence.models import (  # noqa: F401
+        activity,
         account,
         policy,
         proposal,

--- a/trip_planner/persistence/models/__init__.py
+++ b/trip_planner/persistence/models/__init__.py
@@ -1,5 +1,9 @@
 """Persistence models for runtime-backed storage."""
 
+from trip_planner.persistence.models.activity import (
+    PersistedActivityLogEvent,
+    PersistedPlannerAction,
+)
 from trip_planner.persistence.models.account import UserAccount
 from trip_planner.persistence.models.budget import (
     PersistedActualSpendEvent,
@@ -8,10 +12,7 @@ from trip_planner.persistence.models.budget import (
 )
 from trip_planner.persistence.models.policy import PersistedPolicyState
 from trip_planner.persistence.models.proposal import PersistedProposalState
-from trip_planner.persistence.models.scenario import (
-    PersistedActivityLogEvent,
-    PersistedSavedScenario,
-)
+from trip_planner.persistence.models.scenario import PersistedSavedScenario
 from trip_planner.persistence.models.session import (
     AuthSession,
     PersistedPlanningSessionState,
@@ -24,6 +25,7 @@ __all__ = [
     "PersistedActualSpendEvent",
     "PersistedBudgetPlan",
     "PersistedBudgetPlanVersion",
+    "PersistedPlannerAction",
     "PersistedPlanningSessionState",
     "PersistedPolicyState",
     "PersistedProposalState",

--- a/trip_planner/persistence/models/activity.py
+++ b/trip_planner/persistence/models/activity.py
@@ -48,7 +48,11 @@ class PersistedPlannerAction(Base):
         index=True,
     )
     session_state_id: Mapped[str] = mapped_column(String(96), index=True)
-    activity_event_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    activity_event_id: Mapped[str | None] = mapped_column(
+        ForeignKey("persisted_activity_log_events.activity_event_id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
     occurred_at: Mapped[str] = mapped_column(String(64), index=True)
     action_type: Mapped[str] = mapped_column(String(64))
     decision_id: Mapped[str | None] = mapped_column(String(96), nullable=True)

--- a/trip_planner/persistence/models/activity.py
+++ b/trip_planner/persistence/models/activity.py
@@ -1,0 +1,59 @@
+"""SQLAlchemy models for persisted activity-trail and planner-action state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from trip_planner.persistence.db import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class PersistedActivityLogEvent(Base):
+    __tablename__ = "persisted_activity_log_events"
+
+    activity_event_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    session_state_id: Mapped[str] = mapped_column(String(96))
+    occurred_at: Mapped[str] = mapped_column(String(64), index=True)
+    event_kind: Mapped[str] = mapped_column(String(64))
+    summary: Mapped[str] = mapped_column(String(600))
+    actor: Mapped[str] = mapped_column(String(64), default="system")
+    related_decision_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    related_option_set_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    saved_scenario_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    budget_plan_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    scenario_budget_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    checkpoint_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    metadata_payload: Mapped[dict[str, str]] = mapped_column("metadata", JSON, default=dict)
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    notes: Mapped[list[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+
+
+class PersistedPlannerAction(Base):
+    __tablename__ = "persisted_planner_actions"
+
+    planner_action_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    session_state_id: Mapped[str] = mapped_column(String(96), index=True)
+    activity_event_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    occurred_at: Mapped[str] = mapped_column(String(64), index=True)
+    action_type: Mapped[str] = mapped_column(String(64))
+    decision_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    option_set_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    option_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    choice: Mapped[str | None] = mapped_column(String(160), nullable=True)
+    payload: Mapped[dict[str, str]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)

--- a/trip_planner/persistence/models/scenario.py
+++ b/trip_planner/persistence/models/scenario.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy models for persisted saved-scenario and planning-history state."""
+"""SQLAlchemy models for persisted saved-scenario state."""
 
 from __future__ import annotations
 
@@ -33,28 +33,3 @@ class PersistedSavedScenario(Base):
         default=_utcnow,
         onupdate=_utcnow,
     )
-
-
-class PersistedActivityLogEvent(Base):
-    __tablename__ = "persisted_activity_log_events"
-
-    activity_event_id: Mapped[str] = mapped_column(String(96), primary_key=True)
-    trip_id: Mapped[str] = mapped_column(
-        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
-        index=True,
-    )
-    session_state_id: Mapped[str] = mapped_column(String(96))
-    occurred_at: Mapped[str] = mapped_column(String(64), index=True)
-    event_kind: Mapped[str] = mapped_column(String(64))
-    summary: Mapped[str] = mapped_column(String(600))
-    actor: Mapped[str] = mapped_column(String(64), default="system")
-    related_decision_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
-    related_option_set_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
-    saved_scenario_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
-    budget_plan_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
-    scenario_budget_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
-    checkpoint_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
-    metadata_payload: Mapped[dict[str, str]] = mapped_column("metadata", JSON, default=dict)
-    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
-    notes: Mapped[list[str]] = mapped_column(JSON, default=list)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #689

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The planner only becomes a real interactive system when user decisions and option-feedback actions are stored durably and reflected after reload. Otherwise the workspace is still a stateless UI wrapper.

Parent epic: #676

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#676](https://github.com/stranske/trip-planner/issues/676)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add backend API endpoints in `trip_planner/app/routes/planner.py` to record planner decision actions and option-feedback actions.
  - [x] Define scope for: Create a POST endpoint in planner.py to record user decision actions with trip/session context (verify: confirm completion in repo)
  - [x] Implement focused slice for: Create a POST endpoint in planner.py to record user decision actions with trip/session context (verify: confirm completion in repo)
  - [x] Validate focused slice for: Create a POST endpoint in planner.py to record user decision actions with trip/session context (verify: confirm completion in repo)
  - [x] Define scope for: Create a POST endpoint in planner.py to record option-feedback actions with associated option identifiers (verify: confirm completion in repo)
  - [x] Implement focused slice for: Create a POST endpoint in planner.py to record option-feedback actions with associated option identifiers (verify: confirm completion in repo)
  - [x] Validate focused slice for: Create a POST endpoint in planner.py to record option-feedback actions with associated option identifiers (verify: confirm completion in repo)
  - [x] Define request (verify: confirm completion in repo) response schemas for decision action endpoints using Pydantic models (verify: confirm completion in repo) response schemas for option-feedback action endpoints using Pydantic models (verify: confirm completion in repo)
  - [x] Implement validation logic to ensure decision actions reference valid planner states (verify: confirm completion in repo)
  - [x] Implement validation logic to ensure option-feedback actions reference valid options (verify: confirm completion in repo)
- [x] Update persistence models in `trip_planner/persistence/models/session.py` and/or `trip_planner/persistence/models/activity.py` to store planner actions tied to the trip/session activity trail (use explicit planner action types).
  - [x] Define an enumeration of explicit planner action types for decisions (verify: confirm completion in repo) feedback (verify: confirm completion in repo)
  - [x] Add a PlannerAction model or table to store action type, timestamp, (verify: confirm completion in repo) payload (verify: confirm completion in repo)
  - [x] Create foreign key relationships linking planner actions to trip (verify: confirm completion in repo) session records (verify: confirm completion in repo)
  - [x] Add fields to the activity trail model to reference associated planner actions (verify: confirm completion in repo)
  - [x] Define scope for: Write database migration scripts to create the new planner action storage schema (verify: confirm completion in repo)
  - [x] Implement focused slice for: Write database migration scripts to create the new planner action storage schema (verify: confirm completion in repo)
  - [x] Validate focused slice for: Write database migration scripts to create the new planner action storage schema (verify: confirm completion in repo)
  - [x] Add model methods to query planner actions by trip or session identifier (verify: confirm completion in repo)
- [x] Implement server-side logic to reload/recompute planner panel state from persisted actions and return updated state after an action is recorded.
  - [x] Define scope for: Create a service function to load all persisted planner actions for a given trip or session (verify: confirm completion in repo)
  - [x] Implement focused slice for: Create a service function to load all persisted planner actions for a given trip or session (verify: confirm completion in repo)
  - [x] Validate focused slice for: Create a service function to load all persisted planner actions for a given trip or session (verify: confirm completion in repo)
  - [x] Define scope for: Implement action replay logic that reconstructs planner state from a sequence of actions (verify: confirm completion in repo)
  - [x] Implement focused slice for: Implement action replay logic that reconstructs planner state from a sequence of actions (verify: confirm completion in repo)
  - [x] Validate focused slice for: Implement action replay logic that reconstructs planner state from a sequence of actions (verify: confirm completion in repo)
  - [x] Define scope for: Write a state computation function that applies a new action to current planner state (verify: confirm completion in repo)
  - [x] Implement focused slice for: Write a state computation function that applies a new action to current planner state (verify: confirm completion in repo)
  - [x] Validate focused slice for: Write a state computation function that applies a new action to current planner state (verify: confirm completion in repo)
  - [x] Create a response builder that serializes updated planner state for API responses (verify: confirm completion in repo)
  - [x] Add error handling for invalid action sequences or corrupted state (verify: confirm completion in repo)
  - [x] Implement caching strategy to avoid recomputing state from scratch on every request (verify: confirm completion in repo)
- [x] Update frontend workspace planner components under `frontend/src/components/planner/` to call the new endpoints and refresh planner state after action completion without losing current context.
  - [x] Create API client functions to call the decision action recording endpoint (verify: confirm completion in repo)
  - [x] Create API client functions to call the option-feedback action recording endpoint (verify: confirm completion in repo)
  - [x] Update planner component state management to handle action submission (verify: confirm completion in repo) response (verify: confirm completion in repo)
  - [x] Implement optimistic UI updates that show action effects before server confirmation (verify: confirm completion in repo)
  - [x] Add error handling (verify: confirm completion in repo) rollback logic for failed action submissions (verify: confirm completion in repo)
  - [x] Preserve scroll position (verify: confirm completion in repo) expanded sections when refreshing planner state after actions (verify: confirm completion in repo)
  - [x] Define scope for: Update component lifecycle methods to reload planner state on mount from persisted data (verify: confirm completion in repo)
  - [x] Implement focused slice for: Update component lifecycle methods to reload planner state on mount from persisted data (verify: confirm completion in repo)
  - [x] Validate focused slice for: Update component lifecycle methods to reload planner state on mount from persisted data (verify: confirm completion in repo)
- [x] Write automated tests covering (1) one decision flow and (2) one option-feedback flow that persist actions and verify state after refresh/re-entry.
  - [x] Define scope for: Write backend unit tests that verify decision actions are correctly persisted to the database
  - [x] Implement focused slice for: Write backend unit tests that verify decision actions are correctly persisted to the database
  - [x] Validate focused slice for: Write backend unit tests that verify decision actions are correctly persisted to the database
  - [x] Define scope for: Write backend unit tests that verify option-feedback actions are correctly persisted to the database
  - [x] Implement focused slice for: Write backend unit tests that verify option-feedback actions are correctly persisted to the database
  - [x] Validate focused slice for: Write backend unit tests that verify option-feedback actions are correctly persisted to the database
  - [x] Create API integration tests that POST a decision action (verify: tests pass) verify the returned state
  - [x] Create API integration tests that POST an option-feedback action (verify: tests pass)
  - [x] Write tests that reload planner state from persistence (verify: tests pass) verify it matches expected state
  - [x] Define scope for: Create end-to-end tests that simulate page reload (verify: tests pass)
  - [x] Implement focused slice for: Create end-to-end tests that simulate page reload (verify: tests pass)
  - [x] Validate focused slice for: Create end-to-end tests that simulate page reload (verify: tests pass) verify planner state is restored
  - [x] Add tests that verify action history is correctly linked to trip
- [x] Write documentation describing how planner actions are stored and replayed into workspace state (including action types and where they are persisted).

#### Acceptance criteria
- [x] Recording a planner decision action via the backend results in an updated planner/workspace state returned by the API and reflected in the UI.
- [x] Recording an option-feedback action via the backend results in an updated planner/workspace state returned by the API and reflected in the UI.
- [x] After a page reload and later re-entry, previously recorded planner actions are loaded from persistence and the planner/workspace state matches the post-action state.
- [x] Persisted planner actions are linked to the trip/session activity trail (inspectable in `trip_planner/persistence/models/activity.py`-backed storage for the trip/session).
- [x] Automated tests pass and include at least one end-to-end persisted interaction cycle covering refresh/re-entry for both a decision and an option-feedback action.

**Head SHA:** 13650a7b9860b3c9bfe0cfe5c981332389e597cf
**Latest Runs:** ❔ in progress — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24233772051) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24233772095) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/24233209510) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/24233209485) |
<!-- auto-status-summary:end -->
