### PR TITLE
Issue #762: persist planner memory checkpoints

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -231,6 +231,30 @@ export type FeasibilitySummary = {
   }>;
 };
 
+export type PlannerCheckpoint = {
+  checkpoint_id: string;
+  checkpoint_kind: string;
+  turn_index: number;
+  message_count: number;
+  summary: string;
+  source_message_ids: string[];
+  created_at: string;
+  updated_at: string;
+};
+
+export type PlannerMemoryArtifact = {
+  memory_artifact_id: string;
+  checkpoint_id: string | null;
+  artifact_kind: string;
+  title: string;
+  summary: string;
+  detail: string;
+  source_message_ids: string[];
+  tags: string[];
+  created_at: string;
+  updated_at: string;
+};
+
 export type WorkspaceData = {
   trip_record: TripRecord;
   session: SessionState;
@@ -248,6 +272,11 @@ export type WorkspaceData = {
     event_kind: string;
     summary: string;
   }>;
+  planner_memory: {
+    current_checkpoint_id: string | null;
+    checkpoints: PlannerCheckpoint[];
+    artifacts: PlannerMemoryArtifact[];
+  };
   planner_panel_state: PlannerPanelState;
   feasibility_summary: FeasibilitySummary;
   inventory_summary: {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -209,6 +209,44 @@ const workspacePayload = {
     focus_areas: ["recovery", "route_coherence", "weather_resilience"],
   },
   activity_log: [],
+  planner_memory: {
+    current_checkpoint_id: "planner-checkpoint:trip-leisure-kyoto-draft:1",
+    checkpoints: [
+      {
+        checkpoint_id: "planner-checkpoint:trip-leisure-kyoto-draft:1",
+        checkpoint_kind: "conversation_summary",
+        turn_index: 1,
+        message_count: 2,
+        summary:
+          "Turn 1 checkpoint keeps the latest traveler intent and planner guidance available for later resume.",
+        source_message_ids: [
+          "planner-action:trip-leisure-kyoto-draft:user-1",
+          "planner-action:trip-leisure-kyoto-draft:planner-1",
+        ],
+        created_at: "2026-04-12T06:10:00+00:00",
+        updated_at: "2026-04-12T06:10:00+00:00",
+      },
+    ],
+    artifacts: [
+      {
+        memory_artifact_id: "planner-memory:trip-leisure-kyoto-draft:1",
+        checkpoint_id: "planner-checkpoint:trip-leisure-kyoto-draft:1",
+        artifact_kind: "conversation_summary",
+        title: "Planner checkpoint 1",
+        summary:
+          "Turn 1 checkpoint keeps the latest traveler intent and planner guidance available for later resume.",
+        detail:
+          "Traveler focus: Keep the Kyoto baseline but protect recovery time. Planner summary: The planner recommends preserving the Kyoto baseline and revisiting transfers later.",
+        source_message_ids: [
+          "planner-action:trip-leisure-kyoto-draft:user-1",
+          "planner-action:trip-leisure-kyoto-draft:planner-1",
+        ],
+        tags: ["planner-memory", "user-visible", "checkpoint-summary"],
+        created_at: "2026-04-12T06:10:00+00:00",
+        updated_at: "2026-04-12T06:10:00+00:00",
+      },
+    ],
+  },
   scenario_search: {
     title: "Kyoto leisure scenario comparison",
     scenarios: [
@@ -618,6 +656,8 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Approval-ready proposal")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Comparables and readiness signals" })).toBeInTheDocument();
     expect(screen.getByText("Conference Hotel")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "User-visible planner checkpoints" })).toBeInTheDocument();
+    expect(screen.getByText("Planner checkpoint 1")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Compare this workspace with other saved trips" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Compare 2. Kyoto plus Osaka fallback" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Compare with Tokyo client summit" })).toBeInTheDocument();

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -679,6 +679,31 @@ function WorkspacePageContent({
         </section>
 
         <section className="status-card">
+          <p className="status-label">Planner memory</p>
+          <h2>
+            {currentWorkspace.planner_memory.artifacts.length > 0
+              ? "User-visible planner checkpoints"
+              : "Planner memory has not been summarized yet"}
+          </h2>
+          {currentWorkspace.planner_memory.artifacts.length === 0 ? (
+            <p className="muted-copy">
+              The workspace will surface durable planner summaries here after the first persisted
+              planner conversation turn.
+            </p>
+          ) : (
+            <div className="decision-stack">
+              {currentWorkspace.planner_memory.artifacts.slice(0, 3).map((artifact) => (
+                <article key={artifact.memory_artifact_id} className="decision-card">
+                  <h3>{artifact.title}</h3>
+                  <p>{artifact.summary}</p>
+                  <p className="muted-copy">{artifact.detail}</p>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="status-card">
           <p className="status-label">Activity trail</p>
           <h2>Persisted planner actions</h2>
           <div className="decision-stack">

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -100,7 +100,7 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
     assert "Help me decide" in payload["messages"][0]["content"]
     assert payload["messages"][1]["refs"]
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
-    assert payload["planner_memory"]["current_checkpoint_id"] == f"planner-checkpoint:{trip_id}:1"
+    assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
     assert payload["planner_memory"]["artifacts"][0]["title"] == "Planner checkpoint 1"
 
     with get_session_factory()() as db_session:
@@ -123,10 +123,16 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
             "planner_message",
         ]
         assert [item.actor for item in activity_events] == ["traveler", "planner"]
-        checkpoint = db_session.get(PersistedPlannerCheckpoint, f"planner-checkpoint:{trip_id}:1")
+        checkpoint_id = payload["planner_memory"]["current_checkpoint_id"]
+        checkpoint = db_session.get(PersistedPlannerCheckpoint, checkpoint_id)
         assert checkpoint is not None
-        artifact = db_session.get(PersistedPlannerMemoryArtifact, f"planner-memory:{trip_id}:1")
+        assert len(checkpoint_id) <= 96
+        artifact = db_session.get(
+            PersistedPlannerMemoryArtifact,
+            payload["planner_memory"]["artifacts"][0]["memory_artifact_id"],
+        )
         assert artifact is not None
+        assert artifact.memory_artifact_id.startswith("planner-mem:")
         assert artifact.checkpoint_id == checkpoint.checkpoint_id
 
 
@@ -262,5 +268,5 @@ def test_planner_resume_regenerates_memory_from_raw_transcript(client: TestClien
 
     assert resumed.status_code == 200
     payload = resumed.json()
-    assert payload["planner_memory"]["current_checkpoint_id"] == f"planner-checkpoint:{trip_id}:1"
+    assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
     assert payload["planner_memory"]["artifacts"][0]["summary"].startswith("Turn 1 checkpoint")

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -3,13 +3,17 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import select
+from sqlalchemy import delete, select
 
 from trip_planner.app.main import create_app
 from trip_planner.persistence.db import get_session_factory, reset_database_state
 from trip_planner.persistence.models.activity import (
     PersistedActivityLogEvent,
     PersistedPlannerAction,
+)
+from trip_planner.persistence.models.planner_memory import (
+    PersistedPlannerCheckpoint,
+    PersistedPlannerMemoryArtifact,
 )
 from trip_planner.persistence.models.session import PersistedPlanningSessionState
 
@@ -71,6 +75,7 @@ def test_planner_session_endpoint_bootstraps_trip_scoped_session(client: TestCli
     assert payload["conversation_id"] == f"planner-conversation:{trip_id}"
     assert payload["session"]["trip_id"] == trip_id
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
+    assert payload["planner_memory"]["current_checkpoint_id"] is None
     assert payload["available_tools"]
     assert payload["available_tools"][0]["tool_name"] == "read_workspace_state"
     assert payload["messages"] == []
@@ -95,6 +100,8 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
     assert "Help me decide" in payload["messages"][0]["content"]
     assert payload["messages"][1]["refs"]
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
+    assert payload["planner_memory"]["current_checkpoint_id"] == f"planner-checkpoint:{trip_id}:1"
+    assert payload["planner_memory"]["artifacts"][0]["title"] == "Planner checkpoint 1"
 
     with get_session_factory()() as db_session:
         stored = db_session.scalars(
@@ -116,6 +123,11 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
             "planner_message",
         ]
         assert [item.actor for item in activity_events] == ["traveler", "planner"]
+        checkpoint = db_session.get(PersistedPlannerCheckpoint, f"planner-checkpoint:{trip_id}:1")
+        assert checkpoint is not None
+        artifact = db_session.get(PersistedPlannerMemoryArtifact, f"planner-memory:{trip_id}:1")
+        assert artifact is not None
+        assert artifact.checkpoint_id == checkpoint.checkpoint_id
 
 
 def test_planner_turn_executes_explicit_tool_calls(client: TestClient) -> None:
@@ -219,3 +231,36 @@ def test_planner_resume_returns_prior_conversation_history(client: TestClient) -
     assert payload["resumed_at"] is not None
     assert [message["role"] for message in payload["messages"]] == ["user", "planner"]
     assert payload["messages"][1]["content"].startswith("Planner API kickoff is using")
+    assert payload["planner_memory"]["artifacts"][0]["title"] == "Planner checkpoint 1"
+
+
+def test_planner_resume_regenerates_memory_from_raw_transcript(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+    first_turn = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Keep the baseline narrow and summarize the current direction."},
+    )
+    assert first_turn.status_code == 200
+
+    with get_session_factory()() as db_session:
+        db_session.execute(
+            delete(PersistedPlannerMemoryArtifact).where(
+                PersistedPlannerMemoryArtifact.trip_id == trip_id
+            )
+        )
+        db_session.execute(
+            delete(PersistedPlannerCheckpoint).where(
+                PersistedPlannerCheckpoint.trip_id == trip_id
+            )
+        )
+        session = db_session.get(PersistedPlanningSessionState, f"session:{trip_id}")
+        assert session is not None
+        session.current_checkpoint_id = None
+        db_session.commit()
+
+    resumed = client.post(f"/api/planner/{trip_id}/resume")
+
+    assert resumed.status_code == 200
+    payload = resumed.json()
+    assert payload["planner_memory"]["current_checkpoint_id"] == f"planner-checkpoint:{trip_id}:1"
+    assert payload["planner_memory"]["artifacts"][0]["summary"].startswith("Turn 1 checkpoint")

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -347,7 +347,7 @@ def test_workspace_endpoint_surfaces_user_visible_planner_memory(client: TestCli
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["planner_memory"]["current_checkpoint_id"] == f"planner-checkpoint:{trip_id}:1"
+    assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
     assert payload["planner_memory"]["artifacts"][0]["title"] == "Planner checkpoint 1"
     assert "Traveler focus:" in payload["planner_memory"]["artifacts"][0]["detail"]
 

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -233,6 +233,7 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisu
         for scenario in payload["runtime_scenario_comparison"]["scenarios"]
     )
     assert payload["planner_panel_state"]["option_set"]["purpose"] == "workspace_review"
+    assert payload["planner_memory"]["current_checkpoint_id"] is None
 
 
 def test_workspace_endpoint_keeps_leisure_fixture_defaults_when_trip_frame_is_sparse(
@@ -317,6 +318,38 @@ def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_tri
     assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Policy posture loaded"
     assert payload["planner_panel_state"]["next_step_actions"][0]["target_section"] == "approval"
     assert "Navan" in payload["planner_panel_state"]["policy_evaluation"]["notes"][-2]
+
+
+def test_workspace_endpoint_surfaces_user_visible_planner_memory(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Planner memory workspace",
+            "summary": "Surface summarized memory in the workspace.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-07-01",
+                "end_date": "2026-07-04",
+                "duration_days": 4,
+                "primary_regions": ["Kyoto"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    planner_turn = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Keep the Kyoto baseline and remember that recovery time matters."},
+    )
+    assert planner_turn.status_code == 200
+
+    response = client.get(f"/api/workspace/{trip_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["planner_memory"]["current_checkpoint_id"] == f"planner-checkpoint:{trip_id}:1"
+    assert payload["planner_memory"]["artifacts"][0]["title"] == "Planner checkpoint 1"
+    assert "Traveler focus:" in payload["planner_memory"]["artifacts"][0]["detail"]
 
 
 def test_workspace_endpoint_prefers_persisted_proposal_lifecycle_for_business_trip(

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -82,6 +82,8 @@ trip_planner/app/services/budget.py
 trip_planner/app/services/feasibility.py
 trip_planner/app/services/inventory.py
 trip_planner/app/services/planner.py
+trip_planner/app/services/planner_memory.py
+trip_planner/app/services/planner_tools.py
 trip_planner/app/services/policy.py
 trip_planner/app/services/proposal.py
 trip_planner/app/services/scenario_history.py
@@ -152,10 +154,12 @@ trip_planner/persistence/alembic/versions/20260408_02_budget_state.py
 trip_planner/persistence/alembic/versions/20260408_03_policy_state.py
 trip_planner/persistence/alembic/versions/20260409_01_proposal_state.py
 trip_planner/persistence/alembic/versions/20260410_01_planner_actions.py
+trip_planner/persistence/alembic/versions/20260412_01_planner_memory.py
 trip_planner/persistence/models/__init__.py
 trip_planner/persistence/models/account.py
 trip_planner/persistence/models/activity.py
 trip_planner/persistence/models/budget.py
+trip_planner/persistence/models/planner_memory.py
 trip_planner/persistence/models/policy.py
 trip_planner/persistence/models/proposal.py
 trip_planner/persistence/models/scenario.py

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -31,6 +31,36 @@ class PlannerMessageResponse(BaseModel):
     tool_calls: list[PlannerToolCallResponse] = Field(default_factory=list)
 
 
+class PlannerCheckpointResponse(BaseModel):
+    checkpoint_id: str
+    checkpoint_kind: str
+    turn_index: int
+    message_count: int
+    summary: str
+    source_message_ids: list[str] = Field(default_factory=list)
+    created_at: str
+    updated_at: str
+
+
+class PlannerMemoryArtifactResponse(BaseModel):
+    memory_artifact_id: str
+    checkpoint_id: str | None = None
+    artifact_kind: str
+    title: str
+    summary: str
+    detail: str
+    source_message_ids: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    created_at: str
+    updated_at: str
+
+
+class PlannerMemoryResponse(BaseModel):
+    current_checkpoint_id: str | None = None
+    checkpoints: list[PlannerCheckpointResponse] = Field(default_factory=list)
+    artifacts: list[PlannerMemoryArtifactResponse] = Field(default_factory=list)
+
+
 class PlannerSessionResponse(BaseModel):
     trip_id: str
     session_state_id: str
@@ -38,6 +68,7 @@ class PlannerSessionResponse(BaseModel):
     resumed_at: str | None = None
     session: dict[str, Any]
     planner_panel_state: dict[str, Any]
+    planner_memory: PlannerMemoryResponse
     available_tools: list[dict[str, Any]] = Field(default_factory=list)
     activity_log: list[dict[str, Any]] = Field(default_factory=list)
     messages: list[PlannerMessageResponse] = Field(default_factory=list)

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -27,6 +27,10 @@ class WorkspaceResponse(BaseModel):
         default_factory=list,
         description="Recent persisted workspace activity entries tied to the trip/session trail.",
     )
+    planner_memory: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Persisted planner checkpoints and user-visible summarized memory.",
+    )
     planner_panel_state: dict[str, Any] = Field(
         description="Workspace-scoped planner panel payload for the mounted side-panel UI.",
     )

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -11,6 +11,10 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.app.services.planner_memory import (
+    build_planner_memory_payload,
+    refresh_planner_memory,
+)
 from trip_planner.app.services.planner_tools import (
     execute_planner_tool_call,
     list_planner_tools,
@@ -202,6 +206,11 @@ def _planner_session_payload(
         "resumed_at": resumed_at,
         "session": session,
         "planner_panel_state": workspace_payload["planner_panel_state"],
+        "planner_memory": build_planner_memory_payload(
+            db_session,
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+        ),
         "available_tools": list_planner_tools(),
         "activity_log": _activity_log(db_session, trip_id=trip_id),
         "messages": _conversation_messages(db_session, session_state_id=session_state_id),
@@ -356,6 +365,12 @@ def submit_planner_turn(
             "refs": ",".join(reply.refs),
             "tool_calls": reply.tool_calls,
         },
+    )
+    refresh_planner_memory(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        occurred_at=occurred_at,
     )
 
     db_session.commit()

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from trip_planner.app.services.auth import AuthenticatedUser
 from trip_planner.app.services.planner_memory import (
     build_planner_memory_payload,
+    ensure_planner_memory_persisted,
     refresh_planner_memory,
 )
 from trip_planner.app.services.planner_tools import (
@@ -246,6 +247,12 @@ def resume_planner_session_payload(
     resumed_at = _isoformat(datetime.now(UTC))
     session_record.last_updated_at = resumed_at
     record.updated_at = datetime.now(UTC)
+    ensure_planner_memory_persisted(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session_record.session_state_id,
+        occurred_at=resumed_at,
+    )
     db_session.commit()
     return _planner_session_payload(
         db_session,

--- a/trip_planner/app/services/planner_memory.py
+++ b/trip_planner/app/services/planner_memory.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import hashlib
+from datetime import UTC
 from typing import Any
 
 from sqlalchemy import select
@@ -82,6 +83,17 @@ def _checkpoint_summary(messages: list[PersistedPlannerAction], *, turn_index: i
     }
 
 
+def _planner_memory_ids(
+    *,
+    session_state_id: str,
+    source_message_ids: list[str],
+) -> tuple[str, str]:
+    digest = hashlib.sha256(
+        "|".join([session_state_id, *source_message_ids]).encode("utf-8")
+    ).hexdigest()[:20]
+    return (f"planner-chk:{digest}", f"planner-mem:{digest}")
+
+
 def refresh_planner_memory(
     db_session: Session,
     *,
@@ -95,10 +107,12 @@ def refresh_planner_memory(
     if turn_index == 0:
         return None
 
-    checkpoint_id = f"planner-checkpoint:{trip_id}:{turn_index}"
-    artifact_id = f"planner-memory:{trip_id}:{turn_index}"
     summary_payload = _checkpoint_summary(messages, turn_index=turn_index)
     source_message_ids = [record.planner_action_id for record in messages[-2:]]
+    checkpoint_id, artifact_id = _planner_memory_ids(
+        session_state_id=session_state_id,
+        source_message_ids=source_message_ids,
+    )
     checkpoint = db_session.get(PersistedPlannerCheckpoint, checkpoint_id)
     if checkpoint is None:
         checkpoint = PersistedPlannerCheckpoint(
@@ -155,6 +169,37 @@ def refresh_planner_memory(
     return checkpoint_id
 
 
+def ensure_planner_memory_persisted(
+    db_session: Session,
+    *,
+    trip_id: str,
+    session_state_id: str,
+    occurred_at: str | None = None,
+) -> str | None:
+    messages = _planner_message_records(db_session, session_state_id=session_state_id)
+    turn_index = sum(1 for record in messages if record.action_type == "planner_response")
+    if turn_index == 0:
+        return None
+
+    source_message_ids = [record.planner_action_id for record in messages[-2:]]
+    checkpoint_id, artifact_id = _planner_memory_ids(
+        session_state_id=session_state_id,
+        source_message_ids=source_message_ids,
+    )
+    if (
+        db_session.get(PersistedPlannerCheckpoint, checkpoint_id) is not None
+        and db_session.get(PersistedPlannerMemoryArtifact, artifact_id) is not None
+    ):
+        return checkpoint_id
+
+    return refresh_planner_memory(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session_state_id,
+        occurred_at=occurred_at,
+    )
+
+
 def _serialize_checkpoint(record: PersistedPlannerCheckpoint) -> dict[str, Any]:
     return {
         "checkpoint_id": record.checkpoint_id,
@@ -189,25 +234,6 @@ def build_planner_memory_payload(
     trip_id: str,
     session_state_id: str,
 ) -> dict[str, Any]:
-    latest_turn_index = sum(
-        1
-        for record in _planner_message_records(db_session, session_state_id=session_state_id)
-        if record.action_type == "planner_response"
-    )
-    if latest_turn_index > 0:
-        expected_checkpoint_id = f"planner-checkpoint:{trip_id}:{latest_turn_index}"
-        expected_artifact_id = f"planner-memory:{trip_id}:{latest_turn_index}"
-        if (
-            db_session.get(PersistedPlannerCheckpoint, expected_checkpoint_id) is None
-            or db_session.get(PersistedPlannerMemoryArtifact, expected_artifact_id) is None
-        ):
-            refresh_planner_memory(
-                db_session,
-                trip_id=trip_id,
-                session_state_id=session_state_id,
-            )
-            db_session.flush()
-
     checkpoints = db_session.scalars(
         select(PersistedPlannerCheckpoint)
         .where(PersistedPlannerCheckpoint.session_state_id == session_state_id)

--- a/trip_planner/app/services/planner_memory.py
+++ b/trip_planner/app/services/planner_memory.py
@@ -1,0 +1,229 @@
+"""Helpers for persisted planner checkpoints and user-visible memory."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from trip_planner.persistence.models.planner_memory import (
+    PersistedPlannerCheckpoint,
+    PersistedPlannerMemoryArtifact,
+)
+from trip_planner.persistence.models.session import PersistedPlanningSessionState
+from trip_planner.persistence.models.activity import PersistedPlannerAction
+
+
+def _truncate(value: str, limit: int) -> str:
+    normalized = " ".join(value.split())
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[: limit - 1].rstrip()}…"
+
+
+def _planner_message_records(
+    db_session: Session,
+    *,
+    session_state_id: str,
+) -> list[PersistedPlannerAction]:
+    return db_session.scalars(
+        select(PersistedPlannerAction)
+        .where(PersistedPlannerAction.session_state_id == session_state_id)
+        .where(PersistedPlannerAction.action_type.in_(["planner_user_turn", "planner_response"]))
+        .order_by(
+            PersistedPlannerAction.created_at.asc(),
+            PersistedPlannerAction.planner_action_id.asc(),
+        )
+    ).all()
+
+
+def _checkpoint_summary(messages: list[PersistedPlannerAction], *, turn_index: int) -> dict[str, Any]:
+    latest_user = next(
+        (
+            record.payload.get("content", "").strip()
+            for record in reversed(messages)
+            if record.action_type == "planner_user_turn"
+        ),
+        "",
+    )
+    latest_reply = next(
+        (
+            record.payload.get("content", "").strip()
+            for record in reversed(messages)
+            if record.action_type == "planner_response"
+        ),
+        "",
+    )
+    refs = list(
+        dict.fromkeys(
+            ref
+            for record in messages
+            for ref in str(record.payload.get("refs", "")).split(",")
+            if ref
+        )
+    )
+    summary = (
+        f"Turn {turn_index} checkpoint keeps the latest traveler intent and planner guidance "
+        f"available for later resume."
+    )
+    detail_lines = [
+        f"Traveler focus: {_truncate(latest_user or 'No traveler message stored.', 220)}",
+        f"Planner summary: {_truncate(latest_reply or 'No planner reply stored.', 320)}",
+    ]
+    if refs:
+        detail_lines.append(f"Linked refs: {', '.join(refs[:4])}")
+    return {
+        "summary": summary,
+        "title": f"Planner checkpoint {turn_index}",
+        "detail": " ".join(detail_lines),
+        "refs": refs[:8],
+    }
+
+
+def refresh_planner_memory(
+    db_session: Session,
+    *,
+    trip_id: str,
+    session_state_id: str,
+    occurred_at: str | None = None,
+) -> str | None:
+    db_session.flush()
+    messages = _planner_message_records(db_session, session_state_id=session_state_id)
+    turn_index = sum(1 for record in messages if record.action_type == "planner_response")
+    if turn_index == 0:
+        return None
+
+    checkpoint_id = f"planner-checkpoint:{trip_id}:{turn_index}"
+    artifact_id = f"planner-memory:{trip_id}:{turn_index}"
+    summary_payload = _checkpoint_summary(messages, turn_index=turn_index)
+    source_message_ids = [record.planner_action_id for record in messages[-2:]]
+    checkpoint = db_session.get(PersistedPlannerCheckpoint, checkpoint_id)
+    if checkpoint is None:
+        checkpoint = PersistedPlannerCheckpoint(
+            checkpoint_id=checkpoint_id,
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+            checkpoint_kind="conversation_summary",
+            turn_index=turn_index,
+            message_count=len(messages),
+            summary=summary_payload["summary"],
+            source_message_ids=source_message_ids,
+            metadata_payload={"ref_count": len(summary_payload["refs"])},
+        )
+        db_session.add(checkpoint)
+    else:
+        checkpoint.message_count = len(messages)
+        checkpoint.summary = summary_payload["summary"]
+        checkpoint.source_message_ids = source_message_ids
+        checkpoint.metadata_payload = {"ref_count": len(summary_payload["refs"])}
+
+    artifact = db_session.get(PersistedPlannerMemoryArtifact, artifact_id)
+    if artifact is None:
+        artifact = PersistedPlannerMemoryArtifact(
+            memory_artifact_id=artifact_id,
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+            checkpoint_id=checkpoint_id,
+            artifact_kind="conversation_summary",
+            title=summary_payload["title"],
+            summary=summary_payload["summary"],
+            detail=summary_payload["detail"],
+            source_message_ids=source_message_ids,
+            tags=["planner-memory", "user-visible", "checkpoint-summary"],
+        )
+        db_session.add(artifact)
+    else:
+        artifact.checkpoint_id = checkpoint_id
+        artifact.title = summary_payload["title"]
+        artifact.summary = summary_payload["summary"]
+        artifact.detail = summary_payload["detail"]
+        artifact.source_message_ids = source_message_ids
+        artifact.tags = ["planner-memory", "user-visible", "checkpoint-summary"]
+
+    session_record = db_session.get(PersistedPlanningSessionState, session_state_id)
+    if session_record is not None:
+        session_record.current_checkpoint_id = checkpoint_id
+        if occurred_at is not None:
+            session_record.last_updated_at = occurred_at
+        notes = list(session_record.notes)
+        note = f"planner-memory:{checkpoint_id}"
+        if note not in notes:
+            notes.append(note)
+        session_record.notes = notes
+    return checkpoint_id
+
+
+def _serialize_checkpoint(record: PersistedPlannerCheckpoint) -> dict[str, Any]:
+    return {
+        "checkpoint_id": record.checkpoint_id,
+        "checkpoint_kind": record.checkpoint_kind,
+        "turn_index": record.turn_index,
+        "message_count": record.message_count,
+        "summary": record.summary,
+        "source_message_ids": list(record.source_message_ids),
+        "created_at": record.created_at.astimezone(UTC).isoformat(),
+        "updated_at": record.updated_at.astimezone(UTC).isoformat(),
+    }
+
+
+def _serialize_artifact(record: PersistedPlannerMemoryArtifact) -> dict[str, Any]:
+    return {
+        "memory_artifact_id": record.memory_artifact_id,
+        "checkpoint_id": record.checkpoint_id,
+        "artifact_kind": record.artifact_kind,
+        "title": record.title,
+        "summary": record.summary,
+        "detail": record.detail,
+        "source_message_ids": list(record.source_message_ids),
+        "tags": list(record.tags),
+        "created_at": record.created_at.astimezone(UTC).isoformat(),
+        "updated_at": record.updated_at.astimezone(UTC).isoformat(),
+    }
+
+
+def build_planner_memory_payload(
+    db_session: Session,
+    *,
+    trip_id: str,
+    session_state_id: str,
+) -> dict[str, Any]:
+    latest_turn_index = sum(
+        1
+        for record in _planner_message_records(db_session, session_state_id=session_state_id)
+        if record.action_type == "planner_response"
+    )
+    if latest_turn_index > 0:
+        expected_checkpoint_id = f"planner-checkpoint:{trip_id}:{latest_turn_index}"
+        expected_artifact_id = f"planner-memory:{trip_id}:{latest_turn_index}"
+        if (
+            db_session.get(PersistedPlannerCheckpoint, expected_checkpoint_id) is None
+            or db_session.get(PersistedPlannerMemoryArtifact, expected_artifact_id) is None
+        ):
+            refresh_planner_memory(
+                db_session,
+                trip_id=trip_id,
+                session_state_id=session_state_id,
+            )
+            db_session.flush()
+
+    checkpoints = db_session.scalars(
+        select(PersistedPlannerCheckpoint)
+        .where(PersistedPlannerCheckpoint.session_state_id == session_state_id)
+        .order_by(
+            PersistedPlannerCheckpoint.turn_index.desc(),
+            PersistedPlannerCheckpoint.created_at.desc(),
+        )
+    ).all()
+    artifacts = db_session.scalars(
+        select(PersistedPlannerMemoryArtifact)
+        .where(PersistedPlannerMemoryArtifact.session_state_id == session_state_id)
+        .order_by(PersistedPlannerMemoryArtifact.created_at.desc())
+    ).all()
+    current_checkpoint = checkpoints[0].checkpoint_id if checkpoints else None
+    return {
+        "current_checkpoint_id": current_checkpoint,
+        "checkpoints": [_serialize_checkpoint(record) for record in checkpoints],
+        "artifacts": [_serialize_artifact(record) for record in artifacts],
+    }

--- a/trip_planner/app/services/planner_memory.py
+++ b/trip_planner/app/services/planner_memory.py
@@ -29,15 +29,17 @@ def _planner_message_records(
     *,
     session_state_id: str,
 ) -> list[PersistedPlannerAction]:
-    return db_session.scalars(
-        select(PersistedPlannerAction)
-        .where(PersistedPlannerAction.session_state_id == session_state_id)
-        .where(PersistedPlannerAction.action_type.in_(["planner_user_turn", "planner_response"]))
-        .order_by(
-            PersistedPlannerAction.created_at.asc(),
-            PersistedPlannerAction.planner_action_id.asc(),
-        )
-    ).all()
+    return list(
+        db_session.scalars(
+            select(PersistedPlannerAction)
+            .where(PersistedPlannerAction.session_state_id == session_state_id)
+            .where(PersistedPlannerAction.action_type.in_(["planner_user_turn", "planner_response"]))
+            .order_by(
+                PersistedPlannerAction.created_at.asc(),
+                PersistedPlannerAction.planner_action_id.asc(),
+            )
+        ).all()
+    )
 
 
 def _checkpoint_summary(messages: list[PersistedPlannerAction], *, turn_index: int) -> dict[str, Any]:
@@ -241,7 +243,8 @@ def build_planner_memory_payload(
             PersistedPlannerCheckpoint.turn_index.desc(),
             PersistedPlannerCheckpoint.created_at.desc(),
         )
-    ).all()
+        ).all()
+    )
     artifacts = db_session.scalars(
         select(PersistedPlannerMemoryArtifact)
         .where(PersistedPlannerMemoryArtifact.session_state_id == session_state_id)

--- a/trip_planner/app/services/planner_memory.py
+++ b/trip_planner/app/services/planner_memory.py
@@ -243,8 +243,7 @@ def build_planner_memory_payload(
             PersistedPlannerCheckpoint.turn_index.desc(),
             PersistedPlannerCheckpoint.created_at.desc(),
         )
-        ).all()
-    )
+    ).all()
     artifacts = db_session.scalars(
         select(PersistedPlannerMemoryArtifact)
         .where(PersistedPlannerMemoryArtifact.session_state_id == session_state_id)

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -25,6 +25,7 @@ from trip_planner.app.services.inventory import (
     assemble_inventory_bundles_for_trip,
     build_inventory_summary_payload,
 )
+from trip_planner.app.services.planner_memory import build_planner_memory_payload
 from trip_planner.app.services.policy import get_workspace_policy_payload
 from trip_planner.app.services.proposal import get_workspace_proposal_payload
 from trip_planner.app.services.scenarios import (
@@ -1019,6 +1020,7 @@ def _build_persisted_trip_workspace(
     session: dict[str, Any] | None = None,
     saved_scenarios: list[dict[str, Any]] | None = None,
     activity_log: list[dict[str, Any]] | None = None,
+    planner_memory: dict[str, Any] | None = None,
     budget_state: dict[str, Any] | None = None,
     policy_context: dict[str, Any] | None = None,
     proposal_context: dict[str, Any] | None = None,
@@ -1079,6 +1081,12 @@ def _build_persisted_trip_workspace(
         "scenario_search": resolved_scenario_search,
         "runtime_scenario_comparison": runtime_scenario_comparison,
         "activity_log": resolved_activity_log,
+        "planner_memory": planner_memory
+        or {
+            "current_checkpoint_id": resolved_session.get("current_checkpoint_id"),
+            "checkpoints": [],
+            "artifacts": [],
+        },
         "planner_panel_state": _build_planner_panel_state(
             trip=trip_record["trip"],
             scenario_search=resolved_scenario_search,
@@ -1686,6 +1694,11 @@ def get_workspace_payload(
             "scenario_search": scenario_search.to_dict(),
             "runtime_scenario_comparison": runtime_scenario_comparison,
             "activity_log": [],
+            "planner_memory": {
+                "current_checkpoint_id": session.current_checkpoint_id,
+                "checkpoints": [],
+                "artifacts": [],
+            },
             "planner_panel_state": _build_planner_panel_state(
                 trip=trip_record.to_dict()["trip"],
                 scenario_search=scenario_search.to_dict(),
@@ -1802,6 +1815,11 @@ def get_workspace_payload(
             for scenario in persisted_saved_scenarios
         ],
         activity_log=[_serialize_activity_record(item) for item in activity_records],
+        planner_memory=build_planner_memory_payload(
+            db_session,
+            trip_id=trip_id,
+            session_state_id=session_record.session_state_id,
+        ),
         budget_state=load_budget_payload_for_workspace(db_session, record=record),
         policy_context=(
             get_workspace_policy_payload(db_session, user=user, trip_id=trip_id)

--- a/trip_planner/persistence/alembic/versions/20260412_01_planner_memory.py
+++ b/trip_planner/persistence/alembic/versions/20260412_01_planner_memory.py
@@ -1,0 +1,121 @@
+"""add planner checkpoints and user-visible memory artifacts
+
+Revision ID: 20260412_01
+Revises: 20260410_01
+Create Date: 2026-04-12 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260412_01"
+down_revision = "20260410_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "persisted_planner_checkpoints",
+        sa.Column("checkpoint_id", sa.String(length=96), primary_key=True),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("session_state_id", sa.String(length=96), nullable=False),
+        sa.Column("checkpoint_kind", sa.String(length=32), nullable=False),
+        sa.Column("turn_index", sa.Integer(), nullable=False),
+        sa.Column("message_count", sa.Integer(), nullable=False),
+        sa.Column("summary", sa.String(length=600), nullable=False),
+        sa.Column("source_message_ids", sa.JSON(), nullable=False),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_persisted_planner_checkpoints_trip_id"),
+        "persisted_planner_checkpoints",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_planner_checkpoints_session_state_id"),
+        "persisted_planner_checkpoints",
+        ["session_state_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "persisted_planner_memory_artifacts",
+        sa.Column("memory_artifact_id", sa.String(length=96), primary_key=True),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("session_state_id", sa.String(length=96), nullable=False),
+        sa.Column(
+            "checkpoint_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_planner_checkpoints.checkpoint_id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("artifact_kind", sa.String(length=32), nullable=False),
+        sa.Column("title", sa.String(length=160), nullable=False),
+        sa.Column("summary", sa.String(length=600), nullable=False),
+        sa.Column("detail", sa.Text(), nullable=False),
+        sa.Column("source_message_ids", sa.JSON(), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_persisted_planner_memory_artifacts_trip_id"),
+        "persisted_planner_memory_artifacts",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_planner_memory_artifacts_session_state_id"),
+        "persisted_planner_memory_artifacts",
+        ["session_state_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_planner_memory_artifacts_checkpoint_id"),
+        "persisted_planner_memory_artifacts",
+        ["checkpoint_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_persisted_planner_memory_artifacts_checkpoint_id"),
+        table_name="persisted_planner_memory_artifacts",
+    )
+    op.drop_index(
+        op.f("ix_persisted_planner_memory_artifacts_session_state_id"),
+        table_name="persisted_planner_memory_artifacts",
+    )
+    op.drop_index(
+        op.f("ix_persisted_planner_memory_artifacts_trip_id"),
+        table_name="persisted_planner_memory_artifacts",
+    )
+    op.drop_table("persisted_planner_memory_artifacts")
+
+    op.drop_index(
+        op.f("ix_persisted_planner_checkpoints_session_state_id"),
+        table_name="persisted_planner_checkpoints",
+    )
+    op.drop_index(
+        op.f("ix_persisted_planner_checkpoints_trip_id"),
+        table_name="persisted_planner_checkpoints",
+    )
+    op.drop_table("persisted_planner_checkpoints")

--- a/trip_planner/persistence/db.py
+++ b/trip_planner/persistence/db.py
@@ -90,6 +90,7 @@ def ensure_database_ready(url: str | None = None) -> None:
         return
 
     from trip_planner.persistence.models import budget  # noqa: F401
+    from trip_planner.persistence.models import planner_memory  # noqa: F401
     from trip_planner.persistence.models import (  # noqa: F401
         activity,
         account,

--- a/trip_planner/persistence/models/__init__.py
+++ b/trip_planner/persistence/models/__init__.py
@@ -10,6 +10,10 @@ from trip_planner.persistence.models.budget import (
     PersistedBudgetPlan,
     PersistedBudgetPlanVersion,
 )
+from trip_planner.persistence.models.planner_memory import (
+    PersistedPlannerCheckpoint,
+    PersistedPlannerMemoryArtifact,
+)
 from trip_planner.persistence.models.policy import PersistedPolicyState
 from trip_planner.persistence.models.proposal import PersistedProposalState
 from trip_planner.persistence.models.scenario import PersistedSavedScenario
@@ -25,7 +29,9 @@ __all__ = [
     "PersistedActualSpendEvent",
     "PersistedBudgetPlan",
     "PersistedBudgetPlanVersion",
+    "PersistedPlannerCheckpoint",
     "PersistedPlannerAction",
+    "PersistedPlannerMemoryArtifact",
     "PersistedPlanningSessionState",
     "PersistedPolicyState",
     "PersistedProposalState",

--- a/trip_planner/persistence/models/planner_memory.py
+++ b/trip_planner/persistence/models/planner_memory.py
@@ -1,0 +1,65 @@
+"""SQLAlchemy models for persisted planner checkpoints and user-visible memory."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from trip_planner.persistence.db import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class PersistedPlannerCheckpoint(Base):
+    __tablename__ = "persisted_planner_checkpoints"
+
+    checkpoint_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    session_state_id: Mapped[str] = mapped_column(String(96), index=True)
+    checkpoint_kind: Mapped[str] = mapped_column(String(32), default="conversation_summary")
+    turn_index: Mapped[int] = mapped_column(Integer)
+    message_count: Mapped[int] = mapped_column(Integer)
+    summary: Mapped[str] = mapped_column(String(600))
+    source_message_ids: Mapped[list[str]] = mapped_column(JSON, default=list)
+    metadata_payload: Mapped[dict] = mapped_column("metadata", JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+    )
+
+
+class PersistedPlannerMemoryArtifact(Base):
+    __tablename__ = "persisted_planner_memory_artifacts"
+
+    memory_artifact_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    session_state_id: Mapped[str] = mapped_column(String(96), index=True)
+    checkpoint_id: Mapped[str | None] = mapped_column(
+        ForeignKey("persisted_planner_checkpoints.checkpoint_id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    artifact_kind: Mapped[str] = mapped_column(String(32), default="conversation_summary")
+    title: Mapped[str] = mapped_column(String(160))
+    summary: Mapped[str] = mapped_column(String(600))
+    detail: Mapped[str] = mapped_column(Text, default="")
+    source_message_ids: Mapped[list[str]] = mapped_column(JSON, default=list)
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_utcnow,
+        onupdate=_utcnow,
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #762

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The original design expects collaborative iteration, revealed-preference
learning, and in-trip adjustment over time. That requires planner memory that
survives refreshes and later sessions, not just transient UI state.

Parent epic: #754

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#754](https://github.com/stranske/trip-planner/issues/754)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add persisted planner conversation/checkpoint records linked to trip sessions.
- [ ] Store planner summaries and memory artifacts that can be surfaced in the workspace.
- [ ] Distinguish raw transcript storage from user-facing summarized memory.
- [x] Expose planner memory/checkpoint state through the planner API and workspace UI.
- [ ] Add tests for checkpoint persistence, reload, summary regeneration, and display integrity.

#### Acceptance criteria
- [ ] Planner memory survives page refresh and later session re-entry.
- [ ] The app can surface planner memory/checkpoint state as part of the workspace.
- [ ] Tests cover persisted checkpoint creation, reload, and summary integrity.

<!-- auto-status-summary:end -->