### PR TITLE
Follow-up for #808: close runtime readiness gaps

### DIFF
--- a/tests/app/test_inventory.py
+++ b/tests/app/test_inventory.py
@@ -10,9 +10,7 @@ from trip_planner.persistence.db import reset_database_state
 
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
-    monkeypatch.setenv(
-        "TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'inventory.db'}"
-    )
+    monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'inventory.db'}")
     reset_database_state()
     app = create_app()
 
@@ -75,8 +73,7 @@ def test_inventory_endpoint_assembles_bundles_for_persisted_trip(client: TestCli
     assert payload["bundles"][0]["bundle_id"].startswith("bundle-")
     assert payload["summary"]["runtime_state"]["status"] == "ready"
     assert any(
-        "adapter-backed inventory assembly seam" in note
-        for note in payload["summary"]["notes"]
+        "adapter-backed inventory assembly seam" in note for note in payload["summary"]["notes"]
     )
 
 
@@ -135,4 +132,4 @@ def test_inventory_endpoint_returns_bounded_empty_fallback_for_partial_trip_inpu
     assert payload["trip_id"] == trip_id
     assert payload["bundle_count"] == 0
     assert payload["summary"]["runtime_state"]["status"] == "empty"
-    assert "No adapter-backed inventory input is available" in payload["summary"]["notes"][0]
+    assert "Primary regions are still missing" in payload["summary"]["notes"][0]

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -19,9 +19,7 @@ from trip_planner.persistence.models.activity import PersistedPlannerAction
 
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
-    monkeypatch.setenv(
-        "TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'workspace.db'}"
-    )
+    monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'workspace.db'}")
     reset_database_state()
     app = create_app()
 
@@ -45,15 +43,13 @@ def test_workspace_endpoint_returns_trip_scenario_payload(client: TestClient) ->
     assert response.status_code == 200
     payload = response.json()
     assert payload["trip_record"]["trip"]["trip_id"] == "trip-leisure-kyoto-draft"
-    assert (
-        payload["session"]["current_saved_scenario_id"]
-        == "saved-scenario:kyoto-baseline"
-    )
+    assert payload["session"]["current_saved_scenario_id"] == "saved-scenario:kyoto-baseline"
     assert payload["scenario_search"]["title"] == "Kyoto ranked scenario workspace"
     assert payload["scenario_search"]["scenarios"][0]["title"] == "Kyoto cultural anchor"
-    assert payload["scenario_search"]["scenarios"][0]["scenario_summary"][
-        "route_sequence"
-    ] == ["dest-city-osaka", "dest-city-kyoto"]
+    assert payload["scenario_search"]["scenarios"][0]["scenario_summary"]["route_sequence"] == [
+        "dest-city-osaka",
+        "dest-city-kyoto",
+    ]
     assert payload["inventory_summary"]["bundle_count"] == 2
     assert payload["inventory_summary"]["bundles"][0]["title"] == "Osaka arrival buffer"
     assert payload["feasibility_summary"]["assessment_count"] == 2
@@ -64,9 +60,10 @@ def test_workspace_endpoint_returns_trip_scenario_payload(client: TestClient) ->
     assert payload["planner_panel_state"]["outputs"][0]["tags"][0] == "feasibility"
     assert payload["planner_panel_state"]["outputs"][3]["title"] == "Scenario ranking summary"
     assert payload["planner_panel_state"]["outputs"][4]["title"].startswith("Rank #1 ")
-    assert payload["runtime_scenario_comparison"]["lead_scenario_id"] == payload["scenario_search"][
-        "scenarios"
-    ][0]["scenario_id"]
+    assert (
+        payload["runtime_scenario_comparison"]["lead_scenario_id"]
+        == payload["scenario_search"]["scenarios"][0]["scenario_id"]
+    )
     assert payload["runtime_state"]["status"] == "ready"
     assert payload["inventory_summary"]["runtime_state"]["status"] == "ready"
     assert payload["runtime_scenario_comparison"]["comparison_axes"][-1]["key"] == "estimated_total"
@@ -95,13 +92,17 @@ def test_workspace_endpoint_surfaces_business_ranked_scenarios(client: TestClien
     payload = response.json()
     assert payload["scenario_search"]["title"] == "Client summit ranked scenarios"
     assert payload["scenario_search"]["scenarios"][0]["title"] == "Airport arrival bundle"
-    assert payload["runtime_scenario_comparison"]["lead_scenario_id"] == payload["runtime_scenario_comparison"][
-        "scenarios"
-    ][0]["scenario_id"]
+    assert (
+        payload["runtime_scenario_comparison"]["lead_scenario_id"]
+        == payload["runtime_scenario_comparison"]["scenarios"][0]["scenario_id"]
+    )
     assert payload["runtime_scenario_comparison"]["scenarios"][0]["status"] == "fallback"
     assert payload["planner_panel_state"]["outputs"][2]["title"] == "Scenario ranking summary"
     assert payload["planner_panel_state"]["outputs"][3]["title"] == "Rank #1 Airport arrival bundle"
-    assert payload["planner_panel_state"]["option_set"]["options"][0]["label"] == "Airport arrival bundle"
+    assert (
+        payload["planner_panel_state"]["option_set"]["options"][0]["label"]
+        == "Airport arrival bundle"
+    )
 
 
 def test_workspace_scenario_comparison_endpoint_returns_runtime_surface(
@@ -164,9 +165,10 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_busin
     assert payload["trip_record"]["trip"]["title"] == "Chicago kickoff"
     assert payload["trip_record"]["artifact_refs"]["session_state_id"] == f"session:{trip_id}"
     assert payload["session"]["trip_id"] == trip_id
-    assert payload["session"]["current_saved_scenario_id"] == payload["saved_scenarios"][0][
-        "saved_scenario_id"
-    ]
+    assert (
+        payload["session"]["current_saved_scenario_id"]
+        == payload["saved_scenarios"][0]["saved_scenario_id"]
+    )
     assert payload["session"]["pending_decisions"][0]["decision_id"].startswith("decision:")
     assert len(payload["saved_scenarios"]) == 2
     lead_saved_scenario_id = payload["saved_scenarios"][0]["saved_scenario_id"]
@@ -198,9 +200,10 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_busin
     assert scenario_history.status_code == 200
     history_payload = scenario_history.json()
     assert len(history_payload["saved_scenarios"]) == 2
-    assert history_payload["planning_sessions"][0]["current_saved_scenario_id"] == payload["session"][
-        "current_saved_scenario_id"
-    ]
+    assert (
+        history_payload["planning_sessions"][0]["current_saved_scenario_id"]
+        == payload["session"]["current_saved_scenario_id"]
+    )
 
 
 def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisure_trip(
@@ -334,15 +337,18 @@ def test_workspace_endpoint_returns_bounded_empty_runtime_state_when_trip_frame_
     assert initial_payload["inventory_summary"]["runtime_state"]["status"] == "empty"
     assert initial_payload["scenario_search"]["scenarios"] == []
     assert initial_payload["runtime_scenario_comparison"]["scenarios"] == []
-    assert initial_payload["scenario_search"]["scenarios"] == reloaded_payload["scenario_search"][
-        "scenarios"
-    ]
-    assert initial_payload["planner_panel_state"]["option_set"]["options"] == reloaded_payload[
-        "planner_panel_state"
-    ]["option_set"]["options"]
-    assert initial_payload["runtime_scenario_comparison"]["scenarios"] == reloaded_payload[
-        "runtime_scenario_comparison"
-    ]["scenarios"]
+    assert (
+        initial_payload["scenario_search"]["scenarios"]
+        == reloaded_payload["scenario_search"]["scenarios"]
+    )
+    assert (
+        initial_payload["planner_panel_state"]["option_set"]["options"]
+        == reloaded_payload["planner_panel_state"]["option_set"]["options"]
+    )
+    assert (
+        initial_payload["runtime_scenario_comparison"]["scenarios"]
+        == reloaded_payload["runtime_scenario_comparison"]["scenarios"]
+    )
 
 
 def test_workspace_endpoint_surfaces_partial_runtime_state_for_under_scoped_trip(
@@ -370,6 +376,17 @@ def test_workspace_endpoint_surfaces_partial_runtime_state_for_under_scoped_trip
     assert payload["inventory_summary"]["runtime_state"]["status"] == "partial"
     assert payload["scenario_search"]["scenarios"] == []
     assert payload["runtime_scenario_comparison"]["scenarios"] == []
+
+    comparison_response = client.get(f"/api/workspace/{trip_id}/scenarios/compare")
+
+    assert comparison_response.status_code == 200
+    comparison_payload = comparison_response.json()
+    assert comparison_payload["scenarios"] == []
+    assert comparison_payload["lead_scenario_id"] is None
+    assert (
+        "does not have runtime scenario comparison data yet"
+        in comparison_payload["summary"].lower()
+    )
 
 
 def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_trip(
@@ -416,7 +433,9 @@ def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_tri
     payload = response.json()
     assert payload["policy_state"]["policy_id"] == "policy-standard-2026-02"
     assert payload["planner_panel_state"]["policy_evaluation"]["status"] == "compliant"
-    assert payload["planner_panel_state"]["proposal"]["constraint_set_id"] == "policy-standard-2026-02"
+    assert (
+        payload["planner_panel_state"]["proposal"]["constraint_set_id"] == "policy-standard-2026-02"
+    )
     assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Policy posture loaded"
     assert payload["planner_panel_state"]["next_step_actions"][0]["target_section"] == "approval"
     assert "Navan" in payload["planner_panel_state"]["policy_evaluation"]["notes"][-2]
@@ -498,9 +517,9 @@ def test_workspace_endpoint_prefers_persisted_proposal_lifecycle_for_business_tr
     evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
     evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
     evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
-    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
-        f"proposal:{trip_id}"
-    )
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"][
+        "proposal_id"
+    ] = f"proposal:{trip_id}"
     proposal_payload = {
         "proposal_id": f"proposal:{trip_id}",
         "trip_id": trip_id,
@@ -581,7 +600,9 @@ def test_workspace_endpoint_prefers_persisted_proposal_lifecycle_for_business_tr
     payload = response.json()
     assert payload["proposal_state"]["summary"]["approval_ready"] is True
     assert payload["planner_panel_state"]["proposal"]["proposal_id"] == f"proposal:{trip_id}"
-    assert payload["planner_panel_state"]["policy_evaluation"]["evaluation_id"] == "eval-approved-001"
+    assert (
+        payload["planner_panel_state"]["policy_evaluation"]["evaluation_id"] == "eval-approved-001"
+    )
     titles = [item["title"] for item in payload["planner_panel_state"]["outputs"]]
     assert "Proposal lifecycle loaded" in titles
     assert "Approval-ready proposal" in titles
@@ -744,9 +765,9 @@ def test_workspace_endpoint_surfaces_reoptimization_follow_up_for_non_compliant_
     evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
     evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
     evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
-    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
-        f"proposal:{trip_id}"
-    )
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"][
+        "proposal_id"
+    ] = f"proposal:{trip_id}"
     proposal_payload = {
         "proposal_id": f"proposal:{trip_id}",
         "trip_id": trip_id,
@@ -920,9 +941,7 @@ def test_workspace_endpoint_surfaces_exception_follow_up_for_live_policy_results
                         "Attach the compliant comparable to the exception packet.",
                         "Explain why the earlier arrival is required for the client meeting.",
                     ],
-                    "notes": [
-                        "Exception review is required before approval can continue."
-                    ],
+                    "notes": ["Exception review is required before approval can continue."],
                     "compliance_score": 0.61,
                 },
             },
@@ -934,9 +953,9 @@ def test_workspace_endpoint_surfaces_exception_follow_up_for_live_policy_results
     evaluation_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
     evaluation_fixture["response"]["result_payload"]["trip_id"] = trip_id
     evaluation_fixture["response"]["result_payload"]["proposal_id"] = f"proposal:{trip_id}"
-    evaluation_fixture["response"]["result_payload"]["evaluation_result"]["proposal_id"] = (
-        f"proposal:{trip_id}"
-    )
+    evaluation_fixture["response"]["result_payload"]["evaluation_result"][
+        "proposal_id"
+    ] = f"proposal:{trip_id}"
     proposal_payload = {
         "proposal_id": f"proposal:{trip_id}",
         "trip_id": trip_id,
@@ -1014,8 +1033,13 @@ def test_workspace_endpoint_surfaces_exception_follow_up_for_live_policy_results
     assert response.status_code == 200
     payload = response.json()
     assert payload["proposal_state"]["follow_up"]["status"] == "exception_required"
-    assert payload["planner_panel_state"]["next_step_actions"][0]["action_kind"] == "request_exception"
-    assert payload["planner_panel_state"]["next_step_actions"][0]["label"] == "Prepare exception request"
+    assert (
+        payload["planner_panel_state"]["next_step_actions"][0]["action_kind"] == "request_exception"
+    )
+    assert (
+        payload["planner_panel_state"]["next_step_actions"][0]["label"]
+        == "Prepare exception request"
+    )
     assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Exception path required"
     assert payload["planner_panel_state"]["outputs"][-1]["status"] == "caution"
 
@@ -1250,7 +1274,9 @@ def test_feasibility_summary_payload_keeps_ready_and_blocked_bundles_distinct() 
     assert payload["assessment_count"] == 2
     assert payload["recommended_bundle_count"] == 1
     assert payload["blocking_bundle_count"] == 1
-    statuses = {assessment["bundle_id"]: assessment["status"] for assessment in payload["assessments"]}
+    statuses = {
+        assessment["bundle_id"]: assessment["status"] for assessment in payload["assessments"]
+    }
     assert statuses["bundle:kyoto-low-friction"] == "positive"
     assert statuses["bundle:unrealistic-same-day"] == "critical"
 

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -35,7 +35,6 @@ class WorkspaceResponse(BaseModel):
         description="Workspace-scoped planner panel payload for the mounted side-panel UI.",
     )
     runtime_state: dict[str, Any] = Field(
-        default_factory=dict,
         description="Top-level runtime readiness summary for the workspace surface.",
     )
     feasibility_summary: dict[str, Any] = Field(

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -236,7 +236,9 @@ def _build_inventory_assembly_input(
         snapshot=snapshot,
         handoff=handoff,
         fixture_names=tuple(
-            record.metadata["fixture_name"] for record in snapshot.records if "fixture_name" in record.metadata
+            record.metadata["fixture_name"]
+            for record in snapshot.records
+            if "fixture_name" in record.metadata
         ),
     )
 
@@ -285,6 +287,10 @@ def build_inventory_summary_payload(
         if issue.code == "missing_inventory_trip_duration":
             notes = [
                 "Trip dates or duration are still missing, so runtime inventory stays in a bounded partial state until those inputs are filled in."
+            ]
+        elif issue.code == "missing_inventory_primary_regions":
+            notes = [
+                "Primary regions are still missing, so add at least one destination before the workspace can assemble runtime inventory bundles."
             ]
         else:
             notes = [

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -370,7 +370,11 @@ def _build_runtime_scenario_search_for_trip(
     record: PersistedTrip,
     inventory_bundles: list[Any],
     saved_scenarios: list[dict[str, Any]],
+    inventory_status: str = "ready",
 ) -> dict[str, Any]:
+    if inventory_status != "ready":
+        return _empty_workspace_scenario_search()
+
     if inventory_bundles:
         return _build_scenario_search(
             trip_id=record.trip_id,
@@ -435,10 +439,11 @@ def _comparison_highlights(
         highlights.append("Lead scenario for the current workspace comparison set.")
     else:
         score_delta = round(float(scenario["score"]) - float(lead["score"]), 2)
-        travel_delta = summary["total_travel_minutes"] - lead["scenario_summary"]["total_travel_minutes"]
+        travel_delta = (
+            summary["total_travel_minutes"] - lead["scenario_summary"]["total_travel_minutes"]
+        )
         transfers_delta = (
-            summary["total_transfer_count"]
-            - lead["scenario_summary"]["total_transfer_count"]
+            summary["total_transfer_count"] - lead["scenario_summary"]["total_transfer_count"]
         )
         delta_parts = [f"Score {score_delta:+.2f} versus the lead scenario."]
         if travel_delta:
@@ -506,7 +511,8 @@ def _build_runtime_scenario_comparison(
                 "checkpoint_id": None,
                 "budget_variant_id": None,
                 "route_sequence": list(summary.get("route_sequence") or []),
-                "route_summary": " -> ".join(summary.get("route_sequence") or []) or "route pending",
+                "route_summary": " -> ".join(summary.get("route_sequence") or [])
+                or "route pending",
                 "recommended_for_selection": summary["recommended_for_selection"],
                 "feasible": summary["feasible"],
                 "metrics": {
@@ -919,9 +925,7 @@ def _build_saved_scenario_runtime_search(
                 },
                 "supporting_option_ids": list(version["snapshot_refs"].get("option_set_ids") or []),
                 "objective_refs": [
-                    ref
-                    for ref in [version["snapshot_refs"].get("objective_id")]
-                    if ref is not None
+                    ref for ref in [version["snapshot_refs"].get("objective_id")] if ref is not None
                 ],
                 "unresolved_tradeoffs": (
                     [
@@ -1069,9 +1073,8 @@ def _build_persisted_trip_workspace(
             record=record,
             inventory_bundles=resolved_inventory_bundles,
             saved_scenarios=ordered_saved_scenarios,
+            inventory_status=inventory_status,
         )
-        if inventory_status == "ready"
-        else _empty_workspace_scenario_search()
     )
     resolved_feasibility_summary = feasibility_summary or build_feasibility_summary_payload(
         resolved_inventory_bundles
@@ -1236,12 +1239,20 @@ def _build_runtime_scenario_comparison_payload(
         ).all()
     ]
 
-    inventory_bundles = assemble_inventory_bundles_for_trip(
+    inventory_assembly_input = _build_inventory_assembly_input(
         trip_id=record.trip_id,
         trip_mode=record.mode,
         primary_regions=record.primary_regions,
         duration_days=record.duration_days,
     )
+    inventory_bundles = assemble_inventory_bundles_for_trip(
+        assembly_input=inventory_assembly_input,
+    )
+    inventory_summary = build_inventory_summary_payload(
+        inventory_bundles,
+        assembly_input=inventory_assembly_input,
+    )
+    inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
     return _build_runtime_scenario_comparison(
         trip_id=trip_id,
         trip_title=record.title,
@@ -1249,6 +1260,7 @@ def _build_runtime_scenario_comparison_payload(
             record=record,
             inventory_bundles=inventory_bundles,
             saved_scenarios=persisted_saved_scenarios,
+            inventory_status=inventory_status,
         ),
     )
 
@@ -1462,7 +1474,9 @@ def _build_planner_panel_state(
                     "kind": "trip_setup",
                     "label": "Keep the current trip frame narrow",
                     "summary": f"Use {region_summary} as the first planner pass boundary.",
-                    "drawbacks": ["You may need another pass if the trip should span more regions."],
+                    "drawbacks": [
+                        "You may need another pass if the trip should span more regions."
+                    ],
                     "explanation": [
                         "Best when the user wants to start from one durable trip container and iterate later.",
                     ],
@@ -1610,9 +1624,7 @@ def _build_planner_panel_state(
             else None
         )
         proposal = (
-            dict(proposal_state["proposal"])
-            if proposal_state.get("proposal") is not None
-            else None
+            dict(proposal_state["proposal"]) if proposal_state.get("proposal") is not None else None
         )
     else:
         policy_evaluation = (
@@ -1632,9 +1644,13 @@ def _build_planner_panel_state(
                 "title": "Policy posture loaded",
                 "body": "The workspace is using persisted policy inputs instead of mock approval-readiness state.",
                 "tags": ["policy", "workspace", trip["mode"]],
-                "status": "positive"
-                if policy_evaluation["status"] == "compliant"
-                else ("critical" if policy_evaluation["status"] == "non_compliant" else "caution"),
+                "status": (
+                    "positive"
+                    if policy_evaluation["status"] == "compliant"
+                    else (
+                        "critical" if policy_evaluation["status"] == "non_compliant" else "caution"
+                    )
+                ),
                 "highlights": list(policy_evaluation.get("notes") or [])[:3],
             }
         )
@@ -1677,7 +1693,11 @@ def _build_planner_panel_state(
                     "status": (
                         "positive"
                         if follow_up.get("status") in {"resolved", "approval_pending"}
-                        else ("critical" if follow_up.get("status") == "reoptimization_required" else "caution")
+                        else (
+                            "critical"
+                            if follow_up.get("status") == "reoptimization_required"
+                            else "caution"
+                        )
                     ),
                     "highlights": list(follow_up.get("guidance") or [])[:2],
                 }
@@ -1818,9 +1838,9 @@ def get_workspace_payload(
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     persisted_saved_scenarios = list(
         db_session.scalars(
-        select(PersistedSavedScenario)
-        .where(PersistedSavedScenario.trip_id == trip_id)
-        .order_by(PersistedSavedScenario.updated_at.desc())
+            select(PersistedSavedScenario)
+            .where(PersistedSavedScenario.trip_id == trip_id)
+            .order_by(PersistedSavedScenario.updated_at.desc())
         ).all()
     )
     bootstrap_updated = False
@@ -1837,25 +1857,22 @@ def get_workspace_payload(
         assembly_input=inventory_assembly_input,
     )
     inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
-    runtime_search = (
-        _build_runtime_scenario_search_for_trip(
-            record=record,
-            inventory_bundles=inventory_bundles,
-            saved_scenarios=[
-                {
-                    "saved_scenario_id": scenario.saved_scenario_id,
-                    "trip_id": scenario.trip_id,
-                    "current_version_id": scenario.current_version_id,
-                    "versions": list(scenario.versions),
-                    "comparisons": list(scenario.comparisons),
-                    "tags": list(scenario.tags),
-                    "notes": list(scenario.notes),
-                }
-                for scenario in persisted_saved_scenarios
-            ],
-        )
-        if inventory_status == "ready"
-        else _empty_workspace_scenario_search()
+    runtime_search = _build_runtime_scenario_search_for_trip(
+        record=record,
+        inventory_bundles=inventory_bundles,
+        saved_scenarios=[
+            {
+                "saved_scenario_id": scenario.saved_scenario_id,
+                "trip_id": scenario.trip_id,
+                "current_version_id": scenario.current_version_id,
+                "versions": list(scenario.versions),
+                "comparisons": list(scenario.comparisons),
+                "tags": list(scenario.tags),
+                "notes": list(scenario.notes),
+            }
+            for scenario in persisted_saved_scenarios
+        ],
+        inventory_status=inventory_status,
     )
     if _sync_workspace_session_record(
         session_record,
@@ -1891,11 +1908,7 @@ def get_workspace_payload(
     feasibility_summary = build_feasibility_summary_payload(inventory_bundles)
     return _build_persisted_trip_workspace(
         record,
-        session=(
-            _serialize_session_record(session_record)
-            if session_record is not None
-            else None
-        ),
+        session=(_serialize_session_record(session_record) if session_record is not None else None),
         saved_scenarios=[
             {
                 "saved_scenario_id": scenario.saved_scenario_id,
@@ -2153,7 +2166,9 @@ def submit_workspace_option_feedback(
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
     option_set_id, valid_option_ids = _current_workspace_option_set(session, trip_id=trip_id)
     if option_id not in valid_option_ids:
-        raise ValueError(f"Option '{option_id}' is not available in the current workspace option set.")
+        raise ValueError(
+            f"Option '{option_id}' is not available in the current workspace option set."
+        )
     presentation = (
         session.recent_option_presentations[0]
         if session.recent_option_presentations
@@ -2184,10 +2199,14 @@ def submit_workspace_option_feedback(
         event_kind = "option_rejected"
         summary = f"Traveler rejected option '{option_id}' from the workspace planner panel."
     elif action_type == "save_as_fallback":
-        presentation.notes = [note for note in presentation.notes if not note.startswith("fallback:")]
+        presentation.notes = [
+            note for note in presentation.notes if not note.startswith("fallback:")
+        ]
         presentation.notes.append(f"fallback:{option_id}")
         event_kind = "decision_recorded"
-        summary = f"Traveler saved option '{option_id}' as a fallback in the workspace planner panel."
+        summary = (
+            f"Traveler saved option '{option_id}' as a fallback in the workspace planner panel."
+        )
     else:
         session.interaction_state.auto_advance_research_passes += 1
         event_kind = "rerank_requested"


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #808

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo now ships a usable full-stack MVP, but the strongest runtime behavior
for inventory, scenario generation, and comparison still leans on seeded or
fixture-dominant paths for arbitrary persisted trips. That keeps the app
testable, but it prevents the runtime from being mature enough to treat a
newly-created trip as a first-class planning object instead of a partial demo.

#### Tasks
- [ ] Replace the current fixture-first inventory path in `trip_planner/app/services/inventory.py` with a persisted-trip-first assembly flow that only falls back when runtime inputs are genuinely missing
- [ ] Update `trip_planner/app/services/scenarios.py` and adjacent services so arbitrary persisted trips receive the same scenario and comparison depth as the seeded examples
- [ ] Ensure empty and partial inventory states remain explicit and bounded in the backend payload instead of silently collapsing into seeded data
- [ ] Update workspace payload shaping so the frontend can distinguish `ready`, `partial`, and `empty` runtime states without heuristics
- [ ] Add route/service tests proving newly-created leisure and business trips can move from trip creation to workspace comparison without seeded trip IDs
- [ ] Add frontend tests that verify the workspace renders meaningful partial and empty runtime states for non-seeded trips

#### Acceptance criteria
- [ ] Newly-created persisted trips can load workspace inventory, scenarios, and comparison payloads without relying on seeded trip IDs as the primary path
- [ ] Partial runtime data produces explicit fallback messaging instead of hidden fixture substitution
- [ ] Backend and frontend tests cover both leisure and business trips using persisted runtime state
- [ ] `make runtime-check` passes

**Head SHA:** b0186add07475e5fc0dabc8370d37f5d8c0786e6
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/24491922779) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/24491922767) |
<!-- auto-status-summary:end -->