### PR TITLE
Issue #763: replace passive TPP transport with live HTTP client

### DIFF
--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -23,6 +23,7 @@ def _load_fixture(name: str) -> dict:
 
 class _FakeHTTPResponse:
     def __init__(self, status_code: int, payload: dict[str, object]) -> None:
+        self.status = status_code
         self.status_code = status_code
         self._payload = payload
         self.text = json.dumps(payload)

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -1,6 +1,7 @@
 import json
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Literal
 from urllib import error as urllib_error
 import pytest
 from fastapi.testclient import TestClient
@@ -32,7 +33,7 @@ class _FakeHTTPResponse:
     def __enter__(self) -> "_FakeHTTPResponse":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> bool:
+    def __exit__(self, exc_type, exc, tb) -> Literal[False]:
         del exc_type, exc, tb
         return False
 

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -23,7 +23,6 @@ def _load_fixture(name: str) -> dict:
 class _FakeHTTPResponse:
     def __init__(self, status_code: int, payload: dict[str, object]) -> None:
         self.status_code = status_code
-        self.status = status_code
         self._payload = payload
         self.text = json.dumps(payload)
 
@@ -42,14 +41,20 @@ def _install_fake_http(
     monkeypatch: pytest.MonkeyPatch,
     responses: list[_FakeHTTPResponse | Exception],
     *,
-    captured_requests: list[object] | None = None,
+    captured_requests: list[dict[str, object]] | None = None,
 ) -> None:
     queue = list(responses)
 
     def _fake_urlopen(request, timeout=0):
-        del timeout
         if captured_requests is not None:
-            captured_requests.append(request)
+            captured_requests.append(
+                {
+                    "full_url": request.full_url,
+                    "method": request.get_method(),
+                    "body": json.loads((request.data or b"{}").decode("utf-8")),
+                }
+            )
+        del timeout
         response = queue.pop(0)
         if isinstance(response, Exception):
             raise response
@@ -154,7 +159,7 @@ def test_workspace_policy_import_uses_live_tpp_transport_when_response_is_omitte
     monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
-    captured_requests: list[object] = []
+    captured_requests: list[dict[str, object]] = []
     _install_fake_http(
         monkeypatch,
         [
@@ -236,10 +241,18 @@ def test_workspace_policy_import_uses_live_tpp_transport_when_response_is_omitte
     assert payload["policy_state"]["policy_version"] == "d7a6d25a"
     assert payload["summary"]["documentation_rules"] == ["fare_evidence"]
     assert payload["summary"]["approval_triggers"] == ["manager_review"]
-    request_body = json.loads(captured_requests[0].data.decode("utf-8"))
-    assert "requested_at" in request_body
-    assert "organization_context" in request_body
-    assert "proposal_id" not in request_body
+    assert captured_requests == [
+        {
+            "full_url": "https://tpp.example.test/api/planner/policy-snapshot",
+            "method": "GET",
+            "body": {
+                "policy_scope": "business_planning",
+                "organization_context": True,
+                "trip_id": trip_id,
+                "requested_at": "2026-02-15T12:00:00Z",
+            },
+        }
+    ]
 
 
 def test_workspace_policy_import_surfaces_live_tpp_unavailable_errors(

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -1,12 +1,13 @@
 import json
 from collections.abc import Iterator
 from pathlib import Path
-
+from urllib import error as urllib_error
 import pytest
 from fastapi.testclient import TestClient
 
 from trip_planner.app.main import create_app
 from trip_planner.persistence.db import reset_database_state
+from trip_planner.integrations.tpp import client as tpp_client_module
 
 
 def _fixture_path(name: str) -> Path:
@@ -17,6 +18,39 @@ def _fixture_path(name: str) -> Path:
 
 def _load_fixture(name: str) -> dict:
     return json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status_code: int, payload: dict[str, object]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        del exc_type, exc, tb
+        return False
+
+
+def _install_fake_http(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[_FakeHTTPResponse | Exception],
+) -> None:
+    queue = list(responses)
+
+    def _fake_urlopen(request, timeout=0):
+        del request, timeout
+        response = queue.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(tpp_client_module.urllib_request, "urlopen", _fake_urlopen)
 
 
 @pytest.fixture
@@ -106,3 +140,133 @@ def test_workspace_policy_import_rejects_leisure_trip(client: TestClient) -> Non
 
     assert response.status_code == 400
     assert "business trips" in response.json()["detail"]
+
+
+def test_workspace_policy_import_uses_live_tpp_transport_when_response_is_omitted(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    _install_fake_http(
+        monkeypatch,
+        [
+            _FakeHTTPResponse(
+                200,
+                {
+                    "trip_id": "placeholder",
+                    "freshness": "current",
+                    "generated_at": "2026-04-11T05:05:00Z",
+                    "expires_at": "2026-04-12T05:05:00Z",
+                    "invalidated_at": None,
+                    "invalidation_reason": None,
+                    "policy_status": "pass",
+                    "booking_requirements": [],
+                    "documentation_rules": [
+                        {
+                            "code": "fare_evidence",
+                            "summary": "Attach fare evidence before approval.",
+                            "severity": "error",
+                        }
+                    ],
+                    "approval_triggers": [
+                        {
+                            "code": "manager_review",
+                            "summary": "Manager review is required.",
+                            "blocking": True,
+                            "source": "policy_rule",
+                        }
+                    ],
+                    "auth": {
+                        "endpoint": "GET /api/planner/policy-snapshot",
+                        "required_permission": "view",
+                        "auth_scheme": "Bearer token",
+                        "supported_sso": ["okta"],
+                    },
+                    "versioning": {
+                        "contract_version": "2026-04-11",
+                        "policy_version": "d7a6d25a",
+                        "planner_known_policy_version": None,
+                        "compatible_with_planner_cache": True,
+                        "etag": "trip:policy:d7a6d25a",
+                    },
+                },
+            )
+        ],
+    )
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Live policy sync",
+            "summary": "Use runtime TPP HTTP transport.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = _load_fixture("standard_policy_sync.json")
+    fixture["request"]["trip_id"] = trip_id
+
+    imported = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={
+            "request": fixture["request"],
+            "source_kind": "tpp_sync",
+            "tags": ["live-http"],
+            "notes": ["Fetched through the live TPP client."],
+        },
+    )
+
+    assert imported.status_code == 200
+    payload = imported.json()
+    assert payload["policy_state"]["policy_version"] == "d7a6d25a"
+    assert payload["summary"]["documentation_rules"] == ["fare_evidence"]
+    assert payload["summary"]["approval_triggers"] == ["manager_review"]
+
+
+def test_workspace_policy_import_surfaces_live_tpp_unavailable_errors(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    _install_fake_http(
+        monkeypatch,
+        [
+            urllib_error.URLError("connection refused"),
+        ],
+    )
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Unavailable policy sync",
+            "summary": "Surface live TPP transport failures.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = _load_fixture("standard_policy_sync.json")
+    fixture["request"]["trip_id"] = trip_id
+
+    response = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={"request": fixture["request"]},
+    )
+
+    assert response.status_code == 503
+    assert "failed" in response.json()["detail"]

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -23,6 +23,7 @@ def _load_fixture(name: str) -> dict:
 class _FakeHTTPResponse:
     def __init__(self, status_code: int, payload: dict[str, object]) -> None:
         self.status_code = status_code
+        self.status = status_code
         self._payload = payload
         self.text = json.dumps(payload)
 
@@ -40,11 +41,15 @@ class _FakeHTTPResponse:
 def _install_fake_http(
     monkeypatch: pytest.MonkeyPatch,
     responses: list[_FakeHTTPResponse | Exception],
+    *,
+    captured_requests: list[object] | None = None,
 ) -> None:
     queue = list(responses)
 
     def _fake_urlopen(request, timeout=0):
-        del request, timeout
+        del timeout
+        if captured_requests is not None:
+            captured_requests.append(request)
         response = queue.pop(0)
         if isinstance(response, Exception):
             raise response
@@ -149,6 +154,7 @@ def test_workspace_policy_import_uses_live_tpp_transport_when_response_is_omitte
     monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    captured_requests: list[object] = []
     _install_fake_http(
         monkeypatch,
         [
@@ -194,6 +200,7 @@ def test_workspace_policy_import_uses_live_tpp_transport_when_response_is_omitte
                 },
             )
         ],
+        captured_requests=captured_requests,
     )
 
     created = client.post(
@@ -229,6 +236,10 @@ def test_workspace_policy_import_uses_live_tpp_transport_when_response_is_omitte
     assert payload["policy_state"]["policy_version"] == "d7a6d25a"
     assert payload["summary"]["documentation_rules"] == ["fare_evidence"]
     assert payload["summary"]["approval_triggers"] == ["manager_review"]
+    request_body = json.loads(captured_requests[0].data.decode("utf-8"))
+    assert "requested_at" in request_body
+    assert "organization_context" in request_body
+    assert "proposal_id" not in request_body
 
 
 def test_workspace_policy_import_surfaces_live_tpp_unavailable_errors(

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -21,6 +21,7 @@ def _load_fixture(*parts: str) -> dict:
 class _FakeHTTPResponse:
     def __init__(self, status_code: int, payload: dict[str, object]) -> None:
         self.status_code = status_code
+        self.status = status_code
         self._payload = payload
         self.text = json.dumps(payload)
 
@@ -38,11 +39,15 @@ class _FakeHTTPResponse:
 def _install_fake_http(
     monkeypatch: pytest.MonkeyPatch,
     responses: list[_FakeHTTPResponse | Exception],
+    *,
+    captured_requests: list[object] | None = None,
 ) -> None:
     queue = list(responses)
 
     def _fake_urlopen(request, timeout=0):
-        del request, timeout
+        del timeout
+        if captured_requests is not None:
+            captured_requests.append(request)
         response = queue.pop(0)
         if isinstance(response, Exception):
             raise response
@@ -810,6 +815,23 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
     monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Live proposal transport",
+            "summary": "Use runtime TPP HTTP transport.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    captured_requests: list[object] = []
     _install_fake_http(
         monkeypatch,
         [
@@ -848,8 +870,8 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
             _FakeHTTPResponse(
                 200,
                 {
-                    "trip_id": "placeholder",
-                    "proposal_id": "placeholder",
+                    "trip_id": trip_id,
+                    "proposal_id": f"proposal:{trip_id}",
                     "proposal_version": "proposal-v3",
                     "execution_id": "exec-live-001",
                     "request_id": "ignored-eval",
@@ -870,23 +892,8 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
                 },
             ),
         ],
+        captured_requests=captured_requests,
     )
-
-    created = client.post(
-        "/api/trips",
-        json={
-            "title": "Live proposal transport",
-            "summary": "Use runtime TPP HTTP transport.",
-            "mode": "business",
-            "trip_frame": {
-                "start_date": "2026-05-04",
-                "end_date": "2026-05-06",
-                "duration_days": 3,
-                "primary_regions": ["Chicago"],
-            },
-        },
-    )
-    trip_id = created.json()["trip"]["trip_id"]
     submission_fixture = _load_fixture("proposal_submit_deferred.json")
     submission_fixture["request"]["trip_id"] = trip_id
     submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
@@ -921,6 +928,11 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
     payload = evaluated.json()["proposal_state"]
     assert payload["evaluation"]["evaluation_result"]["status"] == "compliant"
     assert payload["summary"]["approval_ready"] is True
+    submission_body = json.loads(captured_requests[0].data.decode("utf-8"))
+    assert submission_body["proposal_version"] == "proposal-v3"
+    assert "execution_id" not in submission_body
+    evaluation_body = json.loads(captured_requests[1].data.decode("utf-8"))
+    assert evaluation_body["execution_id"] == "exec-live-001"
 
 
 def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
@@ -964,5 +976,5 @@ def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
         },
     )
 
-    assert response.status_code == 502
-    assert "execution_status" in response.json()["detail"] or "contract" in response.json()["detail"].lower()
+    assert response.status_code == 400
+    assert "execution_id is required" in response.json()["detail"]

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -21,6 +21,7 @@ def _load_fixture(*parts: str) -> dict:
 
 class _FakeHTTPResponse:
     def __init__(self, status_code: int, payload: dict[str, object]) -> None:
+        self.status = status_code
         self.status_code = status_code
         self._payload = payload
         self.text = json.dumps(payload)
@@ -822,66 +823,65 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
     captured_requests: list[dict[str, object]] = []
+    submission_response = _FakeHTTPResponse(
+        200,
+        {
+            "operation": "submit_proposal",
+            "submission_status": "submitted",
+            "request_id": "ignored-submit",
+            "correlation_id": {"value": "ignored", "issued_by": "tpp"},
+            "transport_pattern": "deferred",
+            "execution_status": {
+                "state": "deferred",
+                "terminal": False,
+                "summary": "Proposal queued for evaluation",
+                "poll_after_seconds": 30,
+                "external_status": "202 Accepted",
+                "updated_at": "2026-04-03T00:41:01Z",
+            },
+            "result_payload": {
+                "execution_id": "exec-live-001",
+                "queue_state": "waiting_for_policy_engine",
+            },
+            "retry": {
+                "attempt": 0,
+                "max_attempts": 5,
+                "retryable": True,
+                "backoff_seconds": 30,
+                "next_retry_at": "2026-04-03T00:41:31Z",
+                "reason": "Await evaluator completion",
+            },
+            "received_at": "2026-04-03T00:41:01Z",
+            "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-001",
+        },
+    )
+    evaluation_response = _FakeHTTPResponse(
+        200,
+        {
+            "trip_id": "trip-placeholder",
+            "proposal_id": "proposal:trip-placeholder",
+            "proposal_version": "proposal-v3",
+            "execution_id": "exec-live-001",
+            "request_id": "ignored-eval",
+            "correlation_id": {"value": "ignored", "issued_by": "tpp"},
+            "outcome": "compliant",
+            "result_endpoint": "GET /api/planner/executions/exec-live-001/evaluation-result",
+            "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-001",
+            "policy_result": {
+                "status": "pass",
+                "issues": [],
+                "policy_version": "policy-v1",
+            },
+            "blocking_issues": [],
+            "preferred_alternatives": [],
+            "exception_requirements": [],
+            "reoptimization_guidance": [],
+            "generated_at": "2026-04-03T02:15:04Z",
+        },
+    )
     _install_fake_http(
         monkeypatch,
-        [
-            _FakeHTTPResponse(
-                200,
-                {
-                    "operation": "submit_proposal",
-                    "submission_status": "submitted",
-                    "request_id": "ignored-submit",
-                    "correlation_id": {"value": "ignored", "issued_by": "tpp"},
-                    "transport_pattern": "deferred",
-                    "execution_status": {
-                        "state": "deferred",
-                        "terminal": False,
-                        "summary": "Proposal queued for evaluation",
-                        "poll_after_seconds": 30,
-                        "external_status": "202 Accepted",
-                        "updated_at": "2026-04-03T00:41:01Z",
-                    },
-                    "result_payload": {
-                        "execution_id": "exec-live-001",
-                        "queue_state": "waiting_for_policy_engine",
-                    },
-                    "retry": {
-                        "attempt": 0,
-                        "max_attempts": 5,
-                        "retryable": True,
-                        "backoff_seconds": 30,
-                        "next_retry_at": "2026-04-03T00:41:31Z",
-                        "reason": "Await evaluator completion",
-                    },
-                    "received_at": "2026-04-03T00:41:01Z",
-                    "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-001",
-                },
-            ),
-            _FakeHTTPResponse(
-                200,
-                {
-                    "trip_id": "placeholder",
-                    "proposal_id": "placeholder",
-                    "proposal_version": "proposal-v3",
-                    "execution_id": "exec-live-001",
-                    "request_id": "ignored-eval",
-                    "correlation_id": {"value": "ignored", "issued_by": "tpp"},
-                    "outcome": "compliant",
-                    "result_endpoint": "GET /api/planner/executions/exec-live-001/evaluation-result",
-                    "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-001",
-                    "policy_result": {
-                        "status": "pass",
-                        "issues": [],
-                        "policy_version": "policy-v1",
-                    },
-                    "blocking_issues": [],
-                    "preferred_alternatives": [],
-                    "exception_requirements": [],
-                    "reoptimization_guidance": [],
-                    "generated_at": "2026-04-03T02:15:04Z",
-                },
-            ),
-        ],
+        [submission_response, evaluation_response],
         captured_requests=captured_requests,
     )
 
@@ -921,6 +921,9 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
     evaluation_fixture["request"]["trip_id"] = trip_id
     evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
     evaluation_fixture["request"]["payload"]["execution_id"] = "exec-live-001"
+    evaluation_response._payload["trip_id"] = trip_id
+    evaluation_response._payload["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_response.text = json.dumps(evaluation_response._payload)
 
     evaluated = client.put(
         f"/api/workspace/{trip_id}/proposal/evaluation",
@@ -1005,5 +1008,5 @@ def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
         },
     )
 
-    assert response.status_code == 502
-    assert "execution_status" in response.json()["detail"] or "contract" in response.json()["detail"].lower()
+    assert response.status_code == 400
+    assert response.json()["detail"] == "result_payload.execution_id is required for non-terminal submissions"

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -21,7 +21,6 @@ def _load_fixture(*parts: str) -> dict:
 class _FakeHTTPResponse:
     def __init__(self, status_code: int, payload: dict[str, object]) -> None:
         self.status_code = status_code
-        self.status = status_code
         self._payload = payload
         self.text = json.dumps(payload)
 
@@ -40,14 +39,20 @@ def _install_fake_http(
     monkeypatch: pytest.MonkeyPatch,
     responses: list[_FakeHTTPResponse | Exception],
     *,
-    captured_requests: list[object] | None = None,
+    captured_requests: list[dict[str, object]] | None = None,
 ) -> None:
     queue = list(responses)
 
     def _fake_urlopen(request, timeout=0):
-        del timeout
         if captured_requests is not None:
-            captured_requests.append(request)
+            captured_requests.append(
+                {
+                    "full_url": request.full_url,
+                    "method": request.get_method(),
+                    "body": json.loads((request.data or b"{}").decode("utf-8")),
+                }
+            )
+        del timeout
         response = queue.pop(0)
         if isinstance(response, Exception):
             raise response
@@ -815,23 +820,7 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
     monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
-
-    created = client.post(
-        "/api/trips",
-        json={
-            "title": "Live proposal transport",
-            "summary": "Use runtime TPP HTTP transport.",
-            "mode": "business",
-            "trip_frame": {
-                "start_date": "2026-05-04",
-                "end_date": "2026-05-06",
-                "duration_days": 3,
-                "primary_regions": ["Chicago"],
-            },
-        },
-    )
-    trip_id = created.json()["trip"]["trip_id"]
-    captured_requests: list[object] = []
+    captured_requests: list[dict[str, object]] = []
     _install_fake_http(
         monkeypatch,
         [
@@ -870,8 +859,8 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
             _FakeHTTPResponse(
                 200,
                 {
-                    "trip_id": trip_id,
-                    "proposal_id": f"proposal:{trip_id}",
+                    "trip_id": "placeholder",
+                    "proposal_id": "placeholder",
                     "proposal_version": "proposal-v3",
                     "execution_id": "exec-live-001",
                     "request_id": "ignored-eval",
@@ -894,6 +883,22 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
         ],
         captured_requests=captured_requests,
     )
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Live proposal transport",
+            "summary": "Use runtime TPP HTTP transport.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
     submission_fixture = _load_fixture("proposal_submit_deferred.json")
     submission_fixture["request"]["trip_id"] = trip_id
     submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
@@ -928,11 +933,34 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
     payload = evaluated.json()["proposal_state"]
     assert payload["evaluation"]["evaluation_result"]["status"] == "compliant"
     assert payload["summary"]["approval_ready"] is True
-    submission_body = json.loads(captured_requests[0].data.decode("utf-8"))
-    assert submission_body["proposal_version"] == "proposal-v3"
-    assert "execution_id" not in submission_body
-    evaluation_body = json.loads(captured_requests[1].data.decode("utf-8"))
-    assert evaluation_body["execution_id"] == "exec-live-001"
+    assert captured_requests[0] == {
+        "full_url": "https://tpp.example.test/api/planner/proposals",
+        "method": "POST",
+        "body": {
+            "proposal_ref": f"proposal:{trip_id}",
+            "submission_mode": "queue",
+            "trip_id": trip_id,
+            "proposal_id": f"proposal:{trip_id}",
+            "proposal_version": "proposal-v3",
+            "request_id": submission_fixture["request"]["request_id"],
+            "correlation_id": submission_fixture["request"]["correlation_id"],
+            "transport_pattern": submission_fixture["request"]["transport_pattern"],
+            "organization_id": submission_fixture["request"]["organization_id"],
+            "submitted_at": submission_fixture["request"]["submitted_at"],
+        },
+    }
+    assert captured_requests[1] == {
+        "full_url": "https://tpp.example.test/api/planner/executions/exec-live-001/evaluation-result",
+        "method": "GET",
+        "body": {
+            "execution_id": "exec-live-001",
+            "trip_id": trip_id,
+            "proposal_id": f"proposal:{trip_id}",
+            "proposal_version": "proposal-v3",
+            "request_id": evaluation_fixture["request"]["request_id"],
+            "requested_at": evaluation_fixture["request"]["submitted_at"],
+        },
+    }
 
 
 def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
@@ -976,5 +1004,5 @@ def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
         },
     )
 
-    assert response.status_code == 400
-    assert "execution_id is required" in response.json()["detail"]
+    assert response.status_code == 502
+    assert "execution_status" in response.json()["detail"] or "contract" in response.json()["detail"].lower()

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -1,11 +1,11 @@
 import json
 from collections.abc import Iterator
 from pathlib import Path
-
 import pytest
 from fastapi.testclient import TestClient
 
 from trip_planner.app.main import create_app
+from trip_planner.integrations.tpp import client as tpp_client_module
 from trip_planner.persistence.db import get_session_factory, reset_database_state
 from trip_planner.persistence.models.proposal import PersistedProposalState
 
@@ -16,6 +16,39 @@ def _fixture_path(*parts: str) -> Path:
 
 def _load_fixture(*parts: str) -> dict:
     return json.loads(_fixture_path(*parts).read_text(encoding="utf-8"))
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status_code: int, payload: dict[str, object]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        del exc_type, exc, tb
+        return False
+
+
+def _install_fake_http(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[_FakeHTTPResponse | Exception],
+) -> None:
+    queue = list(responses)
+
+    def _fake_urlopen(request, timeout=0):
+        del request, timeout
+        response = queue.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(tpp_client_module.urllib_request, "urlopen", _fake_urlopen)
 
 
 def _proposal_payload(trip_id: str) -> dict:
@@ -768,3 +801,168 @@ def test_workspace_proposal_submission_rejects_leisure_trip(client: TestClient) 
 
     assert response.status_code == 400
     assert "business trips" in response.json()["detail"]
+
+
+def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    _install_fake_http(
+        monkeypatch,
+        [
+            _FakeHTTPResponse(
+                200,
+                {
+                    "operation": "submit_proposal",
+                    "submission_status": "submitted",
+                    "request_id": "ignored-submit",
+                    "correlation_id": {"value": "ignored", "issued_by": "tpp"},
+                    "transport_pattern": "deferred",
+                    "execution_status": {
+                        "state": "deferred",
+                        "terminal": False,
+                        "summary": "Proposal queued for evaluation",
+                        "poll_after_seconds": 30,
+                        "external_status": "202 Accepted",
+                        "updated_at": "2026-04-03T00:41:01Z",
+                    },
+                    "result_payload": {
+                        "execution_id": "exec-live-001",
+                        "queue_state": "waiting_for_policy_engine",
+                    },
+                    "retry": {
+                        "attempt": 0,
+                        "max_attempts": 5,
+                        "retryable": True,
+                        "backoff_seconds": 30,
+                        "next_retry_at": "2026-04-03T00:41:31Z",
+                        "reason": "Await evaluator completion",
+                    },
+                    "received_at": "2026-04-03T00:41:01Z",
+                    "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-001",
+                },
+            ),
+            _FakeHTTPResponse(
+                200,
+                {
+                    "trip_id": "placeholder",
+                    "proposal_id": "placeholder",
+                    "proposal_version": "proposal-v3",
+                    "execution_id": "exec-live-001",
+                    "request_id": "ignored-eval",
+                    "correlation_id": {"value": "ignored", "issued_by": "tpp"},
+                    "outcome": "compliant",
+                    "result_endpoint": "GET /api/planner/executions/exec-live-001/evaluation-result",
+                    "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-001",
+                    "policy_result": {
+                        "status": "pass",
+                        "issues": [],
+                        "policy_version": "policy-v1",
+                    },
+                    "blocking_issues": [],
+                    "preferred_alternatives": [],
+                    "exception_requirements": [],
+                    "reoptimization_guidance": [],
+                    "generated_at": "2026-04-03T02:15:04Z",
+                },
+            ),
+        ],
+    )
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Live proposal transport",
+            "summary": "Use runtime TPP HTTP transport.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+    assert submitted.json()["proposal_state"]["execution_id"] == "exec-live-001"
+
+    evaluation_fixture = _load_fixture("results", "approved_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["request"]["payload"]["execution_id"] = "exec-live-001"
+
+    evaluated = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert evaluated.status_code == 200
+    payload = evaluated.json()["proposal_state"]
+    assert payload["evaluation"]["evaluation_result"]["status"] == "compliant"
+    assert payload["summary"]["approval_ready"] is True
+
+
+def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    _install_fake_http(
+        monkeypatch,
+        [_FakeHTTPResponse(200, {"submission_status": "submitted"})],
+    )
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Invalid proposal transport",
+            "summary": "Surface invalid live TPP contracts.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    response = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "proposal_version": "proposal-v3",
+        },
+    )
+
+    assert response.status_code == 502
+    assert "execution_status" in response.json()["detail"] or "contract" in response.json()["detail"].lower()

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -1,6 +1,7 @@
 import json
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Literal
 import pytest
 from fastapi.testclient import TestClient
 
@@ -30,7 +31,7 @@ class _FakeHTTPResponse:
     def __enter__(self) -> "_FakeHTTPResponse":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> bool:
+    def __exit__(self, exc_type, exc, tb) -> Literal[False]:
         del exc_type, exc, tb
         return False
 

--- a/trip_planner/app/routes/policy.py
+++ b/trip_planner/app/routes/policy.py
@@ -11,6 +11,7 @@ from trip_planner.app.services.policy import (
     get_workspace_policy_payload,
     import_workspace_policy_constraints,
 )
+from trip_planner.integrations.tpp import TPPTransportError
 from trip_planner.persistence.db import get_db_session
 
 router = APIRouter(tags=["policy"])
@@ -49,6 +50,8 @@ def save_workspace_policy(
         )
     except WorkspacePolicyNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
+    except TPPTransportError as error:
+        raise HTTPException(status_code=error.status_code, detail=str(error)) from error
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return WorkspacePolicyResponse.model_validate(result)

--- a/trip_planner/app/routes/proposal.py
+++ b/trip_planner/app/routes/proposal.py
@@ -15,6 +15,7 @@ from trip_planner.app.services.proposal import (
     save_workspace_proposal_evaluation,
     save_workspace_proposal_submission,
 )
+from trip_planner.integrations.tpp import TPPTransportError
 from trip_planner.persistence.db import get_db_session
 
 router = APIRouter(tags=["proposal"])
@@ -53,6 +54,8 @@ def save_workspace_proposal(
         )
     except WorkspaceProposalNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
+    except TPPTransportError as error:
+        raise HTTPException(status_code=error.status_code, detail=str(error)) from error
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return WorkspaceProposalResponse.model_validate(result)
@@ -77,6 +80,8 @@ def save_workspace_proposal_result(
         )
     except WorkspaceProposalNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
+    except TPPTransportError as error:
+        raise HTTPException(status_code=error.status_code, detail=str(error)) from error
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return WorkspaceProposalResponse.model_validate(result)

--- a/trip_planner/app/schemas/policy.py
+++ b/trip_planner/app/schemas/policy.py
@@ -7,8 +7,9 @@ class PolicySyncImportRequest(BaseModel):
     request: dict[str, Any] = Field(
         description="Serialized TPPRequestEnvelope payload used to fetch policy constraints."
     )
-    response: dict[str, Any] = Field(
-        description="Serialized TPPResponseEnvelope payload returned by the policy sync source."
+    response: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional serialized TPPResponseEnvelope payload for fixture-driven imports."
     )
     source_kind: Literal["tpp_sync", "manual_import"] = "tpp_sync"
     tags: list[str] = Field(default_factory=list)

--- a/trip_planner/app/schemas/proposal.py
+++ b/trip_planner/app/schemas/proposal.py
@@ -10,8 +10,9 @@ class WorkspaceProposalSubmissionRequest(BaseModel):
     request: dict[str, Any] = Field(
         description="Serialized TPPRequestEnvelope payload used to submit the proposal."
     )
-    response: dict[str, Any] = Field(
-        description="Serialized TPPResponseEnvelope payload returned by proposal submission."
+    response: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional serialized TPPResponseEnvelope payload for fixture-driven proposal submission."
     )
     proposal_version: str = Field(min_length=1, max_length=96)
     scenario_id: str | None = Field(default=None, max_length=96)
@@ -21,8 +22,9 @@ class WorkspaceProposalEvaluationRequest(BaseModel):
     request: dict[str, Any] = Field(
         description="Serialized TPPRequestEnvelope payload used to ingest evaluation state."
     )
-    response: dict[str, Any] = Field(
-        description="Serialized TPPResponseEnvelope payload returned by evaluation ingestion."
+    response: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional serialized TPPResponseEnvelope payload for fixture-driven evaluation ingestion."
     )
     proposal_version: str = Field(min_length=1, max_length=96)
     scenario_id: str | None = Field(default=None, max_length=96)

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -17,6 +17,7 @@ from trip_planner.business import (
     TripPlanProposal,
 )
 from trip_planner.integrations.tpp import (
+    HTTPTPPIntegrationClient,
     OrganizationContextSnapshot,
     PolicyConstraintImport,
     PolicyFreshness,
@@ -91,6 +92,15 @@ class _PassiveTPPClient:
 
     def poll_execution_status(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         raise NotImplementedError("Passive policy import client does not poll execution status.")
+
+
+def _resolve_policy_response(
+    request: TPPRequestEnvelope,
+    response_payload: dict[str, Any] | None,
+) -> TPPResponseEnvelope:
+    if response_payload is not None:
+        return TPPResponseEnvelope.from_dict(response_payload)
+    return HTTPTPPIntegrationClient().fetch_policy_constraints(request)
 
 
 def _is_effectively_stale(imported: PolicyConstraintImport) -> bool:
@@ -327,7 +337,7 @@ def import_workspace_policy_constraints(
     user: AuthenticatedUser,
     trip_id: str,
     request_payload: dict[str, Any],
-    response_payload: dict[str, Any],
+    response_payload: dict[str, Any] | None,
     source_kind: str,
     tags: list[str],
     notes: list[str],
@@ -337,7 +347,7 @@ def import_workspace_policy_constraints(
         raise ValueError("Only business trips can import workspace policy constraints.")
 
     request = TPPRequestEnvelope.from_dict(request_payload)
-    response = TPPResponseEnvelope.from_dict(response_payload)
+    response = _resolve_policy_response(request, response_payload)
     imported = TPPPolicySyncService(_PassiveTPPClient(response)).import_policy_constraints(request)
     imported_at = _isoformat(datetime.now(UTC))
     existing = _get_latest_policy_state(

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -10,6 +10,7 @@ from trip_planner.app.services.auth import AuthenticatedUser
 from trip_planner.business import ExceptionRequest, TripPlanProposal
 from trip_planner.integrations.tpp import (
     BaseTPPIntegrationClient,
+    HTTPTPPIntegrationClient,
     TPPEvaluationResultIngestionService,
     TPPProposalSubmissionService,
     TPPRequestEnvelope,
@@ -67,6 +68,56 @@ class _PassiveTPPClient(BaseTPPIntegrationClient):
 
     def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         return self.response
+
+
+def _resolve_submission_response(
+    request: TPPRequestEnvelope,
+    response_payload: dict[str, Any] | None,
+    *,
+    proposal_version: str,
+) -> TPPResponseEnvelope:
+    if response_payload is not None:
+        return TPPResponseEnvelope.from_dict(response_payload)
+    live_request = request
+    if not request.payload.get("proposal_version"):
+        live_request = TPPRequestEnvelope(
+            operation=request.operation,
+            request_id=request.request_id,
+            correlation_id=request.correlation_id,
+            payload={**request.payload, "proposal_version": proposal_version},
+            transport_pattern=request.transport_pattern,
+            organization_id=request.organization_id,
+            trip_id=request.trip_id,
+            proposal_id=request.proposal_id,
+            submitted_at=request.submitted_at,
+            metadata=dict(request.metadata),
+        )
+    return HTTPTPPIntegrationClient().submit_proposal(live_request)
+
+
+def _resolve_evaluation_response(
+    request: TPPRequestEnvelope,
+    response_payload: dict[str, Any] | None,
+    *,
+    proposal_version: str,
+) -> TPPResponseEnvelope:
+    if response_payload is not None:
+        return TPPResponseEnvelope.from_dict(response_payload)
+    live_request = request
+    if not request.payload.get("proposal_version"):
+        live_request = TPPRequestEnvelope(
+            operation=request.operation,
+            request_id=request.request_id,
+            correlation_id=request.correlation_id,
+            payload={**request.payload, "proposal_version": proposal_version},
+            transport_pattern=request.transport_pattern,
+            organization_id=request.organization_id,
+            trip_id=request.trip_id,
+            proposal_id=request.proposal_id,
+            submitted_at=request.submitted_at,
+            metadata=dict(request.metadata),
+        )
+    return HTTPTPPIntegrationClient().fetch_evaluation_result(live_request)
 
 
 def _now_iso() -> str:
@@ -306,7 +357,7 @@ def save_workspace_proposal_submission(
     trip_id: str,
     proposal_payload: dict[str, Any],
     request_payload: dict[str, Any],
-    response_payload: dict[str, Any],
+    response_payload: dict[str, Any] | None,
     proposal_version: str,
     scenario_id: str | None,
 ) -> dict[str, Any]:
@@ -319,7 +370,11 @@ def save_workspace_proposal_submission(
         raise ValueError("proposal.trip_id must match the workspace trip.")
 
     request = TPPRequestEnvelope.from_dict(request_payload)
-    response = TPPResponseEnvelope.from_dict(response_payload)
+    response = _resolve_submission_response(
+        request,
+        response_payload,
+        proposal_version=proposal_version,
+    )
     submission = TPPProposalSubmissionService(_PassiveTPPClient(response)).submit_proposal(
         request,
         proposal,
@@ -383,7 +438,7 @@ def save_workspace_proposal_evaluation(
     user: AuthenticatedUser,
     trip_id: str,
     request_payload: dict[str, Any],
-    response_payload: dict[str, Any],
+    response_payload: dict[str, Any] | None,
     proposal_version: str,
     scenario_id: str | None,
 ) -> dict[str, Any]:
@@ -398,7 +453,11 @@ def save_workspace_proposal_evaluation(
         )
 
     request = TPPRequestEnvelope.from_dict(request_payload)
-    response = TPPResponseEnvelope.from_dict(response_payload)
+    response = _resolve_evaluation_response(
+        request,
+        response_payload,
+        proposal_version=proposal_version,
+    )
     evaluation = TPPEvaluationResultIngestionService(_PassiveTPPClient(response)).fetch_evaluation_result(
         request,
         proposal_version=proposal_version,

--- a/trip_planner/integrations/tpp/__init__.py
+++ b/trip_planner/integrations/tpp/__init__.py
@@ -1,6 +1,15 @@
 """Travel-Plan-Permission integration contracts and client interfaces."""
 
-from .client import BaseTPPIntegrationClient, TPPIntegrationClient
+from .client import (
+    BaseTPPIntegrationClient,
+    HTTPTPPIntegrationClient,
+    TPPConfigurationError,
+    TPPContractError,
+    TPPIntegrationClient,
+    TPPRuntimeSettings,
+    TPPServiceUnavailableError,
+    TPPTransportError,
+)
 from .contracts import (
     TPPErrorRecord,
     TPPExecutionStatus,
@@ -39,6 +48,7 @@ from .reoptimization import (
 
 __all__ = [
     "BaseTPPIntegrationClient",
+    "HTTPTPPIntegrationClient",
     "OrganizationContextSnapshot",
     "PolicyConstraintImport",
     "PolicyFreshness",
@@ -56,9 +66,14 @@ __all__ = [
     "TPPEvaluationResultIngestionService",
     "TPPExecutionStatus",
     "TPPIntegrationClient",
+    "TPPConfigurationError",
+    "TPPContractError",
     "TPPOperationRequest",
     "TPPProposalSubmissionService",
     "TPPPolicySyncService",
+    "TPPRuntimeSettings",
+    "TPPServiceUnavailableError",
+    "TPPTransportError",
     "TPPReoptimizationService",
     "TPPRequestEnvelope",
     "TPPResponseEnvelope",

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -80,6 +80,20 @@ class TPPServiceUnavailableError(TPPTransportError):
         super().__init__(message, status_code=503)
 
 
+def _strip_none_values(value: Any) -> Any:
+    """Drop null fields before serializing live TPP request payloads."""
+
+    if isinstance(value, dict):
+        return {
+            key: _strip_none_values(item)
+            for key, item in value.items()
+            if item is not None
+        }
+    if isinstance(value, list):
+        return [_strip_none_values(item) for item in value if item is not None]
+    return value
+
+
 @dataclass(slots=True)
 class TPPRuntimeSettings:
     base_url: str
@@ -216,7 +230,7 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             raise TPPContractError(
                 "Live policy sync requires request.trip_id or payload.trip_id."
             )
-        return payload
+        return _strip_none_values(payload)
 
     def _proposal_request_payload(self, request: TPPRequestEnvelope) -> dict[str, Any]:
         payload = dict(request.payload)
@@ -237,7 +251,7 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             raise TPPContractError(
                 "Live proposal submission requires trip_id, proposal_id, and proposal_version."
             )
-        return payload
+        return _strip_none_values(payload)
 
     def _status_request_payload(self, request: TPPRequestEnvelope) -> dict[str, Any]:
         payload = dict(request.payload)
@@ -260,7 +274,7 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             raise TPPContractError(
                 "Live TPP status operations require payload.execution_id."
             )
-        return payload
+        return _strip_none_values(payload)
 
     def _adapt_execution_status(self, payload: dict[str, Any]) -> dict[str, Any]:
         execution = payload.get("execution_status")
@@ -345,16 +359,13 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         if not policy_version:
             raise TPPContractError("TPP policy snapshot response is missing policy_version.")
 
+        organization_context = request.payload.get("organization_context")
+        organization_context_dict = (
+            organization_context if isinstance(organization_context, dict) else {}
+        )
         organization_id = (
             request.organization_id
-            or str(
-                (
-                    request.payload.get("organization_context")
-                    if isinstance(request.payload.get("organization_context"), dict)
-                    else {}
-                ).get("organization_id")
-                or ""
-            ).strip()
+            or str(organization_context_dict.get("organization_id") or "").strip()
             or "tpp"
         )
         documentation_rules = [

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -197,10 +197,10 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
 
         try:
             payload = json.loads(raw_body)
-        except ValueError as exc:
+        except ValueError:
             raise TPPContractError(
                 f"TPP request to {path} returned a non-JSON response."
-            ) from exc
+            )
         if not isinstance(payload, dict):
             raise TPPContractError(
                 f"TPP request to {path} returned a non-object JSON payload."

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -80,20 +80,6 @@ class TPPServiceUnavailableError(TPPTransportError):
         super().__init__(message, status_code=503)
 
 
-def _strip_none_values(value: Any) -> Any:
-    """Drop null fields before serializing live TPP request payloads."""
-
-    if isinstance(value, dict):
-        return {
-            key: _strip_none_values(item)
-            for key, item in value.items()
-            if item is not None
-        }
-    if isinstance(value, list):
-        return [_strip_none_values(item) for item in value if item is not None]
-    return value
-
-
 @dataclass(slots=True)
 class TPPRuntimeSettings:
     base_url: str
@@ -167,6 +153,10 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             "X-TPP-OIDC-Provider": self.settings.oidc_provider,
         }
 
+    @staticmethod
+    def _strip_none_values(payload: dict[str, Any]) -> dict[str, Any]:
+        return {key: value for key, value in payload.items() if value is not None}
+
     def _request_json(
         self,
         *,
@@ -226,11 +216,12 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         payload.setdefault("trip_id", request.trip_id)
         if request.submitted_at is not None:
             payload.setdefault("requested_at", request.submitted_at)
+        payload = self._strip_none_values(payload)
         if payload.get("trip_id") in (None, ""):
             raise TPPContractError(
                 "Live policy sync requires request.trip_id or payload.trip_id."
             )
-        return _strip_none_values(payload)
+        return payload
 
     def _proposal_request_payload(self, request: TPPRequestEnvelope) -> dict[str, Any]:
         payload = dict(request.payload)
@@ -243,6 +234,7 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         payload.setdefault("organization_id", request.organization_id)
         if request.submitted_at is not None:
             payload.setdefault("submitted_at", request.submitted_at)
+        payload = self._strip_none_values(payload)
         if (
             payload.get("trip_id") in (None, "")
             or payload.get("proposal_id") in (None, "")
@@ -251,7 +243,7 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             raise TPPContractError(
                 "Live proposal submission requires trip_id, proposal_id, and proposal_version."
             )
-        return _strip_none_values(payload)
+        return payload
 
     def _status_request_payload(self, request: TPPRequestEnvelope) -> dict[str, Any]:
         payload = dict(request.payload)
@@ -262,6 +254,7 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         payload.setdefault("request_id", request.request_id)
         if request.submitted_at is not None:
             payload.setdefault("requested_at", request.submitted_at)
+        payload = self._strip_none_values(payload)
         if payload.get("trip_id") in (None, "") or payload.get("proposal_id") in (None, ""):
             raise TPPContractError(
                 "Live TPP status operations require trip_id and proposal_id."
@@ -274,7 +267,7 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             raise TPPContractError(
                 "Live TPP status operations require payload.execution_id."
             )
-        return _strip_none_values(payload)
+        return payload
 
     def _adapt_execution_status(self, payload: dict[str, Any]) -> dict[str, Any]:
         execution = payload.get("execution_status")
@@ -359,13 +352,16 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         if not policy_version:
             raise TPPContractError("TPP policy snapshot response is missing policy_version.")
 
-        organization_context = request.payload.get("organization_context")
-        organization_context_dict = (
-            organization_context if isinstance(organization_context, dict) else {}
-        )
         organization_id = (
             request.organization_id
-            or str(organization_context_dict.get("organization_id") or "").strip()
+            or str(
+                (
+                    request.payload.get("organization_context")
+                    if isinstance(request.payload.get("organization_context"), dict)
+                    else {}
+                ).get("organization_id")
+                or ""
+            ).strip()
             or "tpp"
         )
         documentation_rules = [

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -352,16 +352,13 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         if not policy_version:
             raise TPPContractError("TPP policy snapshot response is missing policy_version.")
 
+        organization_context_raw = request.payload.get("organization_context")
+        organization_context = (
+            organization_context_raw if isinstance(organization_context_raw, dict) else {}
+        )
         organization_id = (
             request.organization_id
-            or str(
-                (
-                    request.payload.get("organization_context")
-                    if isinstance(request.payload.get("organization_context"), dict)
-                    else {}
-                ).get("organization_id")
-                or ""
-            ).strip()
+            or str(organization_context.get("organization_id") or "").strip()
             or "tpp"
         )
         documentation_rules = [

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
-from typing import Protocol
+from dataclasses import dataclass
+from typing import Any, Protocol
+import json
+from urllib import error as urllib_error
+from urllib import request as urllib_request
 
 from .contracts import TPPRequestEnvelope, TPPResponseEnvelope
 
@@ -47,3 +52,507 @@ class BaseTPPIntegrationClient(ABC):
     @abstractmethod
     def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         """Execute a validated TPP request through the concrete transport."""
+
+
+class TPPTransportError(RuntimeError):
+    """Raised when a live TPP transport call cannot be completed safely."""
+
+    def __init__(self, message: str, *, status_code: int = 502) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TPPConfigurationError(TPPTransportError):
+    """Raised when live TPP transport is requested without runtime config."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, status_code=503)
+
+
+class TPPContractError(TPPTransportError):
+    """Raised when the upstream TPP service returns an invalid contract."""
+
+
+class TPPServiceUnavailableError(TPPTransportError):
+    """Raised when the upstream TPP service cannot be reached."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message, status_code=503)
+
+
+@dataclass(slots=True)
+class TPPRuntimeSettings:
+    base_url: str
+    access_token: str
+    oidc_provider: str
+    timeout_seconds: float = 10.0
+
+    @classmethod
+    def from_env(cls) -> "TPPRuntimeSettings":
+        base_url = os.getenv("TPP_BASE_URL", "").strip()
+        access_token = os.getenv("TPP_ACCESS_TOKEN", "").strip()
+        oidc_provider = os.getenv("TPP_OIDC_PROVIDER", "").strip()
+        timeout_raw = os.getenv("TPP_TIMEOUT_SECONDS", "").strip()
+
+        missing = [
+            name
+            for name, value in (
+                ("TPP_BASE_URL", base_url),
+                ("TPP_ACCESS_TOKEN", access_token),
+                ("TPP_OIDC_PROVIDER", oidc_provider),
+            )
+            if not value
+        ]
+        if missing:
+            joined = ", ".join(missing)
+            raise TPPConfigurationError(
+                f"Live TPP transport requires runtime configuration for {joined}."
+            )
+
+        timeout_seconds = 10.0
+        if timeout_raw:
+            try:
+                timeout_seconds = float(timeout_raw)
+            except ValueError as exc:
+                raise TPPConfigurationError(
+                    "TPP_TIMEOUT_SECONDS must be a numeric value when provided."
+                ) from exc
+            if timeout_seconds <= 0:
+                raise TPPConfigurationError("TPP_TIMEOUT_SECONDS must be greater than 0.")
+
+        return cls(
+            base_url=base_url.rstrip("/"),
+            access_token=access_token,
+            oidc_provider=oidc_provider,
+            timeout_seconds=timeout_seconds,
+        )
+
+
+class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
+    """Executes TPP operations over the planner-facing HTTP seam."""
+
+    def __init__(self, settings: TPPRuntimeSettings | None = None) -> None:
+        self.settings = settings or TPPRuntimeSettings.from_env()
+
+    def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        if request.operation == "fetch_policy_constraints":
+            return self._fetch_policy_constraints(request)
+        if request.operation == "submit_proposal":
+            return self._submit_proposal(request)
+        if request.operation == "fetch_evaluation_result":
+            return self._fetch_evaluation_result(request)
+        if request.operation == "poll_execution_status":
+            return self._poll_execution_status(request)
+        raise TPPContractError(f"Unsupported TPP operation {request.operation!r}.")
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.settings.access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-TPP-OIDC-Provider": self.settings.oidc_provider,
+        }
+
+    def _request_json(
+        self,
+        *,
+        method: str,
+        path: str,
+        json_payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        url = f"{self.settings.base_url}{path}"
+        body = json.dumps(json_payload).encode("utf-8")
+        request = urllib_request.Request(
+            url,
+            data=body,
+            headers=self._headers(),
+            method=method,
+        )
+        try:
+            with urllib_request.urlopen(request, timeout=self.settings.timeout_seconds) as response:
+                status_code = response.status
+                raw_body = response.read().decode("utf-8")
+        except urllib_error.HTTPError as exc:
+            raw_body = exc.read().decode("utf-8", errors="replace")
+            body_excerpt = raw_body.strip()
+            if len(body_excerpt) > 280:
+                body_excerpt = f"{body_excerpt[:277]}..."
+            raise TPPTransportError(
+                f"TPP request to {path} returned HTTP {exc.code}: {body_excerpt or 'no response body'}",
+                status_code=502,
+            ) from exc
+        except urllib_error.URLError as exc:
+            raise TPPServiceUnavailableError(
+                f"TPP request to {path} failed: {exc}."
+            ) from exc
+
+        if status_code >= 400:
+            body_excerpt = raw_body.strip()
+            if len(body_excerpt) > 280:
+                body_excerpt = f"{body_excerpt[:277]}..."
+            raise TPPTransportError(
+                f"TPP request to {path} returned HTTP {status_code}: {body_excerpt or 'no response body'}",
+                status_code=502,
+            )
+
+        try:
+            payload = json.loads(raw_body)
+        except ValueError as exc:
+            raise TPPContractError(
+                f"TPP request to {path} returned a non-JSON response."
+            ) from exc
+        if not isinstance(payload, dict):
+            raise TPPContractError(
+                f"TPP request to {path} returned a non-object JSON payload."
+            )
+        return payload
+
+    def _policy_request_payload(self, request: TPPRequestEnvelope) -> dict[str, Any]:
+        payload = dict(request.payload)
+        payload.setdefault("trip_id", request.trip_id)
+        if request.submitted_at is not None:
+            payload.setdefault("requested_at", request.submitted_at)
+        if payload.get("trip_id") in (None, ""):
+            raise TPPContractError(
+                "Live policy sync requires request.trip_id or payload.trip_id."
+            )
+        return payload
+
+    def _proposal_request_payload(self, request: TPPRequestEnvelope) -> dict[str, Any]:
+        payload = dict(request.payload)
+        payload.setdefault("trip_id", request.trip_id)
+        payload.setdefault("proposal_id", request.proposal_id)
+        payload.setdefault("proposal_version", payload.get("proposal_version"))
+        payload.setdefault("request_id", request.request_id)
+        payload.setdefault("correlation_id", request.correlation_id.to_dict())
+        payload.setdefault("transport_pattern", request.transport_pattern)
+        payload.setdefault("organization_id", request.organization_id)
+        if request.submitted_at is not None:
+            payload.setdefault("submitted_at", request.submitted_at)
+        if (
+            payload.get("trip_id") in (None, "")
+            or payload.get("proposal_id") in (None, "")
+            or payload.get("proposal_version") in (None, "")
+        ):
+            raise TPPContractError(
+                "Live proposal submission requires trip_id, proposal_id, and proposal_version."
+            )
+        return payload
+
+    def _status_request_payload(self, request: TPPRequestEnvelope) -> dict[str, Any]:
+        payload = dict(request.payload)
+        payload.setdefault("trip_id", request.trip_id)
+        payload.setdefault("proposal_id", request.proposal_id)
+        payload.setdefault("proposal_version", payload.get("proposal_version"))
+        payload.setdefault("execution_id", payload.get("execution_id"))
+        payload.setdefault("request_id", request.request_id)
+        if request.submitted_at is not None:
+            payload.setdefault("requested_at", request.submitted_at)
+        if payload.get("trip_id") in (None, "") or payload.get("proposal_id") in (None, ""):
+            raise TPPContractError(
+                "Live TPP status operations require trip_id and proposal_id."
+            )
+        if payload.get("proposal_version") in (None, ""):
+            raise TPPContractError(
+                "Live TPP status operations require payload.proposal_version."
+            )
+        if payload.get("execution_id") in (None, ""):
+            raise TPPContractError(
+                "Live TPP status operations require payload.execution_id."
+            )
+        return payload
+
+    def _adapt_execution_status(self, payload: dict[str, Any]) -> dict[str, Any]:
+        execution = payload.get("execution_status")
+        if execution is None:
+            submission_status = str(payload.get("submission_status") or "").strip().lower()
+            if submission_status in {"approved", "compliant", "succeeded"}:
+                state = "succeeded"
+                terminal = True
+            elif submission_status in {"rejected", "failed", "non_compliant"}:
+                state = "failed"
+                terminal = True
+            elif submission_status in {"submitted", "queued"}:
+                state = "accepted"
+                terminal = False
+            else:
+                state = "running"
+                terminal = False
+            return {
+                "state": state,
+                "terminal": terminal,
+                "summary": str(payload.get("submission_status") or "").replace("_", " "),
+                "external_status": "",
+                "updated_at": payload.get("received_at"),
+            }
+        if not isinstance(execution, dict):
+            raise TPPContractError("TPP execution_status must be an object when provided.")
+        return {
+            "state": execution.get("state"),
+            "terminal": execution.get("terminal"),
+            "summary": execution.get("summary", ""),
+            "external_status": execution.get("external_status", ""),
+            "poll_after_seconds": execution.get("poll_after_seconds"),
+            "updated_at": execution.get("updated_at"),
+        }
+
+    def _adapt_error(self, payload: dict[str, Any]) -> dict[str, Any] | None:
+        error = payload.get("error")
+        if error is None:
+            return None
+        if not isinstance(error, dict):
+            raise TPPContractError("TPP error must be an object when provided.")
+        return {
+            "code": str(error.get("code") or "tpp_error"),
+            "message": str(error.get("message") or "TPP returned an error."),
+            "category": str(error.get("category") or "transport"),
+            "retryable": bool(error.get("retryable", False)),
+            "details": {
+                key: str(value)
+                for key, value in error.items()
+                if key not in {"code", "message", "category", "retryable"} and value is not None
+            },
+        }
+
+    def _adapt_retry(self, payload: dict[str, Any]) -> dict[str, Any] | None:
+        retry = payload.get("retry")
+        if retry is None:
+            return None
+        if not isinstance(retry, dict):
+            raise TPPContractError("TPP retry metadata must be an object when provided.")
+        return {
+            "attempt": int(retry.get("attempt", 0)),
+            "max_attempts": int(retry.get("max_attempts", 1)),
+            "retryable": bool(retry.get("retryable", False)),
+            "backoff_seconds": retry.get("backoff_seconds"),
+            "next_retry_at": retry.get("next_retry_at"),
+            "reason": str(retry.get("reason") or ""),
+        }
+
+    def _fetch_policy_constraints(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        payload = self._request_json(
+            method="GET",
+            path="/api/planner/policy-snapshot",
+            json_payload=self._policy_request_payload(request),
+        )
+        versioning = payload.get("versioning")
+        if not isinstance(versioning, dict):
+            raise TPPContractError(
+                "TPP policy snapshot response is missing versioning metadata."
+            )
+
+        policy_version = str(versioning.get("policy_version") or "").strip()
+        if not policy_version:
+            raise TPPContractError("TPP policy snapshot response is missing policy_version.")
+
+        organization_id = (
+            request.organization_id
+            or str(
+                (
+                    request.payload.get("organization_context")
+                    if isinstance(request.payload.get("organization_context"), dict)
+                    else {}
+                ).get("organization_id")
+                or ""
+            ).strip()
+            or "tpp"
+        )
+        documentation_rules = [
+            str(item.get("code") or item.get("summary") or "").strip()
+            for item in payload.get("documentation_rules") or []
+            if isinstance(item, dict) and str(item.get("code") or item.get("summary") or "").strip()
+        ]
+        approval_triggers = [
+            str(item.get("code") or item.get("summary") or "").strip()
+            for item in payload.get("approval_triggers") or []
+            if isinstance(item, dict) and str(item.get("code") or item.get("summary") or "").strip()
+        ]
+        freshness = str(payload.get("freshness") or "current").strip() or "current"
+        result_payload = {
+            "constraint_set": {
+                "policy_id": str(versioning.get("etag") or f"{organization_id}:{policy_version}"),
+                "organization_id": organization_id,
+                "policy_version": policy_version,
+                "required_booking_channels": [],
+                "airfare_rules": {},
+                "lodging_rules": {},
+                "ground_transport_rules": {},
+                "meal_rules": {},
+                "approval_rules": approval_triggers,
+                "documentation_rules": documentation_rules,
+                "allowed_exception_types": [],
+            },
+            "organization_context": {
+                "organization_id": organization_id,
+                "approved_channels": [],
+                "comparable_requirements": {},
+                "documentation_rules": documentation_rules,
+                "approval_triggers": approval_triggers,
+                "comfort_preferences": {},
+                "class_of_service_limits": {},
+                "metadata": {
+                    "policy_status": str(payload.get("policy_status") or ""),
+                    "contract_version": str(versioning.get("contract_version") or ""),
+                    "etag": str(versioning.get("etag") or ""),
+                },
+            },
+            "freshness": {
+                "snapshot_version": str(versioning.get("etag") or policy_version),
+                "captured_at": payload.get("generated_at"),
+                "fresh_until": payload.get("expires_at"),
+                "invalidated_at": payload.get("invalidated_at"),
+                "invalidation_reason": payload.get("invalidation_reason"),
+                "status": freshness,
+            },
+        }
+        return TPPResponseEnvelope.from_dict(
+            {
+                "operation": request.operation,
+                "request_id": request.request_id,
+                "correlation_id": request.correlation_id.to_dict(),
+                "transport_pattern": request.transport_pattern,
+                "execution_status": {
+                    "state": "succeeded",
+                    "terminal": True,
+                    "summary": "Policy snapshot fetched from TPP.",
+                    "external_status": "200 OK",
+                    "updated_at": payload.get("generated_at"),
+                },
+                "result_payload": result_payload,
+                "received_at": payload.get("generated_at"),
+            }
+        )
+
+    def _submit_proposal(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        payload = self._request_json(
+            method="POST",
+            path="/api/planner/proposals",
+            json_payload=self._proposal_request_payload(request),
+        )
+        return TPPResponseEnvelope.from_dict(
+            {
+                "operation": request.operation,
+                "request_id": request.request_id,
+                "correlation_id": request.correlation_id.to_dict(),
+                "transport_pattern": payload.get("transport_pattern", request.transport_pattern),
+                "execution_status": self._adapt_execution_status(payload),
+                "result_payload": payload.get("result_payload") or {},
+                "error": self._adapt_error(payload),
+                "retry": self._adapt_retry(payload),
+                "received_at": payload.get("received_at"),
+                "status_endpoint": payload.get("status_endpoint"),
+            }
+        )
+
+    def _poll_execution_status(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        status_request = self._status_request_payload(request)
+        payload = self._request_json(
+            method="GET",
+            path=(
+                f"/api/planner/proposals/{status_request['proposal_id']}"
+                f"/executions/{status_request['execution_id']}"
+            ),
+            json_payload=status_request,
+        )
+        return TPPResponseEnvelope.from_dict(
+            {
+                "operation": request.operation,
+                "request_id": request.request_id,
+                "correlation_id": request.correlation_id.to_dict(),
+                "transport_pattern": payload.get("transport_pattern", request.transport_pattern),
+                "execution_status": self._adapt_execution_status(payload),
+                "result_payload": payload.get("result_payload") or {},
+                "error": self._adapt_error(payload),
+                "retry": self._adapt_retry(payload),
+                "received_at": payload.get("received_at"),
+                "status_endpoint": payload.get("status_endpoint"),
+            }
+        )
+
+    def _fetch_evaluation_result(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        status_request = self._status_request_payload(request)
+        payload = self._request_json(
+            method="GET",
+            path=f"/api/planner/executions/{status_request['execution_id']}/evaluation-result",
+            json_payload=status_request,
+        )
+        outcome = str(payload.get("outcome") or "").strip()
+        if outcome not in {"compliant", "non_compliant", "exception_required"}:
+            raise TPPContractError(
+                "TPP evaluation response is missing a supported outcome."
+            )
+
+        evaluation_result = {
+            "evaluation_id": str(payload.get("request_id") or request.request_id),
+            "proposal_id": str(payload.get("proposal_id") or request.proposal_id or ""),
+            "status": outcome,
+            "approval_requirements": [
+                {
+                    "role": str(item.get("required_role") or item.get("role") or "approver"),
+                    "reason": str(item.get("summary") or item.get("reason") or "Approval required."),
+                    "mandatory": True,
+                }
+                for item in payload.get("exception_requirements") or []
+                if isinstance(item, dict)
+            ],
+            "failure_reasons": [
+                {
+                    "code": str(item.get("code") or "policy_blocker"),
+                    "message": str(item.get("summary") or item.get("message") or "Policy blocker."),
+                    "severity": "blocking",
+                    "related_category": str(item.get("category") or ""),
+                }
+                for item in payload.get("blocking_issues") or []
+                if isinstance(item, dict)
+            ],
+            "preferred_alternatives": [
+                {
+                    "category": str(item.get("category") or "policy"),
+                    "summary": str(item.get("summary") or "Preferred alternative available."),
+                    "rationale": str(item.get("rationale") or item.get("summary") or "Follow the suggested alternative."),
+                    "comparable_ref": item.get("comparable_ref"),
+                }
+                for item in payload.get("preferred_alternatives") or []
+                if isinstance(item, dict)
+            ],
+            "exception_guidance": [
+                str(item.get("summary") or item.get("message") or "").strip()
+                for item in (
+                    list(payload.get("reoptimization_guidance") or [])
+                    + list(payload.get("exception_requirements") or [])
+                )
+                if isinstance(item, dict) and str(item.get("summary") or item.get("message") or "").strip()
+            ],
+            "notes": [
+                f"Planner evaluation outcome: {outcome}.",
+                f"Underlying policy status: {str((payload.get('policy_result') or {}).get('status') or '').strip() or 'unknown'}.",
+            ],
+            "compliance_score": (
+                1.0 if outcome == "compliant" else 0.45 if outcome == "exception_required" else 0.15
+            ),
+        }
+        return TPPResponseEnvelope.from_dict(
+            {
+                "operation": request.operation,
+                "request_id": request.request_id,
+                "correlation_id": request.correlation_id.to_dict(),
+                "transport_pattern": request.transport_pattern,
+                "execution_status": {
+                    "state": "succeeded",
+                    "terminal": True,
+                    "summary": f"Policy evaluation {outcome.replace('_', ' ')}.",
+                    "external_status": "200 OK",
+                    "updated_at": payload.get("generated_at"),
+                },
+                "result_payload": {
+                    "trip_id": payload.get("trip_id") or request.trip_id,
+                    "proposal_id": payload.get("proposal_id") or request.proposal_id,
+                    "proposal_version": payload.get("proposal_version")
+                    or status_request.get("proposal_version"),
+                    "execution_id": payload.get("execution_id") or status_request.get("execution_id"),
+                    "evaluation_result": evaluation_result,
+                },
+                "received_at": payload.get("generated_at"),
+                "status_endpoint": payload.get("status_endpoint"),
+            }
+        )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #763

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The current app-side policy and proposal services still use passive transport
stubs. That means business planning remains advisory even though the repo now has
persisted policy/proposal state and approval-readiness UI.

Parent epic: #755

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#745](https://github.com/stranske/Travel-Plan-Permission/issues/745)
- [stranske/Travel-Plan-Permission#746](https://github.com/stranske/Travel-Plan-Permission/issues/746)
- [#755](https://github.com/stranske/trip-planner/issues/755)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Implement a real HTTP client for planner-facing TPP operations.
- [x] Add runtime configuration for the external policy-service base URL and credentials.
- [x] Replace passive policy/proposal transport usage in app services with the real client.
- [x] Preserve clear error handling for unavailable service, invalid contract, and non-success responses.
- [x] Add tests covering successful and failure transport cases.

#### Acceptance criteria
- [x] `trip-planner` can call TPP policy/proposal endpoints through a real HTTP client.
- [x] Passive transport stubs are no longer the primary runtime path.
- [x] Tests cover success, contract error, and unavailable-service cases.

**Head SHA:** 972d19cd02fb353c500487df410a3f27cdf7fb6d
**Merge commit:** bd21aa6e124302fee1d2bc68c44d5c55c81579f2
**Validation evidence:** `tests/app/test_policy.py`, `tests/app/test_proposal.py`, and `trip_planner/integrations/tpp/client.py` landed in #785.
<!-- auto-status-summary:end -->
