### PR TITLE
Issue #767: harden router warnings and runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 The runtime baseline now treats the saved trip record as the durable planning container. New scenario, budget, workspace, and policy work should attach to a persisted trip instead of inventing a parallel root object.
 Saved scenarios and trip-level planning history now persist underneath that same trip container, so later comparison and workspace slices should consume those records instead of reintroducing fixture-only storage.
+The shipped full-stack MVP now includes authenticated trip creation, persisted trip and scenario routes, the workspace shell, planner session APIs, and stored policy/proposal state. Live external policy transport and provider-backed maps remain follow-on integrations, so docs and checks in this repo should describe those gaps explicitly instead of implying they already ship.
 
 ## Key Docs
 
@@ -89,6 +90,8 @@ python -m pip install -e ".[dev]"
 npm --prefix frontend install
 ```
 
+`make runtime-check` and `make runtime-smoke` assume those installs have already completed. If either the backend dev extras or `frontend/node_modules` are missing, the check script exits early and points back to these two commands.
+
 Repo dependency layout:
 
 - Python tooling installs into the active virtualenv from the repo root.
@@ -116,3 +119,5 @@ The verification path covers:
 - backend runtime tests for the live FastAPI routes
 - frontend unit/build checks
 - a smoke test that runs the frontend client against a live backend process
+
+These checks validate the local full-stack MVP that already exists in this repo. They do not prove live Google Maps rendering or remote Travel-Plan-Permission transport, which are still documented as active follow-on integrations.

--- a/docs/frontend-route-loading-foundation.md
+++ b/docs/frontend-route-loading-foundation.md
@@ -26,6 +26,7 @@ Issue `#681` establishes a single frontend seam for runtime-backed routes instea
 
 ## Current Coverage
 
-- `HealthPage` uses the shared client and deferred loader path.
-- `WorkspacePage` uses the same loader boundary for persisted runtime state.
-- Tests cover client success/error handling and route-level loading/error treatment.
+- `HealthPage`, `TripsPage`, `TripDetailPage`, and `WorkspacePage` all load through the shared route/client seam instead of owning ad hoc `fetch` wiring.
+- Auth-aware route loaders gate login/signup, trip list/detail, and workspace entry through the same session bootstrap path.
+- Tests cover client success/error handling, route-level loading/error treatment, and the React Router future flags already opted into by the runtime and test harnesses.
+- Deferred gaps stay explicit here: live external policy transport and provider-backed maps are separate runtime layers, not hidden assumptions inside the current route loader foundation.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,6 @@ import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <RouterProvider router={router} future={{ v7_startTransition: true }} />
   </React.StrictMode>
 );

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -193,6 +193,5 @@ export const router = createBrowserRouter(appRoutes, {
     v7_normalizeFormMethod: true,
     v7_partialHydration: true,
     v7_relativeSplatPath: true,
-    v7_startTransition: true,
   },
 });

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -192,5 +192,7 @@ export const router = createBrowserRouter(appRoutes, {
   future: {
     v7_normalizeFormMethod: true,
     v7_partialHydration: true,
+    v7_relativeSplatPath: true,
+    v7_startTransition: true,
   },
 });

--- a/frontend/src/routes/HealthPage.test.tsx
+++ b/frontend/src/routes/HealthPage.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, useLoaderData } from "react-router-dom";
+import { useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { HealthPage } from "./HealthPage";
+import { TestMemoryRouter } from "../test/router";
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -16,9 +17,9 @@ const mockedUseLoaderData = vi.mocked(useLoaderData);
 
 function renderHealthPage() {
   return render(
-    <MemoryRouter>
+    <TestMemoryRouter>
       <HealthPage />
-    </MemoryRouter>
+    </TestMemoryRouter>
   );
 }
 

--- a/frontend/src/routes/LoginPage.test.tsx
+++ b/frontend/src/routes/LoginPage.test.tsx
@@ -1,9 +1,9 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { login } from "../api/auth";
 import { LoginPage } from "./LoginPage";
+import { TestMemoryRouter } from "../test/router";
 
 vi.mock("../api/auth", () => ({
   login: vi.fn(),
@@ -38,9 +38,9 @@ describe("LoginPage", () => {
     });
 
     render(
-      <MemoryRouter>
+      <TestMemoryRouter>
         <LoginPage />
-      </MemoryRouter>
+      </TestMemoryRouter>
     );
 
     fireEvent.change(screen.getByLabelText("Email"), { target: { value: "traveler@example.com" } });
@@ -60,9 +60,9 @@ describe("LoginPage", () => {
     mockedLogin.mockRejectedValue(new Error("Email or password was not recognized."));
 
     render(
-      <MemoryRouter>
+      <TestMemoryRouter>
         <LoginPage />
-      </MemoryRouter>
+      </TestMemoryRouter>
     );
 
     fireEvent.change(screen.getByLabelText("Email"), { target: { value: "traveler@example.com" } });

--- a/frontend/src/routes/NewTripPage.test.tsx
+++ b/frontend/src/routes/NewTripPage.test.tsx
@@ -1,9 +1,9 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createTrip } from "../api/trips";
 import { NewTripPage } from "./NewTripPage";
+import { TestMemoryRouter } from "../test/router";
 
 vi.mock("../api/trips", () => ({
   createTrip: vi.fn(),
@@ -56,9 +56,9 @@ describe("NewTripPage", () => {
     });
 
     render(
-      <MemoryRouter>
+      <TestMemoryRouter>
         <NewTripPage />
-      </MemoryRouter>
+      </TestMemoryRouter>
     );
 
     fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Kyoto Spring" } });

--- a/frontend/src/routes/SignupPage.test.tsx
+++ b/frontend/src/routes/SignupPage.test.tsx
@@ -1,9 +1,9 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { signup } from "../api/auth";
 import { SignupPage } from "./SignupPage";
+import { TestMemoryRouter } from "../test/router";
 
 vi.mock("../api/auth", () => ({
   signup: vi.fn(),
@@ -37,9 +37,9 @@ describe("SignupPage", () => {
     });
 
     render(
-      <MemoryRouter>
+      <TestMemoryRouter>
         <SignupPage />
-      </MemoryRouter>
+      </TestMemoryRouter>
     );
 
     fireEvent.change(screen.getByLabelText("Display name"), { target: { value: "Owner" } });

--- a/frontend/src/routes/TripDetailPage.test.tsx
+++ b/frontend/src/routes/TripDetailPage.test.tsx
@@ -1,8 +1,9 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, useLoaderData } from "react-router-dom";
+import { useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TripDetailPage } from "./TripDetailPage";
+import { TestMemoryRouter } from "../test/router";
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -111,9 +112,9 @@ describe("TripDetailPage", () => {
     });
 
     render(
-      <MemoryRouter>
+      <TestMemoryRouter>
         <TripDetailPage />
-      </MemoryRouter>
+      </TestMemoryRouter>
     );
 
     await waitFor(() => {
@@ -175,9 +176,9 @@ describe("TripDetailPage", () => {
     });
 
     render(
-      <MemoryRouter>
+      <TestMemoryRouter>
         <TripDetailPage />
-      </MemoryRouter>
+      </TestMemoryRouter>
     );
 
     await waitFor(() => {

--- a/frontend/src/routes/TripsPage.test.tsx
+++ b/frontend/src/routes/TripsPage.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { MemoryRouter, useLoaderData } from "react-router-dom";
+import { useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { TripsPage } from "./TripsPage";
+import { TestMemoryRouter } from "../test/router";
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -52,9 +53,9 @@ describe("TripsPage", () => {
     });
 
     render(
-      <MemoryRouter>
+      <TestMemoryRouter>
         <TripsPage />
-      </MemoryRouter>
+      </TestMemoryRouter>
     );
 
     await waitFor(() => {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, useLoaderData } from "react-router-dom";
+import { useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ApiClientError } from "../lib/api/errors";
@@ -11,6 +11,7 @@ import {
   submitPlannerOptionFeedback,
   type WorkspaceData,
 } from "../api/workspace";
+import { TestMemoryRouter } from "../test/router";
 import type { TripRecord } from "../api/trips";
 import { WorkspacePage } from "./WorkspacePage";
 
@@ -605,9 +606,9 @@ const workspacePayload = {
 
 function renderWorkspacePage() {
   return render(
-    <MemoryRouter>
+    <TestMemoryRouter>
       <WorkspacePage />
-    </MemoryRouter>
+    </TestMemoryRouter>
   );
 }
 

--- a/frontend/src/test/router.tsx
+++ b/frontend/src/test/router.tsx
@@ -1,0 +1,13 @@
+import type { PropsWithChildren } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+export const TEST_ROUTER_FUTURE = {
+  v7_normalizeFormMethod: true,
+  v7_partialHydration: true,
+  v7_relativeSplatPath: true,
+  v7_startTransition: true,
+} as const;
+
+export function TestMemoryRouter({ children }: PropsWithChildren): JSX.Element {
+  return <MemoryRouter future={TEST_ROUTER_FUTURE}>{children}</MemoryRouter>;
+}

--- a/scripts/check_full_stack_runtime.sh
+++ b/scripts/check_full_stack_runtime.sh
@@ -10,6 +10,35 @@ backend_log="$(mktemp -d "${TMPDIR:-/tmp}/trip-planner-runtime.XXXXXX")/backend.
 smoke_only="false"
 backend_pid=""
 
+prereq_failure() {
+  cat >&2 <<'EOF'
+Full-stack runtime checks require both dependency installs to be present first:
+  1. python -m pip install -e ".[dev]"
+  2. npm --prefix frontend install
+
+Then rerun `make runtime-check` (or `make runtime-smoke`).
+EOF
+  exit 1
+}
+
+require_backend_prereqs() {
+  if ! python -m pytest --version >/dev/null 2>&1; then
+    echo "Missing backend test dependencies (`python -m pytest` is unavailable)." >&2
+    prereq_failure
+  fi
+}
+
+require_frontend_prereqs() {
+  if ! npm --prefix frontend exec -- vitest --version >/dev/null 2>&1; then
+    echo "Missing frontend test dependencies (`vitest` is unavailable under frontend/node_modules)." >&2
+    prereq_failure
+  fi
+  if ! npm --prefix frontend exec -- vite --version >/dev/null 2>&1; then
+    echo "Missing frontend build dependencies (`vite` is unavailable under frontend/node_modules)." >&2
+    prereq_failure
+  fi
+}
+
 if [ "${1:-}" = "--smoke-only" ]; then
   smoke_only="true"
 fi
@@ -51,6 +80,9 @@ PY
 trap cleanup EXIT INT TERM
 
 cd "${repo_root}"
+
+require_backend_prereqs
+require_frontend_prereqs
 
 if [ "${smoke_only}" != "true" ]; then
   python -m pytest tests/app/test_health.py tests/app/test_workspace.py

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -82,6 +82,8 @@ trip_planner/app/services/budget.py
 trip_planner/app/services/feasibility.py
 trip_planner/app/services/inventory.py
 trip_planner/app/services/planner.py
+trip_planner/app/services/planner_memory.py
+trip_planner/app/services/planner_tools.py
 trip_planner/app/services/policy.py
 trip_planner/app/services/proposal.py
 trip_planner/app/services/scenario_history.py
@@ -152,10 +154,12 @@ trip_planner/persistence/alembic/versions/20260408_02_budget_state.py
 trip_planner/persistence/alembic/versions/20260408_03_policy_state.py
 trip_planner/persistence/alembic/versions/20260409_01_proposal_state.py
 trip_planner/persistence/alembic/versions/20260410_01_planner_actions.py
+trip_planner/persistence/alembic/versions/20260412_01_planner_memory.py
 trip_planner/persistence/models/__init__.py
 trip_planner/persistence/models/account.py
 trip_planner/persistence/models/activity.py
 trip_planner/persistence/models/budget.py
+trip_planner/persistence/models/planner_memory.py
 trip_planner/persistence/models/policy.py
 trip_planner/persistence/models/proposal.py
 trip_planner/persistence/models/scenario.py


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #767

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The runtime now works, but the repo still has warning-level drift and
documentation lag that can mislead future work. That debt is smaller than the
product features, but it is still real and should be cleaned up while the new
runtime shape is fresh.

Parent epic: #756

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#756](https://github.com/stranske/trip-planner/issues/756)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Eliminate or explicitly opt into the current React Router future-flag warnings emitted by tests.
- [x] Tighten runtime-check messaging and prerequisite docs where needed.
- [x] Refresh design coverage docs and README sections that still undersell or misstate the implemented runtime.
- [x] Add tests or assertions where needed to keep the updated runtime assumptions from drifting again.
- [x] Document any intentionally deferred runtime gaps precisely instead of leaving them implied.

#### Acceptance criteria
- [x] Frontend tests no longer emit the current avoidable router warnings.
- [x] Runtime verification docs accurately describe prerequisite install steps and runtime checks.
- [x] Design/reality docs reflect the current full-stack MVP rather than the older contracts-only stage.

<!-- auto-status-summary:end -->