### PR TITLE
Issue #759: wire persisted runtime scenario search

### DIFF
--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -235,6 +235,40 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisu
     assert payload["planner_panel_state"]["option_set"]["purpose"] == "workspace_review"
 
 
+def test_workspace_endpoint_keeps_leisure_fixture_defaults_when_trip_frame_is_sparse(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Flexible weekend",
+            "summary": "Exercise sparse persisted leisure trip inputs.",
+            "mode": "leisure",
+            "trip_frame": {},
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    initial = client.get(f"/api/workspace/{trip_id}")
+    reloaded = client.get(f"/api/workspace/{trip_id}")
+
+    assert initial.status_code == 200
+    assert reloaded.status_code == 200
+    initial_payload = initial.json()
+    reloaded_payload = reloaded.json()
+    assert initial_payload["scenario_search"]["scenarios"]
+    assert initial_payload["scenario_search"]["scenarios"] == reloaded_payload["scenario_search"][
+        "scenarios"
+    ]
+    assert initial_payload["planner_panel_state"]["option_set"]["options"] == reloaded_payload[
+        "planner_panel_state"
+    ]["option_set"]["options"]
+    assert initial_payload["runtime_scenario_comparison"]["scenarios"] == reloaded_payload[
+        "runtime_scenario_comparison"
+    ]["scenarios"]
+
+
 def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_trip(
     client: TestClient,
 ) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -170,8 +170,12 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_busin
     assert payload["saved_scenarios"][0]["versions"][0]["label"] == "baseline"
     assert payload["saved_scenarios"][1]["versions"][0]["label"] == "fallback"
     assert payload["scenario_comparison"]["baseline_scenario_id"] == lead_saved_scenario_id
-    assert payload["runtime_scenario_comparison"]["scenarios"][0]["scenario_id"] == lead_saved_scenario_id
-    assert payload["runtime_scenario_comparison"]["scenarios"][1]["status"] == "fallback"
+    assert payload["scenario_search"]["title"] == "Chicago kickoff ranked scenarios"
+    assert payload["scenario_search"]["purpose"] == "final_selection"
+    assert payload["scenario_search"]["scenarios"][0]["scenario_id"] == f"scenario:{trip_id}:1"
+    assert payload["scenario_search"]["scenarios"][0]["scenario_id"] != lead_saved_scenario_id
+    assert payload["runtime_scenario_comparison"]["lead_scenario_id"] == f"scenario:{trip_id}:1"
+    assert len(payload["runtime_scenario_comparison"]["scenarios"]) == 1
     assert payload["inventory_summary"]["bundle_count"] == 1
     assert payload["inventory_summary"]["bundles"][0]["title"] == "Airport arrival bundle"
     assert payload["feasibility_summary"]["assessment_count"] == 1
@@ -218,13 +222,16 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisu
     payload = client.get(f"/api/workspace/{trip_id}").json()
 
     assert payload["saved_scenarios"][0]["versions"][0]["title"].startswith("Lisbon")
-    assert payload["runtime_scenario_comparison"]["scenarios"][0]["route_sequence"] == [
-        "Lisbon"
-    ]
-    assert payload["runtime_scenario_comparison"]["scenarios"][1]["route_sequence"] == [
-        "Lisbon",
-        "comparison-pass",
-    ]
+    assert payload["scenario_search"]["title"] == "Lisbon weekend runtime scenarios"
+    assert payload["scenario_search"]["purpose"] == "final_selection"
+    assert payload["runtime_scenario_comparison"]["lead_scenario_id"] == f"scenario:{trip_id}:1"
+    assert payload["runtime_scenario_comparison"]["scenarios"][0]["scenario_id"] == (
+        f"scenario:{trip_id}:1"
+    )
+    assert all(
+        "comparison-pass" not in scenario["route_sequence"]
+        for scenario in payload["runtime_scenario_comparison"]["scenarios"]
+    )
     assert payload["planner_panel_state"]["option_set"]["purpose"] == "workspace_review"
 
 

--- a/trip_planner/app/services/scenarios.py
+++ b/trip_planner/app/services/scenarios.py
@@ -161,8 +161,10 @@ def build_workspace_scenario_search(
         )
         traveler_fixture = load_fixture_map()[leisure_fixture_id]
         profile = deepcopy(traveler_fixture.profile)
-        profile.trip_frame.duration_days = duration_days
-        profile.trip_frame.regions_in_scope = list(primary_regions)
+        if duration_days is not None:
+            profile.trip_frame.duration_days = duration_days
+        if primary_regions:
+            profile.trip_frame.regions_in_scope = list(primary_regions)
         if traveler_party_kind in {"solo", "pair", "family", "friends"}:
             profile.trip_frame.traveler_party = traveler_party_kind
         resolved_profile = resolve_leisure_profile(

--- a/trip_planner/app/services/scenarios.py
+++ b/trip_planner/app/services/scenarios.py
@@ -160,15 +160,15 @@ def build_workspace_scenario_search(
             else _DEFAULT_LEISURE_FIXTURE_ID
         )
         traveler_fixture = load_fixture_map()[leisure_fixture_id]
-        profile = deepcopy(traveler_fixture.profile)
+        leisure_profile = deepcopy(traveler_fixture.profile)
         if duration_days is not None:
-            profile.trip_frame.duration_days = duration_days
+            leisure_profile.trip_frame.duration_days = duration_days
         if primary_regions:
-            profile.trip_frame.regions_in_scope = list(primary_regions)
+            leisure_profile.trip_frame.regions_in_scope = list(primary_regions)
         if traveler_party_kind in {"solo", "pair", "family", "friends"}:
-            profile.trip_frame.traveler_party = traveler_party_kind
+            leisure_profile.trip_frame.traveler_party = traveler_party_kind
         resolved_profile = resolve_leisure_profile(
-            profile,
+            leisure_profile,
             traveler_fixture.evidence,
         )
         leisure_objectives = derive_itinerary_objectives(
@@ -196,7 +196,7 @@ def build_workspace_scenario_search(
             if fixture_seed is not None and fixture_seed.business_constraint_fixture is not None
             else _DEFAULT_BUSINESS_CONSTRAINT_FIXTURE
         )
-        profile = BusinessTravelProfile.from_dict(
+        business_profile = BusinessTravelProfile.from_dict(
             _load_json(_business_fixture_dir() / business_profile_fixture)
         )
         constraint_payload = _load_json(
@@ -204,12 +204,12 @@ def build_workspace_scenario_search(
         )
         constraint_set = PolicyConstraintSet(**constraint_payload["constraint_set"])
         business_objectives = derive_business_planning_objectives(
-            profile,
+            business_profile,
             trip_id=trip_id,
             constraint_set=constraint_set,
         )
         ranked_results = BusinessRankingEngine().rank_bundles(
-            profile,
+            business_profile,
             business_objectives,
             bundles,
             trip_id=trip_id,

--- a/trip_planner/app/services/scenarios.py
+++ b/trip_planner/app/services/scenarios.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,6 +50,10 @@ _SCENARIO_FIXTURE_SEEDS: dict[str, ScenarioFixtureSeed] = {
     ),
 }
 
+_DEFAULT_LEISURE_FIXTURE_ID = "urban-historian"
+_DEFAULT_BUSINESS_PROFILE_FIXTURE = "client_meeting_profile.json"
+_DEFAULT_BUSINESS_CONSTRAINT_FIXTURE = "policy_round_trip_exception.json"
+
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
@@ -60,6 +65,17 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def _business_fixture_dir() -> Path:
     return _repo_root() / "tests" / "fixtures" / "business"
+
+
+def _default_scenario_title(
+    *,
+    trip_mode: str,
+    trip_title: str | None,
+    primary_regions: tuple[str, ...],
+) -> str:
+    subject = trip_title or ", ".join(primary_regions[:2]) or "Persisted trip"
+    suffix = "ranked scenarios" if trip_mode == "business" else "runtime scenarios"
+    return f"{subject} {suffix}"
 
 
 def _bundle_ranked_results(
@@ -115,9 +131,18 @@ def build_workspace_scenario_search(
     trip_id: str,
     trip_mode: str,
     bundles: list[InventoryBundle],
+    trip_title: str | None = None,
+    primary_regions: tuple[str, ...] = (),
+    duration_days: int | None = None,
+    traveler_party_kind: str | None = None,
 ):
     fixture_seed = _SCENARIO_FIXTURE_SEEDS.get(trip_id)
-    if fixture_seed is None or fixture_seed.trip_mode != trip_mode:
+    title = _default_scenario_title(
+        trip_mode=trip_mode,
+        trip_title=trip_title,
+        primary_regions=primary_regions,
+    )
+    if fixture_seed is not None and fixture_seed.trip_mode != trip_mode:
         raise KeyError(f"Unsupported scenario fixture trip: {trip_id}")
     if not bundles:
         raise ValueError("Workspace scenario search requires at least one inventory bundle")
@@ -129,9 +154,19 @@ def build_workspace_scenario_search(
     scenario_objectives: object
 
     if trip_mode == "leisure":
-        traveler_fixture = load_fixture_map()[fixture_seed.leisure_fixture_id or ""]
+        leisure_fixture_id = (
+            fixture_seed.leisure_fixture_id
+            if fixture_seed is not None and fixture_seed.leisure_fixture_id is not None
+            else _DEFAULT_LEISURE_FIXTURE_ID
+        )
+        traveler_fixture = load_fixture_map()[leisure_fixture_id]
+        profile = deepcopy(traveler_fixture.profile)
+        profile.trip_frame.duration_days = duration_days
+        profile.trip_frame.regions_in_scope = list(primary_regions)
+        if traveler_party_kind in {"solo", "pair", "family", "friends"}:
+            profile.trip_frame.traveler_party = traveler_party_kind
         resolved_profile = resolve_leisure_profile(
-            traveler_fixture.profile,
+            profile,
             traveler_fixture.evidence,
         )
         leisure_objectives = derive_itinerary_objectives(
@@ -140,20 +175,30 @@ def build_workspace_scenario_search(
             objective_id=f"objective:{trip_id}:ranking",
         )
         ranked_results = LeisureRankingEngine().rank_bundles(
-            traveler_fixture.profile,
+            resolved_profile.profile,
             leisure_objectives,
             bundles,
             trip_id=trip_id,
-            title=fixture_seed.title,
+            title=fixture_seed.title if fixture_seed is not None else title,
             feasibility_outputs=feasibility_outputs,
         )
         scenario_objectives = leisure_objectives
     else:
+        business_profile_fixture = (
+            fixture_seed.business_profile_fixture
+            if fixture_seed is not None and fixture_seed.business_profile_fixture is not None
+            else _DEFAULT_BUSINESS_PROFILE_FIXTURE
+        )
+        business_constraint_fixture = (
+            fixture_seed.business_constraint_fixture
+            if fixture_seed is not None and fixture_seed.business_constraint_fixture is not None
+            else _DEFAULT_BUSINESS_CONSTRAINT_FIXTURE
+        )
         profile = BusinessTravelProfile.from_dict(
-            _load_json(_business_fixture_dir() / (fixture_seed.business_profile_fixture or ""))
+            _load_json(_business_fixture_dir() / business_profile_fixture)
         )
         constraint_payload = _load_json(
-            _business_fixture_dir() / (fixture_seed.business_constraint_fixture or "")
+            _business_fixture_dir() / business_constraint_fixture
         )
         constraint_set = PolicyConstraintSet(**constraint_payload["constraint_set"])
         business_objectives = derive_business_planning_objectives(
@@ -166,7 +211,7 @@ def build_workspace_scenario_search(
             business_objectives,
             bundles,
             trip_id=trip_id,
-            title=fixture_seed.title,
+            title=fixture_seed.title if fixture_seed is not None else title,
             constraint_set=constraint_set,
             feasibility_outputs=feasibility_outputs,
         )
@@ -177,7 +222,7 @@ def build_workspace_scenario_search(
         bundles=bundles,
         objectives=scenario_objectives,
         feasibility_outputs=feasibility_outputs,
-        title=fixture_seed.title,
+        title=fixture_seed.title if fixture_seed is not None else title,
     )
 
 

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -346,12 +346,45 @@ def _build_scenario_search(
     trip_id: str,
     trip_mode: str,
     bundles: list[Any],
+    trip_title: str | None = None,
+    primary_regions: tuple[str, ...] = (),
+    duration_days: int | None = None,
+    traveler_party_kind: str | None = None,
 ) -> ScenarioSearchResult:
     return build_workspace_scenario_search(
         trip_id=trip_id,
         trip_mode=trip_mode,
         bundles=bundles,
+        trip_title=trip_title,
+        primary_regions=primary_regions,
+        duration_days=duration_days,
+        traveler_party_kind=traveler_party_kind,
     )
+
+
+def _build_runtime_scenario_search_for_trip(
+    *,
+    record: PersistedTrip,
+    inventory_bundles: list[Any],
+    saved_scenarios: list[dict[str, Any]],
+) -> dict[str, Any]:
+    if inventory_bundles:
+        return _build_scenario_search(
+            trip_id=record.trip_id,
+            trip_mode=record.mode,
+            bundles=inventory_bundles,
+            trip_title=record.title,
+            primary_regions=tuple(record.primary_regions),
+            duration_days=record.duration_days,
+            traveler_party_kind=record.traveler_party_kind,
+        ).to_dict()
+
+    if saved_scenarios:
+        return _build_saved_scenario_runtime_search(
+            record,
+            saved_scenarios=saved_scenarios,
+        )
+    return _empty_workspace_scenario_search()
 
 
 def _comparison_status_label(scenario: dict[str, Any]) -> str:
@@ -1011,19 +1044,15 @@ def _build_persisted_trip_workspace(
         },
     }
     ordered_saved_scenarios = _ordered_saved_scenarios(saved_scenarios or [])
-    scenario_search = (
-        _build_saved_scenario_runtime_search(
-            record,
-            saved_scenarios=ordered_saved_scenarios,
-        )
-        if ordered_saved_scenarios
-        else _empty_workspace_scenario_search()
-    )
-
     inventory_bundles = assemble_inventory_bundles_for_trip(
         trip_id=record.trip_id,
         trip_mode=record.mode,
         primary_regions=record.primary_regions,
+    )
+    scenario_search = _build_runtime_scenario_search_for_trip(
+        record=record,
+        inventory_bundles=inventory_bundles,
+        saved_scenarios=ordered_saved_scenarios,
     )
     feasibility_summary = build_feasibility_summary_payload(inventory_bundles)
     runtime_scenario_comparison = _build_runtime_scenario_comparison(
@@ -1091,6 +1120,10 @@ def _build_runtime_scenario_comparison_payload(
             trip_id=trip_id,
             trip_mode=trip_record.trip.mode,
             bundles=inventory_bundles,
+            trip_title=trip_record.trip.title,
+            primary_regions=tuple(trip_record.trip.trip_frame.primary_regions),
+            duration_days=trip_record.trip.trip_frame.duration_days,
+            traveler_party_kind=trip_record.trip.trip_frame.traveler_party.kind,
         )
         return _build_runtime_scenario_comparison(
             trip_id=trip_id,
@@ -1120,16 +1153,18 @@ def _build_runtime_scenario_comparison_payload(
         ).all()
     ]
 
+    inventory_bundles = assemble_inventory_bundles_for_trip(
+        trip_id=record.trip_id,
+        trip_mode=record.mode,
+        primary_regions=record.primary_regions,
+    )
     return _build_runtime_scenario_comparison(
         trip_id=trip_id,
         trip_title=record.title,
-        scenario_search=(
-            _build_saved_scenario_runtime_search(
-                record,
-                saved_scenarios=persisted_saved_scenarios,
-            )
-            if persisted_saved_scenarios
-            else _empty_workspace_scenario_search()
+        scenario_search=_build_runtime_scenario_search_for_trip(
+            record=record,
+            inventory_bundles=inventory_bundles,
+            saved_scenarios=persisted_saved_scenarios,
         ),
     )
 
@@ -1186,6 +1221,7 @@ def _sync_workspace_session_record(
     *,
     record: PersistedTrip,
     saved_scenarios: list[PersistedSavedScenario],
+    runtime_option_ids: list[str] | None = None,
 ) -> bool:
     ordered_ids = [
         scenario["saved_scenario_id"]
@@ -1208,6 +1244,7 @@ def _sync_workspace_session_record(
         updated = True
 
     option_set_id = _bootstrap_option_set_id(record.trip_id)
+    surfaced_option_ids = list(runtime_option_ids or ordered_ids)
     presentation = (
         session_record.recent_option_presentations[0]
         if session_record.recent_option_presentations
@@ -1216,8 +1253,8 @@ def _sync_workspace_session_record(
     if (
         presentation is None
         or presentation.get("option_set_id") != option_set_id
-        or presentation.get("surfaced_option_ids") != ordered_ids
-        or presentation.get("highlighted_option_id") not in ordered_ids
+        or presentation.get("surfaced_option_ids") != surfaced_option_ids
+        or presentation.get("highlighted_option_id") not in surfaced_option_ids
     ):
         session_record.recent_option_presentations = [
             OptionPresentationRecord(
@@ -1225,9 +1262,13 @@ def _sync_workspace_session_record(
                 option_set_id=option_set_id,
                 shown_at=session_record.last_updated_at,
                 surface_kind="scenario_comparison",
-                surfaced_option_ids=ordered_ids,
-                highlighted_option_id=ordered_ids[0],
-                summary="Persisted workspace bootstrap scenarios are ready for comparison.",
+                surfaced_option_ids=surfaced_option_ids,
+                highlighted_option_id=surfaced_option_ids[0],
+                summary=(
+                    "Runtime workspace scenarios are ready for comparison."
+                    if runtime_option_ids
+                    else "Persisted workspace bootstrap scenarios are ready for comparison."
+                ),
                 notes=["Initial workspace planner presentation."],
             ).to_dict()
         ]
@@ -1236,8 +1277,8 @@ def _sync_workspace_session_record(
     if session_record.pending_decisions:
         decision = dict(session_record.pending_decisions[0])
         if (
-            decision.get("related_saved_scenario_id") is None
-            or decision.get("related_option_set_id") != option_set_id
+            decision.get("related_option_set_id") != option_set_id
+            or decision.get("related_saved_scenario_id") is None
         ):
             decision["related_saved_scenario_id"] = ordered_ids[0]
             decision["related_option_set_id"] = option_set_id
@@ -1619,6 +1660,10 @@ def get_workspace_payload(
             trip_id=trip_id,
             trip_mode=trip_record.trip.mode,
             bundles=inventory_bundles,
+            trip_title=trip_record.trip.title,
+            primary_regions=tuple(trip_record.trip.trip_frame.primary_regions),
+            duration_days=trip_record.trip.trip_frame.duration_days,
+            traveler_party_kind=trip_record.trip.trip_frame.traveler_party.kind,
         )
         feasibility_summary = build_feasibility_summary_payload(inventory_bundles)
         runtime_scenario_comparison = _build_runtime_scenario_comparison(
@@ -1678,10 +1723,34 @@ def get_workspace_payload(
             session_record=session_record,
         )
         bootstrap_updated = True
+    inventory_bundles = assemble_inventory_bundles_for_trip(
+        trip_id=record.trip_id,
+        trip_mode=record.mode,
+        primary_regions=record.primary_regions,
+    )
+    runtime_search = _build_runtime_scenario_search_for_trip(
+        record=record,
+        inventory_bundles=inventory_bundles,
+        saved_scenarios=[
+            {
+                "saved_scenario_id": scenario.saved_scenario_id,
+                "trip_id": scenario.trip_id,
+                "current_version_id": scenario.current_version_id,
+                "versions": list(scenario.versions),
+                "comparisons": list(scenario.comparisons),
+                "tags": list(scenario.tags),
+                "notes": list(scenario.notes),
+            }
+            for scenario in persisted_saved_scenarios
+        ],
+    )
     if _sync_workspace_session_record(
         session_record,
         record=record,
         saved_scenarios=persisted_saved_scenarios,
+        runtime_option_ids=[
+            scenario["scenario_id"] for scenario in runtime_search.get("scenarios", [])
+        ],
     ):
         bootstrap_updated = True
     if bootstrap_updated:

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1021,6 +1021,9 @@ def _build_persisted_trip_workspace(
     budget_state: dict[str, Any] | None = None,
     policy_context: dict[str, Any] | None = None,
     proposal_context: dict[str, Any] | None = None,
+    inventory_bundles: list[InventoryBundle] | None = None,
+    scenario_search: dict[str, Any] | None = None,
+    feasibility_summary: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     resolved_session = session or _default_workspace_session(record).to_dict()
     trip_record = _serialize_persisted_trip_record(record)
@@ -1044,21 +1047,23 @@ def _build_persisted_trip_workspace(
         },
     }
     ordered_saved_scenarios = _ordered_saved_scenarios(saved_scenarios or [])
-    inventory_bundles = assemble_inventory_bundles_for_trip(
+    resolved_inventory_bundles = inventory_bundles or assemble_inventory_bundles_for_trip(
         trip_id=record.trip_id,
         trip_mode=record.mode,
         primary_regions=record.primary_regions,
     )
-    scenario_search = _build_runtime_scenario_search_for_trip(
+    resolved_scenario_search = scenario_search or _build_runtime_scenario_search_for_trip(
         record=record,
-        inventory_bundles=inventory_bundles,
+        inventory_bundles=resolved_inventory_bundles,
         saved_scenarios=ordered_saved_scenarios,
     )
-    feasibility_summary = build_feasibility_summary_payload(inventory_bundles)
+    resolved_feasibility_summary = feasibility_summary or build_feasibility_summary_payload(
+        resolved_inventory_bundles
+    )
     runtime_scenario_comparison = _build_runtime_scenario_comparison(
         trip_id=record.trip_id,
         trip_title=trip_record["trip"]["title"],
-        scenario_search=scenario_search,
+        scenario_search=resolved_scenario_search,
     )
 
     return {
@@ -1070,21 +1075,21 @@ def _build_persisted_trip_workspace(
             if ordered_saved_scenarios and ordered_saved_scenarios[0].get("comparisons")
             else None
         ),
-        "scenario_search": scenario_search,
+        "scenario_search": resolved_scenario_search,
         "runtime_scenario_comparison": runtime_scenario_comparison,
         "activity_log": resolved_activity_log,
         "planner_panel_state": _build_planner_panel_state(
             trip=trip_record["trip"],
-            scenario_search=scenario_search,
+            scenario_search=resolved_scenario_search,
             session=resolved_session,
             saved_scenarios=ordered_saved_scenarios,
             activity_log=resolved_activity_log,
-            feasibility_summary=feasibility_summary,
+            feasibility_summary=resolved_feasibility_summary,
             policy_context=policy_context,
             proposal_context=proposal_context,
         ),
-        "feasibility_summary": feasibility_summary,
-        "inventory_summary": build_inventory_summary_payload(inventory_bundles),
+        "feasibility_summary": resolved_feasibility_summary,
+        "inventory_summary": build_inventory_summary_payload(resolved_inventory_bundles),
         "budget_state": resolved_budget_state,
         "policy_state": (policy_context or {}).get("policy_state"),
         "proposal_state": (proposal_context or {}).get("proposal_state"),
@@ -1775,6 +1780,7 @@ def get_workspace_payload(
         .order_by(PersistedActivityLogEvent.occurred_at.desc())
         .limit(WORKSPACE_ACTIVITY_LOG_LIMIT)
     ).all()
+    feasibility_summary = build_feasibility_summary_payload(inventory_bundles)
     return _build_persisted_trip_workspace(
         record,
         session=(
@@ -1806,6 +1812,9 @@ def get_workspace_payload(
             if record.mode == "business"
             else None
         ),
+        inventory_bundles=inventory_bundles,
+        scenario_search=runtime_search,
+        feasibility_summary=feasibility_summary,
     )
 
 

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -39,6 +39,7 @@ from trip_planner.itinerary import (
     ScenarioSummary,
     ScenarioTradeoff,
 )
+from trip_planner.options import InventoryBundle
 from trip_planner.persistence.models.activity import (
     PersistedActivityLogEvent,
     PersistedPlannerAction,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #759

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo already has ranking, feasibility, and itinerary-search modules, but the
workspace still needs a stronger persisted-trip path that uses those modules for
arbitrary trips rather than static scenario payloads or seeded variants.

Parent epic: #753

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#753](https://github.com/stranske/trip-planner/issues/753)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Use persisted inventory bundles as the input to feasibility evaluation and ranking.
- [x] Build persisted scenario-search results for arbitrary trips through the existing ranking and itinerary modules.
- [x] Feed runtime scenario-comparison output into the existing workspace surfaces.
- [x] Add service and UI tests for persisted leisure and business trip ranking/comparison paths.
- [x] Remove or demote fixture-only scenario branches once runtime outputs are available.

#### Acceptance criteria
- [x] Arbitrary persisted trips can produce feasibility, ranking, and scenario-comparison outputs through runtime services.
- [x] Workspace comparison and timeline surfaces read those outputs rather than fixture-only scenario branches.
- [x] Tests cover the persisted scenario-generation path end to end at the service and route layers.

**Head SHA:** 1a840a81f05aec30e09c52f55a11d8909732d49d
**Latest Runs:** ❔ in progress — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24297670095) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24297670094) |
<!-- auto-status-summary:end -->
