### PR TITLE
Issue #817: remove fixture inventory from workspace path

### DIFF
--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -387,6 +387,34 @@ def test_workspace_endpoint_surfaces_partial_runtime_state_for_under_scoped_trip
     assert "runtime scenario" in comparison_payload["summary"].lower()
 
 
+def test_workspace_endpoint_treats_whitespace_only_primary_regions_as_missing(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Whitespace regions",
+            "summary": "Whitespace-only regions should not unlock runtime inventory.",
+            "mode": "business",
+            "trip_frame": {
+                "duration_days": 3,
+                "primary_regions": [" ", ""],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    payload = client.get(f"/api/workspace/{trip_id}").json()
+
+    assert payload["runtime_state"]["status"] == "empty"
+    assert payload["inventory_summary"]["runtime_state"]["status"] == "empty"
+    assert any(
+        "add at least one destination" in note.lower()
+        for note in payload["inventory_summary"]["notes"]
+    )
+
+
 def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_trip(
     client: TestClient,
 ) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -175,16 +175,19 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_busin
     assert payload["saved_scenarios"][0]["versions"][0]["label"] == "baseline"
     assert payload["saved_scenarios"][1]["versions"][0]["label"] == "fallback"
     assert payload["scenario_comparison"]["baseline_scenario_id"] == lead_saved_scenario_id
-    assert payload["scenario_search"]["title"] == "Chicago kickoff ranked scenarios"
-    assert payload["runtime_state"]["status"] == "ready"
-    assert payload["scenario_search"]["purpose"] == "final_selection"
-    assert payload["scenario_search"]["scenarios"][0]["scenario_id"] == f"scenario:{trip_id}:1"
-    assert payload["scenario_search"]["scenarios"][0]["scenario_id"] != lead_saved_scenario_id
-    assert payload["runtime_scenario_comparison"]["lead_scenario_id"] == f"scenario:{trip_id}:1"
-    assert len(payload["runtime_scenario_comparison"]["scenarios"]) == 1
-    assert payload["inventory_summary"]["bundle_count"] == 1
-    assert payload["inventory_summary"]["bundles"][0]["title"] == "Airport arrival bundle"
-    assert payload["feasibility_summary"]["assessment_count"] == 1
+    assert payload["scenario_search"]["title"] == "Persisted workspace bootstrap comparison"
+    assert payload["runtime_state"]["status"] == "empty"
+    assert payload["scenario_search"]["purpose"] == "workspace_bootstrap"
+    assert payload["scenario_search"]["scenarios"][0]["scenario_id"] == lead_saved_scenario_id
+    assert payload["runtime_scenario_comparison"]["lead_scenario_id"] == lead_saved_scenario_id
+    assert len(payload["runtime_scenario_comparison"]["scenarios"]) == 2
+    assert payload["inventory_summary"]["bundle_count"] == 0
+    assert payload["inventory_summary"]["bundles"] == []
+    assert any(
+        "no longer assemble inventory from fixtures" in note.lower()
+        for note in payload["inventory_summary"]["notes"]
+    )
+    assert payload["feasibility_summary"]["assessment_count"] == 0
     assert payload["activity_log"] == []
     assert payload["budget_state"]["summary"]["planned_total"] == 0
     assert payload["budget_state"]["summary"]["actual_total"] == 0
@@ -228,16 +231,16 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisu
 
     payload = client.get(f"/api/workspace/{trip_id}").json()
 
-    assert payload["runtime_state"]["status"] == "ready"
+    assert payload["runtime_state"]["status"] == "empty"
     assert payload["saved_scenarios"][0]["versions"][0]["title"].startswith("Lisbon")
-    assert payload["scenario_search"]["title"] == "Lisbon weekend runtime scenarios"
-    assert payload["scenario_search"]["purpose"] == "final_selection"
-    assert payload["runtime_scenario_comparison"]["lead_scenario_id"] == f"scenario:{trip_id}:1"
-    assert payload["runtime_scenario_comparison"]["scenarios"][0]["scenario_id"] == (
-        f"scenario:{trip_id}:1"
+    assert payload["scenario_search"]["title"] == "Persisted workspace bootstrap comparison"
+    assert payload["scenario_search"]["purpose"] == "workspace_bootstrap"
+    assert payload["runtime_scenario_comparison"]["lead_scenario_id"].startswith("saved-scenario:")
+    assert payload["runtime_scenario_comparison"]["scenarios"][0]["scenario_id"].startswith(
+        "saved-scenario:"
     )
-    assert all(
-        "comparison-pass" not in scenario["route_sequence"]
+    assert any(
+        "comparison-pass" in scenario["route_sequence"]
         for scenario in payload["runtime_scenario_comparison"]["scenarios"]
     )
     assert payload["planner_panel_state"]["option_set"]["purpose"] == "workspace_review"
@@ -268,10 +271,9 @@ def test_workspace_scenario_comparison_endpoint_returns_runtime_surface_for_pers
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["lead_scenario_id"] == f"scenario:{trip_id}:1"
-    assert payload["scenarios"][0]["scenario_id"] == f"scenario:{trip_id}:1"
-    assert not payload["scenarios"][0]["scenario_id"].startswith("saved-scenario:")
-    assert payload["scenarios"][0]["option_count"] >= 1
+    assert payload["lead_scenario_id"].startswith("saved-scenario:")
+    assert payload["scenarios"][0]["scenario_id"].startswith("saved-scenario:")
+    assert payload["scenarios"][0]["option_count"] == 1
     assert "runtime scenario" in payload["summary"].lower()
 
 
@@ -304,10 +306,9 @@ def test_workspace_scenario_comparison_endpoint_returns_runtime_surface_for_pers
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["lead_scenario_id"] == f"scenario:{trip_id}:1"
-    assert payload["scenarios"][0]["scenario_id"] == f"scenario:{trip_id}:1"
-    assert not payload["scenarios"][0]["scenario_id"].startswith("saved-scenario:")
-    assert payload["scenarios"][0]["status"] == "fallback"
+    assert payload["lead_scenario_id"].startswith("saved-scenario:")
+    assert payload["scenarios"][0]["scenario_id"].startswith("saved-scenario:")
+    assert payload["scenarios"][0]["status"] == "recommended"
     assert "runtime scenario" in payload["summary"].lower()
 
 
@@ -335,19 +336,19 @@ def test_workspace_endpoint_returns_bounded_empty_runtime_state_when_trip_frame_
     reloaded_payload = reloaded.json()
     assert initial_payload["runtime_state"]["status"] == "empty"
     assert initial_payload["inventory_summary"]["runtime_state"]["status"] == "empty"
-    assert initial_payload["scenario_search"]["scenarios"] == []
-    assert initial_payload["runtime_scenario_comparison"]["scenarios"] == []
+    assert len(initial_payload["scenario_search"]["scenarios"]) == 2
+    assert len(initial_payload["runtime_scenario_comparison"]["scenarios"]) == 2
     assert (
-        initial_payload["scenario_search"]["scenarios"]
-        == reloaded_payload["scenario_search"]["scenarios"]
+        initial_payload["scenario_search"]["scenarios"][0]["scenario_id"]
+        == reloaded_payload["scenario_search"]["scenarios"][0]["scenario_id"]
     )
     assert (
-        initial_payload["planner_panel_state"]["option_set"]["options"]
-        == reloaded_payload["planner_panel_state"]["option_set"]["options"]
+        initial_payload["planner_panel_state"]["option_set"]["purpose"]
+        == reloaded_payload["planner_panel_state"]["option_set"]["purpose"]
     )
     assert (
-        initial_payload["runtime_scenario_comparison"]["scenarios"]
-        == reloaded_payload["runtime_scenario_comparison"]["scenarios"]
+        initial_payload["runtime_scenario_comparison"]["lead_scenario_id"]
+        == reloaded_payload["runtime_scenario_comparison"]["lead_scenario_id"]
     )
 
 
@@ -374,19 +375,16 @@ def test_workspace_endpoint_surfaces_partial_runtime_state_for_under_scoped_trip
     payload = response.json()
     assert payload["runtime_state"]["status"] == "partial"
     assert payload["inventory_summary"]["runtime_state"]["status"] == "partial"
-    assert payload["scenario_search"]["scenarios"] == []
-    assert payload["runtime_scenario_comparison"]["scenarios"] == []
+    assert len(payload["scenario_search"]["scenarios"]) == 2
+    assert len(payload["runtime_scenario_comparison"]["scenarios"]) == 2
 
     comparison_response = client.get(f"/api/workspace/{trip_id}/scenarios/compare")
 
     assert comparison_response.status_code == 200
     comparison_payload = comparison_response.json()
-    assert comparison_payload["scenarios"] == []
-    assert comparison_payload["lead_scenario_id"] is None
-    assert (
-        "does not have runtime scenario comparison data yet"
-        in comparison_payload["summary"].lower()
-    )
+    assert len(comparison_payload["scenarios"]) == 2
+    assert comparison_payload["lead_scenario_id"].startswith("saved-scenario:")
+    assert "runtime scenario" in comparison_payload["summary"].lower()
 
 
 def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_trip(

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -52,6 +52,7 @@ class InventoryAssemblyInput:
     snapshot: RawSnapshot
     handoff: NormalizationHandoff
     fixture_names: tuple[str, ...]
+    allow_fixture_fallback: bool
 
 
 class PersistedTripInventoryFixtureAdapter(SourceAdapter):
@@ -64,11 +65,13 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
         trip_mode: str,
         primary_regions: Sequence[str],
         duration_days: int | None = None,
+        allow_fixture_fallback: bool = True,
     ) -> None:
         self.trip_id = trip_id
         self.trip_mode = trip_mode
         self.primary_regions = tuple(region for region in primary_regions if region)
         self.duration_days = duration_days
+        self.allow_fixture_fallback = allow_fixture_fallback
         self.adapter_id = "persisted-trip-fixture-inventory"
         self.source_record = SourceRecord(
             source_id="fixture-normalized-inventory",
@@ -89,6 +92,8 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
         fixture_seed = _FIXTURE_BUNDLE_INPUTS.get(self.trip_id)
         if fixture_seed is not None and fixture_seed.trip_mode == self.trip_mode:
             return fixture_seed.fixture_names
+        if not self.allow_fixture_fallback:
+            return ()
         if not self.primary_regions:
             return ()
         if self.duration_days is None or self.duration_days <= 0:
@@ -117,18 +122,32 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
                     )
                 )
             else:
-                issues.append(
-                    AdapterIssue(
-                        issue_id=f"issue:{self.trip_id}:inventory-missing-duration",
-                        stage="availability",
-                        severity="warning",
-                        code="missing_inventory_trip_duration",
-                        message=(
-                            "Trip dates or duration are still missing, so inventory assembly stays partial."
-                        ),
-                        details={"trip_id": self.trip_id, "trip_mode": self.trip_mode},
+                if self.duration_days is None or self.duration_days <= 0:
+                    issues.append(
+                        AdapterIssue(
+                            issue_id=f"issue:{self.trip_id}:inventory-missing-duration",
+                            stage="availability",
+                            severity="warning",
+                            code="missing_inventory_trip_duration",
+                            message=(
+                                "Trip dates or duration are still missing, so inventory assembly stays partial."
+                            ),
+                            details={"trip_id": self.trip_id, "trip_mode": self.trip_mode},
+                        )
                     )
-                )
+                elif not self.allow_fixture_fallback:
+                    issues.append(
+                        AdapterIssue(
+                            issue_id=f"issue:{self.trip_id}:inventory-live-adapter-pending",
+                            stage="availability",
+                            severity="warning",
+                            code="missing_inventory_live_adapter",
+                            message=(
+                                "Fixture-backed inventory is disabled for the persisted workspace path until a live adapter is connected."
+                            ),
+                            details={"trip_id": self.trip_id, "trip_mode": self.trip_mode},
+                        )
+                    )
         records = [
             RawSourceRecord(
                 record_id=f"{query.query_id}:{index}",
@@ -210,6 +229,7 @@ def _build_inventory_assembly_input(
     trip_mode: str,
     primary_regions: Sequence[str] = (),
     duration_days: int | None = None,
+    allow_fixture_fallback: bool = True,
 ) -> InventoryAssemblyInput:
     query = SourceQuery(
         query_id=f"inventory-query:{trip_id}",
@@ -225,6 +245,7 @@ def _build_inventory_assembly_input(
         trip_mode=trip_mode,
         primary_regions=primary_regions,
         duration_days=duration_days,
+        allow_fixture_fallback=allow_fixture_fallback,
     )
     snapshot = adapter.fetch_snapshot(query)
     handoff = adapter.build_handoff(snapshot)
@@ -240,6 +261,7 @@ def _build_inventory_assembly_input(
             for record in snapshot.records
             if "fixture_name" in record.metadata
         ),
+        allow_fixture_fallback=allow_fixture_fallback,
     )
 
 
@@ -292,6 +314,10 @@ def build_inventory_summary_payload(
             notes = [
                 "Primary regions are still missing, so add at least one destination before the workspace can assemble runtime inventory bundles."
             ]
+        elif issue.code == "missing_inventory_live_adapter":
+            notes = [
+                "The persisted workspace path no longer assembles inventory from bundled fixtures, so runtime inventory will stay empty until a live adapter is wired in."
+            ]
         else:
             notes = [
                 "No adapter-backed inventory input is available for this persisted trip yet, so the workspace remains available with an empty bundle set."
@@ -314,6 +340,12 @@ def build_inventory_summary_payload(
                 "status": "partial",
                 "title": "Runtime inventory is partially specified",
                 "summary": "Add trip dates or duration to replace the bounded fallback with runtime bundle assembly.",
+            }
+        elif issue.code == "missing_inventory_live_adapter":
+            runtime_state = {
+                "status": "empty",
+                "title": "Runtime inventory is waiting on a live adapter",
+                "summary": "The main workspace no longer falls back to bundled fixture inventory for persisted trips.",
             }
         else:
             runtime_state = {

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -69,7 +69,7 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
     ) -> None:
         self.trip_id = trip_id
         self.trip_mode = trip_mode
-        self.primary_regions = tuple(region for region in primary_regions if region)
+        self.primary_regions = tuple(region.strip() for region in primary_regions if region.strip())
         self.duration_days = duration_days
         self.allow_fixture_fallback = allow_fixture_fallback
         self.adapter_id = "persisted-trip-fixture-inventory"
@@ -89,11 +89,11 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
         self.capabilities = ("read_fixture", "supports_normalization_handoff")
 
     def fixture_names(self) -> tuple[str, ...]:
+        if not self.allow_fixture_fallback:
+            return ()
         fixture_seed = _FIXTURE_BUNDLE_INPUTS.get(self.trip_id)
         if fixture_seed is not None and fixture_seed.trip_mode == self.trip_mode:
             return fixture_seed.fixture_names
-        if not self.allow_fixture_fallback:
-            return ()
         if not self.primary_regions:
             return ()
         if self.duration_days is None or self.duration_days <= 0:
@@ -316,7 +316,7 @@ def build_inventory_summary_payload(
             ]
         elif issue.code == "missing_inventory_live_adapter":
             notes = [
-                "The persisted workspace path no longer assembles inventory from bundled fixtures, so runtime inventory will stay empty until a live adapter is wired in."
+                "Persisted workspace reads no longer assemble inventory from fixtures, so runtime inventory will stay empty until a live adapter is wired in."
             ]
         else:
             notes = [

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -558,46 +558,16 @@ def _build_runtime_scenario_comparison(
 
 
 def _build_workspace_inventory_summary(record: PersistedTrip) -> dict[str, Any]:
-    if not record.primary_regions:
-        return {
-            "bundle_count": 0,
-            "bundles": [],
-            "notes": [
-                "Primary regions are still missing, so add at least one destination before the workspace can assemble runtime inventory bundles."
-            ],
-            "runtime_state": {
-                "status": "empty",
-                "title": "Runtime inventory is still empty",
-                "summary": "Add at least one primary region before the workspace can assemble runtime inventory bundles.",
-            },
-        }
-
-    if record.duration_days is None or record.duration_days <= 0:
-        return {
-            "bundle_count": 0,
-            "bundles": [],
-            "notes": [
-                "Trip dates or duration are still missing, so runtime inventory stays in a bounded partial state until those inputs are filled in."
-            ],
-            "runtime_state": {
-                "status": "partial",
-                "title": "Runtime inventory is partially specified",
-                "summary": "Add trip dates or duration to replace the bounded fallback with runtime bundle assembly.",
-            },
-        }
-
-    return {
-        "bundle_count": 0,
-        "bundles": [],
-        "notes": [
-            "Persisted workspace reads no longer assemble inventory from fixtures. Runtime bundles will appear after a non-fixture inventory source writes trip-scoped inventory state."
-        ],
-        "runtime_state": {
-            "status": "empty",
-            "title": "Runtime inventory is still empty",
-            "summary": "The workspace stays in bootstrap mode until trip-scoped inventory is persisted from a non-fixture source.",
-        },
-    }
+    return build_inventory_summary_payload(
+        [],
+        assembly_input=_build_inventory_assembly_input(
+            trip_id=record.trip_id,
+            trip_mode=record.mode,
+            primary_regions=record.primary_regions,
+            duration_days=record.duration_days,
+            allow_fixture_fallback=False,
+        ),
+    )
 
 
 def _isoformat(value: datetime) -> str:
@@ -1111,8 +1081,12 @@ def _build_persisted_trip_workspace(
         duration_days=record.duration_days,
         allow_fixture_fallback=False,
     )
-    resolved_inventory_bundles = inventory_bundles or assemble_inventory_bundles_for_trip(
-        assembly_input=inventory_assembly_input,
+    resolved_inventory_bundles = (
+        inventory_bundles
+        if inventory_bundles is not None
+        else assemble_inventory_bundles_for_trip(
+            assembly_input=inventory_assembly_input,
+        )
     )
     resolved_inventory_summary = inventory_summary or build_inventory_summary_payload(
         resolved_inventory_bundles,
@@ -1302,7 +1276,7 @@ def _build_runtime_scenario_comparison_payload(
         }
         for scenario in persisted_saved_scenarios_records
     ]
-    inventory_bundles: list[InventoryBundle] = []
+    persisted_inventory_bundles: list[InventoryBundle] = []
     inventory_summary = _build_workspace_inventory_summary(record)
     inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
     return _build_runtime_scenario_comparison(
@@ -1310,7 +1284,7 @@ def _build_runtime_scenario_comparison_payload(
         trip_title=record.title,
         scenario_search=_build_runtime_scenario_search_for_trip(
             record=record,
-            inventory_bundles=inventory_bundles,
+            inventory_bundles=persisted_inventory_bundles,
             saved_scenarios=persisted_saved_scenarios,
             inventory_status=inventory_status,
         ),
@@ -1897,12 +1871,12 @@ def get_workspace_payload(
             session_record=session_record,
         )
         bootstrap_updated = True
-    inventory_bundles: list[InventoryBundle] = []
+    persisted_inventory_bundles: list[InventoryBundle] = []
     inventory_summary = _build_workspace_inventory_summary(record)
     inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
     runtime_search = _build_runtime_scenario_search_for_trip(
         record=record,
-        inventory_bundles=inventory_bundles,
+        inventory_bundles=persisted_inventory_bundles,
         saved_scenarios=[
             {
                 "saved_scenario_id": scenario.saved_scenario_id,
@@ -1948,7 +1922,7 @@ def get_workspace_payload(
         .order_by(PersistedActivityLogEvent.occurred_at.desc())
         .limit(WORKSPACE_ACTIVITY_LOG_LIMIT)
     ).all()
-    feasibility_summary = build_feasibility_summary_payload(inventory_bundles)
+    feasibility_summary = build_feasibility_summary_payload(persisted_inventory_bundles)
     return _build_persisted_trip_workspace(
         record,
         session=(_serialize_session_record(session_record) if session_record is not None else None),
@@ -1981,7 +1955,7 @@ def get_workspace_payload(
             if record.mode == "business"
             else None
         ),
-        inventory_bundles=inventory_bundles,
+        inventory_bundles=persisted_inventory_bundles,
         inventory_summary=inventory_summary,
         scenario_search=runtime_search,
         feasibility_summary=feasibility_summary,

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -373,6 +373,11 @@ def _build_runtime_scenario_search_for_trip(
     inventory_status: str = "ready",
 ) -> dict[str, Any]:
     if inventory_status != "ready":
+        if saved_scenarios:
+            return _build_saved_scenario_runtime_search(
+                record,
+                saved_scenarios=saved_scenarios,
+            )
         return _empty_workspace_scenario_search()
 
     if inventory_bundles:
@@ -549,6 +554,49 @@ def _build_runtime_scenario_comparison(
         "lead_scenario_id": lead["scenario_id"],
         "scenarios": rows,
         "source_refs": list(scenario_search.get("source_refs") or []),
+    }
+
+
+def _build_workspace_inventory_summary(record: PersistedTrip) -> dict[str, Any]:
+    if not record.primary_regions:
+        return {
+            "bundle_count": 0,
+            "bundles": [],
+            "notes": [
+                "Primary regions are still missing, so add at least one destination before the workspace can assemble runtime inventory bundles."
+            ],
+            "runtime_state": {
+                "status": "empty",
+                "title": "Runtime inventory is still empty",
+                "summary": "Add at least one primary region before the workspace can assemble runtime inventory bundles.",
+            },
+        }
+
+    if record.duration_days is None or record.duration_days <= 0:
+        return {
+            "bundle_count": 0,
+            "bundles": [],
+            "notes": [
+                "Trip dates or duration are still missing, so runtime inventory stays in a bounded partial state until those inputs are filled in."
+            ],
+            "runtime_state": {
+                "status": "partial",
+                "title": "Runtime inventory is partially specified",
+                "summary": "Add trip dates or duration to replace the bounded fallback with runtime bundle assembly.",
+            },
+        }
+
+    return {
+        "bundle_count": 0,
+        "bundles": [],
+        "notes": [
+            "Persisted workspace reads no longer assemble inventory from fixtures. Runtime bundles will appear after a non-fixture inventory source writes trip-scoped inventory state."
+        ],
+        "runtime_state": {
+            "status": "empty",
+            "title": "Runtime inventory is still empty",
+            "summary": "The workspace stays in bootstrap mode until trip-scoped inventory is persisted from a non-fixture source.",
+        },
     }
 
 
@@ -1056,14 +1104,19 @@ def _build_persisted_trip_workspace(
         },
     }
     ordered_saved_scenarios = _ordered_saved_scenarios(saved_scenarios or [])
-    resolved_inventory_bundles = inventory_bundles or assemble_inventory_bundles_for_trip(
+    inventory_assembly_input = _build_inventory_assembly_input(
         trip_id=record.trip_id,
         trip_mode=record.mode,
         primary_regions=record.primary_regions,
         duration_days=record.duration_days,
+        allow_fixture_fallback=False,
+    )
+    resolved_inventory_bundles = inventory_bundles or assemble_inventory_bundles_for_trip(
+        assembly_input=inventory_assembly_input,
     )
     resolved_inventory_summary = inventory_summary or build_inventory_summary_payload(
-        resolved_inventory_bundles
+        resolved_inventory_bundles,
+        assembly_input=inventory_assembly_input,
     )
     inventory_status = str(
         (resolved_inventory_summary.get("runtime_state") or {}).get("status") or "empty"
@@ -1222,6 +1275,21 @@ def _build_runtime_scenario_comparison_payload(
     except WorkspaceTripNotFoundError:
         return None
 
+    persisted_saved_scenarios_records = list(
+        db_session.scalars(
+            select(PersistedSavedScenario)
+            .where(PersistedSavedScenario.trip_id == trip_id)
+            .order_by(PersistedSavedScenario.updated_at.desc())
+        ).all()
+    )
+    if not persisted_saved_scenarios_records:
+        session_record = _get_or_create_workspace_session_record(db_session, record=record)
+        persisted_saved_scenarios_records = _create_bootstrap_saved_scenarios(
+            db_session,
+            record=record,
+            session_record=session_record,
+        )
+        db_session.commit()
     persisted_saved_scenarios = [
         {
             "saved_scenario_id": scenario.saved_scenario_id,
@@ -1232,26 +1300,10 @@ def _build_runtime_scenario_comparison_payload(
             "tags": list(scenario.tags),
             "notes": list(scenario.notes),
         }
-        for scenario in db_session.scalars(
-            select(PersistedSavedScenario)
-            .where(PersistedSavedScenario.trip_id == trip_id)
-            .order_by(PersistedSavedScenario.updated_at.desc())
-        ).all()
+        for scenario in persisted_saved_scenarios_records
     ]
-
-    inventory_assembly_input = _build_inventory_assembly_input(
-        trip_id=record.trip_id,
-        trip_mode=record.mode,
-        primary_regions=record.primary_regions,
-        duration_days=record.duration_days,
-    )
-    inventory_bundles = assemble_inventory_bundles_for_trip(
-        assembly_input=inventory_assembly_input,
-    )
-    inventory_summary = build_inventory_summary_payload(
-        inventory_bundles,
-        assembly_input=inventory_assembly_input,
-    )
+    inventory_bundles: list[InventoryBundle] = []
+    inventory_summary = _build_workspace_inventory_summary(record)
     inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
     return _build_runtime_scenario_comparison(
         trip_id=trip_id,
@@ -1829,12 +1881,6 @@ def get_workspace_payload(
     )
     if record is None:
         return None
-    inventory_assembly_input = _build_inventory_assembly_input(
-        trip_id=record.trip_id,
-        trip_mode=record.mode,
-        primary_regions=record.primary_regions,
-        duration_days=record.duration_days,
-    )
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     persisted_saved_scenarios = list(
         db_session.scalars(
@@ -1851,11 +1897,8 @@ def get_workspace_payload(
             session_record=session_record,
         )
         bootstrap_updated = True
-    inventory_bundles = assemble_inventory_bundles_for_trip(assembly_input=inventory_assembly_input)
-    inventory_summary = build_inventory_summary_payload(
-        inventory_bundles,
-        assembly_input=inventory_assembly_input,
-    )
+    inventory_bundles: list[InventoryBundle] = []
+    inventory_summary = _build_workspace_inventory_summary(record)
     inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
     runtime_search = _build_runtime_scenario_search_for_trip(
         record=record,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #817

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
- persisted workspace reads should not quietly assemble runtime inventory from bundled fixtures
- trips without a live inventory adapter should stay in bootstrap mode instead of presenting fixture-backed runtime state

#### Tasks
- [x] stop fixture-backed inventory assembly on the main persisted workspace path
- [x] keep persisted workspace scenario surfaces in bootstrap mode when runtime inventory is absent
- [x] update workspace tests to assert the persisted bootstrap behavior

#### Acceptance criteria
- [x] persisted `/api/workspace/{trip_id}` reads no longer report fixture-backed runtime inventory bundles for saved trips
- [x] persisted scenario search and comparison surfaces stay anchored to saved-scenario bootstrap data when no live inventory exists
- [x] targeted workspace tests cover the empty or partial runtime-state behavior without fixture fallback

<!-- auto-status-summary:end -->
