### PR TITLE
[codex] Follow up issue 807 review threads

### DIFF
--- a/frontend/src/components/planner/PlannerSidePanelSurface.tsx
+++ b/frontend/src/components/planner/PlannerSidePanelSurface.tsx
@@ -32,6 +32,7 @@ export function PlannerSidePanelSurface({
 }) {
   const mountRef = useRef<HTMLDivElement | null>(null);
   const controllerRef = useRef<PlannerSidePanelController | null>(null);
+  const latestStateRef = useRef(state);
   const [plannerMountNode, setPlannerMountNode] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -61,7 +62,10 @@ export function PlannerSidePanelSurface({
         return;
       }
 
-      controllerRef.current = plannerModule.renderPlannerSidePanel(plannerMount, state);
+      controllerRef.current = plannerModule.renderPlannerSidePanel(
+        plannerMount,
+        latestStateRef.current
+      );
     }
 
     void mountPlannerPanel();
@@ -76,6 +80,7 @@ export function PlannerSidePanelSurface({
   }, []);
 
   useEffect(() => {
+    latestStateRef.current = state;
     controllerRef.current?.replaceState(state);
   }, [state]);
 

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -865,6 +865,48 @@ describe("WorkspacePage", () => {
     expect(within(runtime).getByText("Fallback")).toBeInTheDocument();
   });
 
+  it("merges fetched planner session state into the workspace surface", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(workspacePayload),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+    mockedFetchPlannerSession.mockResolvedValueOnce({
+      ...plannerSessionPayload,
+      planner_panel_state: {
+        ...workspacePayload.planner_panel_state,
+        planner_behavior: {
+          ...workspacePayload.planner_panel_state.planner_behavior,
+          runtime_status: "ready",
+          runtime_mode: "model",
+          runtime_label: "Model-backed planner",
+          runtime_summary: "Planner model configuration is active for this workspace.",
+        },
+      },
+      activity_log: [
+        {
+          activity_event_id: "activity:session-refresh",
+          occurred_at: "2026-04-12T07:09:00+00:00",
+          event_kind: "planner_session_loaded",
+          summary: "Planner session loaded model-backed workspace context.",
+        },
+      ],
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Planner runtime state")).toBeInTheDocument();
+    });
+
+    const runtime = screen.getByLabelText("Planner runtime state");
+    await waitFor(() => {
+      expect(within(runtime).getByText("Model-backed planner")).toHaveClass(
+        "planner-runtime-pill--ready"
+      );
+    });
+    expect(screen.getByText("Planner session loaded model-backed workspace context.")).toBeInTheDocument();
+  });
+
   it("labels the planner panel as model-backed when runtime metadata reports a configured model", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -527,15 +527,12 @@ function WorkspacePageContent({
 
     fetchPlannerSession(workspace.trip_record.trip.trip_id)
       .then((nextPlannerSession) => {
-        if (isCancelled) {
+        if (isCancelled || plannerSessionLoadVersion.current !== loadVersion) {
           return;
         }
         startTransition(() => {
           setPlannerSession(nextPlannerSession);
           setCurrentWorkspace((current) => {
-            if (plannerSessionLoadVersion.current !== loadVersion) {
-              return current;
-            }
             if (
               current.session === nextPlannerSession.session &&
               current.planner_panel_state === nextPlannerSession.planner_panel_state &&
@@ -549,7 +546,7 @@ function WorkspacePageContent({
         });
       })
       .catch((error) => {
-        if (isCancelled) {
+        if (isCancelled || plannerSessionLoadVersion.current !== loadVersion) {
           return;
         }
         setPlannerConversationError(
@@ -557,7 +554,7 @@ function WorkspacePageContent({
         );
       })
       .finally(() => {
-        if (!isCancelled) {
+        if (!isCancelled && plannerSessionLoadVersion.current === loadVersion) {
           setPlannerConversationBusyLabel(null);
         }
       });

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -426,12 +426,25 @@ function mergePlannerSessionState(
   workspace: WorkspaceData,
   plannerSession: PlannerSessionResponse
 ): WorkspaceData {
+  const plannerActivityIds = new Set(
+    plannerSession.activity_log.map((entry) => entry.activity_event_id)
+  );
+  const sessionIncludesWorkspaceActivity = workspace.activity_log.every((entry) =>
+    plannerActivityIds.has(entry.activity_event_id)
+  );
+
   return {
     ...workspace,
     session: plannerSession.session,
-    planner_panel_state: plannerSession.planner_panel_state,
-    planner_memory: plannerSession.planner_memory,
-    activity_log: plannerSession.activity_log,
+    planner_panel_state: sessionIncludesWorkspaceActivity
+      ? plannerSession.planner_panel_state
+      : workspace.planner_panel_state,
+    planner_memory: sessionIncludesWorkspaceActivity
+      ? plannerSession.planner_memory
+      : workspace.planner_memory,
+    activity_log: sessionIncludesWorkspaceActivity
+      ? plannerSession.activity_log
+      : workspace.activity_log,
   };
 }
 

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useEffect, useState, type FormEvent } from "react";
+import { startTransition, useEffect, useRef, useState, type FormEvent } from "react";
 import { useLoaderData } from "react-router-dom";
 
 import type { TripRecord } from "../api/trips";
@@ -488,6 +488,7 @@ function WorkspacePageContent({
   const [budgetBusyLabel, setBudgetBusyLabel] = useState<string | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
   const [proposalBusyLabel, setProposalBusyLabel] = useState<string | null>(null);
+  const plannerSessionLoadVersion = useRef(0);
   const isCompactLayout = useCompactWorkspaceLayout();
   useEffect(() => {
     setCurrentWorkspace(workspace);
@@ -495,6 +496,9 @@ function WorkspacePageContent({
     setSelectedScenarioComparisonId(
       workspace.runtime_scenario_comparison.lead_scenario_id
     );
+  }, [workspace]);
+
+  useEffect(() => {
     setSelectedTripComparisonId(
       trips.find((trip) => trip.trip_id !== workspace.trip_record.trip.trip_id)?.trip_id ?? null
     );
@@ -502,6 +506,8 @@ function WorkspacePageContent({
 
   useEffect(() => {
     let isCancelled = false;
+    plannerSessionLoadVersion.current += 1;
+    const loadVersion = plannerSessionLoadVersion.current;
     setPlannerSession(null);
     setPlannerConversationError(null);
     setPlannerConversationBusyLabel("Loading planner conversation...");
@@ -513,6 +519,20 @@ function WorkspacePageContent({
         }
         startTransition(() => {
           setPlannerSession(nextPlannerSession);
+          setCurrentWorkspace((current) => {
+            if (plannerSessionLoadVersion.current !== loadVersion) {
+              return current;
+            }
+            if (
+              current.session === nextPlannerSession.session &&
+              current.planner_panel_state === nextPlannerSession.planner_panel_state &&
+              current.planner_memory === nextPlannerSession.planner_memory &&
+              current.activity_log === nextPlannerSession.activity_log
+            ) {
+              return current;
+            }
+            return mergePlannerSessionState(current, nextPlannerSession);
+          });
         });
       })
       .catch((error) => {
@@ -559,11 +579,10 @@ function WorkspacePageContent({
   async function handleDecisionAnswer(decisionId: string, choice: string) {
     setPlannerError(null);
     setPlannerBusyLabel("Saving planner decision...");
+    plannerSessionLoadVersion.current += 1;
     try {
       const nextWorkspace = await answerPlannerDecision(trip.trip_id, decisionId, choice);
-      startTransition(() => {
-        setCurrentWorkspace(nextWorkspace);
-      });
+      setCurrentWorkspace(nextWorkspace);
     } catch (error) {
       setPlannerError(error instanceof Error ? error.message : "Planner decision update failed.");
     } finally {
@@ -578,6 +597,7 @@ function WorkspacePageContent({
   ) {
     setPlannerError(null);
     setPlannerBusyLabel("Saving planner feedback...");
+    plannerSessionLoadVersion.current += 1;
     try {
       const nextWorkspace = await submitPlannerOptionFeedback(
         trip.trip_id,
@@ -590,9 +610,7 @@ function WorkspacePageContent({
           | "do_more_before_asking_again",
         decisionId
       );
-      startTransition(() => {
-        setCurrentWorkspace(nextWorkspace);
-      });
+      setCurrentWorkspace(nextWorkspace);
     } catch (error) {
       setPlannerError(error instanceof Error ? error.message : "Planner feedback update failed.");
     } finally {
@@ -610,6 +628,7 @@ function WorkspacePageContent({
 
     setPlannerConversationError(null);
     setPlannerConversationBusyLabel("Sending planner turn...");
+    plannerSessionLoadVersion.current += 1;
     try {
       const nextPlannerSession = await submitPlannerTurn(trip.trip_id, message);
       startTransition(() => {
@@ -737,6 +756,7 @@ function WorkspacePageContent({
           {plannerBusyLabel ? <p className="muted-copy">{plannerBusyLabel}</p> : null}
           {plannerError ? <p className="planner-inline-error">{plannerError}</p> : null}
           <PlannerSidePanelSurface
+            key={currentWorkspace.planner_panel_state === workspace.planner_panel_state ? "loader" : "workspace"}
             state={currentWorkspace.planner_panel_state}
             onDecisionAnswer={handleDecisionAnswer}
             onOptionFeedback={handleOptionFeedback}

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -7,7 +7,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 from trip_planner.app.main import create_app
+from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.app.services.policy import _tpp_trip_plan_payload
 from trip_planner.persistence.db import reset_database_state
+from trip_planner.persistence.models.trip import PersistedTrip
 from trip_planner.integrations.tpp import client as tpp_client_module
 
 
@@ -19,6 +22,31 @@ def _fixture_path(name: str) -> Path:
 
 def _load_fixture(name: str) -> dict:
     return json.loads(_fixture_path(name).read_text(encoding="utf-8"))
+
+
+def test_tpp_trip_plan_payload_falls_back_to_owner_profile_department() -> None:
+    record = PersistedTrip(
+        trip_id="trip-leisure-1",
+        user_id="user-1",
+        title="Leisure policy sync",
+        summary="Check fallback department.",
+        mode="leisure",
+        start_date="2026-05-04",
+        end_date="2026-05-06",
+        duration_days=3,
+        primary_regions=["Chicago"],
+        leisure_profile_id="profile:trip-leisure-1:leisure",
+        business_profile_id=None,
+    )
+    user = AuthenticatedUser(
+        user_id="user-1",
+        email="owner@example.test",
+        display_name="Policy Owner",
+    )
+
+    payload = _tpp_trip_plan_payload(record, user=user)
+
+    assert payload["department"] == "profile:trip-leisure-1:leisure"
 
 
 class _FakeHTTPResponse:

--- a/tests/integrations/test_tpp_contracts.py
+++ b/tests/integrations/test_tpp_contracts.py
@@ -5,8 +5,11 @@ import pytest
 
 from trip_planner.integrations.tpp import (
     BaseTPPIntegrationClient,
+    HTTPTPPIntegrationClient,
+    TPPContractError,
     TPPRequestEnvelope,
     TPPResponseEnvelope,
+    TPPRuntimeSettings,
 )
 
 
@@ -106,3 +109,40 @@ def test_base_client_rejects_mismatched_operation() -> None:
 
     with pytest.raises(ValueError, match="submit_proposal"):
         client.submit_proposal(request)
+
+
+def test_http_policy_payload_accepts_trip_plan_trip_id() -> None:
+    fixture = _load_fixture("policy_fetch_success.json")
+    fixture["request"].pop("trip_id", None)
+    fixture["request"]["payload"] = {
+        "trip_plan": {"trip_id": "trip-plan-id", "destination": "Chicago"}
+    }
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    client = HTTPTPPIntegrationClient(
+        TPPRuntimeSettings(
+            base_url="https://tpp.example.test",
+            access_token="token-123",
+            oidc_provider="okta",
+        )
+    )
+
+    payload = client._policy_request_payload(request)
+
+    assert payload["request"]["trip_id"] == "trip-plan-id"
+
+
+def test_http_policy_payload_names_all_trip_id_sources() -> None:
+    fixture = _load_fixture("policy_fetch_success.json")
+    fixture["request"].pop("trip_id", None)
+    fixture["request"]["payload"] = {"trip_plan": {"destination": "Chicago"}}
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    client = HTTPTPPIntegrationClient(
+        TPPRuntimeSettings(
+            base_url="https://tpp.example.test",
+            access_token="token-123",
+            oidc_provider="okta",
+        )
+    )
+
+    with pytest.raises(TPPContractError, match="payload.trip_plan.trip_id"):
+        client._policy_request_payload(request)

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -89,7 +89,7 @@ def _tpp_trip_plan_payload(record: PersistedTrip, *, user: AuthenticatedUser) ->
         "trip_id": record.trip_id,
         "traveler_name": user.display_name,
         "traveler_role": "business traveler",
-        "department": record.business_profile_id,
+        "department": _owner_profile_id(record),
         "destination": ", ".join(primary_regions),
         "destination_city": primary_regions[0],
         "departure_date": _required_tpp_trip_date(record.start_date, "start_date"),

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -226,7 +226,8 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         trip_id = payload.get("trip_id") or request.trip_id or trip_plan.get("trip_id")
         if trip_id in (None, ""):
             raise TPPContractError(
-                "Live policy sync requires request.trip_id or payload.trip_id."
+                "Live policy sync requires request.trip_id, payload.trip_id, "
+                "or payload.trip_plan.trip_id."
             )
         snapshot_request = self._strip_none_values(
             {


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #807

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The repo now contains a real HTTP transport seam for `Travel-Plan-Permission`,
but the current product posture still treats remote execution as a follow-on
integration. That leaves a gap between "we can call the service" and "the
planner workspace is usable when live policy execution is configured, slow, or
failing."

#### Tasks
- [ ] Finish wiring live execution paths in `trip_planner/app/services/policy.py` and `trip_planner/app/services/proposal.py` so configured environments use the real transport path end to end
- [ ] Persist submission, polling, and evaluation lifecycle updates so workspace reloads preserve the true remote execution state
- [ ] Add explicit frontend states for `pending`, `deferred`, `running`, `failed`, and `completed-with-follow-up` proposal execution outcomes
- [ ] Add UI affordances in the workspace for remediation details, approval-readiness messaging, and reoptimization triggers after live policy results
- [ ] Add integration-style backend tests for configured live transport request/response shaping and error handling
- [ ] Add frontend tests covering success, delayed execution, transport failure, and non-compliant result states

#### Acceptance criteria
- [ ] A configured environment can submit a proposal through the live TPP seam and surface the resulting execution status in the workspace
- [ ] Reloading the workspace preserves the latest stored execution and evaluation state
- [ ] The workspace UI exposes actionable non-happy-path states instead of generic failure copy
- [ ] Live transport failures and invalid upstream responses produce bounded user-visible errors and covered tests

<!-- auto-status-summary:end -->