### PR TITLE
Issue #765: add Google Maps workspace surface

### DIFF
--- a/docs/frontend-route-visualization.md
+++ b/docs/frontend-route-visualization.md
@@ -21,6 +21,7 @@ Issue `#559` adds visualization-oriented shell surfaces that consume route and f
 - The component consumes `runtime_scenario_comparison.scenarios[*].route_sequence`, `route_summary`, `metrics`, and `inventory_summary.bundles[*].destination_names`.
 - `feasibility_summary.assessments` remains the source of route-attention and bundle-readiness signals; the map surface may summarize those signals, but it must not recalculate feasibility in the browser.
 - Scenario preview changes are local presentation changes. The selected map preview should start from persisted workspace state and then update the rendered map surface without mutating backend route logic.
+- When `VITE_GOOGLE_MAPS_EMBED_API_KEY` is configured, the workspace may render a Google Maps directions embed for the selected scenario. When that key is absent or a route is too sparse to render, the UI must fall back to the textual route schematic instead of inventing client-side routing logic.
 
 ## Representative states
 

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -1,51 +1,10 @@
-import type {
-  FeasibilitySummary,
-  RuntimeScenarioComparison,
-  WorkspaceData,
-} from "../../api/workspace";
+import type { FeasibilitySummary, RuntimeScenarioComparison, WorkspaceData } from "../../api/workspace";
+import {
+  buildTripMapSurfaceModel,
+  formatEstimatedTotal,
+} from "./mapSurface";
 
-type TripMapScenario = RuntimeScenarioComparison["scenarios"][number];
 type InventoryBundle = WorkspaceData["inventory_summary"]["bundles"][number];
-
-function humanizeStop(stop: string): string {
-  return stop
-    .replace(/^dest-city-/, "")
-    .replace(/^dest-/, "")
-    .replace(/^city-/, "")
-    .split(/[-_]/g)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function formatEstimatedTotal(
-  value: RuntimeScenarioComparison["scenarios"][number]["metrics"]["estimated_total"]
-): string {
-  if (value == null) {
-    return "Pending";
-  }
-
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: value.currency,
-    maximumFractionDigits: 0,
-  }).format(value.typical_amount);
-}
-
-function summarizeFeasibility(
-  feasibilitySummary: FeasibilitySummary,
-  bundleDestinations: string[]
-): string {
-  if (feasibilitySummary.assessment_count === 0) {
-    return "No inventory bundles have produced route-feasibility signals yet.";
-  }
-
-  if (bundleDestinations.length === 0) {
-    return `${feasibilitySummary.assessment_count} bundle checks are available, but destination anchors have not been attached yet.`;
-  }
-
-  return `${bundleDestinations.length} destination anchors are backed by ${feasibilitySummary.assessment_count} feasibility assessment(s).`;
-}
 
 export function TripMap({
   comparison,
@@ -78,20 +37,21 @@ export function TripMap({
     );
   }
 
-  const bundleDestinations = Array.from(
-    new Set(
-      bundles
-        .flatMap((bundle) => bundle.destination_names)
-        .map((destination) => destination.trim())
-        .filter(Boolean)
-    )
-  );
+  const mapSurface = buildTripMapSurfaceModel({
+    activeScenario,
+    bundles,
+    feasibilitySummary,
+    googleMapsApiKey: import.meta.env.VITE_GOOGLE_MAPS_EMBED_API_KEY,
+  });
 
   return (
     <section className="status-card map-card">
       <p className="status-label">Map surface</p>
       <h2>Map preview for {activeScenario.title}</h2>
       <p>{activeScenario.summary}</p>
+      <p className="muted-copy">
+        {mapSurface.provider.label} is the current map path. {mapSurface.provider.summary}
+      </p>
       <div className="map-scenario-toggle" aria-label="Map scenario previews">
         {comparison.scenarios.map((scenario) => (
           <button
@@ -108,25 +68,31 @@ export function TripMap({
         ))}
       </div>
       <div className="map-surface" aria-label="Route context map">
-        <div className="map-route">
-          {activeScenario.route_sequence.map((stop, index) => (
-            <div key={`${activeScenario.scenario_id}-${stop}-${index}`} className="map-stop">
-              <div className="map-stop-marker">
-                <span>{index + 1}</span>
+        {mapSurface.provider.kind === "google-maps" ? (
+          <div className="map-route">
+            <iframe
+              title={`Google Maps route preview for ${activeScenario.title}`}
+              src={mapSurface.provider.iframeSrc}
+              className="map-provider-frame"
+              loading="lazy"
+              referrerPolicy="no-referrer-when-downgrade"
+            />
+          </div>
+        ) : (
+          <div className="map-route">
+            {mapSurface.routeStops.map((stop, index) => (
+              <div key={stop.id} className="map-stop">
+                <div className="map-stop-marker">
+                  <span>{index + 1}</span>
+                </div>
+                <div className="map-stop-copy">
+                  <h3>{stop.label}</h3>
+                  <p>{stop.description}</p>
+                </div>
               </div>
-              <div className="map-stop-copy">
-                <h3>{humanizeStop(stop)}</h3>
-                <p>
-                  {index === 0
-                    ? "Current route origin for the workspace preview."
-                    : index === activeScenario.route_sequence.length - 1
-                      ? "Current route destination anchor."
-                      : "Intermediate route checkpoint preserved in the active scenario."}
-                </p>
-              </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
         <div className="map-sidebar">
           <dl className="workspace-meta map-metrics">
             <div>
@@ -153,12 +119,12 @@ export function TripMap({
           </article>
           <article className="decision-card">
             <h3>Destination anchors</h3>
-            <p>{summarizeFeasibility(feasibilitySummary, bundleDestinations)}</p>
+            <p>{mapSurface.feasibilitySummary}</p>
             <div className="map-anchor-list">
-              {bundleDestinations.length === 0 ? (
+              {mapSurface.destinationAnchors.length === 0 ? (
                 <span className="map-anchor-chip map-anchor-chip-muted">Awaiting option anchors</span>
               ) : (
-                bundleDestinations.map((destination) => (
+                mapSurface.destinationAnchors.map((destination) => (
                   <span key={destination} className="map-anchor-chip">
                     {destination}
                   </span>

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -13,11 +13,17 @@ describe("mapSurface", () => {
   });
 
   it("builds a Google Maps directions URL with waypoints", () => {
-    expect(
+    const url = new URL(
       buildGoogleMapsEmbedUrl(["Kyoto", "Uji", "Kyoto"], "test-key")
-    ).toContain(
-      "https://www.google.com/maps/embed/v1/directions?key=test-key&origin=Kyoto&destination=Kyoto&mode=transit&waypoints=Uji"
     );
+
+    expect(url.origin).toBe("https://www.google.com");
+    expect(url.pathname).toBe("/maps/embed/v1/directions");
+    expect(url.searchParams.get("key")).toBe("test-key");
+    expect(url.searchParams.get("origin")).toBe("Kyoto");
+    expect(url.searchParams.get("destination")).toBe("Kyoto");
+    expect(url.searchParams.get("mode")).toBe("transit");
+    expect(url.searchParams.get("waypoints")).toBe("Uji");
   });
 
   it("selects the live Google Maps provider when a key and route are available", () => {

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGoogleMapsEmbedUrl,
+  buildTripMapSurfaceModel,
+  humanizeStop,
+} from "./mapSurface";
+
+describe("mapSurface", () => {
+  it("normalizes route stop labels for provider-independent map shaping", () => {
+    expect(humanizeStop("dest-city-new-york")).toBe("New York");
+    expect(humanizeStop("kyoto_station")).toBe("Kyoto Station");
+  });
+
+  it("builds a Google Maps directions URL with waypoints", () => {
+    expect(
+      buildGoogleMapsEmbedUrl(["Kyoto", "Uji", "Kyoto"], "test-key")
+    ).toContain(
+      "https://www.google.com/maps/embed/v1/directions?key=test-key&origin=Kyoto&destination=Kyoto&mode=transit&waypoints=Uji"
+    );
+  });
+
+  it("selects the live Google Maps provider when a key and route are available", () => {
+    const model = buildTripMapSurfaceModel({
+      activeScenario: {
+        scenario_id: "scenario:1",
+        title: "Kyoto base",
+        rank: 1,
+        status: "lead",
+        summary: "Baseline",
+        comparison_note: "Lead route",
+        option_count: 2,
+        route_sequence: ["kyoto", "uji", "kyoto"],
+        route_summary: "kyoto -> uji -> kyoto",
+        recommended_for_selection: true,
+        feasible: true,
+        metrics: {
+          score: 0.93,
+          travel_minutes: 265,
+          transfers: 4,
+          estimated_total: { currency: "JPY", typical_amount: 3400 },
+        },
+        delta: {
+          score_delta: 0,
+          travel_minutes_delta: 0,
+          transfers_delta: 0,
+          estimated_total_delta: 0,
+        },
+        highlights: ["Low-friction baseline."],
+      },
+      bundles: [
+        {
+          bundle_id: "bundle-1",
+          title: "Kyoto anchor",
+          bundle_context: "route_level",
+          summary: "Bundle summary",
+          destination_names: ["Kyoto", "Uji"],
+          option_count: 2,
+          strengths: [],
+          tradeoffs: [],
+        },
+      ],
+      feasibilitySummary: {
+        assessment_count: 2,
+        recommended_bundle_count: 1,
+        blocking_bundle_count: 0,
+        attention_bundle_count: 1,
+        notes: [],
+        assessments: [],
+      },
+      googleMapsApiKey: "test-key",
+    });
+
+    expect(model.provider.kind).toBe("google-maps");
+    expect(model.destinationAnchors).toEqual(["Kyoto", "Uji"]);
+    expect(model.routeStops.map((stop) => stop.label)).toEqual(["Kyoto", "Uji", "Kyoto"]);
+  });
+
+  it("falls back when Google Maps is not configured", () => {
+    const model = buildTripMapSurfaceModel({
+      activeScenario: {
+        scenario_id: "scenario:1",
+        title: "Kyoto base",
+        rank: 1,
+        status: "lead",
+        summary: "Baseline",
+        comparison_note: "Lead route",
+        option_count: 2,
+        route_sequence: ["kyoto", "uji"],
+        route_summary: "kyoto -> uji",
+        recommended_for_selection: true,
+        feasible: true,
+        metrics: {
+          score: 0.93,
+          travel_minutes: 265,
+          transfers: 4,
+          estimated_total: null,
+        },
+        delta: {
+          score_delta: 0,
+          travel_minutes_delta: 0,
+          transfers_delta: 0,
+          estimated_total_delta: null,
+        },
+        highlights: ["Low-friction baseline."],
+      },
+      bundles: [],
+      feasibilitySummary: {
+        assessment_count: 0,
+        recommended_bundle_count: 0,
+        blocking_bundle_count: 0,
+        attention_bundle_count: 0,
+        notes: [],
+        assessments: [],
+      },
+    });
+
+    expect(model.provider.kind).toBe("fallback");
+    expect(model.provider.summary).toContain("bounded textual route fallback");
+  });
+});

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -1,0 +1,157 @@
+import type {
+  FeasibilitySummary,
+  RuntimeScenarioComparison,
+  WorkspaceData,
+} from "../../api/workspace";
+
+type TripMapScenario = RuntimeScenarioComparison["scenarios"][number];
+type InventoryBundle = WorkspaceData["inventory_summary"]["bundles"][number];
+
+export type MapSurfaceProvider =
+  | {
+      kind: "google-maps";
+      label: "Google Maps";
+      status: "live";
+      iframeSrc: string;
+      summary: string;
+    }
+  | {
+      kind: "fallback";
+      label: "Fallback schematic";
+      status: "fallback";
+      summary: string;
+    };
+
+export type RouteStop = {
+  id: string;
+  label: string;
+  description: string;
+};
+
+export type TripMapSurfaceModel = {
+  provider: MapSurfaceProvider;
+  routeStops: RouteStop[];
+  destinationAnchors: string[];
+  feasibilitySummary: string;
+};
+
+export function humanizeStop(stop: string): string {
+  return stop
+    .replace(/^dest-city-/, "")
+    .replace(/^dest-/, "")
+    .replace(/^city-/, "")
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function formatEstimatedTotal(
+  value: RuntimeScenarioComparison["scenarios"][number]["metrics"]["estimated_total"]
+): string {
+  if (value == null) {
+    return "Pending";
+  }
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: value.currency,
+    maximumFractionDigits: 0,
+  }).format(value.typical_amount);
+}
+
+export function summarizeFeasibility(
+  feasibilitySummary: FeasibilitySummary,
+  bundleDestinations: string[]
+): string {
+  if (feasibilitySummary.assessment_count === 0) {
+    return "No inventory bundles have produced route-feasibility signals yet.";
+  }
+
+  if (bundleDestinations.length === 0) {
+    return `${feasibilitySummary.assessment_count} bundle checks are available, but destination anchors have not been attached yet.`;
+  }
+
+  return `${bundleDestinations.length} destination anchors are backed by ${feasibilitySummary.assessment_count} feasibility assessment(s).`;
+}
+
+function describeStop(index: number, routeLength: number): string {
+  if (index === 0) {
+    return "Current route origin for the workspace preview.";
+  }
+  if (index === routeLength - 1) {
+    return "Current route destination anchor.";
+  }
+  return "Intermediate route checkpoint preserved in the active scenario.";
+}
+
+export function buildGoogleMapsEmbedUrl(routeLabels: string[], apiKey: string): string {
+  const origin = routeLabels[0] ?? "";
+  const destination = routeLabels[routeLabels.length - 1] ?? origin;
+  const waypointLabels = routeLabels.slice(1, -1);
+  const params = new URLSearchParams({
+    key: apiKey,
+    origin,
+    destination,
+    mode: "transit",
+  });
+
+  if (waypointLabels.length > 0) {
+    params.set("waypoints", waypointLabels.join("|"));
+  }
+
+  return `https://www.google.com/maps/embed/v1/directions?${params.toString()}`;
+}
+
+export function buildTripMapSurfaceModel({
+  activeScenario,
+  bundles,
+  feasibilitySummary,
+  googleMapsApiKey,
+}: {
+  activeScenario: TripMapScenario;
+  bundles: InventoryBundle[];
+  feasibilitySummary: FeasibilitySummary;
+  googleMapsApiKey?: string | null;
+}): TripMapSurfaceModel {
+  const destinationAnchors = Array.from(
+    new Set(
+      bundles
+        .flatMap((bundle) => bundle.destination_names)
+        .map((destination) => destination.trim())
+        .filter(Boolean)
+    )
+  );
+  const routeStops = activeScenario.route_sequence.map((stop, index) => ({
+    id: `${activeScenario.scenario_id}-${stop}-${index}`,
+    label: humanizeStop(stop),
+    description: describeStop(index, activeScenario.route_sequence.length),
+  }));
+  const trimmedApiKey = googleMapsApiKey?.trim() ?? "";
+  const routeLabels = routeStops.map((stop) => stop.label);
+  const provider =
+    trimmedApiKey !== "" && routeLabels.length >= 2
+      ? ({
+          kind: "google-maps",
+          label: "Google Maps",
+          status: "live",
+          iframeSrc: buildGoogleMapsEmbedUrl(routeLabels, trimmedApiKey),
+          summary: "Google Maps is rendering the current route with the workspace fallback kept in reserve.",
+        } satisfies MapSurfaceProvider)
+      : ({
+          kind: "fallback",
+          label: "Fallback schematic",
+          status: "fallback",
+          summary:
+            trimmedApiKey === ""
+              ? "Google Maps is not configured in this environment, so the workspace is showing the bounded textual route fallback."
+              : "The route needs at least an origin and destination before the live provider view can render.",
+        } satisfies MapSurfaceProvider);
+
+  return {
+    provider,
+    routeStops,
+    destinationAnchors,
+    feasibilitySummary: summarizeFeasibility(feasibilitySummary, destinationAnchors),
+  };
+}

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -622,6 +622,7 @@ describe("WorkspacePage", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     mockedAnswerPlannerDecision.mockReset();
     mockedSubmitPlannerOptionFeedback.mockReset();
     mockedSaveWorkspaceBudget.mockReset();
@@ -693,6 +694,33 @@ describe("WorkspacePage", () => {
     ).toBeInTheDocument();
     expect(within(screen.getByLabelText("Route context map")).getByRole("heading", { name: "Osaka" })).toBeInTheDocument();
     expect(screen.getByText("Higher transfer load to preserve nightlife breadth.")).toBeInTheDocument();
+  });
+
+  it("renders the Google Maps provider path when configured", async () => {
+    vi.stubEnv("VITE_GOOGLE_MAPS_EMBED_API_KEY", "test-key");
+    const user = userEvent.setup();
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(workspacePayload),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTitle("Google Maps route preview for Kyoto base with Uji day trip")
+      ).toBeInTheDocument();
+    });
+
+    const initialFrame = screen.getByTitle("Google Maps route preview for Kyoto base with Uji day trip");
+    expect(initialFrame).toHaveAttribute("src", expect.stringContaining("key=test-key"));
+    expect(initialFrame).toHaveAttribute("src", expect.stringContaining("origin=Kyoto"));
+    expect(initialFrame).toHaveAttribute("src", expect.stringContaining("waypoints=Uji"));
+
+    await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
+
+    const updatedFrame = screen.getByTitle("Google Maps route preview for Kyoto plus Osaka fallback");
+    expect(updatedFrame).toHaveAttribute("src", expect.stringContaining("waypoints=Osaka"));
   });
 
   it("updates the dedicated comparison surfaces when scenario and trip selections change", async () => {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GOOGLE_MAPS_EMBED_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #765

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The current map surface is useful, but it is still a route-context preview rather
than a true mapped experience. The original design called for interactive maps,
and Google Maps is the target provider.

Parent epic: #756

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#756](https://github.com/stranske/trip-planner/issues/756)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Define a provider boundary for map rendering, geocoding, and route overlays.
- [x] Add a Google Maps-backed frontend map implementation for workspace scenarios and options.
- [x] Add a bounded fallback implementation path for local development or temporary provider failure.
- [x] Render route sequence, destination anchors, and option context on the map surface.
- [x] Add tests for provider-independent map data shaping and visible map-state switching behavior.

#### Acceptance criteria
- [x] The workspace can render a real map-backed route and option surface.
- [x] Google Maps is the target provider for the main implementation path.
- [x] The app retains a bounded fallback/provider seam rather than hard-coding one brittle map path.

**Head SHA:** fc2e34a000892d348f845cdf7b7690cd83b3e735
**Latest Runs:** ❔ in progress — Agents PR Meta
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24320913900) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24320913884) |
<!-- auto-status-summary:end -->
