### PR TITLE
Issue #764: tighten live evaluation follow-up state

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1000,6 +1000,85 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Nightly lodging exceeds the allowed cap.")).toBeInTheDocument();
   });
 
+  it("surfaces exception guidance and approval requirements from live policy results", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          follow_up: {
+            status: "exception_required",
+            path: "exception",
+            title: "Exception review required",
+            summary: "Document the schedule exception and route the packet for manager approval.",
+            recommended_action: "request_exception",
+            recommended_label: "Prepare exception packet",
+            alternatives: [],
+            guidance: [
+              "Attach the compliant comparable to the exception packet.",
+              "Explain why the earlier arrival is required for the client meeting.",
+            ],
+            notes: [],
+            selected_alternative: null,
+            requested_exception: {
+              exception_type: "schedule_protection",
+              reason: "The client workshop starts before the first compliant arrival window.",
+              requested_approval_roles: ["manager"],
+              notes: ["Reference the supported comparable in the packet."],
+            },
+          },
+          evaluation: {
+            evaluation_result: {
+              ...workspacePayload.proposal_state.evaluation.evaluation_result,
+              status: "exception_required",
+              approval_requirements: [
+                {
+                  role: "manager",
+                  reason: "Schedule exception requires manager approval.",
+                  mandatory: true,
+                },
+              ],
+              failure_reasons: [
+                {
+                  code: "arrival_window_conflict",
+                  message: "The compliant itinerary misses the client workshop start time.",
+                  severity: "blocking",
+                  related_category: "flight",
+                },
+              ],
+              notes: ["Exception review is required before approval can continue."],
+              compliance_score: 0.61,
+            },
+          },
+          summary: {
+            ...workspacePayload.proposal_state.summary,
+            approval_ready: false,
+            evaluation_result_status: "exception_required",
+            follow_up_status: "exception_required",
+            follow_up_title: "Exception review required",
+            follow_up_summary:
+              "Document the schedule exception and route the packet for manager approval.",
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Exception review required")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Prepare exception packet")).toBeInTheDocument();
+    expect(screen.getAllByText("Attach the compliant comparable to the exception packet.")).toHaveLength(2);
+    expect(
+      screen.getByText("Explain why the earlier arrival is required for the client meeting."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Exception rationale: The client workshop starts before the first compliant arrival window."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Schedule exception requires manager approval.")).toBeInTheDocument();
+  });
+
   it("skips the follow-up card when legacy records expose an empty follow-up object", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1120,12 +1120,15 @@ describe("WorkspacePage", () => {
     });
 
     const user = userEvent.setup();
-    await user.clear(screen.getByLabelText("Budget title"));
-    await user.type(screen.getByLabelText("Budget title"), "Kyoto spring guardrails");
-    await user.clear(screen.getByLabelText("Lodging cap"));
-    await user.type(screen.getByLabelText("Lodging cap"), "600");
-    await user.clear(screen.getByLabelText("Food cap"));
-    await user.type(screen.getByLabelText("Food cap"), "180");
+    fireEvent.change(screen.getByLabelText("Budget title"), {
+      target: { value: "Kyoto spring guardrails" },
+    });
+    fireEvent.change(screen.getByLabelText("Lodging cap"), {
+      target: { value: "600" },
+    });
+    fireEvent.change(screen.getByLabelText("Food cap"), {
+      target: { value: "180" },
+    });
     await user.click(screen.getByRole("button", { name: "Save budget plan" }));
 
     await waitFor(() => {

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -633,6 +633,12 @@ function WorkspacePageContent({
                   ) : null}
                 </article>
               ) : null}
+              {(renderableProposalFollowUp?.guidance ?? []).map((guidance) => (
+                <article key={guidance} className="decision-card">
+                  <h3>Guidance</h3>
+                  <p>{guidance}</p>
+                </article>
+              ))}
               {(renderableProposalFollowUp?.alternatives ?? []).map((alternative) => (
                 <article
                   key={`${alternative.category}-${alternative.summary}`}

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -919,8 +919,10 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
     assert submitted.json()["proposal_state"]["execution_id"] == "exec-live-001"
 
     evaluation_fixture = _load_fixture("results", "approved_evaluation.json")
-    evaluation_fixture["request"]["trip_id"] = trip_id
-    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["request"]["trip_id"] = "trip-stale"
+    evaluation_fixture["request"]["proposal_id"] = "proposal:stale"
+    evaluation_fixture["request"]["organization_id"] = "org-stale"
+    evaluation_fixture["request"]["payload"]["proposal_version"] = "proposal-stale"
     evaluation_response._payload["trip_id"] = trip_id
     evaluation_response._payload["proposal_id"] = f"proposal:{trip_id}"
     evaluation_response.text = json.dumps(evaluation_response._payload)
@@ -965,6 +967,15 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
             "requested_at": evaluation_fixture["request"]["submitted_at"],
         },
     }
+    assert payload["evaluation"]["request_payload"] == {
+        "execution_id": "exec-live-001",
+        "proposal_version": "proposal-v3",
+    }
+    assert payload["evaluation"]["linkage"]["trip_id"] == trip_id
+    assert payload["evaluation"]["linkage"]["proposal_id"] == f"proposal:{trip_id}"
+    assert payload["evaluation"]["linkage"]["organization_id"] == submission_fixture["request"][
+        "organization_id"
+    ]
 
 
 def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -269,6 +269,118 @@ def test_workspace_proposal_evaluation_derives_reoptimization_follow_up(client: 
     assert follow_up["selected_alternative"]["summary"] == "Use a compliant downtown property"
 
 
+def test_workspace_proposal_evaluation_derives_exception_follow_up(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Exception follow-up workspace",
+            "summary": "Persist deterministic exception guidance from live policy results.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    evaluation_fixture = _load_fixture("results", "approved_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["status"] = (
+        "exception_required"
+    )
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"][
+        "approval_requirements"
+    ] = [
+        {
+            "role": "manager",
+            "reason": "Operational exception requires manager approval",
+            "mandatory": True,
+        },
+        {
+            "role": "finance",
+            "reason": "Lodging cap exception requires finance review",
+            "mandatory": True,
+        },
+    ]
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["failure_reasons"] = [
+        {
+            "code": "lodging_cap_exception",
+            "message": "Selected lodging exceeds the nightly cap.",
+            "severity": "warning",
+            "related_category": "lodging",
+        }
+    ]
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"][
+        "preferred_alternatives"
+    ] = [
+        {
+            "category": "lodging",
+            "summary": "Use the lower-cost comparable if the exception is denied.",
+            "rationale": "Preserves site access with a lower nightly cost ceiling.",
+            "comparable_ref": "lodging-alt-2",
+        }
+    ]
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"][
+        "exception_guidance"
+    ] = [
+        "Retain the lower-cost comparable in the approval packet.",
+        "Document the operational-safety rationale in the manager approval request.",
+    ]
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["notes"] = [
+        "Proposal is exception-eligible if the fatigue-management rationale is approved."
+    ]
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["compliance_score"] = 0.68
+
+    evaluated = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert evaluated.status_code == 200
+    payload = evaluated.json()["proposal_state"]
+    follow_up = payload["follow_up"]
+    assert follow_up["status"] == "exception_required"
+    assert follow_up["path"] == "exception"
+    assert follow_up["recommended_action"] == "request_exception"
+    assert follow_up["approval_requirements"][0]["role"] == "manager"
+    assert follow_up["alternatives"][0]["category"] == "lodging"
+    assert follow_up["guidance"] == [
+        "Retain the lower-cost comparable in the approval packet.",
+        "Document the operational-safety rationale in the manager approval request.",
+    ]
+    assert payload["summary"]["evaluation_result_status"] == "exception_required"
+    assert payload["summary"]["approval_ready"] is False
+    assert payload["summary"]["follow_up_status"] == "exception_required"
+
+
 def test_workspace_proposal_submission_clears_stale_evaluation_state(client: TestClient) -> None:
     created = client.post(
         "/api/trips",

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -482,8 +482,14 @@ def test_workspace_proposal_evaluation_rejects_mismatched_scenario_and_organizat
             "scenario_id": "scenario-a",
         },
     )
-    assert organization_response.status_code == 400
-    assert "organization_id" in organization_response.json()["detail"]
+    assert organization_response.status_code == 200
+    assert organization_response.json()["proposal_state"]["evaluation"]["request_payload"] == {
+        "execution_id": "exec-001",
+        "proposal_version": "proposal-v3",
+    }
+    assert organization_response.json()["proposal_state"]["evaluation"]["linkage"]["organization_id"] == (
+        submission_fixture["request"]["organization_id"]
+    )
 
 
 def test_workspace_proposal_follow_up_patch_persists_exception_request(client: TestClient) -> None:

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -266,6 +266,7 @@ def test_workspace_proposal_evaluation_derives_reoptimization_follow_up(client: 
     assert follow_up["status"] == "reoptimization_required"
     assert follow_up["recommended_action"] == "reoptimize"
     assert follow_up["alternatives"][0]["category"] == "lodging"
+    assert follow_up["selected_alternative"]["summary"] == "Use a compliant downtown property"
 
 
 def test_workspace_proposal_submission_clears_stale_evaluation_state(client: TestClient) -> None:
@@ -920,7 +921,6 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
     evaluation_fixture = _load_fixture("results", "approved_evaluation.json")
     evaluation_fixture["request"]["trip_id"] = trip_id
     evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
-    evaluation_fixture["request"]["payload"]["execution_id"] = "exec-live-001"
     evaluation_response._payload["trip_id"] = trip_id
     evaluation_response._payload["proposal_id"] = f"proposal:{trip_id}"
     evaluation_response.text = json.dumps(evaluation_response._payload)

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -515,6 +515,74 @@ def test_workspace_proposal_evaluation_rejects_mismatched_submission_linkage(
     assert "persisted proposal" in evaluated.json()["detail"]
 
 
+def test_workspace_proposal_evaluation_normalizes_stale_request_linkage(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Proposal evaluation request normalization",
+            "summary": "Stale request linkage should be repaired from the stored submission.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+
+    evaluation_fixture = _load_fixture("results", "approved_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = "trip-stale"
+    evaluation_fixture["request"]["proposal_id"] = "proposal:stale"
+    evaluation_fixture["request"]["organization_id"] = "org-stale"
+    evaluation_fixture["request"]["payload"]["proposal_version"] = "proposal-v1"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["proposal_version"] = "proposal-v3"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+
+    evaluated = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v1",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert evaluated.status_code == 200
+    evaluation = evaluated.json()["proposal_state"]["evaluation"]
+    assert evaluation["request_payload"] == {
+        "execution_id": "exec-001",
+        "proposal_version": "proposal-v3",
+    }
+    assert evaluation["linkage"]["trip_id"] == trip_id
+    assert evaluation["linkage"]["proposal_id"] == f"proposal:{trip_id}"
+    assert evaluation["linkage"]["organization_id"] == submission_fixture["request"]["organization_id"]
+
+
 def test_workspace_proposal_evaluation_rejects_mismatched_scenario_and_organization(
     client: TestClient,
 ) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -726,6 +726,198 @@ def test_workspace_endpoint_surfaces_reoptimization_follow_up_for_non_compliant_
     assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Reoptimization path required"
 
 
+def test_workspace_endpoint_surfaces_exception_follow_up_for_live_policy_results(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Exception workflow workspace",
+            "summary": "Workspace should expose the exception-oriented follow-up lane.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "fixtures"
+            / "integrations"
+            / "tpp"
+            / "proposal_submit_deferred.json"
+        ).read_text(encoding="utf-8")
+    )
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    evaluation_fixture = {
+        "request": {
+            "operation": "fetch_evaluation_result",
+            "request_id": "req-result-exception-required",
+            "correlation_id": {
+                "value": "corr-result-exception-required",
+                "issued_by": "trip-planner",
+            },
+            "payload": {
+                "execution_id": "exec-exception-001",
+            },
+            "transport_pattern": "async",
+            "organization_id": "org-acme",
+            "trip_id": "trip-100",
+            "proposal_id": "proposal-123",
+            "submitted_at": "2026-04-03T02:18:00Z",
+        },
+        "response": {
+            "operation": "fetch_evaluation_result",
+            "request_id": "req-result-exception-required",
+            "correlation_id": {
+                "value": "corr-result-exception-required",
+                "issued_by": "trip-planner",
+            },
+            "transport_pattern": "async",
+            "execution_status": {
+                "state": "succeeded",
+                "terminal": True,
+                "summary": "Policy evaluation completed with an exception requirement",
+                "external_status": "200 OK",
+                "updated_at": "2026-04-03T02:18:08Z",
+            },
+            "result_payload": {
+                "execution_id": "exec-exception-001",
+                "trip_id": "trip-100",
+                "proposal_id": "proposal-123",
+                "proposal_version": "proposal-v3",
+                "scenario_id": "scenario-a",
+                "evaluation_result": {
+                    "evaluation_id": "eval-exception-001",
+                    "proposal_id": "proposal-123",
+                    "status": "exception_required",
+                    "approval_requirements": [
+                        {
+                            "role": "manager",
+                            "reason": "Schedule exception requires manager approval.",
+                            "mandatory": True,
+                        }
+                    ],
+                    "failure_reasons": [
+                        {
+                            "code": "arrival_window_conflict",
+                            "message": "The compliant itinerary misses the client workshop start time.",
+                            "severity": "blocking",
+                            "related_category": "flight",
+                        }
+                    ],
+                    "preferred_alternatives": [],
+                    "exception_guidance": [
+                        "Attach the compliant comparable to the exception packet.",
+                        "Explain why the earlier arrival is required for the client meeting.",
+                    ],
+                    "notes": [
+                        "Exception review is required before approval can continue."
+                    ],
+                    "compliance_score": 0.61,
+                },
+            },
+            "received_at": "2026-04-03T02:18:08Z",
+            "status_endpoint": "https://tpp.example.test/executions/exec-exception-001",
+        },
+    }
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
+    evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
+        f"proposal:{trip_id}"
+    )
+    proposal_payload = {
+        "proposal_id": f"proposal:{trip_id}",
+        "trip_id": trip_id,
+        "mode": "business",
+        "traveler_context": {
+            "employee_type": "employee",
+            "traveler_experience": "frequent",
+            "home_airport": "ORD",
+            "loyalty_programs": ["United"],
+            "mobility_or_access_needs": [],
+        },
+        "selected_options": [
+            {
+                "category": "airfare",
+                "option_id": "flight-1",
+                "label": "United 123",
+                "vendor": "United",
+                "booking_channel": "Navan",
+                "estimated_cost": {
+                    "currency": "USD",
+                    "typical_amount": 620.0,
+                    "min_amount": 620.0,
+                    "max_amount": 620.0,
+                },
+                "justification_refs": ["schedule-policy"],
+            }
+        ],
+        "cost_summary": {
+            "currency": "USD",
+            "total_estimated_cost": 620.0,
+            "category_estimates": {"airfare": 620.0},
+            "notes": ["Costs include taxes."],
+        },
+        "comparables": [
+            {
+                "category": "airfare",
+                "label": "Compliant later departure",
+                "vendor": "United",
+                "booking_channel": "Navan",
+                "estimated_cost": {
+                    "currency": "USD",
+                    "typical_amount": 610.0,
+                    "min_amount": 610.0,
+                    "max_amount": 610.0,
+                },
+                "notes": ["Compliant arrival misses the workshop setup window."],
+            }
+        ],
+        "approval_notes": ["Schedule exception needs a manager decision before booking."],
+        "constraint_set_id": "policy-standard-2026-02",
+    }
+
+    client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": proposal_payload,
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+
+    response = client.get(f"/api/workspace/{trip_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["proposal_state"]["follow_up"]["status"] == "exception_required"
+    assert payload["planner_panel_state"]["next_step_actions"][0]["action_kind"] == "request_exception"
+    assert payload["planner_panel_state"]["next_step_actions"][0]["label"] == "Prepare exception request"
+    assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Exception path required"
+    assert payload["planner_panel_state"]["outputs"][-1]["status"] == "caution"
+
+
 def test_workspace_planner_decision_answer_persists_across_reload(client: TestClient) -> None:
     created = client.post(
         "/api/trips",

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterator
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -756,7 +757,7 @@ def test_workspace_endpoint_surfaces_exception_follow_up_for_live_policy_results
     submission_fixture["request"]["trip_id"] = trip_id
     submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
     submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
-    evaluation_fixture = {
+    evaluation_fixture: dict[str, Any] = {
         "request": {
             "operation": "fetch_evaluation_result",
             "request_id": "req-result-exception-required",

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -99,21 +99,31 @@ def _resolve_evaluation_response(
     request: TPPRequestEnvelope,
     response_payload: dict[str, Any] | None,
     *,
+    existing: PersistedProposalState,
     proposal_version: str,
 ) -> TPPResponseEnvelope:
     if response_payload is not None:
         return TPPResponseEnvelope.from_dict(response_payload)
+    live_payload = dict(request.payload)
+    live_payload.setdefault("proposal_version", proposal_version or existing.proposal_version)
+    if existing.execution_id:
+        live_payload["execution_id"] = existing.execution_id
     live_request = request
-    if not request.payload.get("proposal_version"):
+    if (
+        live_payload != request.payload
+        or request.trip_id is None
+        or request.proposal_id is None
+        or request.organization_id is None
+    ):
         live_request = TPPRequestEnvelope(
             operation=request.operation,
             request_id=request.request_id,
             correlation_id=request.correlation_id,
-            payload={**request.payload, "proposal_version": proposal_version},
+            payload=live_payload,
             transport_pattern=request.transport_pattern,
-            organization_id=request.organization_id,
-            trip_id=request.trip_id,
-            proposal_id=request.proposal_id,
+            organization_id=request.organization_id or existing.organization_id,
+            trip_id=request.trip_id or existing.trip_id,
+            proposal_id=request.proposal_id or existing.proposal_id,
             submitted_at=request.submitted_at,
             metadata=dict(request.metadata),
         )
@@ -163,6 +173,7 @@ def _derive_follow_up_state(
             ),
             "recommended_action": "reoptimize",
             "recommended_label": "Reoptimize plan",
+            "selected_alternative": alternative if isinstance(alternative, dict) else None,
         }
     elif status == "exception_required":
         follow_up = {
@@ -199,7 +210,7 @@ def _derive_follow_up_state(
     follow_up["failure_reasons"] = failure_reasons
     follow_up["guidance"] = exception_guidance
     follow_up["requested_exception"] = requested_exception
-    follow_up["selected_alternative"] = None
+    follow_up["selected_alternative"] = follow_up.get("selected_alternative")
     follow_up["notes"] = []
 
     if persisted_follow_up and persisted_follow_up.get("manual"):
@@ -456,6 +467,7 @@ def save_workspace_proposal_evaluation(
     response = _resolve_evaluation_response(
         request,
         response_payload,
+        existing=existing,
         proposal_version=proposal_version,
     )
     evaluation = TPPEvaluationResultIngestionService(_PassiveTPPClient(response)).fetch_evaluation_result(

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -91,8 +91,41 @@ def _resolve_submission_response(
             proposal_id=request.proposal_id,
             submitted_at=request.submitted_at,
             metadata=dict(request.metadata),
-        )
+    )
     return HTTPTPPIntegrationClient().submit_proposal(live_request)
+
+
+def _normalize_evaluation_request(
+    request: TPPRequestEnvelope,
+    *,
+    existing: PersistedProposalState,
+    proposal_version: str,
+) -> TPPRequestEnvelope:
+    live_payload = dict(request.payload)
+    live_payload["proposal_version"] = proposal_version or existing.proposal_version
+    if existing.execution_id:
+        live_payload["execution_id"] = existing.execution_id
+
+    organization_id = existing.organization_id or request.organization_id
+    if (
+        live_payload != request.payload
+        or request.trip_id != existing.trip_id
+        or request.proposal_id != existing.proposal_id
+        or request.organization_id != organization_id
+    ):
+        return TPPRequestEnvelope(
+            operation=request.operation,
+            request_id=request.request_id,
+            correlation_id=request.correlation_id,
+            payload=live_payload,
+            transport_pattern=request.transport_pattern,
+            organization_id=organization_id,
+            trip_id=existing.trip_id,
+            proposal_id=existing.proposal_id,
+            submitted_at=request.submitted_at,
+            metadata=dict(request.metadata),
+        )
+    return request
 
 
 def _resolve_evaluation_response(
@@ -104,29 +137,11 @@ def _resolve_evaluation_response(
 ) -> TPPResponseEnvelope:
     if response_payload is not None:
         return TPPResponseEnvelope.from_dict(response_payload)
-    live_payload = dict(request.payload)
-    live_payload.setdefault("proposal_version", proposal_version or existing.proposal_version)
-    if existing.execution_id:
-        live_payload["execution_id"] = existing.execution_id
-    live_request = request
-    if (
-        live_payload != request.payload
-        or request.trip_id is None
-        or request.proposal_id is None
-        or request.organization_id is None
-    ):
-        live_request = TPPRequestEnvelope(
-            operation=request.operation,
-            request_id=request.request_id,
-            correlation_id=request.correlation_id,
-            payload=live_payload,
-            transport_pattern=request.transport_pattern,
-            organization_id=request.organization_id or existing.organization_id,
-            trip_id=request.trip_id or existing.trip_id,
-            proposal_id=request.proposal_id or existing.proposal_id,
-            submitted_at=request.submitted_at,
-            metadata=dict(request.metadata),
-        )
+    live_request = _normalize_evaluation_request(
+        request,
+        existing=existing,
+        proposal_version=proposal_version,
+    )
     return HTTPTPPIntegrationClient().fetch_evaluation_result(live_request)
 
 
@@ -463,7 +478,11 @@ def save_workspace_proposal_evaluation(
             "Proposal evaluation cannot be stored before a proposal submission exists."
         )
 
-    request = TPPRequestEnvelope.from_dict(request_payload)
+    request = _normalize_evaluation_request(
+        TPPRequestEnvelope.from_dict(request_payload),
+        existing=existing,
+        proposal_version=proposal_version,
+    )
     response = _resolve_evaluation_response(
         request,
         response_payload,

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -102,7 +102,7 @@ def _normalize_evaluation_request(
     proposal_version: str,
 ) -> TPPRequestEnvelope:
     live_payload = dict(request.payload)
-    live_payload["proposal_version"] = proposal_version or existing.proposal_version
+    live_payload["proposal_version"] = existing.proposal_version or proposal_version
     if existing.execution_id:
         live_payload["execution_id"] = existing.execution_id
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #764

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The app already has proposal follow-up UI and reoptimization concepts, and this
PR moved that flow onto live TPP responses instead of advisory local payload
interpretation alone.

Parent epic: #755

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [stranske/Travel-Plan-Permission#747](https://github.com/stranske/Travel-Plan-Permission/issues/747)
- [#755](https://github.com/stranske/trip-planner/issues/755)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Normalize live TPP evaluation results into persisted proposal follow-up state.
- [x] Surface reoptimization guidance, exception requirements, and approval-ready status in the workspace from live results.
- [x] Connect live result handling to the existing proposal and policy UI surfaces.
- [x] Define deterministic state transitions for compliant, non-compliant, and exception-required branches.
- [x] Add tests for compliant, non-compliant, and exception-required result handling.

#### Acceptance criteria
- [x] Business-trip proposal follow-up state is driven by live TPP result payloads.
- [x] The workspace reflects compliant, reoptimization, and exception-required paths from runtime data.
- [x] Tests cover the major result-driven follow-up branches.

**Head SHA:** 6811e82e3ed596999c1f993f22c94968b780d868
**Latest Runs:** merged at 2026-04-12T22:01:31Z as commit `0e0e781b2fe9466b3cc74c5e1fca2b72e5ffe849`
**Validation:** `pytest tests/app/test_proposal.py -q`; `pytest tests/app/test_workspace.py -q`; `python -m mypy --config-file pyproject.toml --exclude .workflows-lib .`; `npm --prefix frontend test -- src/routes/WorkspacePage.test.tsx`
<!-- auto-status-summary:end -->
