### PR TITLE
Issue #807: ship live proposal status refresh and workspace states

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -368,6 +368,8 @@ export type WorkspaceData = {
     summary: {
       submission_status?: string;
       submission_summary?: string;
+      submission_requires_polling?: boolean;
+      evaluation_transport_status?: string;
       evaluation_result_status?: string;
       approval_ready?: boolean;
       comparable_count?: number;
@@ -423,6 +425,18 @@ export async function fetchWorkspace(tripId: string): Promise<WorkspaceData> {
     path: `/api/workspace/${tripId}`,
     credentials: "include",
   });
+}
+
+export async function refreshWorkspaceProposalStatus(tripId: string): Promise<WorkspaceData["proposal_state"]> {
+  const response = await fetchJson<{
+    proposal_state: WorkspaceData["proposal_state"];
+    summary: NonNullable<WorkspaceData["proposal_state"]>["summary"] | Record<string, never>;
+  }>({
+    path: `/api/workspace/${tripId}/proposal/refresh`,
+    method: "POST",
+    credentials: "include",
+  });
+  return response.proposal_state;
 }
 
 export async function answerPlannerDecision(

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1192,6 +1192,42 @@ describe("WorkspacePage", () => {
     expect(screen.getByRole("button", { name: "Refresh live status" })).toBeInTheDocument();
   });
 
+  it("keeps refresh affordances visible when execution succeeded but evaluation is still missing", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          submission_status: "succeeded",
+          evaluation_status: "succeeded",
+          follow_up: null,
+          summary: {
+            ...workspacePayload.proposal_state.summary,
+            submission_status: "succeeded",
+            submission_summary: "Execution finished, but the evaluation payload still needs to be persisted.",
+            submission_requires_polling: false,
+            evaluation_transport_status: "succeeded",
+            evaluation_result_status: null,
+            approval_ready: false,
+            follow_up_status: null,
+            follow_up_title: null,
+            follow_up_summary: null,
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Awaiting policy evaluation result" })).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: "Refresh live status" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Execution finished, but the evaluation payload still needs to be persisted.")
+    ).toBeInTheDocument();
+  });
+
   it("refreshes the proposal lifecycle when the workspace requests live status", async () => {
     mockedRefreshWorkspaceProposalStatus.mockResolvedValue({
       ...workspacePayload.proposal_state,

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -7,6 +7,7 @@ import { ApiClientError } from "../lib/api/errors";
 import {
   answerPlannerDecision,
   recordWorkspaceSpendEvent,
+  refreshWorkspaceProposalStatus,
   saveWorkspaceBudget,
   submitPlannerOptionFeedback,
   type WorkspaceData,
@@ -23,6 +24,7 @@ vi.mock("../api/workspace", async () => {
     submitPlannerOptionFeedback: vi.fn(),
     saveWorkspaceBudget: vi.fn(),
     recordWorkspaceSpendEvent: vi.fn(),
+    refreshWorkspaceProposalStatus: vi.fn(),
   };
 });
 
@@ -39,6 +41,7 @@ const mockedAnswerPlannerDecision = vi.mocked(answerPlannerDecision);
 const mockedSubmitPlannerOptionFeedback = vi.mocked(submitPlannerOptionFeedback);
 const mockedSaveWorkspaceBudget = vi.mocked(saveWorkspaceBudget);
 const mockedRecordWorkspaceSpendEvent = vi.mocked(recordWorkspaceSpendEvent);
+const mockedRefreshWorkspaceProposalStatus = vi.mocked(refreshWorkspaceProposalStatus);
 const tripComparisonPayload: TripRecord[] = [
   {
     trip_id: "trip-leisure-kyoto-draft",
@@ -510,6 +513,8 @@ const workspacePayload = {
     summary: {
       submission_status: "succeeded",
       submission_summary: "Proposal submitted to the policy engine.",
+      submission_requires_polling: false,
+      evaluation_transport_status: "succeeded",
       evaluation_result_status: "compliant",
       approval_ready: true,
       comparable_count: 1,
@@ -651,6 +656,7 @@ describe("WorkspacePage", () => {
     mockedSubmitPlannerOptionFeedback.mockReset();
     mockedSaveWorkspaceBudget.mockReset();
     mockedRecordWorkspaceSpendEvent.mockReset();
+    mockedRefreshWorkspaceProposalStatus.mockReset();
   });
 
   it("renders timeline structure from persisted trip and scenario state", async () => {
@@ -684,7 +690,8 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Osaka arrival buffer")).toBeInTheDocument();
     expect(screen.getByText("Kyoto cultural anchor")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();
-    expect(screen.getByText("Approval-ready proposal")).toBeInTheDocument();
+    expect(screen.getByText("approval-ready")).toBeInTheDocument();
+    expect(screen.getAllByText("Advance to approval").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Comparables and readiness signals" })).toBeInTheDocument();
     expect(screen.getByText("Conference Hotel")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "User-visible planner checkpoints" })).toBeInTheDocument();
@@ -1034,6 +1041,236 @@ describe("WorkspacePage", () => {
     expect(screen.queryByText("2026-05-04")).not.toBeInTheDocument();
   });
 
+  it("surfaces a pending execution state before the proposal is sent", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          submission_status: "pending",
+          evaluation_status: null,
+          follow_up: null,
+          summary: {
+            submission_status: "pending",
+            submission_summary: "",
+            submission_requires_polling: false,
+            evaluation_transport_status: undefined,
+            evaluation_result_status: undefined,
+            approval_ready: false,
+            comparable_count: 1,
+            highlights: [],
+            follow_up_status: undefined,
+            follow_up_title: undefined,
+            follow_up_summary: undefined,
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Build and submit the approval packet to start live policy execution for this workspace."
+        )
+      ).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("pending").length).toBeGreaterThan(0);
+  });
+
+  it("surfaces a deferred execution state while the remote verdict is queued", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          submission_status: "deferred",
+          evaluation_status: null,
+          follow_up: null,
+          summary: {
+            ...workspacePayload.proposal_state.summary,
+            submission_status: "deferred",
+            submission_summary: "Proposal queued for evaluation",
+            submission_requires_polling: true,
+            evaluation_transport_status: undefined,
+            evaluation_result_status: undefined,
+            approval_ready: false,
+            follow_up_status: undefined,
+            follow_up_title: undefined,
+            follow_up_summary: undefined,
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Policy review is deferred" })).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("deferred").length).toBeGreaterThan(0);
+    expect(screen.getByText("Proposal queued for evaluation")).toBeInTheDocument();
+    expect(screen.getByText("Keep the workspace open for remote results")).toBeInTheDocument();
+  });
+
+  it("surfaces a running execution state while live polling is still in progress", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          submission_status: "submitted",
+          evaluation_status: "running",
+          follow_up: null,
+          summary: {
+            ...workspacePayload.proposal_state.summary,
+            submission_status: "submitted",
+            submission_summary: "Policy engine accepted the packet and is still evaluating it.",
+            submission_requires_polling: true,
+            evaluation_transport_status: "running",
+            evaluation_result_status: undefined,
+            approval_ready: false,
+            follow_up_status: undefined,
+            follow_up_title: undefined,
+            follow_up_summary: undefined,
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Policy review is running" })).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("running").length).toBeGreaterThan(0);
+    expect(screen.getByText("Policy engine accepted the packet and is still evaluating it.")).toBeInTheDocument();
+    expect(screen.getByText("Keep the workspace open for remote results")).toBeInTheDocument();
+  });
+
+  it("refreshes the proposal lifecycle when the workspace requests live status", async () => {
+    mockedRefreshWorkspaceProposalStatus.mockResolvedValue({
+      ...workspacePayload.proposal_state,
+      submission_status: "succeeded",
+      evaluation_status: "succeeded",
+      follow_up: {
+        status: "reoptimization_required",
+        path: "reoptimization",
+        title: "Reoptimization path required",
+        summary: "Use a compliant downtown property before resubmitting the approval packet.",
+        recommended_action: "reoptimize",
+        recommended_label: "Reoptimize plan",
+        alternatives: [
+          {
+            category: "lodging",
+            summary: "Use a compliant downtown property",
+            rationale: "Alternative meets nightly cap and booking-channel requirements.",
+            comparable_ref: "lodging-alt-2",
+          },
+        ],
+        guidance: ["Keep the policy-safe lodging alternative attached to the next submission."],
+        notes: [],
+        selected_alternative: {
+          category: "lodging",
+          summary: "Use a compliant downtown property",
+          rationale: "Alternative meets nightly cap and booking-channel requirements.",
+          comparable_ref: "lodging-alt-2",
+        },
+        requested_exception: null,
+      },
+      summary: {
+        ...workspacePayload.proposal_state.summary,
+        submission_status: "succeeded",
+        submission_summary: "Policy evaluation completed",
+        submission_requires_polling: false,
+        evaluation_transport_status: "succeeded",
+        evaluation_result_status: "non_compliant",
+        approval_ready: false,
+        follow_up_status: "reoptimization_required",
+        follow_up_title: "Reoptimization path required",
+        follow_up_summary: "Use a compliant downtown property before resubmitting the approval packet.",
+      },
+    });
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          submission_status: "deferred",
+          evaluation_status: null,
+          follow_up: null,
+          summary: {
+            ...workspacePayload.proposal_state.summary,
+            submission_status: "deferred",
+            submission_summary: "Proposal queued for evaluation",
+            submission_requires_polling: true,
+            evaluation_transport_status: null,
+            evaluation_result_status: null,
+            approval_ready: false,
+            follow_up_status: null,
+            follow_up_title: null,
+            follow_up_summary: null,
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Refresh live status" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh live status" }));
+
+    await waitFor(() => {
+      expect(mockedRefreshWorkspaceProposalStatus).toHaveBeenCalledWith("trip-leisure-kyoto-draft");
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Policy review finished with follow-up" })).toBeInTheDocument();
+    });
+    expect(
+      screen.getAllByText("Use a compliant downtown property before resubmitting the approval packet.").length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Refresh live status" })).not.toBeInTheDocument();
+  });
+
+  it("surfaces a failed execution state when the live transport breaks", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          submission_status: "failed",
+          evaluation_status: "failed",
+          follow_up: null,
+          summary: {
+            ...workspacePayload.proposal_state.summary,
+            submission_status: "failed",
+            submission_summary: "TPP gateway returned a 502 response for the proposal submission.",
+            submission_requires_polling: false,
+            evaluation_transport_status: "failed",
+            evaluation_result_status: undefined,
+            approval_ready: false,
+            follow_up_status: undefined,
+            follow_up_title: undefined,
+            follow_up_summary: undefined,
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Live policy execution needs attention" })).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("failed").length).toBeGreaterThan(0);
+    expect(screen.getByText("TPP gateway returned a 502 response for the proposal submission.")).toBeInTheDocument();
+    expect(screen.getByText("Review the live transport failure")).toBeInTheDocument();
+  });
+
   it("surfaces reoptimization follow-up guidance for non-compliant policy results", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({
@@ -1097,9 +1334,10 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByText("Reoptimization path required")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Policy review finished with follow-up" })).toBeInTheDocument();
     });
-    expect(screen.getByText("Reoptimize plan")).toBeInTheDocument();
+    expect(screen.getByText("completed with follow-up")).toBeInTheDocument();
+    expect(screen.getAllByText("Reoptimize plan").length).toBeGreaterThan(0);
     expect(screen.getByText("Use a compliant downtown property")).toBeInTheDocument();
     expect(screen.getByText("Nightly lodging exceeds the allowed cap.")).toBeInTheDocument();
   });
@@ -1170,9 +1408,10 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByText("Exception review required")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Policy review finished with follow-up" })).toBeInTheDocument();
     });
-    expect(screen.getByText("Prepare exception packet")).toBeInTheDocument();
+    expect(screen.getByText("completed with follow-up")).toBeInTheDocument();
+    expect(screen.getAllByText("Prepare exception packet").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Attach the compliant comparable to the exception packet.")).toHaveLength(2);
     expect(
       screen.getByText("Explain why the earlier arrival is required for the client meeting."),

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1077,6 +1077,7 @@ describe("WorkspacePage", () => {
       ).toBeInTheDocument();
     });
     expect(screen.getAllByText("pending").length).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: "Refresh live status" })).not.toBeInTheDocument();
   });
 
   it("surfaces a deferred execution state while the remote verdict is queued", async () => {
@@ -1147,6 +1148,48 @@ describe("WorkspacePage", () => {
     expect(screen.getAllByText("running").length).toBeGreaterThan(0);
     expect(screen.getByText("Policy engine accepted the packet and is still evaluating it.")).toBeInTheDocument();
     expect(screen.getByText("Keep the workspace open for remote results")).toBeInTheDocument();
+  });
+
+  it("keeps awaiting evaluation refreshable after execution succeeds", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: {
+          ...workspacePayload.proposal_state,
+          submission_status: "succeeded",
+          evaluation_status: "retry_scheduled",
+          follow_up: {
+            ...workspacePayload.proposal_state.follow_up,
+            status: "awaiting_evaluation",
+            title: "Awaiting policy verdict",
+            summary: "Policy execution finished, but the evaluation result still needs to load.",
+          },
+          summary: {
+            ...workspacePayload.proposal_state.summary,
+            submission_status: "succeeded",
+            submission_summary: "Policy execution completed and the evaluation result is ready.",
+            submission_requires_polling: true,
+            evaluation_transport_status: "retry_scheduled",
+            evaluation_result_status: undefined,
+            approval_ready: false,
+            follow_up_status: "awaiting_evaluation",
+            follow_up_title: "Awaiting policy verdict",
+            follow_up_summary:
+              "Policy execution finished, but the evaluation result still needs to load.",
+          },
+        },
+      }),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Awaiting policy evaluation result" })).toBeInTheDocument();
+    });
+    expect(
+      screen.getAllByText("Policy execution finished, but the evaluation result still needs to load.").length
+    ).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Refresh live status" })).toBeInTheDocument();
   });
 
   it("refreshes the proposal lifecycle when the workspace requests live status", async () => {

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -5,6 +5,7 @@ import type { TripRecord } from "../api/trips";
 import {
   answerPlannerDecision,
   recordWorkspaceSpendEvent,
+  refreshWorkspaceProposalStatus,
   saveWorkspaceBudget,
   type ActualSpendEventUpsertPayload,
   type BudgetPlanUpsertPayload,
@@ -35,6 +36,21 @@ type TimelineStop = {
 type ScenarioReviewMetric = {
   label: string;
   value: string;
+};
+
+type ProposalLifecycleState =
+  | "pending"
+  | "deferred"
+  | "running"
+  | "failed"
+  | "completed-with-follow-up"
+  | "approval-ready";
+
+type ProposalLifecyclePresentation = {
+  state: ProposalLifecycleState;
+  label: string;
+  title: string;
+  summary: string;
 };
 
 function formatDateRange(startDate: string | null, endDate: string | null): string {
@@ -256,6 +272,98 @@ function formatFollowUpStatus(status: string | undefined): string {
   return status.replace(/_/g, " ");
 }
 
+function isFailedLifecycleStatus(status: string | null | undefined): boolean {
+  return status != null && ["failed", "error", "errored", "rejected", "invalid"].includes(status);
+}
+
+function isRunningLifecycleStatus(status: string | null | undefined): boolean {
+  return (
+    status != null &&
+    ["submitted", "queued", "running", "in_progress", "processing"].includes(status)
+  );
+}
+
+function deriveProposalLifecyclePresentation(
+  proposalState: NonNullable<WorkspaceData["proposal_state"]>,
+  followUp: NonNullable<WorkspaceData["proposal_state"]>["follow_up"]
+): ProposalLifecyclePresentation {
+  const summary = proposalState.summary;
+  const submissionStatus = summary.submission_status ?? proposalState.submission_status;
+  const evaluationTransportStatus =
+    summary.evaluation_transport_status ?? proposalState.evaluation_status;
+  const followUpStatus = followUp?.status ?? summary.follow_up_status;
+
+  if (summary.approval_ready || followUpStatus === "resolved") {
+    return {
+      state: "approval-ready",
+      label: "approval-ready",
+      title: "Approval packet is ready",
+      summary:
+        summary.follow_up_summary ??
+        summary.submission_summary ??
+        "Policy evaluation passed and the workspace is ready for approval handling.",
+    };
+  }
+
+  if (isFailedLifecycleStatus(submissionStatus) || isFailedLifecycleStatus(evaluationTransportStatus)) {
+    return {
+      state: "failed",
+      label: "failed",
+      title: "Live policy execution needs attention",
+      summary:
+        summary.submission_summary ??
+        "The proposal could not complete a live policy run. Review the transport failure before retrying.",
+    };
+  }
+
+  if (
+    summary.evaluation_result_status != null ||
+    (followUpStatus != null && followUpStatus !== "awaiting_evaluation")
+  ) {
+    return {
+      state: "completed-with-follow-up",
+      label: "completed with follow-up",
+      title: "Policy review finished with follow-up",
+      summary:
+        summary.follow_up_summary ??
+        "The live policy run completed and the workspace now needs remediation or exception handling.",
+    };
+  }
+
+  if (submissionStatus === "deferred" || evaluationTransportStatus === "deferred") {
+    return {
+      state: "deferred",
+      label: "deferred",
+      title: "Policy review is deferred",
+      summary:
+        summary.submission_summary ??
+        "The remote policy service accepted the proposal and deferred the final verdict.",
+    };
+  }
+
+  if (
+    summary.submission_requires_polling ||
+    isRunningLifecycleStatus(submissionStatus) ||
+    isRunningLifecycleStatus(evaluationTransportStatus)
+  ) {
+    return {
+      state: "running",
+      label: "running",
+      title: "Policy review is running",
+      summary:
+        summary.submission_summary ??
+        "The workspace is waiting for the latest remote policy execution result.",
+    };
+  }
+
+  return {
+    state: "pending",
+    label: "pending",
+    title: "Proposal submission is pending",
+    summary: "Build and submit the approval packet to start live policy execution for this workspace.",
+  };
+}
+
 function hasRenderableFollowUp(
   followUp: NonNullable<WorkspaceData["proposal_state"]>["follow_up"]
 ): followUp is NonNullable<NonNullable<WorkspaceData["proposal_state"]>["follow_up"]> {
@@ -330,6 +438,8 @@ function WorkspacePageContent({
   const [plannerBusyLabel, setPlannerBusyLabel] = useState<string | null>(null);
   const [budgetError, setBudgetError] = useState<string | null>(null);
   const [budgetBusyLabel, setBudgetBusyLabel] = useState<string | null>(null);
+  const [proposalError, setProposalError] = useState<string | null>(null);
+  const [proposalBusyLabel, setProposalBusyLabel] = useState<string | null>(null);
   const isCompactLayout = useCompactWorkspaceLayout();
   useEffect(() => {
     setCurrentWorkspace(workspace);
@@ -355,6 +465,13 @@ function WorkspacePageContent({
   const renderableProposalFollowUp = hasRenderableFollowUp(proposalFollowUp)
     ? proposalFollowUp
     : null;
+  const proposalLifecycle =
+    currentWorkspace.proposal_state == null
+      ? null
+      : deriveProposalLifecyclePresentation(
+          currentWorkspace.proposal_state,
+          renderableProposalFollowUp
+        );
   const scenarioPolicyPosture = formatPolicyPosture(currentWorkspace);
 
   async function handleDecisionAnswer(decisionId: string, choice: string) {
@@ -428,6 +545,24 @@ function WorkspacePageContent({
       setBudgetError(error instanceof Error ? error.message : "Spend entry failed.");
     } finally {
       setBudgetBusyLabel(null);
+    }
+  }
+
+  async function handleProposalRefresh() {
+    setProposalError(null);
+    setProposalBusyLabel("Refreshing live policy status...");
+    try {
+      const nextProposalState = await refreshWorkspaceProposalStatus(trip.trip_id);
+      startTransition(() => {
+        setCurrentWorkspace((current) => ({
+          ...current,
+          proposal_state: nextProposalState,
+        }));
+      });
+    } catch (error) {
+      setProposalError(error instanceof Error ? error.message : "Proposal status refresh failed.");
+    } finally {
+      setProposalBusyLabel(null);
     }
   }
 
@@ -519,21 +654,31 @@ function WorkspacePageContent({
 
         <section className="status-card">
           <p className="status-label">Approval packet</p>
-          <h2>
-            {currentWorkspace.proposal_state?.summary.approval_ready
-              ? "Approval packet is ready"
-              : "Proposal lifecycle in progress"}
-          </h2>
+          <h2>{proposalLifecycle?.title ?? "Proposal lifecycle in progress"}</h2>
           {currentWorkspace.proposal_state == null ? (
             <p className="muted-copy">
               Proposal submission and evaluation records have not been persisted for this workspace yet.
             </p>
           ) : (
             <>
+              {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
+              {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
               <dl className="workspace-meta">
+                <div>
+                  <dt>Workspace state</dt>
+                  <dd>{proposalLifecycle?.label ?? "pending"}</dd>
+                </div>
                 <div>
                   <dt>Submission</dt>
                   <dd>{currentWorkspace.proposal_state.summary.submission_status ?? "unknown"}</dd>
+                </div>
+                <div>
+                  <dt>Transport</dt>
+                  <dd>
+                    {currentWorkspace.proposal_state.summary.evaluation_transport_status ??
+                      currentWorkspace.proposal_state.evaluation_status ??
+                      "pending"}
+                  </dd>
                 </div>
                 <div>
                   <dt>Evaluation</dt>
@@ -557,15 +702,36 @@ function WorkspacePageContent({
                   </dd>
                 </div>
               </dl>
-              <p>{currentWorkspace.proposal_state.summary.submission_summary ?? "Submission stored for later review."}</p>
+              <p>{proposalLifecycle?.summary ?? "Submission stored for later review."}</p>
+              {currentWorkspace.proposal_state.summary.submission_requires_polling ? (
+                <button type="button" className="secondary-button" onClick={handleProposalRefresh}>
+                  Refresh live status
+                </button>
+              ) : null}
               {renderableProposalFollowUp ? (
                 <article className="decision-card">
-                  <h3>{renderableProposalFollowUp.title}</h3>
+                  <h3>{renderableProposalFollowUp.recommended_label ?? renderableProposalFollowUp.title}</h3>
                   <p>{renderableProposalFollowUp.summary}</p>
                   {renderableProposalFollowUp.guidance &&
                   renderableProposalFollowUp.guidance.length > 0 ? (
                     <p className="muted-copy">{renderableProposalFollowUp.guidance[0]}</p>
                   ) : null}
+                </article>
+              ) : proposalLifecycle?.state === "running" || proposalLifecycle?.state === "deferred" ? (
+                <article className="decision-card">
+                  <h3>Keep the workspace open for remote results</h3>
+                  <p>
+                    Reloading the workspace preserves the latest stored execution state, so you can safely return
+                    after the remote policy service posts a new verdict.
+                  </p>
+                </article>
+              ) : proposalLifecycle?.state === "failed" ? (
+                <article className="decision-card">
+                  <h3>Review the live transport failure</h3>
+                  <p>
+                    Validate the remote TPP configuration and retry posture before asking travelers to treat this
+                    workspace as approval-ready.
+                  </p>
                 </article>
               ) : null}
               <div className="decision-stack">

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -283,6 +283,25 @@ function isRunningLifecycleStatus(status: string | null | undefined): boolean {
   );
 }
 
+function shouldShowProposalRefresh(
+  proposalState: NonNullable<WorkspaceData["proposal_state"]>,
+  followUp: NonNullable<WorkspaceData["proposal_state"]>["follow_up"]
+): boolean {
+  const submissionStatus = proposalState.summary.submission_status ?? proposalState.submission_status;
+  const evaluationTransportStatus =
+    proposalState.summary.evaluation_transport_status ?? proposalState.evaluation_status;
+  const awaitingEvaluation =
+    proposalState.summary.evaluation_result_status == null &&
+    (followUp?.status === "awaiting_evaluation" ||
+      proposalState.summary.follow_up_status === "awaiting_evaluation" ||
+      submissionStatus === "succeeded" ||
+      evaluationTransportStatus === "succeeded");
+  return Boolean(
+    proposalState.summary.submission_requires_polling ||
+      awaitingEvaluation
+  );
+}
+
 function deriveProposalLifecyclePresentation(
   proposalState: NonNullable<WorkspaceData["proposal_state"]>,
   followUp: NonNullable<WorkspaceData["proposal_state"]>["follow_up"]
@@ -292,6 +311,11 @@ function deriveProposalLifecyclePresentation(
   const evaluationTransportStatus =
     summary.evaluation_transport_status ?? proposalState.evaluation_status;
   const followUpStatus = followUp?.status ?? summary.follow_up_status;
+  const awaitingEvaluation =
+    summary.evaluation_result_status == null &&
+    (followUpStatus === "awaiting_evaluation" ||
+      submissionStatus === "succeeded" ||
+      evaluationTransportStatus === "succeeded");
 
   if (summary.approval_ready || followUpStatus === "resolved") {
     return {
@@ -342,6 +366,7 @@ function deriveProposalLifecyclePresentation(
   }
 
   if (
+    awaitingEvaluation ||
     summary.submission_requires_polling ||
     isRunningLifecycleStatus(submissionStatus) ||
     isRunningLifecycleStatus(evaluationTransportStatus)
@@ -349,8 +374,9 @@ function deriveProposalLifecyclePresentation(
     return {
       state: "running",
       label: "running",
-      title: "Policy review is running",
+      title: awaitingEvaluation ? "Awaiting policy evaluation result" : "Policy review is running",
       summary:
+        summary.follow_up_summary ??
         summary.submission_summary ??
         "The workspace is waiting for the latest remote policy execution result.",
     };
@@ -703,7 +729,10 @@ function WorkspacePageContent({
                 </div>
               </dl>
               <p>{proposalLifecycle?.summary ?? "Submission stored for later review."}</p>
-              {currentWorkspace.proposal_state.summary.submission_requires_polling ? (
+              {shouldShowProposalRefresh(
+                currentWorkspace.proposal_state,
+                renderableProposalFollowUp
+              ) ? (
                 <button type="button" className="secondary-button" onClick={handleProposalRefresh}>
                   Refresh live status
                 </button>

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -1,7 +1,7 @@
 import json
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 import pytest
 from fastapi.testclient import TestClient
 
@@ -1362,7 +1362,8 @@ def test_workspace_proposal_refresh_polls_live_status_and_persists_evaluation(
         f"https://tpp.example.test/api/planner/proposals/proposal:{trip_id}/executions/exec-live-002"
     )
     assert captured_requests[1]["method"] == "GET"
-    assert captured_requests[1]["body"]["proposal_version"] == "proposal-v3"
+    poll_request_body = cast(dict[str, object], captured_requests[1]["body"])
+    assert poll_request_body["proposal_version"] == "proposal-v3"
     assert captured_requests[2]["full_url"] == (
         "https://tpp.example.test/api/planner/executions/exec-live-002/evaluation-result"
     )
@@ -1469,7 +1470,8 @@ def test_workspace_proposal_refresh_preserves_submission_and_retries_when_evalua
         200,
         _load_fixture("proposal_submit_deferred.json")["response"],
     )
-    submission_response._payload["result_payload"]["execution_id"] = "exec-live-002"
+    submission_result_payload = cast(dict[str, object], submission_response._payload["result_payload"])
+    submission_result_payload["execution_id"] = "exec-live-002"
     submission_response._payload["status_endpoint"] = (
         "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-002"
     )

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -1207,3 +1207,251 @@ def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "result_payload.execution_id is required for non-terminal submissions"
+
+
+def test_workspace_proposal_refresh_polls_live_status_and_persists_evaluation(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    captured_requests: list[dict[str, object]] = []
+    submission_response = _FakeHTTPResponse(
+        200,
+        {
+            "transport_pattern": "deferred",
+            "execution_status": {
+                "state": "deferred",
+                "terminal": False,
+                "summary": "Proposal queued for evaluation",
+                "poll_after_seconds": 30,
+                "external_status": "202 Accepted",
+                "updated_at": "2026-04-03T00:41:01Z",
+            },
+            "result_payload": {
+                "execution_id": "exec-live-002",
+                "queue_state": "waiting_for_policy_engine",
+            },
+            "retry": {
+                "attempt": 0,
+                "max_attempts": 5,
+                "retryable": True,
+                "backoff_seconds": 30,
+                "next_retry_at": "2026-04-03T00:41:31Z",
+                "reason": "Await evaluator completion",
+            },
+            "received_at": "2026-04-03T00:41:01Z",
+            "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-002",
+        },
+    )
+    poll_response = _FakeHTTPResponse(
+        200,
+        {
+            "transport_pattern": "async",
+            "execution_status": {
+                "state": "succeeded",
+                "terminal": True,
+                "summary": "Policy evaluation completed",
+                "external_status": "200 OK",
+                "updated_at": "2026-04-03T00:42:11Z",
+            },
+            "result_payload": {
+                "execution_id": "exec-live-002",
+                "queue_state": "completed",
+            },
+            "received_at": "2026-04-03T00:42:11Z",
+            "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-002",
+        },
+    )
+    evaluation_response = _FakeHTTPResponse(
+        200,
+        {
+            "trip_id": "trip-placeholder",
+            "proposal_id": "proposal:trip-placeholder",
+            "proposal_version": "proposal-v3",
+            "execution_id": "exec-live-002",
+            "request_id": "ignored-eval",
+            "correlation_id": {"value": "ignored", "issued_by": "tpp"},
+            "outcome": "non_compliant",
+            "result_endpoint": "GET /api/planner/executions/exec-live-002/evaluation-result",
+            "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-002",
+            "policy_result": {
+                "status": "fail",
+                "issues": [],
+                "policy_version": "policy-v1",
+            },
+            "blocking_issues": [
+                {
+                    "code": "lodging_cap_exceeded",
+                    "summary": "Nightly lodging exceeds the allowed cap.",
+                    "category": "lodging",
+                }
+            ],
+            "preferred_alternatives": [
+                {
+                    "category": "lodging",
+                    "summary": "Use a compliant downtown property",
+                    "rationale": "Alternative meets nightly cap and booking-channel requirements.",
+                    "comparable_ref": "lodging-alt-2",
+                }
+            ],
+            "exception_requirements": [],
+            "reoptimization_guidance": [
+                {
+                    "summary": "Keep the lower-cost lodging alternative attached to the next submission."
+                }
+            ],
+            "generated_at": "2026-04-03T00:42:13Z",
+        },
+    )
+    _install_fake_http(
+        monkeypatch,
+        [submission_response, poll_response, evaluation_response],
+        captured_requests=captured_requests,
+    )
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Refresh proposal status",
+            "summary": "Advance a deferred live TPP execution from the workspace.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+
+    evaluation_response._payload["trip_id"] = trip_id
+    evaluation_response._payload["proposal_id"] = f"proposal:{trip_id}"
+    evaluation_response.text = json.dumps(evaluation_response._payload)
+
+    refreshed = client.post(f"/api/workspace/{trip_id}/proposal/refresh")
+
+    assert refreshed.status_code == 200
+    payload = refreshed.json()["proposal_state"]
+    assert payload["submission_status"] == "succeeded"
+    assert payload["evaluation_status"] == "succeeded"
+    assert payload["summary"]["submission_requires_polling"] is False
+    assert payload["summary"]["evaluation_transport_status"] == "succeeded"
+    assert payload["follow_up"]["status"] == "reoptimization_required"
+    assert payload["follow_up"]["selected_alternative"]["summary"] == (
+        "Use a compliant downtown property"
+    )
+    assert captured_requests[1]["full_url"] == (
+        f"https://tpp.example.test/api/planner/proposals/proposal:{trip_id}/executions/exec-live-002"
+    )
+    assert captured_requests[1]["method"] == "GET"
+    assert captured_requests[1]["body"]["proposal_version"] == "proposal-v3"
+    assert captured_requests[2]["full_url"] == (
+        "https://tpp.example.test/api/planner/executions/exec-live-002/evaluation-result"
+    )
+
+
+def test_workspace_proposal_refresh_persists_failed_remote_status(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    poll_response = _FakeHTTPResponse(
+        200,
+        {
+            "transport_pattern": "async",
+            "execution_status": {
+                "state": "failed",
+                "terminal": True,
+                "summary": "Evaluator returned an integration error",
+                "external_status": "502 Bad Gateway",
+                "updated_at": "2026-04-03T00:42:02Z",
+            },
+            "error": {
+                "code": "upstream_unavailable",
+                "message": "Travel-Plan-Permission did not return a valid evaluation payload.",
+                "category": "upstream",
+                "retryable": True,
+                "details": {
+                    "provider": "Travel-Plan-Permission",
+                    "http_status": 502,
+                },
+            },
+            "retry": {
+                "attempt": 1,
+                "max_attempts": 4,
+                "retryable": True,
+                "backoff_seconds": 60,
+                "next_retry_at": "2026-04-03T00:43:02Z",
+                "reason": "Transient upstream outage",
+            },
+            "received_at": "2026-04-03T00:42:02Z",
+            "status_endpoint": "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-failed-001",
+        },
+    )
+    _install_fake_http(monkeypatch, [poll_response])
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Refresh proposal failure",
+            "summary": "Persist live TPP execution failures in the workspace.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+    submission_fixture["response"]["result_payload"]["execution_id"] = "exec-failed-001"
+    submission_fixture["response"]["status_endpoint"] = (
+        "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-failed-001"
+    )
+
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+
+    refreshed = client.post(f"/api/workspace/{trip_id}/proposal/refresh")
+
+    assert refreshed.status_code == 200
+    payload = refreshed.json()["proposal_state"]
+    assert payload["submission_status"] == "failed"
+    assert payload["evaluation"] == {}
+    assert payload["summary"]["submission_requires_polling"] is False
+    assert payload["summary"]["evaluation_transport_status"] is None
+    assert payload["summary"]["submission_summary"] == "Evaluator returned an integration error"

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -1455,3 +1455,118 @@ def test_workspace_proposal_refresh_persists_failed_remote_status(
     assert payload["summary"]["submission_requires_polling"] is False
     assert payload["summary"]["evaluation_transport_status"] is None
     assert payload["summary"]["submission_summary"] == "Evaluator returned an integration error"
+
+
+def test_workspace_proposal_refresh_preserves_submission_and_retries_when_evaluation_ingestion_fails(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    captured_requests: list[dict[str, object]] = []
+    submission_response = _FakeHTTPResponse(
+        200,
+        _load_fixture("proposal_submit_deferred.json")["response"],
+    )
+    submission_response._payload["result_payload"]["execution_id"] = "exec-live-002"
+    submission_response._payload["status_endpoint"] = (
+        "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-002"
+    )
+    submission_response.text = json.dumps(submission_response._payload)
+    poll_response = _FakeHTTPResponse(
+        200,
+        {
+            "transport_pattern": "async",
+            "execution_status": {
+                "state": "succeeded",
+                "terminal": True,
+                "summary": "Policy execution completed and the evaluation result is ready.",
+                "external_status": "completed",
+                "updated_at": "2026-04-03T00:42:11Z",
+            },
+            "result_payload": {
+                "execution_id": "exec-live-002",
+                "queue_state": "completed",
+            },
+            "received_at": "2026-04-03T00:42:11Z",
+            "status_endpoint": (
+                "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-002"
+            ),
+        },
+    )
+    malformed_evaluation_response = _FakeHTTPResponse(
+        200,
+        {
+            "trip_id": "trip-placeholder",
+            "proposal_id": "proposal:trip-placeholder",
+            "proposal_version": "proposal-v3",
+            "execution_id": "exec-live-002",
+            "request_id": "ignored-eval",
+            "correlation_id": {"value": "ignored", "issued_by": "tpp"},
+            "outcome": "non_compliant",
+            "result_endpoint": "GET /api/planner/executions/exec-live-002/evaluation-result",
+            "status_endpoint": (
+                "https://tpp.example.test/api/planner/proposals/proposal-live/executions/exec-live-002"
+            ),
+            "generated_at": "2026-04-03T00:42:13Z",
+        },
+    )
+    _install_fake_http(
+        monkeypatch,
+        [submission_response, poll_response, malformed_evaluation_response],
+        captured_requests=captured_requests,
+    )
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Refresh proposal retry",
+            "summary": "Keep refresh retryable when evaluation ingestion fails.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+
+    refreshed = client.post(f"/api/workspace/{trip_id}/proposal/refresh")
+
+    assert refreshed.status_code == 200
+    payload = refreshed.json()["proposal_state"]
+    assert payload["submission"]["request_id"] == submission_fixture["request"]["request_id"]
+    assert payload["submission"]["request_payload"]["proposal_ref"] == f"proposal:{trip_id}"
+    assert payload["submission"]["last_poll_request_payload"] == {
+        "proposal_version": "proposal-v3",
+        "execution_id": "exec-live-002",
+    }
+    assert payload["submission_status"] == "succeeded"
+    assert payload["evaluation_status"] == "retry_scheduled"
+    assert payload["summary"]["submission_requires_polling"] is True
+    assert payload["summary"]["evaluation_transport_status"] == "retry_scheduled"
+    assert payload["summary"]["evaluation_result_status"] is None
+    assert payload["follow_up"]["status"] == "awaiting_evaluation"
+    assert payload["evaluation"]["error"]["code"] == "evaluation_refresh_failed"
+    assert payload["evaluation"]["error"]["retryable"] is True
+    assert captured_requests[2]["full_url"] == (
+        "https://tpp.example.test/api/planner/executions/exec-live-002/evaluation-result"
+    )

--- a/trip_planner/app/routes/proposal.py
+++ b/trip_planner/app/routes/proposal.py
@@ -11,6 +11,7 @@ from trip_planner.app.services.auth import AuthenticatedUser, require_authentica
 from trip_planner.app.services.proposal import (
     WorkspaceProposalNotFoundError,
     get_workspace_proposal_payload,
+    refresh_workspace_proposal_status,
     save_workspace_proposal_follow_up,
     save_workspace_proposal_evaluation,
     save_workspace_proposal_submission,
@@ -116,6 +117,27 @@ def save_workspace_proposal_follow_up_state(
         )
     except WorkspaceProposalNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return WorkspaceProposalResponse.model_validate(result)
+
+
+@router.post("/workspace/{trip_id}/proposal/refresh", response_model=WorkspaceProposalResponse)
+def refresh_workspace_proposal(
+    trip_id: str,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> WorkspaceProposalResponse:
+    try:
+        result = refresh_workspace_proposal_status(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+        )
+    except WorkspaceProposalNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except TPPTransportError as error:
+        raise HTTPException(status_code=error.status_code, detail=str(error)) from error
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return WorkspaceProposalResponse.model_validate(result)

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -282,7 +282,6 @@ def _build_summary(
     submission_requires_polling = (
         execution_status.get("terminal") is False
         or evaluation_transport.get("terminal") is False
-        or follow_up.get("status") == "awaiting_evaluation"
     )
     return {
         "trip_id": proposal_payload.get("trip_id"),
@@ -412,6 +411,9 @@ def _update_submission_record_from_poll(
     submission_record["received_at"] = response.received_at
     submission_record["status_endpoint"] = response.status_endpoint or submission_record.get(
         "status_endpoint"
+    )
+    submission_record["last_poll_status_endpoint"] = response.status_endpoint or submission_record.get(
+        "last_poll_status_endpoint"
     )
     submission_record["execution_id"] = execution_id
     if response_payload.get("queue_state") is not None:

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
+from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -11,6 +12,7 @@ from trip_planner.business import ExceptionRequest, TripPlanProposal
 from trip_planner.integrations.tpp import (
     BaseTPPIntegrationClient,
     HTTPTPPIntegrationClient,
+    TPPCorrelationId,
     TPPEvaluationResultIngestionService,
     TPPProposalSubmissionService,
     TPPRequestEnvelope,
@@ -357,6 +359,66 @@ def _serialize_proposal_state(record: PersistedProposalState) -> dict[str, Any]:
     }
 
 
+def _make_runtime_request(
+    *,
+    operation: str,
+    record: PersistedProposalState,
+    payload: dict[str, Any],
+) -> TPPRequestEnvelope:
+    submission_record = dict(record.submission_record)
+    correlation_id = submission_record.get("correlation_id")
+    if not correlation_id:
+        raise ValueError("Persisted proposal state is missing correlation metadata.")
+    return TPPRequestEnvelope(
+        operation=operation,
+        request_id=f"{operation}:{uuid4().hex}",
+        correlation_id=TPPCorrelationId.from_value(str(correlation_id)),
+        payload=payload,
+        transport_pattern=str(submission_record.get("transport_pattern") or "async"),
+        organization_id=record.organization_id,
+        trip_id=record.trip_id,
+        proposal_id=record.proposal_id,
+        submitted_at=_now_iso(),
+        metadata={"source": "workspace_proposal_refresh"},
+    )
+
+
+def _update_submission_record_from_poll(
+    *,
+    record: PersistedProposalState,
+    request: TPPRequestEnvelope,
+    response: TPPResponseEnvelope,
+) -> None:
+    submission_record = dict(record.submission_record)
+    response_payload = dict(response.result_payload or {})
+    execution_id = response_payload.get("execution_id") or record.execution_id
+
+    submission_record["request_id"] = request.request_id
+    submission_record["request_payload"] = dict(request.payload)
+    submission_record["transport_pattern"] = response.transport_pattern
+    submission_record["execution_status"] = response.execution_status.to_dict()
+    submission_record["response_payload"] = response_payload
+    submission_record["received_at"] = response.received_at
+    submission_record["status_endpoint"] = response.status_endpoint or submission_record.get(
+        "status_endpoint"
+    )
+    submission_record["execution_id"] = execution_id
+    if response_payload.get("queue_state") is not None:
+        submission_record["queue_state"] = response_payload["queue_state"]
+    if response.retry is not None:
+        submission_record["retry"] = response.retry.to_dict()
+    else:
+        submission_record.pop("retry", None)
+    if response.error is not None:
+        submission_record["error"] = response.error.to_dict()
+    else:
+        submission_record.pop("error", None)
+
+    record.execution_id = str(execution_id) if execution_id else None
+    record.submission_status = response.execution_status.state
+    record.submission_record = submission_record
+
+
 def get_workspace_proposal_payload(
     db_session: Session,
     *,
@@ -595,6 +657,73 @@ def save_workspace_proposal_follow_up(
     trip_record.updated_at = datetime.now(UTC)
     db_session.commit()
     db_session.refresh(existing)
+    return {
+        "proposal_state": _serialize_proposal_state(existing),
+        "summary": dict(existing.summary),
+    }
+
+
+def refresh_workspace_proposal_status(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> dict[str, Any]:
+    trip_record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    if trip_record.mode != "business":
+        raise ValueError("Only business trips can persist proposal lifecycle state.")
+
+    existing = _get_latest_proposal_state(db_session, trip_id=trip_id, user_id=user.user_id)
+    if existing is None:
+        raise WorkspaceProposalNotFoundError(
+            "Proposal status cannot be refreshed before a proposal submission exists."
+        )
+    if not existing.execution_id:
+        raise ValueError("Proposal status cannot be refreshed without an execution_id.")
+
+    poll_request = _make_runtime_request(
+        operation="poll_execution_status",
+        record=existing,
+        payload={
+            "proposal_version": existing.proposal_version,
+            "execution_id": existing.execution_id,
+        },
+    )
+    polled_response = HTTPTPPIntegrationClient().poll_execution_status(poll_request)
+    _update_submission_record_from_poll(
+        record=existing,
+        request=poll_request,
+        response=polled_response,
+    )
+    existing.summary = _build_summary(
+        submission_record=dict(existing.submission_record),
+        evaluation_record=dict(existing.evaluation_record),
+        proposal_payload=dict(existing.proposal_payload),
+        persisted_follow_up=dict(existing.summary.get("follow_up") or {}),
+    )
+    trip_record.updated_at = datetime.now(UTC)
+    db_session.commit()
+    db_session.refresh(existing)
+
+    if polled_response.execution_status.state == "succeeded":
+        evaluation_request = _make_runtime_request(
+            operation="fetch_evaluation_result",
+            record=existing,
+            payload={
+                "proposal_version": existing.proposal_version,
+                "execution_id": existing.execution_id,
+            },
+        )
+        return save_workspace_proposal_evaluation(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            request_payload=evaluation_request.to_dict(),
+            response_payload=None,
+            proposal_version=existing.proposal_version,
+            scenario_id=existing.scenario_id,
+        )
+
     return {
         "proposal_state": _serialize_proposal_state(existing),
         "summary": dict(existing.summary),

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -11,12 +11,17 @@ from trip_planner.app.services.auth import AuthenticatedUser
 from trip_planner.business import ExceptionRequest, TripPlanProposal
 from trip_planner.integrations.tpp import (
     BaseTPPIntegrationClient,
+    EvaluationResultIngestionError,
     HTTPTPPIntegrationClient,
     TPPCorrelationId,
+    TPPErrorRecord,
     TPPEvaluationResultIngestionService,
+    TPPExecutionStatus,
     TPPProposalSubmissionService,
     TPPRequestEnvelope,
     TPPResponseEnvelope,
+    TPPRetryMetadata,
+    TPPTransportError,
 )
 from trip_planner.persistence.models.proposal import PersistedProposalState
 from trip_planner.persistence.models.trip import PersistedTrip
@@ -274,13 +279,18 @@ def _build_summary(
     )
     if follow_up.get("summary"):
         highlights = [str(follow_up["summary"]), *highlights][:3]
+    submission_requires_polling = (
+        execution_status.get("terminal") is False
+        or evaluation_transport.get("terminal") is False
+        or follow_up.get("status") == "awaiting_evaluation"
+    )
     return {
         "trip_id": proposal_payload.get("trip_id"),
         "proposal_id": proposal_payload.get("proposal_id"),
         "proposal_version": submission_record.get("linkage", {}).get("proposal_version"),
         "submission_status": execution_status.get("state"),
         "submission_summary": execution_status.get("summary"),
-        "submission_requires_polling": execution_status.get("terminal") is False,
+        "submission_requires_polling": submission_requires_polling,
         "evaluation_transport_status": evaluation_transport.get("state"),
         "evaluation_result_status": evaluation_result.get("status"),
         "approval_ready": evaluation_result.get("status") == "compliant",
@@ -393,11 +403,12 @@ def _update_submission_record_from_poll(
     response_payload = dict(response.result_payload or {})
     execution_id = response_payload.get("execution_id") or record.execution_id
 
-    submission_record["request_id"] = request.request_id
-    submission_record["request_payload"] = dict(request.payload)
+    submission_record["last_poll_request_id"] = request.request_id
+    submission_record["last_poll_request_payload"] = dict(request.payload)
     submission_record["transport_pattern"] = response.transport_pattern
     submission_record["execution_status"] = response.execution_status.to_dict()
-    submission_record["response_payload"] = response_payload
+    submission_record["last_poll_response_payload"] = response_payload
+    submission_record["last_poll_received_at"] = response.received_at
     submission_record["received_at"] = response.received_at
     submission_record["status_endpoint"] = response.status_endpoint or submission_record.get(
         "status_endpoint"
@@ -417,6 +428,65 @@ def _update_submission_record_from_poll(
     record.execution_id = str(execution_id) if execution_id else None
     record.submission_status = response.execution_status.state
     record.submission_record = submission_record
+
+
+def _persist_evaluation_refresh_failure(
+    *,
+    record: PersistedProposalState,
+    request: TPPRequestEnvelope,
+    error: Exception,
+) -> None:
+    status_code = getattr(error, "status_code", None)
+    details: dict[str, str] = {"source": "workspace_proposal_refresh"}
+    if status_code is not None:
+        details["status_code"] = str(status_code)
+
+    if isinstance(error, TPPTransportError):
+        category = "transport"
+    elif isinstance(error, (EvaluationResultIngestionError, ValueError)):
+        category = "contract"
+    else:
+        category = "application"
+
+    record.evaluation_status = "retry_scheduled"
+    record.evaluation_record = {
+        "linkage": {
+            "trip_id": record.trip_id,
+            "proposal_id": record.proposal_id,
+            "proposal_version": record.proposal_version,
+            "scenario_id": record.scenario_id,
+            "execution_id": record.execution_id,
+            "organization_id": record.organization_id,
+        },
+        "request_id": request.request_id,
+        "correlation_id": request.correlation_id.value,
+        "transport_pattern": request.transport_pattern,
+        "execution_status": TPPExecutionStatus(
+            state="retry_scheduled",
+            terminal=False,
+            summary=(
+                "Policy execution finished, but loading the evaluation result failed. "
+                "Refresh live status to retry."
+            ),
+            updated_at=_now_iso(),
+        ).to_dict(),
+        "request_payload": dict(request.payload),
+        "response_payload": {},
+        "retry": TPPRetryMetadata(
+            attempt=1,
+            max_attempts=5,
+            retryable=True,
+            reason="Retry the live workspace refresh after evaluation retrieval fails.",
+        ).to_dict(),
+        "error": TPPErrorRecord(
+            code="evaluation_refresh_failed",
+            message=str(error) or "Live evaluation refresh failed.",
+            category=category,
+            retryable=True,
+            details=details,
+        ).to_dict(),
+        "received_at": _now_iso(),
+    }
 
 
 def get_workspace_proposal_payload(
@@ -714,15 +784,35 @@ def refresh_workspace_proposal_status(
                 "execution_id": existing.execution_id,
             },
         )
-        return save_workspace_proposal_evaluation(
-            db_session,
-            user=user,
-            trip_id=trip_id,
-            request_payload=evaluation_request.to_dict(),
-            response_payload=None,
-            proposal_version=existing.proposal_version,
-            scenario_id=existing.scenario_id,
-        )
+        try:
+            return save_workspace_proposal_evaluation(
+                db_session,
+                user=user,
+                trip_id=trip_id,
+                request_payload=evaluation_request.to_dict(),
+                response_payload=None,
+                proposal_version=existing.proposal_version,
+                scenario_id=existing.scenario_id,
+            )
+        except (EvaluationResultIngestionError, TPPTransportError, ValueError) as error:
+            _persist_evaluation_refresh_failure(
+                record=existing,
+                request=evaluation_request,
+                error=error,
+            )
+            existing.summary = _build_summary(
+                submission_record=dict(existing.submission_record),
+                evaluation_record=dict(existing.evaluation_record),
+                proposal_payload=dict(existing.proposal_payload),
+                persisted_follow_up=dict(existing.summary.get("follow_up") or {}),
+            )
+            trip_record.updated_at = datetime.now(UTC)
+            db_session.commit()
+            db_session.refresh(existing)
+            return {
+                "proposal_state": _serialize_proposal_state(existing),
+                "summary": dict(existing.summary),
+            }
 
     return {
         "proposal_state": _serialize_proposal_state(existing),


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #807

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo now contains a real HTTP transport seam for `Travel-Plan-Permission`,
but the current product posture still treats remote execution as a follow-on
integration. That leaves a gap between "we can call the service" and "the
planner workspace is usable when live policy execution is configured, slow, or
failing."

#### Tasks
- [x] Finish wiring live execution paths in `trip_planner/app/services/policy.py` and `trip_planner/app/services/proposal.py` so configured environments use the real transport path end to end
- [x] Persist submission, polling, and evaluation lifecycle updates so workspace reloads preserve the true remote execution state
- [x] Add explicit frontend states for `pending`, `deferred`, `running`, `failed`, and `completed-with-follow-up` proposal execution outcomes
- [x] Add UI affordances in the workspace for remediation details, approval-readiness messaging, and reoptimization triggers after live policy results
- [x] Add integration-style backend tests for configured live transport request/response shaping and error handling
- [x] Add frontend tests covering success, delayed execution, transport failure, and non-compliant result states

#### Acceptance criteria
- [x] A configured environment can submit a proposal through the live TPP seam and surface the resulting execution status in the workspace
- [x] Reloading the workspace preserves the latest stored execution and evaluation state
- [x] The workspace UI exposes actionable non-happy-path states instead of generic failure copy
- [x] Live transport failures and invalid upstream responses produce bounded user-visible errors and covered tests

**Head SHA:** 8c5e09cc655b60f7b6a33b6c09992c2bb88aee68
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24484657139) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24484657126) |
<!-- auto-status-summary:end -->
