### PR TITLE
Issue #828: add LangChain planner runtime seam

### DIFF
--- a/bundle/planner/orchestration-contracts.d.ts
+++ b/bundle/planner/orchestration-contracts.d.ts
@@ -144,6 +144,10 @@ export interface PlannerOutputRecord {
 
 export interface PlannerBehaviorRecord {
   trip_stage: string;
+  runtime_mode?: "model" | "fallback";
+  runtime_status?: "ready" | "fallback" | "error";
+  runtime_label?: string;
+  runtime_summary?: string;
   ask_before_next_major_change: boolean;
   target_research_passes: number;
   target_options_before_checkpoint: number;

--- a/docs/langchain-planner-runtime-epic.md
+++ b/docs/langchain-planner-runtime-epic.md
@@ -26,6 +26,20 @@ The repo already contains planner-facing design and UI contract surfaces, but it
 
 That means the repo can render planner state and accept bounded planner interactions, but it still lacks the runtime layer that owns conversational planning, explicit tool use, and long-lived planner memory for arbitrary persisted trips.
 
+## Runtime Configuration
+
+Planner turns use a deterministic fallback unless a planner model is configured. The fallback is intentionally visible in the planner session payload so local development and `make runtime-check` do not require live model credentials.
+
+Set these variables only when exercising the model-backed path:
+
+- `TRIP_PLANNER_PLANNER_MODEL_PROVIDER=openai`
+- `TRIP_PLANNER_PLANNER_MODEL=<OpenAI chat model name>`
+- `OPENAI_API_KEY=<key with model access>`
+
+When those values are present, the planner conversation service creates a LangChain-backed runnable and passes structured trip context, inventory, scenario, budget, policy, proposal, memory, activity, and available tool metadata into the model. The model may request only registered planner tools; unsupported tool names and malformed requests are persisted as visible tool errors rather than treated as successful state transitions. When configuration or credentials are absent, the deterministic fallback remains active and the response payload reports the fallback reason.
+
+CI should cover the model-backed path with fake chat models rather than live provider credentials. Live provider checks belong in explicit integration runs.
+
 ## Dependency Chain
 
 This epic depends on the persisted trip, workspace, and runtime seams established by the current app stack on `main`, especially the workspace route/service surfaces that now assemble persisted trip state, scenario search state, and planner panel payloads.

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -818,6 +818,7 @@ describe("WorkspacePage", () => {
       ],
     } satisfies PlannerSessionResponse;
     mockedSubmitPlannerTurn.mockResolvedValue(nextPlannerSession);
+
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve(workspacePayload),
       trips: Promise.resolve(tripComparisonPayload),
@@ -843,6 +844,54 @@ describe("WorkspacePage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("read_workspace_state: Read the current workspace state.")).toBeInTheDocument();
     expect(screen.getByLabelText("Message")).toHaveValue("");
+  });
+
+  it("labels the planner panel as deterministic fallback when runtime metadata is absent", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(workspacePayload),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Planner runtime state")).toBeInTheDocument();
+    });
+
+    const runtime = screen.getByLabelText("Planner runtime state");
+    expect(within(runtime).getByText("Deterministic fallback planner")).toHaveClass(
+      "planner-runtime-pill--fallback"
+    );
+    expect(within(runtime).getByText("Fallback")).toBeInTheDocument();
+  });
+
+  it("labels the planner panel as model-backed when runtime metadata reports a configured model", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        planner_panel_state: {
+          ...workspacePayload.planner_panel_state,
+          planner_behavior: {
+            ...workspacePayload.planner_panel_state.planner_behavior,
+            runtime_status: "ready",
+            runtime_mode: "model",
+            runtime_label: "Model-backed planner",
+            runtime_summary: "Planner model configuration is active for this workspace.",
+          },
+        },
+      }),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Planner runtime state")).toBeInTheDocument();
+    });
+
+    const runtime = screen.getByLabelText("Planner runtime state");
+    expect(within(runtime).getByText("Model-backed planner")).toHaveClass("planner-runtime-pill--ready");
+    expect(within(runtime).getByText("Model-backed")).toBeInTheDocument();
   });
 
   it("updates the map surface when a different scenario preview is selected", async () => {

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -717,8 +717,23 @@ function WorkspacePageContent({
           <p className="status-label">Planner panel</p>
           <h2>Trip-scoped planner surface</h2>
           <p className="muted-copy">
-            The existing planner side panel now mounts inside the workspace route and reads trip-scoped API data.
+            {currentWorkspace.planner_panel_state.planner_behavior.runtime_summary ??
+              "The existing planner side panel now mounts inside the workspace route and reads trip-scoped API data."}
           </p>
+          <div className="planner-runtime-row" aria-label="Planner runtime state">
+            <span
+              className={`planner-runtime-pill planner-runtime-pill--${
+                currentWorkspace.planner_panel_state.planner_behavior.runtime_status ?? "fallback"
+              }`}
+            >
+              {currentWorkspace.planner_panel_state.planner_behavior.runtime_label ?? "Deterministic fallback planner"}
+            </span>
+            <span className="planner-runtime-mode">
+              {currentWorkspace.planner_panel_state.planner_behavior.runtime_mode === "model"
+                ? "Model-backed"
+                : "Fallback"}
+            </span>
+          </div>
           {plannerBusyLabel ? <p className="muted-copy">{plannerBusyLabel}</p> : null}
           {plannerError ? <p className="planner-inline-error">{plannerError}</p> : null}
           <PlannerSidePanelSurface

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -129,6 +129,43 @@ a {
   margin-top: 1.25rem;
 }
 
+.planner-runtime-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.75rem 0 0;
+}
+
+.planner-runtime-pill,
+.planner-runtime-mode {
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.45rem 0.65rem;
+}
+
+.planner-runtime-pill {
+  background: #e8f2ef;
+  color: #25544e;
+}
+
+.planner-runtime-pill--fallback {
+  background: #fff5dc;
+  color: #705016;
+}
+
+.planner-runtime-pill--error {
+  background: #fce8e4;
+  color: #912c22;
+}
+
+.planner-runtime-mode {
+  background: #edf3f8;
+  color: #365063;
+}
+
 .workspace-hero {
   overflow: hidden;
   position: relative;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -151,6 +151,11 @@ a {
   color: #25544e;
 }
 
+.planner-runtime-pill--ready {
+  background: #e8f2ef;
+  color: #25544e;
+}
+
 .planner-runtime-pill--fallback {
   background: #fff5dc;
   color: #705016;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 dependencies = [
     "alembic==1.18.4",
     "fastapi==0.135.3",
+    "langchain-core==1.2.31",
+    "langchain-openai==1.1.14",
     "sqlalchemy==2.0.49",
     "uvicorn==0.44.0",
 ]

--- a/requirements.lock
+++ b/requirements.lock
@@ -9,6 +9,7 @@ annotated-types==0.7.0
 anyio==4.13.0
     # via
     #   httpx
+    #   openai
     #   starlette
 black==26.3.1
     # via trip-planner (pyproject.toml)
@@ -16,6 +17,9 @@ certifi==2026.2.25
     # via
     #   httpcore
     #   httpx
+    #   requests
+charset-normalizer==3.4.7
+    # via requests
 click==8.3.1
     # via
     #   black
@@ -24,8 +28,11 @@ colorama==0.4.6 ; sys_platform == 'win32'
     # via
     #   click
     #   pytest
+    #   tqdm
 coverage==7.13.5
     # via pytest-cov
+distro==1.9.0
+    # via openai
 fastapi==0.135.3
     # via trip-planner (pyproject.toml)
 greenlet==3.4.0 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'
@@ -37,13 +44,31 @@ h11==0.16.0
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
-    # via trip-planner (pyproject.toml)
+    # via
+    #   trip-planner (pyproject.toml)
+    #   langsmith
+    #   openai
 idna==3.11
     # via
     #   anyio
     #   httpx
+    #   requests
 iniconfig==2.3.0
     # via pytest
+jiter==0.14.0
+    # via openai
+jsonpatch==1.33
+    # via langchain-core
+jsonpointer==3.1.1
+    # via jsonpatch
+langchain-core==1.2.31
+    # via
+    #   trip-planner (pyproject.toml)
+    #   langchain-openai
+langchain-openai==1.1.14
+    # via trip-planner (pyproject.toml)
+langsmith==0.7.32
+    # via langchain-core
 librt==0.9.0 ; platform_python_implementation != 'PyPy'
     # via mypy
 mako==1.3.10
@@ -56,9 +81,15 @@ mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
+openai==2.32.0
+    # via langchain-openai
+orjson==3.11.8 ; platform_python_implementation != 'PyPy'
+    # via langsmith
 packaging==25.0
     # via
     #   black
+    #   langchain-core
+    #   langsmith
     #   pytest
 pathspec==1.0.4
     # via
@@ -71,7 +102,11 @@ pluggy==1.6.0
     #   pytest
     #   pytest-cov
 pydantic==2.12.5
-    # via fastapi
+    # via
+    #   fastapi
+    #   langchain-core
+    #   langsmith
+    #   openai
 pydantic-core==2.41.5
     # via pydantic
 pygments==2.19.2
@@ -84,20 +119,41 @@ pytest-cov==7.1.0
     # via trip-planner (pyproject.toml)
 pytokens==0.4.1
     # via black
+pyyaml==6.0.3
+    # via langchain-core
+regex==2026.4.4
+    # via tiktoken
+requests==2.33.1
+    # via
+    #   langsmith
+    #   requests-toolbelt
+    #   tiktoken
+requests-toolbelt==1.0.0
+    # via langsmith
 ruff==0.15.10
     # via trip-planner (pyproject.toml)
+sniffio==1.3.1
+    # via openai
 sqlalchemy==2.0.49
     # via
     #   trip-planner (pyproject.toml)
     #   alembic
 starlette==0.47.3
     # via fastapi
+tenacity==9.1.4
+    # via langchain-core
+tiktoken==0.12.0
+    # via langchain-openai
+tqdm==4.67.3
+    # via openai
 typing-extensions==4.15.0
     # via
     #   alembic
     #   anyio
     #   fastapi
+    #   langchain-core
     #   mypy
+    #   openai
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
@@ -107,5 +163,15 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
+urllib3==2.6.3
+    # via requests
+uuid-utils==0.14.1
+    # via
+    #   langchain-core
+    #   langsmith
 uvicorn==0.44.0
     # via trip-planner (pyproject.toml)
+xxhash==3.6.0
+    # via langsmith
+zstandard==0.25.0
+    # via langsmith

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -105,6 +105,23 @@ def test_planner_session_endpoint_bootstraps_trip_scoped_session(client: TestCli
         assert persisted.trip_id == trip_id
 
 
+def test_planner_session_treats_blank_model_key_as_unconfigured(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "gpt-test")
+    monkeypatch.setenv("OPENAI_API_KEY", "   ")
+
+    response = client.get(f"/api/planner/{trip_id}/session")
+
+    assert response.status_code == 200
+    runtime = response.json()["runtime"]
+    assert runtime["mode"] == "fallback"
+    assert runtime["fallback_reason"] == "openai_api_key_missing"
+
+
 def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> None:
     trip_id = _create_trip(client)
 

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -86,6 +86,30 @@ def _create_trip(client: TestClient) -> str:
     return response.json()["trip"]["trip_id"]
 
 
+def _create_business_trip(client: TestClient) -> str:
+    response = client.post(
+        "/api/trips",
+        json={
+            "title": "Planner API business kickoff",
+            "summary": "Need policy and proposal-backed planner context.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+                "traveler_party": {
+                    "kind": "solo",
+                    "traveler_count": 1,
+                    "notes": "Planner business API test",
+                },
+            },
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["trip"]["trip_id"]
+
+
 def test_planner_session_endpoint_bootstraps_trip_scoped_session(client: TestClient) -> None:
     trip_id = _create_trip(client)
 
@@ -213,7 +237,10 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
     assert isinstance(runtime_context, dict)
     assert runtime_context["trip"]["trip_id"] == trip_id
     assert runtime_context["context_readiness"]["status"] == "ready"
-    assert runtime_context["autonomy_preferences"]["interaction_state"]["initiative_level"] == "balanced"
+    assert (
+        runtime_context["autonomy_preferences"]["interaction_state"]["initiative_level"]
+        == "balanced"
+    )
     assert runtime_context["budget_state"]["summary"]["currency"] == "USD"
     assert "policy_state" in runtime_context
     assert "proposal_state" in runtime_context
@@ -225,7 +252,10 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
             .where(PersistedPlannerAction.trip_id == trip_id)
             .order_by(PersistedPlannerAction.occurred_at.asc())
         ).all()
-        assert stored[-1].payload["tool_calls"][0]["summary"] == "Read the current planner panel workspace state."
+        assert (
+            stored[-1].payload["tool_calls"][0]["summary"]
+            == "Read the current planner panel workspace state."
+        )
         assert stored[-1].payload["selected_planning_mode"] == "leisure"
         assert stored[-1].payload["runtime_mode"] == "model"
         checkpoint = db_session.get(
@@ -235,6 +265,103 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
         assert checkpoint is not None
         assert checkpoint.metadata_payload["tool_call_count"] == 1
         assert checkpoint.metadata_payload["selected_planning_mode"] == "leisure"
+
+
+def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_business_trip(client)
+    seeded_budget = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={
+            "message": "Seed planner budget state before model reads.",
+            "tool_calls": [
+                {"tool_name": "update_budget_plan", "arguments": {"total_amount": 2400}}
+            ],
+        },
+    )
+    assert seeded_budget.status_code == 200
+
+    expected_workspace = client.get(f"/api/workspace/{trip_id}")
+    expected_budget = client.get(f"/api/workspace/{trip_id}/budget")
+    expected_policy = client.get(f"/api/workspace/{trip_id}/policy")
+    expected_proposal = client.get(f"/api/workspace/{trip_id}/proposal")
+    assert expected_workspace.status_code == 200
+    assert expected_budget.status_code == 200
+    assert expected_policy.status_code == 200
+    assert expected_proposal.status_code == 200
+
+    fake_model = FakePlannerChatModel(
+        {
+            "content": "I pulled the latest persisted planner state before recommending a direction.",
+            "tool_calls": [
+                {"tool_name": "read_workspace_state", "arguments": {}},
+                {"tool_name": "refresh_inventory", "arguments": {}},
+                {"tool_name": "refresh_scenarios", "arguments": {}},
+                {"tool_name": "read_budget_state", "arguments": {}},
+                {"tool_name": "read_policy_state", "arguments": {}},
+                {"tool_name": "read_proposal_state", "arguments": {}},
+            ],
+        }
+    )
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+    set_planner_chat_model_factory_for_tests(lambda _: fake_model)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Ground your recommendation in persisted workspace and approval state."},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    planner_reply = payload["messages"][-1]
+    assert payload["runtime"]["mode"] == "model"
+    assert "Tool results:" in planner_reply["content"]
+    tool_outputs = {item["tool_name"]: item for item in planner_reply["tool_calls"]}
+    assert set(tool_outputs) == {
+        "read_workspace_state",
+        "refresh_inventory",
+        "refresh_scenarios",
+        "read_budget_state",
+        "read_policy_state",
+        "read_proposal_state",
+    }
+    for result in tool_outputs.values():
+        assert result["status"] == "completed"
+
+    workspace_payload = expected_workspace.json()
+    budget_payload = expected_budget.json()
+    policy_payload = expected_policy.json()
+    proposal_payload = expected_proposal.json()
+    assert (
+        tool_outputs["read_workspace_state"]["output"]["trip_title"]
+        == workspace_payload["trip_record"]["trip"]["title"]
+    )
+    assert tool_outputs["read_workspace_state"]["output"]["pending_decision_count"] == len(
+        workspace_payload["planner_panel_state"]["pending_decisions"]
+    )
+    assert (
+        tool_outputs["refresh_inventory"]["output"]["bundle_count"]
+        == workspace_payload["inventory_summary"]["bundle_count"]
+    )
+    assert (
+        tool_outputs["refresh_scenarios"]["output"]["lead_scenario_id"]
+        == workspace_payload["runtime_scenario_comparison"]["lead_scenario_id"]
+    )
+    assert (
+        tool_outputs["read_budget_state"]["output"]["planned_total"]
+        == budget_payload["summary"]["planned_total"]
+    )
+    assert (
+        tool_outputs["read_policy_state"]["output"]["status"] == policy_payload["summary"]["status"]
+    )
+    assert (
+        tool_outputs["read_proposal_state"]["output"]["status"]
+        == proposal_payload["summary"]["status"]
+    )
 
 
 def test_planner_turn_records_model_tool_errors_without_fabricating_success(
@@ -401,7 +528,10 @@ def test_planner_turn_normalizes_lowercase_budget_currency(client: TestClient) -
             .where(PersistedPlannerAction.trip_id == trip_id)
             .order_by(PersistedPlannerAction.occurred_at.asc())
         ).all()
-        assert stored[-1].payload["tool_calls"][0]["summary"] == "Updated the workspace budget plan to USD 900.00."
+        assert (
+            stored[-1].payload["tool_calls"][0]["summary"]
+            == "Updated the workspace budget plan to USD 900.00."
+        )
 
 
 def test_planner_resume_returns_prior_conversation_history(client: TestClient) -> None:
@@ -437,9 +567,7 @@ def test_planner_resume_regenerates_memory_from_raw_transcript(client: TestClien
             )
         )
         db_session.execute(
-            delete(PersistedPlannerCheckpoint).where(
-                PersistedPlannerCheckpoint.trip_id == trip_id
-            )
+            delete(PersistedPlannerCheckpoint).where(PersistedPlannerCheckpoint.trip_id == trip_id)
         )
         session = db_session.get(PersistedPlanningSessionState, f"session:{trip_id}")
         assert session is not None

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -56,6 +56,12 @@ class FakePlannerChatModel:
         return self.response
 
 
+class FailingPlannerChatModel:
+    def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        del payload
+        raise RuntimeError("provider timeout")
+
+
 def _create_trip(client: TestClient) -> str:
     response = client.post(
         "/api/trips",
@@ -206,6 +212,12 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
     runtime_context = fake_model.requests[0]["runtime_context"]
     assert isinstance(runtime_context, dict)
     assert runtime_context["trip"]["trip_id"] == trip_id
+    assert runtime_context["context_readiness"]["status"] == "ready"
+    assert runtime_context["autonomy_preferences"]["interaction_state"]["initiative_level"] == "balanced"
+    assert runtime_context["budget_state"]["summary"]["currency"] == "USD"
+    assert "policy_state" in runtime_context
+    assert "proposal_state" in runtime_context
+    assert "recent_activity" in runtime_context
 
     with get_session_factory()() as db_session:
         stored = db_session.scalars(
@@ -214,6 +226,15 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
             .order_by(PersistedPlannerAction.occurred_at.asc())
         ).all()
         assert stored[-1].payload["tool_calls"][0]["summary"] == "Read the current planner panel workspace state."
+        assert stored[-1].payload["selected_planning_mode"] == "leisure"
+        assert stored[-1].payload["runtime_mode"] == "model"
+        checkpoint = db_session.get(
+            PersistedPlannerCheckpoint,
+            payload["planner_memory"]["current_checkpoint_id"],
+        )
+        assert checkpoint is not None
+        assert checkpoint.metadata_payload["tool_call_count"] == 1
+        assert checkpoint.metadata_payload["selected_planning_mode"] == "leisure"
 
 
 def test_planner_turn_records_model_tool_errors_without_fabricating_success(
@@ -243,6 +264,58 @@ def test_planner_turn_records_model_tool_errors_without_fabricating_success(
     assert planner_reply["tool_calls"][0]["tool_name"] == "launch_booking_agent"
     assert planner_reply["tool_calls"][0]["status"] == "error"
     assert "not supported" in planner_reply["tool_calls"][0]["summary"]
+
+
+def test_planner_turn_records_malformed_model_tool_arguments_as_visible_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+    set_planner_chat_model_factory_for_tests(
+        lambda _: FakePlannerChatModel(
+            {
+                "content": "The budget tool received malformed arguments.",
+                "tool_calls": [{"tool_name": "update_budget_plan", "arguments": "not-a-dict"}],
+            }
+        )
+    )
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Set a budget from malformed model output."},
+    )
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    assert planner_reply["tool_calls"][0]["tool_name"] == "update_budget_plan"
+    assert planner_reply["tool_calls"][0]["status"] == "error"
+    assert "dictionary update sequence" in planner_reply["tool_calls"][0]["summary"]
+
+
+def test_planner_turn_records_model_provider_failure_as_visible_error(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+    set_planner_chat_model_factory_for_tests(lambda _: FailingPlannerChatModel())
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Try the configured model path."},
+    )
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    assert "Planner model runtime failed" in planner_reply["content"]
+    assert planner_reply["tool_calls"][0]["tool_name"] == "planner_model"
+    assert planner_reply["tool_calls"][0]["status"] == "error"
+    assert planner_reply["tool_calls"][0]["summary"] == "provider timeout"
 
 
 def test_planner_turn_executes_explicit_tool_calls(client: TestClient) -> None:

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -152,6 +152,24 @@ def test_planner_session_treats_blank_model_key_as_unconfigured(
     assert runtime["fallback_reason"] == "openai_api_key_missing"
 
 
+def test_planner_session_reports_model_runtime_when_configured(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+
+    response = client.get(f"/api/planner/{trip_id}/session")
+
+    assert response.status_code == 200
+    runtime = response.json()["runtime"]
+    assert runtime["mode"] == "model"
+    assert runtime["provider"] == "openai"
+    assert runtime["model"] == "fake-planner-model"
+
+
 def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> None:
     trip_id = _create_trip(client)
 
@@ -232,6 +250,17 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
     assert planner_reply["content"].startswith("I need to compare")
     assert planner_reply["tool_calls"][0]["tool_name"] == "read_workspace_state"
     assert planner_reply["tool_calls"][0]["status"] == "completed"
+    completed_tool_names = {
+        item["tool_name"] for item in planner_reply["tool_calls"] if item["status"] == "completed"
+    }
+    assert completed_tool_names == {
+        "read_workspace_state",
+        "refresh_inventory",
+        "refresh_scenarios",
+        "read_budget_state",
+        "read_policy_state",
+        "read_proposal_state",
+    }
     assert fake_model.requests[0]["available_tools"][0]["tool_name"] == "read_workspace_state"
     runtime_context = fake_model.requests[0]["runtime_context"]
     assert isinstance(runtime_context, dict)
@@ -263,7 +292,7 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
             payload["planner_memory"]["current_checkpoint_id"],
         )
         assert checkpoint is not None
-        assert checkpoint.metadata_payload["tool_call_count"] == 1
+        assert checkpoint.metadata_payload["tool_call_count"] == 6
         assert checkpoint.metadata_payload["selected_planning_mode"] == "leisure"
 
 

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -1,11 +1,13 @@
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import delete, select
 
 from trip_planner.app.main import create_app
+from trip_planner.app.services.planner import set_planner_chat_model_factory_for_tests
 from trip_planner.persistence.db import get_session_factory, reset_database_state
 from trip_planner.persistence.models.activity import (
     PersistedActivityLogEvent,
@@ -21,6 +23,10 @@ from trip_planner.persistence.models.session import PersistedPlanningSessionStat
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'planner.db'}")
+    monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    set_planner_chat_model_factory_for_tests(None)
     reset_database_state()
     app = create_app()
 
@@ -36,7 +42,18 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
         assert signup.status_code == 201
         yield test_client
 
+    set_planner_chat_model_factory_for_tests(None)
     reset_database_state()
+
+
+class FakePlannerChatModel:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        self.requests: list[dict[str, Any]] = []
+
+    def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.requests.append(payload)
+        return self.response
 
 
 def _create_trip(client: TestClient) -> str:
@@ -76,6 +93,8 @@ def test_planner_session_endpoint_bootstraps_trip_scoped_session(client: TestCli
     assert payload["session"]["trip_id"] == trip_id
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
     assert payload["planner_memory"]["current_checkpoint_id"] is None
+    assert payload["runtime"]["mode"] == "fallback"
+    assert payload["runtime"]["fallback_reason"] == "planner_model_not_configured"
     assert payload["available_tools"]
     assert payload["available_tools"][0]["tool_name"] == "read_workspace_state"
     assert payload["messages"] == []
@@ -98,6 +117,7 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
     payload = response.json()
     assert [message["role"] for message in payload["messages"]] == ["user", "planner"]
     assert "Help me decide" in payload["messages"][0]["content"]
+    assert "Deterministic planner fallback is active" in payload["messages"][1]["content"]
     assert payload["messages"][1]["refs"]
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
     assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
@@ -134,6 +154,78 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
         assert artifact is not None
         assert artifact.memory_artifact_id.startswith("planner-mem:")
         assert artifact.checkpoint_id == checkpoint.checkpoint_id
+
+
+def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    fake_model = FakePlannerChatModel(
+        {
+            "content": "I need to compare the current workspace state before recommending next steps.",
+            "tool_calls": [{"tool_name": "read_workspace_state", "arguments": {}}],
+        }
+    )
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+    set_planner_chat_model_factory_for_tests(lambda _: fake_model)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Compare my options and tell me what to revise."},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["runtime"]["mode"] == "model"
+    assert payload["runtime"]["model"] == "fake-planner-model"
+    planner_reply = payload["messages"][-1]
+    assert planner_reply["content"].startswith("I need to compare")
+    assert planner_reply["tool_calls"][0]["tool_name"] == "read_workspace_state"
+    assert planner_reply["tool_calls"][0]["status"] == "completed"
+    assert fake_model.requests[0]["available_tools"][0]["tool_name"] == "read_workspace_state"
+    runtime_context = fake_model.requests[0]["runtime_context"]
+    assert isinstance(runtime_context, dict)
+    assert runtime_context["trip"]["trip_id"] == trip_id
+
+    with get_session_factory()() as db_session:
+        stored = db_session.scalars(
+            select(PersistedPlannerAction)
+            .where(PersistedPlannerAction.trip_id == trip_id)
+            .order_by(PersistedPlannerAction.occurred_at.asc())
+        ).all()
+        assert stored[-1].payload["tool_calls"][0]["summary"] == "Read the current planner panel workspace state."
+
+
+def test_planner_turn_records_model_tool_errors_without_fabricating_success(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+    set_planner_chat_model_factory_for_tests(
+        lambda _: FakePlannerChatModel(
+            {
+                "content": "I tried to use a tool that is outside the app boundary.",
+                "tool_calls": [{"tool_name": "launch_booking_agent", "arguments": {}}],
+            }
+        )
+    )
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Book the lead option for me."},
+    )
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    assert planner_reply["tool_calls"][0]["tool_name"] == "launch_booking_agent"
+    assert planner_reply["tool_calls"][0]["status"] == "error"
+    assert "not supported" in planner_reply["tool_calls"][0]["summary"]
 
 
 def test_planner_turn_executes_explicit_tool_calls(client: TestClient) -> None:

--- a/trip_planner.egg-info/PKG-INFO
+++ b/trip_planner.egg-info/PKG-INFO
@@ -3,6 +3,8 @@ Name: trip-planner
 Version: 0.1.0
 Requires-Dist: alembic==1.18.4
 Requires-Dist: fastapi==0.135.3
+Requires-Dist: langchain-core==1.2.31
+Requires-Dist: langchain-openai==1.1.14
 Requires-Dist: sqlalchemy==2.0.49
 Requires-Dist: uvicorn==0.44.0
 Provides-Extra: dev

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -83,6 +83,7 @@ trip_planner/app/services/feasibility.py
 trip_planner/app/services/inventory.py
 trip_planner/app/services/planner.py
 trip_planner/app/services/planner_memory.py
+trip_planner/app/services/planner_runtime_config.py
 trip_planner/app/services/planner_tools.py
 trip_planner/app/services/policy.py
 trip_planner/app/services/proposal.py

--- a/trip_planner.egg-info/requires.txt
+++ b/trip_planner.egg-info/requires.txt
@@ -1,5 +1,7 @@
 alembic==1.18.4
 fastapi==0.135.3
+langchain-core==1.2.31
+langchain-openai==1.1.14
 sqlalchemy==2.0.49
 uvicorn==0.44.0
 

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -66,6 +66,7 @@ class PlannerSessionResponse(BaseModel):
     session_state_id: str
     conversation_id: str
     resumed_at: str | None = None
+    runtime: dict[str, Any] = Field(default_factory=dict)
     session: dict[str, Any]
     planner_panel_state: dict[str, Any]
     planner_memory: PlannerMemoryResponse

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -72,6 +72,14 @@ class PlannerChatModel(Protocol):
 PlannerChatModelFactory = Callable[[PlannerRuntimeConfig], PlannerChatModel]
 
 _PLANNER_CHAT_MODEL_FACTORY: PlannerChatModelFactory | None = None
+_GROUNDING_TOOL_NAMES: tuple[str, ...] = (
+    "read_workspace_state",
+    "refresh_inventory",
+    "refresh_scenarios",
+    "read_budget_state",
+    "read_policy_state",
+    "read_proposal_state",
+)
 
 
 def set_planner_chat_model_factory_for_tests(factory: PlannerChatModelFactory | None) -> None:
@@ -426,6 +434,19 @@ def _execute_model_tool_calls(
     return executed
 
 
+def _missing_grounding_tool_calls(executed_tool_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen = {
+        str(item.get("tool_name") or "")
+        for item in executed_tool_calls
+        if str(item.get("status") or "") == "completed"
+    }
+    return [
+        {"tool_name": tool_name, "arguments": {}}
+        for tool_name in _GROUNDING_TOOL_NAMES
+        if tool_name not in seen
+    ]
+
+
 def get_planner_session_payload(
     db_session: Session,
     *,
@@ -575,6 +596,17 @@ def submit_planner_turn(
         tool_calls=reply.requested_tool_calls,
     )
     executed_tool_calls.extend(model_tool_calls)
+    if runtime_config.mode == "model":
+        grounding_tool_calls = _missing_grounding_tool_calls(executed_tool_calls)
+        if grounding_tool_calls:
+            executed_tool_calls.extend(
+                _execute_model_tool_calls(
+                    db_session,
+                    user=user,
+                    trip_id=trip_id,
+                    tool_calls=grounding_tool_calls,
+                )
+            )
     if executed_tool_calls:
         tool_summary = " ".join(item["summary"] for item in executed_tool_calls)
         reply = PlannerConversationReply(

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -15,6 +16,10 @@ from trip_planner.app.services.planner_memory import (
     build_planner_memory_payload,
     ensure_planner_memory_persisted,
     refresh_planner_memory,
+)
+from trip_planner.app.services.planner_runtime_config import (
+    PlannerRuntimeConfig,
+    get_planner_runtime_config,
 )
 from trip_planner.app.services.planner_tools import (
     execute_planner_tool_call,
@@ -47,6 +52,7 @@ class PlannerConversationRequest:
     message: str
     planner_panel_state: dict[str, Any]
     session: PlanningSessionState
+    runtime_context: dict[str, Any]
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,6 +60,22 @@ class PlannerConversationReply:
     content: str
     refs: list[str]
     tool_calls: list[dict[str, Any]]
+    requested_tool_calls: list[dict[str, Any]] | None = None
+
+
+class PlannerChatModel(Protocol):
+    def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Return planner content and optional tool call requests."""
+
+
+PlannerChatModelFactory = Callable[[PlannerRuntimeConfig], PlannerChatModel]
+
+_PLANNER_CHAT_MODEL_FACTORY: PlannerChatModelFactory | None = None
+
+
+def set_planner_chat_model_factory_for_tests(factory: PlannerChatModelFactory | None) -> None:
+    global _PLANNER_CHAT_MODEL_FACTORY
+    _PLANNER_CHAT_MODEL_FACTORY = factory
 
 
 class PlannerConversationRunnable(Protocol):
@@ -64,7 +86,7 @@ class PlannerConversationRunnable(Protocol):
 
 
 class DeterministicPlannerConversationRunnable:
-    """Small provider-neutral runnable until a real LangChain chat stack is attached."""
+    """Provider-neutral fallback when planner model configuration is absent."""
 
     def invoke(self, request: PlannerConversationRequest) -> PlannerConversationReply:
         panel = request.planner_panel_state
@@ -105,14 +127,107 @@ class DeterministicPlannerConversationRunnable:
             refs.extend(output["output_id"] for output in outputs[:2])
 
         lines.append(
-            "This reply is generated through the planner runnable boundary so a LangChain-backed engine can replace it without changing the route handlers."
+            "Deterministic planner fallback is active; configure a planner model for tool-grounded orchestration."
         )
         deduped_refs = list(dict.fromkeys(refs))
         return PlannerConversationReply(content=" ".join(lines), refs=deduped_refs, tool_calls=[])
 
 
-def _planner_runnable() -> PlannerConversationRunnable:
-    return DeterministicPlannerConversationRunnable()
+class _OpenAIPlannerChatModel:
+    def __init__(self, config: PlannerRuntimeConfig) -> None:
+        if not config.model:
+            raise ValueError("Planner model name is required.")
+        from langchain_openai import ChatOpenAI
+
+        self._model = ChatOpenAI(model=config.model, temperature=0)
+
+    def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool["tool_name"],
+                    "description": tool["description"],
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": True,
+                    },
+                },
+            }
+            for tool in payload["available_tools"]
+        ]
+        model = self._model.bind_tools(tools)
+        response = model.invoke(
+            [
+                (
+                    "system",
+                    "You are a trip-scoped planner. Use only the listed app tools for "
+                    "workspace, inventory, scenario, budget, policy, or proposal facts. "
+                    "Do not invent persisted state.",
+                ),
+                (
+                    "human",
+                    json.dumps(
+                        {
+                            "message": payload["message"],
+                            "context": payload["runtime_context"],
+                        },
+                        default=str,
+                    ),
+                ),
+            ]
+        )
+        tool_calls: list[dict[str, Any]] = []
+        for call in getattr(response, "tool_calls", []) or []:
+            tool_calls.append(
+                {
+                    "tool_name": call.get("name") or call.get("tool_name") or "",
+                    "arguments": call.get("args") or call.get("arguments") or {},
+                }
+            )
+        return {"content": str(response.content), "tool_calls": tool_calls}
+
+
+class ModelBackedPlannerConversationRunnable:
+    def __init__(self, config: PlannerRuntimeConfig, chat_model: PlannerChatModel) -> None:
+        self._config = config
+        self._chat_model = chat_model
+
+    def invoke(self, request: PlannerConversationRequest) -> PlannerConversationReply:
+        raw = self._chat_model.invoke(
+            {
+                "message": request.message,
+                "trip_id": request.trip_id,
+                "available_tools": list_planner_tools(),
+                "runtime_context": request.runtime_context,
+                "provider": self._config.provider,
+                "model": self._config.model,
+            }
+        )
+        content = str(raw.get("content") or "").strip()
+        if not content:
+            content = "Planner model returned an empty response after reading the current trip context."
+        requested_tool_calls = [
+            {
+                "tool_name": str(item.get("tool_name") or item.get("name") or ""),
+                "arguments": item.get("arguments") or item.get("args") or {},
+            }
+            for item in list(raw.get("tool_calls") or [])
+        ]
+        return PlannerConversationReply(
+            content=content,
+            refs=[request.session.session_state_id],
+            tool_calls=[],
+            requested_tool_calls=requested_tool_calls,
+        )
+
+
+def _planner_runnable(config: PlannerRuntimeConfig) -> PlannerConversationRunnable:
+    if config.mode != "model":
+        return DeterministicPlannerConversationRunnable()
+    factory = _PLANNER_CHAT_MODEL_FACTORY or (lambda runtime_config: _OpenAIPlannerChatModel(runtime_config))
+    return ModelBackedPlannerConversationRunnable(config, factory(config))
 
 
 def _conversation_id(trip_id: str) -> str:
@@ -187,6 +302,29 @@ def _activity_log(
     return [_serialize_activity_record(record) for record in records]
 
 
+def _planner_runtime_context(
+    workspace_payload: dict[str, Any],
+    *,
+    planner_memory: dict[str, Any],
+    activity_log: list[dict[str, Any]],
+) -> dict[str, Any]:
+    panel = workspace_payload["planner_panel_state"]
+    return {
+        "trip": panel["trip"],
+        "pending_decisions": panel.get("pending_decisions") or [],
+        "option_set": panel.get("option_set") or {},
+        "outputs": panel.get("outputs") or [],
+        "inventory_summary": workspace_payload.get("inventory_summary") or {},
+        "scenario_search": workspace_payload.get("scenario_search") or {},
+        "runtime_scenario_comparison": workspace_payload.get("runtime_scenario_comparison") or {},
+        "budget_state": workspace_payload.get("budget_state") or {},
+        "policy_state": workspace_payload.get("policy_state") or {},
+        "proposal_state": workspace_payload.get("proposal_state") or {},
+        "planner_memory": planner_memory,
+        "recent_activity": activity_log[:8],
+    }
+
+
 def _planner_session_payload(
     db_session: Session,
     *,
@@ -200,22 +338,61 @@ def _planner_session_payload(
 
     session = workspace_payload["session"]
     session_state_id = session["session_state_id"]
+    planner_memory = build_planner_memory_payload(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session_state_id,
+    )
+    activity_log = _activity_log(db_session, trip_id=trip_id)
     return {
         "trip_id": trip_id,
         "session_state_id": session_state_id,
         "conversation_id": _conversation_id(trip_id),
         "resumed_at": resumed_at,
+        "runtime": get_planner_runtime_config().to_payload(),
         "session": session,
         "planner_panel_state": workspace_payload["planner_panel_state"],
-        "planner_memory": build_planner_memory_payload(
-            db_session,
-            trip_id=trip_id,
-            session_state_id=session_state_id,
-        ),
+        "planner_memory": planner_memory,
         "available_tools": list_planner_tools(),
-        "activity_log": _activity_log(db_session, trip_id=trip_id),
+        "activity_log": activity_log,
         "messages": _conversation_messages(db_session, session_state_id=session_state_id),
     }
+
+
+def _tool_call_error(tool_name: str, message: str) -> dict[str, Any]:
+    return {
+        "tool_name": tool_name or "unknown",
+        "status": "error",
+        "summary": message,
+        "mutates_state": False,
+        "refs": [],
+        "output": {"error": message},
+    }
+
+
+def _execute_model_tool_calls(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    tool_calls: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    executed: list[dict[str, Any]] = []
+    for tool_call in tool_calls or []:
+        tool_name = str(tool_call.get("tool_name") or "")
+        try:
+            result = execute_planner_tool_call(
+                db_session,
+                user=user,
+                trip_id=trip_id,
+                tool_name=tool_name,
+                arguments=tool_call.get("arguments") or {},
+            )
+        except Exception as error:
+            executed.append(_tool_call_error(tool_name, str(error)))
+        else:
+            executed.append(result.to_dict())
+    return executed
 
 
 def get_planner_session_payload(
@@ -330,15 +507,34 @@ def submit_planner_turn(
     if workspace_payload is None:
         raise WorkspacePlannerTripNotFoundError(f"Trip '{trip_id}' was not found.")
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
-    runnable = _planner_runnable()
+    planner_memory = build_planner_memory_payload(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+    )
+    activity_log = _activity_log(db_session, trip_id=trip_id)
+    runtime_config = get_planner_runtime_config()
+    runnable = _planner_runnable(runtime_config)
     reply = runnable.invoke(
         PlannerConversationRequest(
             trip_id=trip_id,
             message=normalized_message,
             planner_panel_state=workspace_payload["planner_panel_state"],
             session=session,
+            runtime_context=_planner_runtime_context(
+                workspace_payload,
+                planner_memory=planner_memory,
+                activity_log=activity_log,
+            ),
         )
     )
+    model_tool_calls = _execute_model_tool_calls(
+        db_session,
+        user=user,
+        trip_id=trip_id,
+        tool_calls=reply.requested_tool_calls,
+    )
+    executed_tool_calls.extend(model_tool_calls)
     if executed_tool_calls:
         tool_summary = " ".join(item["summary"] for item in executed_tool_calls)
         reply = PlannerConversationReply(

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -25,6 +25,7 @@ from trip_planner.app.services.planner_tools import (
     execute_planner_tool_call,
     list_planner_tools,
 )
+from trip_planner.preferences.autonomy import AutonomyGuardrails
 from trip_planner.app.services.workspace import (
     WORKSPACE_ACTIVITY_LOG_LIMIT,
     _append_activity_event,
@@ -305,23 +306,37 @@ def _activity_log(
 def _planner_runtime_context(
     workspace_payload: dict[str, Any],
     *,
+    session: PlanningSessionState,
     planner_memory: dict[str, Any],
     activity_log: list[dict[str, Any]],
 ) -> dict[str, Any]:
     panel = workspace_payload["planner_panel_state"]
+    required_sections = {
+        "inventory_summary": workspace_payload.get("inventory_summary") or {},
+        "scenario_search": workspace_payload.get("scenario_search") or {},
+        "runtime_scenario_comparison": workspace_payload.get("runtime_scenario_comparison") or {},
+        "budget_state": workspace_payload.get("budget_state") or {},
+        "planner_memory": planner_memory,
+    }
+    missing_sections = [key for key, value in required_sections.items() if not value]
     return {
         "trip": panel["trip"],
         "pending_decisions": panel.get("pending_decisions") or [],
         "option_set": panel.get("option_set") or {},
         "outputs": panel.get("outputs") or [],
-        "inventory_summary": workspace_payload.get("inventory_summary") or {},
-        "scenario_search": workspace_payload.get("scenario_search") or {},
-        "runtime_scenario_comparison": workspace_payload.get("runtime_scenario_comparison") or {},
-        "budget_state": workspace_payload.get("budget_state") or {},
+        **required_sections,
         "policy_state": workspace_payload.get("policy_state") or {},
         "proposal_state": workspace_payload.get("proposal_state") or {},
-        "planner_memory": planner_memory,
+        "autonomy_preferences": {
+            "interaction_state": session.interaction_state.to_dict(),
+            "guardrails": AutonomyGuardrails().to_dict(),
+            "planner_behavior": panel.get("planner_behavior") or {},
+        },
         "recent_activity": activity_log[:8],
+        "context_readiness": {
+            "status": "partial" if missing_sections else "ready",
+            "missing_sections": missing_sections,
+        },
     }
 
 
@@ -368,6 +383,22 @@ def _tool_call_error(tool_name: str, message: str) -> dict[str, Any]:
         "refs": [],
         "output": {"error": message},
     }
+
+
+def _planner_model_error_reply(
+    *,
+    session_state_id: str,
+    error: Exception,
+) -> PlannerConversationReply:
+    message = (
+        "Planner model runtime failed before it could complete the turn. "
+        "The traveler message was saved, and the visible error state is available for retry."
+    )
+    return PlannerConversationReply(
+        content=f"{message} Error: {error}",
+        refs=[session_state_id],
+        tool_calls=[_tool_call_error("planner_model", str(error))],
+    )
 
 
 def _execute_model_tool_calls(
@@ -489,6 +520,7 @@ def submit_planner_turn(
             "content": normalized_message,
             "refs": session.session_state_id,
             "tool_calls": [],
+            "selected_planning_mode": session.mode,
         },
     )
 
@@ -515,19 +547,27 @@ def submit_planner_turn(
     activity_log = _activity_log(db_session, trip_id=trip_id)
     runtime_config = get_planner_runtime_config()
     runnable = _planner_runnable(runtime_config)
-    reply = runnable.invoke(
-        PlannerConversationRequest(
-            trip_id=trip_id,
-            message=normalized_message,
-            planner_panel_state=workspace_payload["planner_panel_state"],
-            session=session,
-            runtime_context=_planner_runtime_context(
-                workspace_payload,
-                planner_memory=planner_memory,
-                activity_log=activity_log,
-            ),
-        )
+    runtime_context = _planner_runtime_context(
+        workspace_payload,
+        session=session,
+        planner_memory=planner_memory,
+        activity_log=activity_log,
     )
+    try:
+        reply = runnable.invoke(
+            PlannerConversationRequest(
+                trip_id=trip_id,
+                message=normalized_message,
+                planner_panel_state=workspace_payload["planner_panel_state"],
+                session=session,
+                runtime_context=runtime_context,
+            )
+        )
+    except Exception as error:
+        reply = _planner_model_error_reply(
+            session_state_id=session.session_state_id,
+            error=error,
+        )
     model_tool_calls = _execute_model_tool_calls(
         db_session,
         user=user,
@@ -567,6 +607,14 @@ def submit_planner_turn(
             "content": reply.content,
             "refs": ",".join(reply.refs),
             "tool_calls": reply.tool_calls,
+            "selected_planning_mode": session.mode,
+            "planning_stage": (
+                workspace_payload["planner_panel_state"]
+                .get("planner_behavior", {})
+                .get("trip_stage")
+            ),
+            "runtime_mode": runtime_config.mode,
+            "context_readiness": runtime_context["context_readiness"],
         },
     )
     refresh_planner_memory(

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -596,7 +596,11 @@ def submit_planner_turn(
         tool_calls=reply.requested_tool_calls,
     )
     executed_tool_calls.extend(model_tool_calls)
-    if runtime_config.mode == "model":
+    model_runtime_failed = any(
+        item.get("tool_name") == "planner_model" and item.get("status") == "error"
+        for item in reply.tool_calls
+    )
+    if runtime_config.mode == "model" and not model_runtime_failed:
         grounding_tool_calls = _missing_grounding_tool_calls(executed_tool_calls)
         if grounding_tool_calls:
             executed_tool_calls.extend(

--- a/trip_planner/app/services/planner_memory.py
+++ b/trip_planner/app/services/planner_memory.py
@@ -43,6 +43,14 @@ def _planner_message_records(
 
 
 def _checkpoint_summary(messages: list[PersistedPlannerAction], *, turn_index: int) -> dict[str, Any]:
+    latest_reply_record = next(
+        (
+            record
+            for record in reversed(messages)
+            if record.action_type == "planner_response"
+        ),
+        None,
+    )
     latest_user = next(
         (
             record.payload.get("content", "").strip()
@@ -51,13 +59,20 @@ def _checkpoint_summary(messages: list[PersistedPlannerAction], *, turn_index: i
         ),
         "",
     )
-    latest_reply = next(
-        (
-            record.payload.get("content", "").strip()
-            for record in reversed(messages)
-            if record.action_type == "planner_response"
-        ),
-        "",
+    latest_reply = (
+        latest_reply_record.payload.get("content", "").strip()
+        if latest_reply_record is not None
+        else ""
+    )
+    tool_calls = (
+        list(latest_reply_record.payload.get("tool_calls") or [])
+        if latest_reply_record is not None
+        else []
+    )
+    selected_planning_mode = (
+        str(latest_reply_record.payload.get("selected_planning_mode") or "")
+        if latest_reply_record is not None
+        else ""
     )
     refs = list(
         dict.fromkeys(
@@ -77,11 +92,30 @@ def _checkpoint_summary(messages: list[PersistedPlannerAction], *, turn_index: i
     ]
     if refs:
         detail_lines.append(f"Linked refs: {', '.join(refs[:4])}")
+    if selected_planning_mode:
+        detail_lines.append(f"Selected planning mode: {selected_planning_mode}.")
+    if tool_calls:
+        detail_lines.append(f"Tool traces persisted: {len(tool_calls)}.")
     return {
         "summary": summary,
         "title": f"Planner checkpoint {turn_index}",
         "detail": " ".join(detail_lines),
         "refs": refs[:8],
+        "metadata": {
+            "ref_count": len(refs[:8]),
+            "tool_call_count": len(tool_calls),
+            "selected_planning_mode": selected_planning_mode or None,
+            "planning_stage": (
+                latest_reply_record.payload.get("planning_stage")
+                if latest_reply_record is not None
+                else None
+            ),
+            "runtime_mode": (
+                latest_reply_record.payload.get("runtime_mode")
+                if latest_reply_record is not None
+                else None
+            ),
+        },
     }
 
 
@@ -126,14 +160,14 @@ def refresh_planner_memory(
             message_count=len(messages),
             summary=summary_payload["summary"],
             source_message_ids=source_message_ids,
-            metadata_payload={"ref_count": len(summary_payload["refs"])},
+            metadata_payload=summary_payload["metadata"],
         )
         db_session.add(checkpoint)
     else:
         checkpoint.message_count = len(messages)
         checkpoint.summary = summary_payload["summary"]
         checkpoint.source_message_ids = source_message_ids
-        checkpoint.metadata_payload = {"ref_count": len(summary_payload["refs"])}
+        checkpoint.metadata_payload = summary_payload["metadata"]
 
     artifact = db_session.get(PersistedPlannerMemoryArtifact, artifact_id)
     if artifact is None:

--- a/trip_planner/app/services/planner_runtime_config.py
+++ b/trip_planner/app/services/planner_runtime_config.py
@@ -39,8 +39,9 @@ def get_planner_runtime_config() -> PlannerRuntimeConfig:
         or ""
     ).strip().lower()
     model = os.getenv("TRIP_PLANNER_PLANNER_MODEL", "").strip()
+    openai_api_key = os.getenv("OPENAI_API_KEY", "").strip()
     fake_enabled = provider == "fake"
-    openai_enabled = provider == "openai" and bool(model) and bool(os.getenv("OPENAI_API_KEY"))
+    openai_enabled = provider == "openai" and bool(model) and bool(openai_api_key)
 
     if fake_enabled or openai_enabled:
         provider_label = provider or "configured"
@@ -58,7 +59,7 @@ def get_planner_runtime_config() -> PlannerRuntimeConfig:
         fallback_reason = "unsupported_planner_model_provider"
     elif provider == "openai" and not model:
         fallback_reason = "planner_model_name_missing"
-    elif provider == "openai" and model and not os.getenv("OPENAI_API_KEY"):
+    elif provider == "openai" and model and not openai_api_key:
         fallback_reason = "openai_api_key_missing"
 
     return PlannerRuntimeConfig(

--- a/trip_planner/app/services/planner_runtime_config.py
+++ b/trip_planner/app/services/planner_runtime_config.py
@@ -1,0 +1,72 @@
+"""Configuration helpers for the planner conversation runtime."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class PlannerRuntimeConfig:
+    mode: str
+    provider: str | None
+    model: str | None
+    status: str
+    title: str
+    summary: str
+    fallback_reason: str | None = None
+
+    @property
+    def model_configured(self) -> bool:
+        return self.mode == "model"
+
+    def to_payload(self) -> dict[str, str | None]:
+        return {
+            "mode": self.mode,
+            "provider": self.provider,
+            "model": self.model,
+            "status": self.status,
+            "title": self.title,
+            "summary": self.summary,
+            "fallback_reason": self.fallback_reason,
+        }
+
+
+def get_planner_runtime_config() -> PlannerRuntimeConfig:
+    provider = (
+        os.getenv("TRIP_PLANNER_PLANNER_PROVIDER")
+        or os.getenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER")
+        or ""
+    ).strip().lower()
+    model = os.getenv("TRIP_PLANNER_PLANNER_MODEL", "").strip()
+    fake_enabled = provider == "fake"
+    openai_enabled = provider == "openai" and bool(model) and bool(os.getenv("OPENAI_API_KEY"))
+
+    if fake_enabled or openai_enabled:
+        provider_label = provider or "configured"
+        return PlannerRuntimeConfig(
+            mode="model",
+            provider=provider_label,
+            model=model or "fake-planner-model",
+            status="ready",
+            title="Model-backed planner",
+            summary="Planner turns use a configured LangChain chat model over explicit app tools.",
+        )
+
+    fallback_reason = "planner_model_not_configured"
+    if provider and provider not in {"openai", "fake"}:
+        fallback_reason = "unsupported_planner_model_provider"
+    elif provider == "openai" and not model:
+        fallback_reason = "planner_model_name_missing"
+    elif provider == "openai" and model and not os.getenv("OPENAI_API_KEY"):
+        fallback_reason = "openai_api_key_missing"
+
+    return PlannerRuntimeConfig(
+        mode="fallback",
+        provider=provider or None,
+        model=model or None,
+        status="fallback",
+        title="Deterministic fallback planner",
+        summary="No planner model credentials are configured, so turns use the local deterministic fallback.",
+        fallback_reason=fallback_reason,
+    )

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -318,7 +318,7 @@ def _read_policy_state(
     payload = get_workspace_policy_payload(db_session, user=user, trip_id=trip_id)
     summary = payload["summary"]
     output = {
-        "status": summary["status"],
+        "status": summary.get("status", "ready" if payload.get("policy_state") else "missing"),
         "ready_for_submission": bool(
             summary.get("ready_for_submission") or summary.get("approval_ready")
         ),
@@ -348,16 +348,22 @@ def _read_proposal_state(
     del arguments
     payload = get_workspace_proposal_payload(db_session, user=user, trip_id=trip_id)
     summary = payload["summary"]
+    follow_up_status = summary.get("follow_up_status")
     output = {
-        "status": summary["status"],
+        "status": summary.get("status") or summary.get("evaluation_result_status") or "missing",
         "requires_follow_up": bool(
             summary.get("requires_follow_up")
-            or summary.get("follow_up_status")
-            in {"reoptimization_required", "exception_required", "exception_requested"}
+            or follow_up_status
+            in {
+                "awaiting_evaluation",
+                "reoptimization_required",
+                "exception_required",
+                "exception_requested",
+            }
         ),
         "needs_exception": bool(
             summary.get("needs_exception")
-            or summary.get("follow_up_status") in {"exception_required", "exception_requested"}
+            or follow_up_status in {"exception_required", "exception_requested"}
         ),
     }
     return PlannerToolResult(

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -316,10 +316,18 @@ def _read_policy_state(
 ) -> PlannerToolResult:
     del arguments
     payload = get_workspace_policy_payload(db_session, user=user, trip_id=trip_id)
+    summary = payload["summary"]
     output = {
-        "status": payload["summary"]["status"],
-        "ready_for_submission": payload["summary"]["ready_for_submission"],
-        "issue_count": payload["summary"]["issue_count"],
+        "status": summary["status"],
+        "ready_for_submission": bool(
+            summary.get("ready_for_submission") or summary.get("approval_ready")
+        ),
+        "issue_count": int(
+            summary.get("issue_count")
+            or summary.get("blocking_failure_count")
+            or summary.get("approval_requirement_count")
+            or 0
+        ),
     }
     return PlannerToolResult(
         tool_name="read_policy_state",
@@ -339,10 +347,18 @@ def _read_proposal_state(
 ) -> PlannerToolResult:
     del arguments
     payload = get_workspace_proposal_payload(db_session, user=user, trip_id=trip_id)
+    summary = payload["summary"]
     output = {
-        "status": payload["summary"]["status"],
-        "requires_follow_up": payload["summary"]["requires_follow_up"],
-        "needs_exception": payload["summary"]["needs_exception"],
+        "status": summary["status"],
+        "requires_follow_up": bool(
+            summary.get("requires_follow_up")
+            or summary.get("follow_up_status")
+            in {"reoptimization_required", "exception_required", "exception_requested"}
+        ),
+        "needs_exception": bool(
+            summary.get("needs_exception")
+            or summary.get("follow_up_status") in {"exception_required", "exception_requested"}
+        ),
     }
     return PlannerToolResult(
         tool_name="read_proposal_state",

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -29,6 +29,7 @@ from trip_planner.app.services.inventory import (
 from trip_planner.app.services.planner_memory import build_planner_memory_payload
 from trip_planner.app.services.policy import get_workspace_policy_payload
 from trip_planner.app.services.proposal import get_workspace_proposal_payload
+from trip_planner.app.services.planner_runtime_config import get_planner_runtime_config
 from trip_planner.app.services.scenarios import (
     build_scenario_ranking_outputs,
     build_workspace_scenario_search,
@@ -1741,6 +1742,7 @@ def _build_planner_panel_state(
                 },
             )
 
+    runtime_config = get_planner_runtime_config()
     return {
         "trip": trip,
         "option_set": option_set,
@@ -1750,6 +1752,10 @@ def _build_planner_panel_state(
         "outputs": outputs,
         "planner_behavior": {
             "trip_stage": "compare" if scenarios else "bootstrap",
+            "runtime_mode": runtime_config.mode,
+            "runtime_status": runtime_config.status,
+            "runtime_label": runtime_config.title,
+            "runtime_summary": runtime_config.summary,
             "ask_before_next_major_change": session["interaction_state"].get(
                 "ask_before_major_change",
                 True,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #828

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The workspace now has planner session APIs and a frontend conversation surface, but planner turns are still produced by a deterministic runnable. That is not the intended interactive planning product. The product goal is a trip-scoped LangChain planner that uses explicit application tools over persisted trip, inventory, ranking, budget, map, proposal, and policy state; preserves user-visible memory; and supports planning modes without hiding state transitions inside untyped chat behavior.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#826](https://github.com/stranske/trip-planner/issues/826)
- [#827](https://github.com/stranske/trip-planner/issues/827)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add the required LangChain runtime dependencies and configuration in `pyproject.toml` without breaking the default local `make runtime-check` path when model credentials are absent.
- [x] Replace or extend `trip_planner/app/services/planner.py` with a model-backed `PlannerConversationRunnable` selected when planner model configuration is present.
- [x] Keep a deterministic fallback runnable only for unconfigured local development, and expose that fallback state explicitly in the planner session payload and UI copy.
- [x] Implement a tool-calling planner loop that uses `trip_planner/app/services/planner_tools.py` and allowed app service functions instead of letting model output mutate workspace state directly.
- [x] Pass trip context, source-backed inventory state, ranked scenarios, budget posture, policy/proposal state, autonomy preferences, planner memory, and recent activity into the planner runtime as structured context.
- [x] Persist tool calls, tool results, planner summaries, checkpoints, selected planning mode, and user-visible memory through the existing planner action and memory persistence seams.
- [x] Add guardrails so unsupported tool names, malformed tool arguments, model errors, and missing runtime context produce visible planner errors or fallback messages rather than fabricated success.
- [x] Update `frontend/src/routes/WorkspacePage.tsx` and planner UI tests so the panel distinguishes model-backed, fallback, tool-running, and error states for the user.
- [x] Add backend tests with a fake chat model that proves the configured model path invokes app tools and records tool traces without requiring live model credentials in CI.
- [x] Update planner runtime docs to describe configuration, fallback behavior, tool boundaries, and verification commands.

#### Acceptance criteria
- [x] With a fake or configured chat model, submitting a planner turn goes through the LangChain-backed runnable rather than `DeterministicPlannerConversationRunnable`.
- [x] A planner turn asking to compare or revise options invokes at least one explicit app tool and persists the tool call and result in the planner session response.
- [x] Planner responses are grounded in persisted workspace state, source-backed inventory, scenario ranking, budget, policy, and proposal data rather than model-invented payloads.
- [x] When model configuration is absent, the planner still works through a clearly labeled deterministic fallback and the UI does not present it as the full interactive planner.
- [x] Malformed tool output, unknown tool names, and model/provider failures are covered by tests and produce visible degraded planner state.
- [x] Backend planner route tests and frontend workspace planner tests cover both model-backed and fallback states.
- [x] `make runtime-check` passes without live model credentials, and targeted fake-model planner tests prove the model-backed path.

<!-- auto-status-summary:end -->


