### PR TITLE
Issue #808: surface explicit persisted runtime states

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -278,6 +278,11 @@ export type WorkspaceData = {
     artifacts: PlannerMemoryArtifact[];
   };
   planner_panel_state: PlannerPanelState;
+  runtime_state: {
+    status: "ready" | "partial" | "empty";
+    title: string;
+    summary: string;
+  };
   feasibility_summary: FeasibilitySummary;
   inventory_summary: {
     bundle_count: number;
@@ -292,6 +297,11 @@ export type WorkspaceData = {
       tradeoffs: string[];
     }>;
     notes: string[];
+    runtime_state: {
+      status: "ready" | "partial" | "empty";
+      title: string;
+      summary: string;
+    };
   };
   budget_state: BudgetWorkspaceState;
   proposal_state: {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -363,6 +363,11 @@ const workspacePayload = {
     ],
     source_refs: ["ranked-results:kyoto-spring"],
   },
+  runtime_state: {
+    status: "ready",
+    title: "Workspace runtime is ready",
+    summary: "Inventory, scenario ranking, and comparison surfaces are ready for review.",
+  },
   inventory_summary: {
     bundle_count: 2,
     bundles: [
@@ -390,6 +395,11 @@ const workspacePayload = {
     notes: [
       "Bundle summaries are assembled from normalized destination, lodging, transport, and activity records.",
     ],
+    runtime_state: {
+      status: "ready",
+      title: "Runtime inventory is ready",
+      summary: "Persisted trip context is rich enough to assemble comparison-ready inventory bundles.",
+    },
   },
   feasibility_summary: {
     assessment_count: 2,
@@ -957,10 +967,20 @@ describe("WorkspacePage", () => {
           title: "Trip setup workspace",
           scenarios: [],
         },
+        runtime_state: {
+          status: "partial",
+          title: "Workspace runtime is partially assembled",
+          summary: "Add trip dates or duration to replace the bounded fallback with runtime bundle assembly.",
+        },
         inventory_summary: {
           bundle_count: 0,
           bundles: [],
-          notes: ["Bundle assembly will appear here once normalized option inputs are available for the trip."],
+          notes: ["Trip dates or duration are still missing, so inventory assembly stays partial."],
+          runtime_state: {
+            status: "partial",
+            title: "Runtime inventory is partially specified",
+            summary: "Add trip dates or duration to replace the bounded fallback with runtime bundle assembly.",
+          },
         },
         planner_panel_state: {
           ...workspacePayload.planner_panel_state,
@@ -1001,7 +1021,10 @@ describe("WorkspacePage", () => {
 
     expect(screen.getByText("Dates not set yet")).toBeInTheDocument();
     expect(screen.getByText("Duration not set yet")).toBeInTheDocument();
-    expect(screen.getByText("Bundle assembly has not started yet for this trip.")).toBeInTheDocument();
+    expect(screen.getByText("Runtime inventory is partially specified")).toBeInTheDocument();
+    expect(
+      screen.getByText("Runtime bundle assembly is waiting on the rest of the trip frame.")
+    ).toBeInTheDocument();
     await waitFor(() => {
       expect(getPlannerHost().shadowRoot?.querySelector('[aria-label="Planner side panel"]')).toBeTruthy();
     });

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -696,7 +696,9 @@ describe("WorkspacePage", () => {
     expect(screen.getByRole("heading", { name: "Review-ready scenario tradeoffs" })).toBeInTheDocument();
     expect(screen.getByLabelText("Scenario review board")).toBeInTheDocument();
     expect(screen.getAllByText("Policy posture").length).toBeGreaterThan(0);
-    expect(screen.getByRole("heading", { name: "Assembled inventory layer" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: workspacePayload.inventory_summary.runtime_state.title })
+    ).toBeInTheDocument();
     expect(screen.getByText("Osaka arrival buffer")).toBeInTheDocument();
     expect(screen.getByText("Kyoto cultural anchor")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -776,11 +776,14 @@ function WorkspacePageContent({
 
         <section className="status-card">
           <p className="status-label">Inventory bundles</p>
-          <h2>Assembled inventory layer</h2>
+          <h2>{workspace.inventory_summary.runtime_state.title}</h2>
+          <p>{workspace.inventory_summary.runtime_state.summary}</p>
           <p className="muted-copy">{workspace.inventory_summary.notes[0]}</p>
           {workspace.inventory_summary.bundle_count === 0 ? (
             <p className="muted-copy">
-              Bundle assembly has not started yet for this trip.
+              {workspace.inventory_summary.runtime_state.status === "partial"
+                ? "Runtime bundle assembly is waiting on the rest of the trip frame."
+                : "Bundle assembly has not started yet for this trip."}
             </p>
           ) : (
             <div className="scenario-stack">
@@ -910,8 +913,9 @@ function WorkspacePageContent({
             </div>
           ) : (
             <p className="muted-copy">
-              No runtime scenarios are available yet, so there is nothing to review in the
-              scenario board.
+              {currentWorkspace.runtime_state.status === "partial"
+                ? "Runtime comparison is waiting on richer trip inputs before scenario review can start."
+                : "No runtime scenarios are available yet, so there is nothing to review in the scenario board."}
             </p>
           )}
         </section>

--- a/tests/app/test_inventory.py
+++ b/tests/app/test_inventory.py
@@ -73,10 +73,37 @@ def test_inventory_endpoint_assembles_bundles_for_persisted_trip(client: TestCli
     assert payload["trip_id"] == trip_id
     assert payload["bundle_count"] == 1
     assert payload["bundles"][0]["bundle_id"].startswith("bundle-")
+    assert payload["summary"]["runtime_state"]["status"] == "ready"
     assert any(
         "adapter-backed inventory assembly seam" in note
         for note in payload["summary"]["notes"]
     )
+
+
+def test_inventory_endpoint_surfaces_partial_runtime_state_when_trip_dates_are_missing(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Chicago kickoff draft",
+            "summary": "Regions exist, but dates do not yet.",
+            "mode": "business",
+            "trip_frame": {
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    response = client.get(f"/api/inventory/{trip_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["bundle_count"] == 0
+    assert payload["summary"]["runtime_state"]["status"] == "partial"
+    assert "duration" in payload["summary"]["notes"][0].lower()
 
 
 def test_inventory_endpoint_returns_bounded_empty_fallback_for_partial_trip_input(
@@ -107,4 +134,5 @@ def test_inventory_endpoint_returns_bounded_empty_fallback_for_partial_trip_inpu
     payload = response.json()
     assert payload["trip_id"] == trip_id
     assert payload["bundle_count"] == 0
+    assert payload["summary"]["runtime_state"]["status"] == "empty"
     assert "No adapter-backed inventory input is available" in payload["summary"]["notes"][0]

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -241,6 +241,73 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisu
     assert payload["planner_memory"]["current_checkpoint_id"] is None
 
 
+def test_workspace_scenario_comparison_endpoint_returns_runtime_surface_for_persisted_leisure_trip(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Lisbon weekend",
+            "summary": "Comparison endpoint should use persisted runtime inputs.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-06-04",
+                "end_date": "2026-06-07",
+                "duration_days": 4,
+                "primary_regions": ["Lisbon"],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    response = client.get(f"/api/workspace/{trip_id}/scenarios/compare")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["lead_scenario_id"] == f"scenario:{trip_id}:1"
+    assert payload["scenarios"][0]["scenario_id"] == f"scenario:{trip_id}:1"
+    assert not payload["scenarios"][0]["scenario_id"].startswith("saved-scenario:")
+    assert payload["scenarios"][0]["option_count"] >= 1
+    assert "runtime scenario" in payload["summary"].lower()
+
+
+def test_workspace_scenario_comparison_endpoint_returns_runtime_surface_for_persisted_business_trip(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Chicago kickoff",
+            "summary": "Comparison endpoint should use persisted runtime inputs.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+                "traveler_party": {
+                    "kind": "team",
+                    "traveler_count": 3,
+                    "notes": "Customer kickoff",
+                },
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    response = client.get(f"/api/workspace/{trip_id}/scenarios/compare")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["lead_scenario_id"] == f"scenario:{trip_id}:1"
+    assert payload["scenarios"][0]["scenario_id"] == f"scenario:{trip_id}:1"
+    assert not payload["scenarios"][0]["scenario_id"].startswith("saved-scenario:")
+    assert payload["scenarios"][0]["status"] == "fallback"
+    assert "runtime scenario" in payload["summary"].lower()
+
+
 def test_workspace_endpoint_returns_bounded_empty_runtime_state_when_trip_frame_is_sparse(
     client: TestClient,
 ) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -67,6 +67,8 @@ def test_workspace_endpoint_returns_trip_scenario_payload(client: TestClient) ->
     assert payload["runtime_scenario_comparison"]["lead_scenario_id"] == payload["scenario_search"][
         "scenarios"
     ][0]["scenario_id"]
+    assert payload["runtime_state"]["status"] == "ready"
+    assert payload["inventory_summary"]["runtime_state"]["status"] == "ready"
     assert payload["runtime_scenario_comparison"]["comparison_axes"][-1]["key"] == "estimated_total"
     assert payload["runtime_scenario_comparison"]["scenarios"][0]["delta"]["transfers_delta"] == 0
     assert payload["runtime_scenario_comparison"]["scenarios"][0]["route_summary"] == (
@@ -172,6 +174,7 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_busin
     assert payload["saved_scenarios"][1]["versions"][0]["label"] == "fallback"
     assert payload["scenario_comparison"]["baseline_scenario_id"] == lead_saved_scenario_id
     assert payload["scenario_search"]["title"] == "Chicago kickoff ranked scenarios"
+    assert payload["runtime_state"]["status"] == "ready"
     assert payload["scenario_search"]["purpose"] == "final_selection"
     assert payload["scenario_search"]["scenarios"][0]["scenario_id"] == f"scenario:{trip_id}:1"
     assert payload["scenario_search"]["scenarios"][0]["scenario_id"] != lead_saved_scenario_id
@@ -222,6 +225,7 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisu
 
     payload = client.get(f"/api/workspace/{trip_id}").json()
 
+    assert payload["runtime_state"]["status"] == "ready"
     assert payload["saved_scenarios"][0]["versions"][0]["title"].startswith("Lisbon")
     assert payload["scenario_search"]["title"] == "Lisbon weekend runtime scenarios"
     assert payload["scenario_search"]["purpose"] == "final_selection"
@@ -237,7 +241,7 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisu
     assert payload["planner_memory"]["current_checkpoint_id"] is None
 
 
-def test_workspace_endpoint_keeps_leisure_fixture_defaults_when_trip_frame_is_sparse(
+def test_workspace_endpoint_returns_bounded_empty_runtime_state_when_trip_frame_is_sparse(
     client: TestClient,
 ) -> None:
     created = client.post(
@@ -259,7 +263,10 @@ def test_workspace_endpoint_keeps_leisure_fixture_defaults_when_trip_frame_is_sp
     assert reloaded.status_code == 200
     initial_payload = initial.json()
     reloaded_payload = reloaded.json()
-    assert initial_payload["scenario_search"]["scenarios"]
+    assert initial_payload["runtime_state"]["status"] == "empty"
+    assert initial_payload["inventory_summary"]["runtime_state"]["status"] == "empty"
+    assert initial_payload["scenario_search"]["scenarios"] == []
+    assert initial_payload["runtime_scenario_comparison"]["scenarios"] == []
     assert initial_payload["scenario_search"]["scenarios"] == reloaded_payload["scenario_search"][
         "scenarios"
     ]
@@ -269,6 +276,33 @@ def test_workspace_endpoint_keeps_leisure_fixture_defaults_when_trip_frame_is_sp
     assert initial_payload["runtime_scenario_comparison"]["scenarios"] == reloaded_payload[
         "runtime_scenario_comparison"
     ]["scenarios"]
+
+
+def test_workspace_endpoint_surfaces_partial_runtime_state_for_under_scoped_trip(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Chicago kickoff draft",
+            "summary": "Primary region exists but runtime inputs are incomplete.",
+            "mode": "business",
+            "trip_frame": {
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    response = client.get(f"/api/workspace/{trip_id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["runtime_state"]["status"] == "partial"
+    assert payload["inventory_summary"]["runtime_state"]["status"] == "partial"
+    assert payload["scenario_search"]["scenarios"] == []
+    assert payload["runtime_scenario_comparison"]["scenarios"] == []
 
 
 def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_trip(

--- a/trip_planner.egg-info/PKG-INFO
+++ b/trip_planner.egg-info/PKG-INFO
@@ -1,14 +1,14 @@
 Metadata-Version: 2.4
 Name: trip-planner
 Version: 0.1.0
-Requires-Dist: alembic==1.16.5
-Requires-Dist: fastapi==0.116.1
-Requires-Dist: sqlalchemy==2.0.43
-Requires-Dist: uvicorn==0.37.0
+Requires-Dist: alembic==1.18.4
+Requires-Dist: fastapi==0.135.3
+Requires-Dist: sqlalchemy==2.0.49
+Requires-Dist: uvicorn==0.44.0
 Provides-Extra: dev
-Requires-Dist: ruff==0.15.1; extra == "dev"
-Requires-Dist: mypy==1.19.1; extra == "dev"
-Requires-Dist: pytest==9.0.2; extra == "dev"
-Requires-Dist: pytest-cov==7.0.0; extra == "dev"
-Requires-Dist: black==26.1.0; extra == "dev"
+Requires-Dist: ruff==0.15.10; extra == "dev"
+Requires-Dist: mypy==1.20.1; extra == "dev"
+Requires-Dist: pytest==9.0.3; extra == "dev"
+Requires-Dist: pytest-cov==7.1.0; extra == "dev"
+Requires-Dist: black==26.3.1; extra == "dev"
 Requires-Dist: httpx==0.28.1; extra == "dev"

--- a/trip_planner.egg-info/requires.txt
+++ b/trip_planner.egg-info/requires.txt
@@ -1,12 +1,12 @@
-alembic==1.16.5
-fastapi==0.116.1
-sqlalchemy==2.0.43
-uvicorn==0.37.0
+alembic==1.18.4
+fastapi==0.135.3
+sqlalchemy==2.0.49
+uvicorn==0.44.0
 
 [dev]
-ruff==0.15.1
-mypy==1.19.1
-pytest==9.0.2
-pytest-cov==7.0.0
-black==26.1.0
+ruff==0.15.10
+mypy==1.20.1
+pytest==9.0.3
+pytest-cov==7.1.0
+black==26.3.1
 httpx==0.28.1

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -34,6 +34,10 @@ class WorkspaceResponse(BaseModel):
     planner_panel_state: dict[str, Any] = Field(
         description="Workspace-scoped planner panel payload for the mounted side-panel UI.",
     )
+    runtime_state: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Top-level runtime readiness summary for the workspace surface.",
+    )
     feasibility_summary: dict[str, Any] = Field(
         description="Structured feasibility and move-cost assessments derived from workspace inventory bundles.",
     )

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -47,6 +47,7 @@ _FIXTURE_BUNDLE_INPUTS: dict[str, InventoryFixtureSeed] = {
 class InventoryAssemblyInput:
     trip_id: str
     trip_mode: str
+    duration_days: int | None
     query: SourceQuery
     snapshot: RawSnapshot
     handoff: NormalizationHandoff
@@ -56,10 +57,18 @@ class InventoryAssemblyInput:
 class PersistedTripInventoryFixtureAdapter(SourceAdapter):
     """Expose fixture-backed inventory as an explicit adapter seam for persisted trips."""
 
-    def __init__(self, *, trip_id: str, trip_mode: str, primary_regions: Sequence[str]) -> None:
+    def __init__(
+        self,
+        *,
+        trip_id: str,
+        trip_mode: str,
+        primary_regions: Sequence[str],
+        duration_days: int | None = None,
+    ) -> None:
         self.trip_id = trip_id
         self.trip_mode = trip_mode
         self.primary_regions = tuple(region for region in primary_regions if region)
+        self.duration_days = duration_days
         self.adapter_id = "persisted-trip-fixture-inventory"
         self.source_record = SourceRecord(
             source_id="fixture-normalized-inventory",
@@ -82,6 +91,8 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
             return fixture_seed.fixture_names
         if not self.primary_regions:
             return ()
+        if self.duration_days is None or self.duration_days <= 0:
+            return ()
         if self.trip_mode == "leisure":
             return ("route_level_mixed_option.json",)
         if self.trip_mode == "business":
@@ -90,22 +101,34 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
 
     def fetch_snapshot(self, query: SourceQuery) -> RawSnapshot:
         fixture_names = self.fixture_names()
-        issues = (
-            []
-            if fixture_names
-            else [
-                AdapterIssue(
-                    issue_id=f"issue:{self.trip_id}:inventory-fallback",
-                    stage="availability",
-                    severity="warning",
-                    code="missing_inventory_adapter_input",
-                    message=(
-                        "No adapter-backed inventory input is available for this persisted trip yet."
-                    ),
-                    details={"trip_id": self.trip_id, "trip_mode": self.trip_mode},
+        issues: list[AdapterIssue] = []
+        if not fixture_names:
+            if not self.primary_regions:
+                issues.append(
+                    AdapterIssue(
+                        issue_id=f"issue:{self.trip_id}:inventory-missing-regions",
+                        stage="availability",
+                        severity="warning",
+                        code="missing_inventory_primary_regions",
+                        message=(
+                            "Primary regions are still missing, so the runtime inventory remains empty."
+                        ),
+                        details={"trip_id": self.trip_id, "trip_mode": self.trip_mode},
+                    )
                 )
-            ]
-        )
+            else:
+                issues.append(
+                    AdapterIssue(
+                        issue_id=f"issue:{self.trip_id}:inventory-missing-duration",
+                        stage="availability",
+                        severity="warning",
+                        code="missing_inventory_trip_duration",
+                        message=(
+                            "Trip dates or duration are still missing, so inventory assembly stays partial."
+                        ),
+                        details={"trip_id": self.trip_id, "trip_mode": self.trip_mode},
+                    )
+                )
         records = [
             RawSourceRecord(
                 record_id=f"{query.query_id}:{index}",
@@ -135,6 +158,7 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
                 "trip_id": self.trip_id,
                 "trip_mode": self.trip_mode,
                 "region_count": str(len(self.primary_regions)),
+                "duration_days": "" if self.duration_days is None else str(self.duration_days),
             },
         )
 
@@ -185,6 +209,7 @@ def _build_inventory_assembly_input(
     trip_id: str,
     trip_mode: str,
     primary_regions: Sequence[str] = (),
+    duration_days: int | None = None,
 ) -> InventoryAssemblyInput:
     query = SourceQuery(
         query_id=f"inventory-query:{trip_id}",
@@ -199,12 +224,14 @@ def _build_inventory_assembly_input(
         trip_id=trip_id,
         trip_mode=trip_mode,
         primary_regions=primary_regions,
+        duration_days=duration_days,
     )
     snapshot = adapter.fetch_snapshot(query)
     handoff = adapter.build_handoff(snapshot)
     return InventoryAssemblyInput(
         trip_id=trip_id,
         trip_mode=trip_mode,
+        duration_days=duration_days,
         query=query,
         snapshot=snapshot,
         handoff=handoff,
@@ -260,6 +287,33 @@ def build_inventory_summary_payload(
             "Bundle assembly will appear here once normalized option inputs are available for the trip."
         ]
 
+    if bundles:
+        runtime_state = {
+            "status": "ready",
+            "title": "Runtime inventory is ready",
+            "summary": "Persisted trip context is rich enough to assemble comparison-ready inventory bundles.",
+        }
+    elif assembly_input is not None and assembly_input.snapshot.issues:
+        issue = assembly_input.snapshot.issues[0]
+        if issue.code == "missing_inventory_trip_duration":
+            runtime_state = {
+                "status": "partial",
+                "title": "Runtime inventory is partially specified",
+                "summary": "Add trip dates or duration to replace the bounded fallback with runtime bundle assembly.",
+            }
+        else:
+            runtime_state = {
+                "status": "empty",
+                "title": "Runtime inventory is still empty",
+                "summary": "Add at least one primary region before the workspace can assemble runtime inventory bundles.",
+            }
+    else:
+        runtime_state = {
+            "status": "empty",
+            "title": "Runtime inventory is still empty",
+            "summary": "Bundle assembly will appear once the trip carries enough persisted runtime context.",
+        }
+
     return {
         "bundle_count": len(bundles),
         "bundles": [
@@ -276,6 +330,7 @@ def build_inventory_summary_payload(
             for bundle in bundles
         ],
         "notes": notes,
+        "runtime_state": runtime_state,
     }
 
 
@@ -288,6 +343,7 @@ def get_inventory_payload(
     fixture_seed = _FIXTURE_BUNDLE_INPUTS.get(trip_id)
     record: PersistedTrip | None = None
     primary_regions: Sequence[str] = ()
+    duration_days: int | None = None
     if fixture_seed is not None:
         trip_mode = fixture_seed.trip_mode
     else:
@@ -300,11 +356,13 @@ def get_inventory_payload(
             return None
         trip_mode = record.mode
         primary_regions = tuple(record.primary_regions)
+        duration_days = record.duration_days
 
     assembly_input = _build_inventory_assembly_input(
         trip_id=trip_id,
         trip_mode=trip_mode,
         primary_regions=primary_regions,
+        duration_days=duration_days,
     )
     bundles = assemble_inventory_bundles_for_trip(assembly_input=assembly_input)
     return {

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -246,6 +246,7 @@ def assemble_inventory_bundles_for_trip(
     trip_id: str | None = None,
     trip_mode: str | None = None,
     primary_regions: Sequence[str] = (),
+    duration_days: int | None = None,
     assembly_input: InventoryAssemblyInput | None = None,
 ) -> list[InventoryBundle]:
     if assembly_input is None:
@@ -256,6 +257,7 @@ def assemble_inventory_bundles_for_trip(
             trip_id=trip_id,
             trip_mode=trip_mode,
             primary_regions=primary_regions,
+            duration_days=duration_days,
         )
 
     bundles: list[InventoryBundle] = []

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -279,9 +279,15 @@ def build_inventory_summary_payload(
                 "Persisted trips use an adapter-backed inventory assembly seam instead of a seeded trip-ID gate."
             )
     elif assembly_input is not None and assembly_input.snapshot.issues:
-        notes = [
-            "No adapter-backed inventory input is available for this persisted trip yet, so the workspace remains available with an empty bundle set."
-        ]
+        issue = assembly_input.snapshot.issues[0]
+        if issue.code == "missing_inventory_trip_duration":
+            notes = [
+                "Trip dates or duration are still missing, so runtime inventory stays in a bounded partial state until those inputs are filled in."
+            ]
+        else:
+            notes = [
+                "No adapter-backed inventory input is available for this persisted trip yet, so the workspace remains available with an empty bundle set."
+            ]
     else:
         notes = [
             "Bundle assembly will appear here once normalized option inputs are available for the trip."

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1056,6 +1056,7 @@ def _build_persisted_trip_workspace(
         trip_id=record.trip_id,
         trip_mode=record.mode,
         primary_regions=record.primary_regions,
+        duration_days=record.duration_days,
     )
     resolved_inventory_summary = inventory_summary or build_inventory_summary_payload(
         resolved_inventory_bundles
@@ -1239,6 +1240,7 @@ def _build_runtime_scenario_comparison_payload(
         trip_id=record.trip_id,
         trip_mode=record.mode,
         primary_regions=record.primary_regions,
+        duration_days=record.duration_days,
     )
     return _build_runtime_scenario_comparison(
         trip_id=trip_id,

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1060,10 +1060,17 @@ def _build_persisted_trip_workspace(
     resolved_inventory_summary = inventory_summary or build_inventory_summary_payload(
         resolved_inventory_bundles
     )
-    resolved_scenario_search = scenario_search or _build_runtime_scenario_search_for_trip(
-        record=record,
-        inventory_bundles=resolved_inventory_bundles,
-        saved_scenarios=ordered_saved_scenarios,
+    inventory_status = str(
+        (resolved_inventory_summary.get("runtime_state") or {}).get("status") or "empty"
+    )
+    resolved_scenario_search = scenario_search or (
+        _build_runtime_scenario_search_for_trip(
+            record=record,
+            inventory_bundles=resolved_inventory_bundles,
+            saved_scenarios=ordered_saved_scenarios,
+        )
+        if inventory_status == "ready"
+        else _empty_workspace_scenario_search()
     )
     resolved_feasibility_summary = feasibility_summary or build_feasibility_summary_payload(
         resolved_inventory_bundles
@@ -1134,14 +1141,35 @@ def _build_workspace_runtime_state(
 ) -> dict[str, str]:
     inventory_runtime_state = dict(inventory_summary.get("runtime_state") or {})
     runtime_scenarios = list(runtime_scenario_comparison.get("scenarios") or [])
+    inventory_status = str(inventory_runtime_state.get("status") or "")
 
-    if runtime_scenarios:
+    if inventory_status == "ready" and runtime_scenarios:
         return {
             "status": "ready",
             "title": "Workspace runtime is ready",
             "summary": "Inventory, scenario ranking, and comparison surfaces are ready for review.",
         }
-    if inventory_summary.get("bundle_count", 0) > 0:
+    if inventory_status in {"partial", "empty"}:
+        return {
+            "status": inventory_status,
+            "title": str(
+                inventory_runtime_state.get("title")
+                or (
+                    "Workspace runtime is partially assembled"
+                    if inventory_status == "partial"
+                    else "Workspace runtime is still empty"
+                )
+            ),
+            "summary": str(
+                inventory_runtime_state.get("summary")
+                or (
+                    "Inventory bundles are available, but scenario comparison is not ready yet."
+                    if inventory_status == "partial"
+                    else "Trip context is not complete enough for runtime workspace assembly yet."
+                )
+            ),
+        }
+    if inventory_summary.get("bundle_count", 0) > 0 or runtime_scenarios:
         return {
             "status": "partial",
             "title": "Workspace runtime is partially assembled",
@@ -1806,21 +1834,26 @@ def get_workspace_payload(
         inventory_bundles,
         assembly_input=inventory_assembly_input,
     )
-    runtime_search = _build_runtime_scenario_search_for_trip(
-        record=record,
-        inventory_bundles=inventory_bundles,
-        saved_scenarios=[
-            {
-                "saved_scenario_id": scenario.saved_scenario_id,
-                "trip_id": scenario.trip_id,
-                "current_version_id": scenario.current_version_id,
-                "versions": list(scenario.versions),
-                "comparisons": list(scenario.comparisons),
-                "tags": list(scenario.tags),
-                "notes": list(scenario.notes),
-            }
-            for scenario in persisted_saved_scenarios
-        ],
+    inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
+    runtime_search = (
+        _build_runtime_scenario_search_for_trip(
+            record=record,
+            inventory_bundles=inventory_bundles,
+            saved_scenarios=[
+                {
+                    "saved_scenario_id": scenario.saved_scenario_id,
+                    "trip_id": scenario.trip_id,
+                    "current_version_id": scenario.current_version_id,
+                    "versions": list(scenario.versions),
+                    "comparisons": list(scenario.comparisons),
+                    "tags": list(scenario.tags),
+                    "notes": list(scenario.notes),
+                }
+                for scenario in persisted_saved_scenarios
+            ],
+        )
+        if inventory_status == "ready"
+        else _empty_workspace_scenario_search()
     )
     if _sync_workspace_session_record(
         session_record,

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -22,6 +22,7 @@ from trip_planner.app.services.feasibility import (
     build_feasibility_summary_payload,
 )
 from trip_planner.app.services.inventory import (
+    _build_inventory_assembly_input,
     assemble_inventory_bundles_for_trip,
     build_inventory_summary_payload,
 )
@@ -1025,6 +1026,7 @@ def _build_persisted_trip_workspace(
     policy_context: dict[str, Any] | None = None,
     proposal_context: dict[str, Any] | None = None,
     inventory_bundles: list[InventoryBundle] | None = None,
+    inventory_summary: dict[str, Any] | None = None,
     scenario_search: dict[str, Any] | None = None,
     feasibility_summary: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -1055,6 +1057,9 @@ def _build_persisted_trip_workspace(
         trip_mode=record.mode,
         primary_regions=record.primary_regions,
     )
+    resolved_inventory_summary = inventory_summary or build_inventory_summary_payload(
+        resolved_inventory_bundles
+    )
     resolved_scenario_search = scenario_search or _build_runtime_scenario_search_for_trip(
         record=record,
         inventory_bundles=resolved_inventory_bundles,
@@ -1067,6 +1072,10 @@ def _build_persisted_trip_workspace(
         trip_id=record.trip_id,
         trip_title=trip_record["trip"]["title"],
         scenario_search=resolved_scenario_search,
+    )
+    runtime_state = _build_workspace_runtime_state(
+        inventory_summary=resolved_inventory_summary,
+        runtime_scenario_comparison=runtime_scenario_comparison,
     )
 
     return {
@@ -1097,8 +1106,9 @@ def _build_persisted_trip_workspace(
             policy_context=policy_context,
             proposal_context=proposal_context,
         ),
+        "runtime_state": runtime_state,
         "feasibility_summary": resolved_feasibility_summary,
-        "inventory_summary": build_inventory_summary_payload(resolved_inventory_bundles),
+        "inventory_summary": resolved_inventory_summary,
         "budget_state": resolved_budget_state,
         "policy_state": (policy_context or {}).get("policy_state"),
         "proposal_state": (proposal_context or {}).get("proposal_state"),
@@ -1114,6 +1124,36 @@ def _empty_workspace_scenario_search() -> dict[str, Any]:
             "Scenario search and comparisons will appear after planning begins.",
         ],
         "source_refs": [],
+    }
+
+
+def _build_workspace_runtime_state(
+    *,
+    inventory_summary: dict[str, Any],
+    runtime_scenario_comparison: dict[str, Any],
+) -> dict[str, str]:
+    inventory_runtime_state = dict(inventory_summary.get("runtime_state") or {})
+    runtime_scenarios = list(runtime_scenario_comparison.get("scenarios") or [])
+
+    if runtime_scenarios:
+        return {
+            "status": "ready",
+            "title": "Workspace runtime is ready",
+            "summary": "Inventory, scenario ranking, and comparison surfaces are ready for review.",
+        }
+    if inventory_summary.get("bundle_count", 0) > 0:
+        return {
+            "status": "partial",
+            "title": "Workspace runtime is partially assembled",
+            "summary": "Inventory bundles are available, but scenario comparison is not ready yet.",
+        }
+    return {
+        "status": str(inventory_runtime_state.get("status") or "empty"),
+        "title": str(inventory_runtime_state.get("title") or "Workspace runtime is still empty"),
+        "summary": str(
+            inventory_runtime_state.get("summary")
+            or "Trip context is not complete enough for runtime workspace assembly yet."
+        ),
     }
 
 
@@ -1666,9 +1706,14 @@ def get_workspace_payload(
         saved_scenarios, scenario_comparison = _load_saved_scenarios(fixture.scenarios_fixture)
         session = _load_session(fixture.session_fixture)
         _canonicalize_saved_scenario_ids(session, saved_scenarios)
-        inventory_bundles = assemble_inventory_bundles_for_trip(
+        inventory_assembly_input = _build_inventory_assembly_input(
             trip_id=trip_id,
             trip_mode=trip_record.trip.mode,
+            primary_regions=tuple(trip_record.trip.trip_frame.primary_regions),
+            duration_days=trip_record.trip.trip_frame.duration_days,
+        )
+        inventory_bundles = assemble_inventory_bundles_for_trip(
+            assembly_input=inventory_assembly_input,
         )
         scenario_search = _build_scenario_search(
             trip_id=trip_id,
@@ -1684,6 +1729,10 @@ def get_workspace_payload(
             trip_id=trip_id,
             trip_title=trip_record.trip.title,
             scenario_search=scenario_search.to_dict(),
+        )
+        inventory_summary = build_inventory_summary_payload(
+            inventory_bundles,
+            assembly_input=inventory_assembly_input,
         )
 
         return {
@@ -1709,8 +1758,12 @@ def get_workspace_payload(
                 policy_context=None,
                 proposal_context=None,
             ),
+            "runtime_state": _build_workspace_runtime_state(
+                inventory_summary=inventory_summary,
+                runtime_scenario_comparison=runtime_scenario_comparison,
+            ),
             "feasibility_summary": feasibility_summary,
-            "inventory_summary": build_inventory_summary_payload(inventory_bundles),
+            "inventory_summary": inventory_summary,
             "budget_state": build_fixture_budget_payload(
                 trip_id=trip_id,
                 trip_mode=trip_record.trip.mode,
@@ -1726,6 +1779,12 @@ def get_workspace_payload(
     )
     if record is None:
         return None
+    inventory_assembly_input = _build_inventory_assembly_input(
+        trip_id=record.trip_id,
+        trip_mode=record.mode,
+        primary_regions=record.primary_regions,
+        duration_days=record.duration_days,
+    )
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     persisted_saved_scenarios = list(
         db_session.scalars(
@@ -1742,10 +1801,10 @@ def get_workspace_payload(
             session_record=session_record,
         )
         bootstrap_updated = True
-    inventory_bundles = assemble_inventory_bundles_for_trip(
-        trip_id=record.trip_id,
-        trip_mode=record.mode,
-        primary_regions=record.primary_regions,
+    inventory_bundles = assemble_inventory_bundles_for_trip(assembly_input=inventory_assembly_input)
+    inventory_summary = build_inventory_summary_payload(
+        inventory_bundles,
+        assembly_input=inventory_assembly_input,
     )
     runtime_search = _build_runtime_scenario_search_for_trip(
         record=record,
@@ -1832,6 +1891,7 @@ def get_workspace_payload(
             else None
         ),
         inventory_bundles=inventory_bundles,
+        inventory_summary=inventory_summary,
         scenario_search=runtime_search,
         feasibility_summary=feasibility_summary,
     )


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #808

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo now ships a usable full-stack MVP, but the strongest runtime behavior
for inventory, scenario generation, and comparison still leans on seeded or
fixture-dominant paths for arbitrary persisted trips. That keeps the app
testable, but it prevents the runtime from being mature enough to treat a
newly-created trip as a first-class planning object instead of a partial demo.

#### Tasks
- [x] Replace the current fixture-first inventory path in `trip_planner/app/services/inventory.py` with a persisted-trip-first assembly flow that only falls back when runtime inputs are genuinely missing
- [ ] Update `trip_planner/app/services/scenarios.py` and adjacent services so arbitrary persisted trips receive the same scenario and comparison depth as the seeded examples
- [ ] Ensure empty and partial inventory states remain explicit and bounded in the backend payload instead of silently collapsing into seeded data
- [ ] Update workspace payload shaping so the frontend can distinguish `ready`, `partial`, and `empty` runtime states without heuristics
- [ ] Add route/service tests proving newly-created leisure and business trips can move from trip creation to workspace comparison without seeded trip IDs
- [ ] Add frontend tests that verify the workspace renders meaningful partial and empty runtime states for non-seeded trips

#### Acceptance criteria
- [ ] Newly-created persisted trips can load workspace inventory, scenarios, and comparison payloads without relying on seeded trip IDs as the primary path
- [ ] Partial runtime data produces explicit fallback messaging instead of hidden fixture substitution
- [ ] Backend and frontend tests cover both leisure and business trips using persisted runtime state
- [ ] `make runtime-check` passes

<!-- auto-status-summary:end -->