### PR TITLE
Codex bootstrap for #767

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ The runtime baseline now treats the saved trip record as the durable planning co
 Saved scenarios and trip-level planning history now persist underneath that same trip container, so later comparison and workspace slices should consume those records instead of reintroducing fixture-only storage.
 The shipped full-stack MVP now includes authenticated trip creation, persisted trip and scenario routes, the workspace shell, planner session APIs, and stored policy/proposal state. Live external policy transport and provider-backed maps remain follow-on integrations, so docs and checks in this repo should describe those gaps explicitly instead of implying they already ship.
 
+## Current MVP Surfaces
+
+The current runtime already ships these inspectable application surfaces:
+
+- authenticated sign-up, sign-in, sign-out, and session restore
+- persisted trip creation plus saved trip, scenario-history, and workspace routes
+- planner session APIs and workspace state hydration for the frontend app shell
+- stored proposal and policy posture state that later `Travel-Plan-Permission` work can consume
+
+The current runtime does not yet ship live Google Maps rendering or remote `Travel-Plan-Permission` execution. Those remain explicit follow-on integrations, so local runtime checks and product docs should continue to call them out as deferred.
+
 ## Key Docs
 
 - [Implementation plan](docs/implementation-plan.md)

--- a/agents/codex-767.md
+++ b/agents/codex-767.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #767 -->

--- a/docs/product-architecture-brief.md
+++ b/docs/product-architecture-brief.md
@@ -199,6 +199,8 @@ Build toward a stateful web app with:
 - LLM chat side panel
 - business-policy readiness summary
 
+The repo is already past the contracts-only stage. The current MVP ships account-backed entry flows, persisted trip creation, saved trip/scenario routes, a workspace shell, planner session APIs, and stored proposal/policy posture state. Provider-backed maps and live `Travel-Plan-Permission` execution are still follow-on integrations, so design work should treat those as explicit deferred seams rather than implied current behavior.
+
 ### Core Backend Services
 
 Organize the application into five bounded modules:

--- a/frontend/src/router.test.ts
+++ b/frontend/src/router.test.ts
@@ -45,6 +45,24 @@ describe("router auth loaders", () => {
     vi.clearAllMocks();
   });
 
+  it("opts the app router into the same React Router future flags used by runtime tests", async () => {
+    vi.resetModules();
+    const { createBrowserRouter } = await import("react-router-dom");
+    vi.mocked(createBrowserRouter).mockClear();
+
+    const { APP_ROUTER_FUTURE } = await import("./router");
+
+    expect(APP_ROUTER_FUTURE).toEqual({
+      v7_normalizeFormMethod: true,
+      v7_partialHydration: true,
+      v7_relativeSplatPath: true,
+      v7_startTransition: true,
+    });
+    expect(createBrowserRouter).toHaveBeenCalledWith(expect.any(Array), {
+      future: APP_ROUTER_FUTURE,
+    });
+  });
+
   it("restores the signed-in session during app bootstrap", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
     vi.mocked(fetchCurrentSession).mockResolvedValueOnce({

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -188,10 +188,13 @@ export const appRoutes: RouteObject[] = [
   },
 ];
 
+export const APP_ROUTER_FUTURE = {
+  v7_normalizeFormMethod: true,
+  v7_partialHydration: true,
+  v7_relativeSplatPath: true,
+  v7_startTransition: true,
+} as const;
+
 export const router = createBrowserRouter(appRoutes, {
-  future: {
-    v7_normalizeFormMethod: true,
-    v7_partialHydration: true,
-    v7_relativeSplatPath: true,
-  },
+  future: APP_ROUTER_FUTURE,
 });

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1354,18 +1354,17 @@ describe("WorkspacePage", () => {
     const host = view.container.querySelector(".planner-panel-host");
     const plannerMountNode = host?.shadowRoot?.lastElementChild;
     expect(plannerMountNode).not.toBeNull();
-    fireEvent(
-      plannerMountNode as Element,
-      new CustomEvent("planner-response-save-as-fallback", {
-        detail: {
-          option_id: "scenario:trip-leisure-kyoto-draft:1",
-          action_type: "save_as_fallback",
-          decision_id: null,
-        },
-      })
-    );
-
     await waitFor(() => {
+      fireEvent(
+        plannerMountNode as Element,
+        new CustomEvent("planner-response-save-as-fallback", {
+          detail: {
+            option_id: "scenario:trip-leisure-kyoto-draft:1",
+            action_type: "save_as_fallback",
+            decision_id: null,
+          },
+        })
+      );
       expect(mockedSubmitPlannerOptionFeedback).toHaveBeenCalledWith(
         "trip-leisure-kyoto-draft",
         "scenario:trip-leisure-kyoto-draft:1",

--- a/scripts/check_full_stack_runtime.sh
+++ b/scripts/check_full_stack_runtime.sh
@@ -17,6 +17,10 @@ Full-stack runtime checks require both dependency installs to be present first:
   2. npm --prefix frontend install
 
 Then rerun `make runtime-check` (or `make runtime-smoke`).
+These commands validate the local FastAPI + Vite MVP in this repo; they do not
+prove live Google Maps rendering or remote Travel-Plan-Permission transport.
+Do not create a repo-root `node_modules/`; local frontend tooling should live
+under `frontend/node_modules`.
 EOF
   exit 1
 }


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The runtime now works, but the repo still had warning-level drift and
documentation lag that could mislead future work. That debt was resolved in the
bounded follow-up patch so the repo reflects the shipped runtime more accurately.

Parent epic: #756

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#756](https://github.com/stranske/trip-planner/issues/756)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Eliminate or explicitly opt into the current React Router future-flag warnings emitted by tests.
- [x] Tighten runtime-check messaging and prerequisite docs where needed.
- [x] Refresh design coverage docs and README sections that still undersell or misstate the implemented runtime.
- [x] Add tests or assertions where needed to keep the updated runtime assumptions from drifting again.
- [x] Document any intentionally deferred runtime gaps precisely instead of leaving them implied.

#### Acceptance criteria
- [x] Frontend tests no longer emit the current avoidable router warnings.
- [x] Runtime verification docs accurately describe prerequisite install steps and runtime checks.
- [x] Design/reality docs reflect the current full-stack MVP rather than the older contracts-only stage.

**Head SHA:** 0ff49173938d0516755c791e5fcab623e03e51ac
**Merge commit:** 1565f6ff1f9bd3ccada8453e9bbcb45641153cb4
**Validation evidence:** `frontend/src/router.tsx`, `frontend/src/router.test.ts`, `README.md`, and the runtime/design docs landed in #792; local verification passed with `npm --prefix frontend exec -- vitest run src/router.test.ts` and `npm --prefix frontend run build`.
<!-- auto-status-summary:end -->

<!-- pr-preamble:start -->
> **Source:** Issue #767

<!-- pr-preamble:end -->
