### PR TITLE
Codex bootstrap for #808

### DIFF
--- a/agents/codex-808.md
+++ b/agents/codex-808.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #808 -->

--- a/trip_planner.egg-info/PKG-INFO
+++ b/trip_planner.egg-info/PKG-INFO
@@ -1,14 +1,8 @@
 Metadata-Version: 2.4
 Name: trip-planner
 Version: 0.1.0
-Requires-Dist: alembic==1.18.4
-Requires-Dist: fastapi==0.135.3
-Requires-Dist: sqlalchemy==2.0.49
-Requires-Dist: uvicorn==0.44.0
 Provides-Extra: dev
-Requires-Dist: ruff==0.15.10; extra == "dev"
-Requires-Dist: mypy==1.20.1; extra == "dev"
-Requires-Dist: pytest==9.0.3; extra == "dev"
-Requires-Dist: pytest-cov==7.1.0; extra == "dev"
-Requires-Dist: black==26.3.1; extra == "dev"
-Requires-Dist: httpx==0.28.1; extra == "dev"
+Requires-Dist: ruff==0.14.14; extra == "dev"
+Requires-Dist: mypy>=1.19.1; extra == "dev"
+Requires-Dist: pytest>=9.0.2; extra == "dev"
+Requires-Dist: pytest-cov>=7.0.0; extra == "dev"

--- a/trip_planner.egg-info/PKG-INFO
+++ b/trip_planner.egg-info/PKG-INFO
@@ -1,14 +1,14 @@
 Metadata-Version: 2.4
 Name: trip-planner
 Version: 0.1.0
-Requires-Dist: alembic==1.16.5
-Requires-Dist: fastapi==0.116.1
-Requires-Dist: sqlalchemy==2.0.43
-Requires-Dist: uvicorn==0.37.0
+Requires-Dist: alembic==1.18.4
+Requires-Dist: fastapi==0.135.3
+Requires-Dist: sqlalchemy==2.0.49
+Requires-Dist: uvicorn==0.44.0
 Provides-Extra: dev
-Requires-Dist: ruff==0.15.1; extra == "dev"
-Requires-Dist: mypy==1.19.1; extra == "dev"
-Requires-Dist: pytest==9.0.2; extra == "dev"
-Requires-Dist: pytest-cov==7.0.0; extra == "dev"
-Requires-Dist: black==26.1.0; extra == "dev"
+Requires-Dist: ruff==0.15.10; extra == "dev"
+Requires-Dist: mypy==1.20.1; extra == "dev"
+Requires-Dist: pytest==9.0.3; extra == "dev"
+Requires-Dist: pytest-cov==7.1.0; extra == "dev"
+Requires-Dist: black==26.3.1; extra == "dev"
 Requires-Dist: httpx==0.28.1; extra == "dev"

--- a/trip_planner.egg-info/PKG-INFO
+++ b/trip_planner.egg-info/PKG-INFO
@@ -1,8 +1,14 @@
 Metadata-Version: 2.4
 Name: trip-planner
 Version: 0.1.0
+Requires-Dist: alembic==1.18.4
+Requires-Dist: fastapi==0.135.3
+Requires-Dist: sqlalchemy==2.0.49
+Requires-Dist: uvicorn==0.44.0
 Provides-Extra: dev
-Requires-Dist: ruff==0.14.14; extra == "dev"
-Requires-Dist: mypy>=1.19.1; extra == "dev"
-Requires-Dist: pytest>=9.0.2; extra == "dev"
-Requires-Dist: pytest-cov>=7.0.0; extra == "dev"
+Requires-Dist: ruff==0.15.10; extra == "dev"
+Requires-Dist: mypy==1.20.1; extra == "dev"
+Requires-Dist: pytest==9.0.3; extra == "dev"
+Requires-Dist: pytest-cov==7.1.0; extra == "dev"
+Requires-Dist: black==26.3.1; extra == "dev"
+Requires-Dist: httpx==0.28.1; extra == "dev"

--- a/trip_planner.egg-info/requires.txt
+++ b/trip_planner.egg-info/requires.txt
@@ -1,6 +1,12 @@
+alembic==1.18.4
+fastapi==0.135.3
+sqlalchemy==2.0.49
+uvicorn==0.44.0
 
 [dev]
-ruff==0.14.14
-mypy>=1.19.1
-pytest>=9.0.2
-pytest-cov>=7.0.0
+ruff==0.15.10
+mypy==1.20.1
+pytest==9.0.3
+pytest-cov==7.1.0
+black==26.3.1
+httpx==0.28.1

--- a/trip_planner.egg-info/requires.txt
+++ b/trip_planner.egg-info/requires.txt
@@ -1,12 +1,6 @@
-alembic==1.18.4
-fastapi==0.135.3
-sqlalchemy==2.0.49
-uvicorn==0.44.0
 
 [dev]
-ruff==0.15.10
-mypy==1.20.1
-pytest==9.0.3
-pytest-cov==7.1.0
-black==26.3.1
-httpx==0.28.1
+ruff==0.14.14
+mypy>=1.19.1
+pytest>=9.0.2
+pytest-cov>=7.0.0

--- a/trip_planner.egg-info/requires.txt
+++ b/trip_planner.egg-info/requires.txt
@@ -1,12 +1,12 @@
-alembic==1.16.5
-fastapi==0.116.1
-sqlalchemy==2.0.43
-uvicorn==0.37.0
+alembic==1.18.4
+fastapi==0.135.3
+sqlalchemy==2.0.49
+uvicorn==0.44.0
 
 [dev]
-ruff==0.15.1
-mypy==1.19.1
-pytest==9.0.2
-pytest-cov==7.0.0
-black==26.1.0
+ruff==0.15.10
+mypy==1.20.1
+pytest==9.0.3
+pytest-cov==7.1.0
+black==26.3.1
 httpx==0.28.1


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo now ships a usable full-stack MVP, but the strongest runtime behavior
for inventory, scenario generation, and comparison still leans on seeded or
fixture-dominant paths for arbitrary persisted trips. That keeps the app
testable, but it prevents the runtime from being mature enough to treat a
newly-created trip as a first-class planning object instead of a partial demo.

#### Tasks
- [ ] Replace the current fixture-first inventory path in `trip_planner/app/services/inventory.py` with a persisted-trip-first assembly flow that only falls back when runtime inputs are genuinely missing
- [ ] Update `trip_planner/app/services/scenarios.py` and adjacent services so arbitrary persisted trips receive the same scenario and comparison depth as the seeded examples
- [ ] Ensure empty and partial inventory states remain explicit and bounded in the backend payload instead of silently collapsing into seeded data
- [ ] Update workspace payload shaping so the frontend can distinguish `ready`, `partial`, and `empty` runtime states without heuristics
- [ ] Add route/service tests proving newly-created leisure and business trips can move from trip creation to workspace comparison without seeded trip IDs
- [ ] Add frontend tests that verify the workspace renders meaningful partial and empty runtime states for non-seeded trips

#### Acceptance criteria
- [ ] Newly-created persisted trips can load workspace inventory, scenarios, and comparison payloads without relying on seeded trip IDs as the primary path
- [ ] Partial runtime data produces explicit fallback messaging instead of hidden fixture substitution
- [ ] Backend and frontend tests cover both leisure and business trips using persisted runtime state
- [ ] `make runtime-check` passes

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

The repo now ships a usable full-stack MVP, but the strongest runtime behavior
for inventory, scenario generation, and comparison still leans on seeded or
fixture-dominant paths for arbitrary persisted trips. That keeps the app
testable, but it prevents the runtime from being mature enough to treat a
newly-created trip as a first-class planning object instead of a partial demo.

## Scope

Replace the primary fixture-dominant runtime path with persisted-trip-driven
inventory assembly, scenario generation, and comparison behavior for both
leisure and business trips.

## Non-Goals

- Adding live provider ingestion in this issue
- Changing the core option or feasibility contracts
- Reworking planner conversation/orchestration behavior beyond what the runtime
  already consumes

## Tasks

- [ ] Replace the current fixture-first inventory path in `trip_planner/app/services/inventory.py` with a persisted-trip-first assembly flow that only falls back when runtime inputs are genuinely missing
- [ ] Update `trip_planner/app/services/scenarios.py` and adjacent services so arbitrary persisted trips receive the same scenario and comparison depth as the seeded examples
- [ ] Ensure empty and partial inventory states remain explicit and bounded in the backend payload instead of silently collapsing into seeded data
- [ ] Update workspace payload shaping so the frontend can distinguish `ready`, `partial`, and `empty` runtime states without heuristics
- [ ] Add route/service tests proving newly-created leisure and business trips can move from trip creation to workspace comparison without seeded trip IDs
- [ ] Add frontend tests that verify the workspace renders meaningful partial and empty runtime states for non-seeded trips

## Acceptance Criteria

- [ ] Newly-created persisted trips can load workspace inventory, scenarios, and comparison payloads without relying on seeded trip IDs as the primary path
- [ ] Partial runtime data produces explicit fallback messaging instead of hidden fixture substitution
- [ ] Backend and frontend tests cover both leisure and business trips using persisted runtime state
- [ ] `make runtime-check` passes

## Implementation Notes

Relevant files:
- `trip_planner/app/services/inventory.py`
- `trip_planner/app/services/scenarios.py`
- `trip_planner/app/services/workspace.py`
- `trip_planner/app/routes/inventory.py`
- `trip_planner/app/routes/workspace.py`
- `frontend/src/routes/WorkspacePage.tsx`
- `frontend/src/api/workspace.ts`
- `tests/app/test_workspace.py`
- `frontend/src/routes/WorkspacePage.test.tsx`

Reference docs:
- `docs/live-runtime-completion-epic.md`
- `docs/runtime-planning-services-epic.md`
- `docs/workspace-comparison-contract.md`



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #808

<!-- pr-preamble:end -->