### PR TITLE
Issue #827: derive runtime scenario profiles

### DIFF
--- a/tests/app/test_inventory.py
+++ b/tests/app/test_inventory.py
@@ -5,7 +5,9 @@ import pytest
 from fastapi.testclient import TestClient
 
 from trip_planner.app.main import create_app
+from trip_planner.app.services.inventory import _build_inventory_assembly_input
 from trip_planner.persistence.db import reset_database_state
+from trip_planner.persistence.models.trip import PersistedTrip
 
 _LEGACY_FIXTURE_BUNDLE_IDS = {
     "bundle-osaka-gateway",
@@ -48,6 +50,38 @@ def test_inventory_endpoint_returns_seeded_bundle_payload(client: TestClient) ->
     assert payload["bundles"][0]["bundle_id"] == "bundle-osaka-gateway"
     assert payload["summary"]["bundles"][1]["title"] == "Kyoto cultural anchor"
     assert payload["summary"]["bundles"][1]["option_count"] == 3
+
+
+def test_inventory_assembly_prefers_persisted_trip_context_over_seeded_trip_id() -> None:
+    persisted_trip = PersistedTrip(
+        trip_id="trip-leisure-kyoto-draft",
+        user_id="user-test",
+        title="Lisbon override for seeded ID",
+        summary="Persisted context should drive runtime inventory adapter selection.",
+        mode="leisure",
+        status="draft",
+        start_date="2026-07-01",
+        end_date="2026-07-05",
+        duration_days=5,
+        primary_regions=["Lisbon"],
+        traveler_party_kind="solo",
+        traveler_count=2,
+        traveler_notes="",
+    )
+
+    assembly_input = _build_inventory_assembly_input(
+        trip_id=persisted_trip.trip_id,
+        trip_mode=persisted_trip.mode,
+        persisted_trip=persisted_trip,
+        allow_fixture_fallback=True,
+    )
+
+    assert assembly_input.snapshot.adapter_id == "persisted-trip-source-inventory"
+    assert assembly_input.query.destination == "Lisbon"
+    assert assembly_input.query.traveler_segment == "solo"
+    assert assembly_input.record_payloads
+    assert assembly_input.snapshot.records[0].payload_type == "runtime_bundle_seed"
+    assert assembly_input.fixture_names == ()
 
 
 def test_inventory_endpoint_returns_not_found_for_unknown_trip(client: TestClient) -> None:

--- a/tests/app/test_inventory.py
+++ b/tests/app/test_inventory.py
@@ -5,7 +5,10 @@ import pytest
 from fastapi.testclient import TestClient
 
 from trip_planner.app.main import create_app
-from trip_planner.app.services.inventory import _build_inventory_assembly_input
+from trip_planner.app.services.inventory import (
+    _build_inventory_assembly_input,
+    assemble_inventory_bundles_for_trip,
+)
 from trip_planner.persistence.db import reset_database_state
 from trip_planner.persistence.models.trip import PersistedTrip
 
@@ -82,6 +85,24 @@ def test_inventory_assembly_prefers_persisted_trip_context_over_seeded_trip_id()
     assert assembly_input.record_payloads
     assert assembly_input.snapshot.records[0].payload_type == "runtime_bundle_seed"
     assert assembly_input.fixture_names == ()
+
+
+def test_seeded_trip_inventory_assembly_uses_record_payload_contract() -> None:
+    assembly_input = _build_inventory_assembly_input(
+        trip_id="trip-leisure-kyoto-draft",
+        trip_mode="leisure",
+        primary_regions=("Kyoto",),
+        duration_days=4,
+    )
+
+    assert assembly_input.snapshot.adapter_id == "persisted-trip-fixture-inventory"
+    assert assembly_input.record_payloads
+    assert assembly_input.record_payloads[0]["bundle_payloads"]
+
+    bundles = assemble_inventory_bundles_for_trip(assembly_input=assembly_input)
+
+    assert len(bundles) == 2
+    assert bundles[0].bundle_id == "bundle-osaka-gateway"
 
 
 def test_inventory_endpoint_returns_not_found_for_unknown_trip(client: TestClient) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -12,6 +12,7 @@ from trip_planner.app.services.feasibility import (
     build_feasibility_planner_outputs,
     build_feasibility_summary_payload,
 )
+from trip_planner.app.services.scenarios import _runtime_business_profile
 from trip_planner.options import InventoryBundle
 from trip_planner.persistence.db import get_session_factory, reset_database_state
 from trip_planner.persistence.models.activity import PersistedPlannerAction
@@ -30,6 +31,26 @@ _FIXTURE_ADAPTER_MARKERS = {
     "Kyoto ranked scenario workspace",
     "Client summit ranked scenarios",
 }
+
+
+def test_runtime_business_profile_normalizes_punctuated_regions_to_home_airports() -> None:
+    profile = _runtime_business_profile(
+        trip_title="Kyoto kickoff",
+        primary_regions=("Kyoto, Japan",),
+        traveler_party_kind="team",
+    )
+
+    assert profile.traveler_context.home_airport == "KIX"
+
+
+def test_runtime_business_profile_uses_valid_default_home_airport_for_unknown_regions() -> None:
+    profile = _runtime_business_profile(
+        trip_title="Regional kickoff",
+        primary_regions=("Remote client campus",),
+        traveler_party_kind=None,
+    )
+
+    assert profile.traveler_context.home_airport == "ORD"
 
 
 @pytest.fixture

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -24,6 +24,11 @@ _LEGACY_FIXTURE_BUNDLE_IDS = {
 _FIXTURE_ADAPTER_MARKERS = {
     "PersistedTripInventoryFixtureAdapter",
     "persisted-trip-fixture-inventory",
+    "urban-historian",
+    "client_meeting_profile",
+    "policy_round_trip_exception",
+    "Kyoto ranked scenario workspace",
+    "Client summit ranked scenarios",
 }
 
 
@@ -248,6 +253,7 @@ def test_workspace_endpoint_bootstraps_persisted_workspace_scaffolding_for_leisu
     assert payload["saved_scenarios"][0]["versions"][0]["title"].startswith("Lisbon")
     assert payload["inventory_summary"]["bundle_count"] > 0
     assert payload["scenario_search"]["scenarios"]
+    assert payload["scenario_search"]["title"] == "Lisbon weekend runtime scenarios"
     assert payload["scenario_search"]["source_refs"]
     assert payload["runtime_scenario_comparison"]["lead_scenario_id"].startswith("scenario:")
     assert payload["runtime_scenario_comparison"]["scenarios"][0]["scenario_id"].startswith(
@@ -359,6 +365,7 @@ def test_workspace_scenario_comparison_endpoint_returns_runtime_surface_for_pers
     assert response.status_code == 200
     payload = response.json()
     assert payload["lead_scenario_id"].startswith("scenario:")
+    assert payload["title"] == "Lisbon weekend runtime scenarios"
     assert payload["scenarios"][0]["scenario_id"].startswith("scenario:")
     assert payload["scenarios"][0]["option_count"] > 0
     assert payload["scenarios"][0]["route_sequence"]
@@ -396,6 +403,7 @@ def test_workspace_scenario_comparison_endpoint_returns_runtime_surface_for_pers
     assert response.status_code == 200
     payload = response.json()
     assert payload["lead_scenario_id"].startswith("scenario:")
+    assert payload["title"] == "Chicago kickoff ranked scenarios"
     assert payload["scenarios"][0]["scenario_id"].startswith("scenario:")
     assert payload["scenarios"][0]["status"] in {"recommended", "fallback", "alternative"}
     assert payload["scenarios"][0]["route_sequence"]

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -223,18 +223,27 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
                             details={"trip_id": self.trip_id, "trip_mode": self.trip_mode},
                         )
                     )
-        records = [
-            RawSourceRecord(
-                record_id=f"{query.query_id}:{index}",
-                entity_scope=query.entity_scope,
-                provider_entity_id=f"{self.trip_id}:{fixture_name}",
-                payload_type="fixture_bundle",
-                payload={"fixture_name": fixture_name, "trip_id": self.trip_id},
-                captured_at="2026-04-11T00:00:00Z",
-                metadata={"fixture_name": fixture_name},
+        records: list[RawSourceRecord] = []
+        for index, fixture_name in enumerate(fixture_names, start=1):
+            mixed_option = _load_mixed_option_fixture(fixture_name)
+            records.append(
+                RawSourceRecord(
+                    record_id=f"{query.query_id}:{index}",
+                    entity_scope=query.entity_scope,
+                    provider_entity_id=f"{self.trip_id}:{fixture_name}",
+                    payload_type="normalized_bundle_seed",
+                    payload={
+                        "fixture_name": fixture_name,
+                        "trip_id": self.trip_id,
+                        "bundle_payloads": [bundle.to_dict() for bundle in mixed_option.bundles],
+                    },
+                    captured_at="2026-04-11T00:00:00Z",
+                    metadata={
+                        "fixture_name": fixture_name,
+                        "bundle_count": str(len(mixed_option.bundles)),
+                    },
+                )
             )
-            for index, fixture_name in enumerate(fixture_names, start=1)
-        ]
         return RawSnapshot(
             snapshot_id=f"snapshot:{self.trip_id}:inventory",
             adapter_id=self.adapter_id,
@@ -845,22 +854,6 @@ def assemble_inventory_bundles_for_trip(
         for bundle_payload in bundle_payloads:
             if isinstance(bundle_payload, dict):
                 bundles.append(InventoryBundle.from_dict(bundle_payload))
-
-    if bundles:
-        return bundles
-
-    uses_seeded_fixture_ids = assembly_input.trip_id in _FIXTURE_BUNDLE_INPUTS
-    for fixture_index, fixture_name in enumerate(assembly_input.fixture_names, start=1):
-        mixed_option = _load_mixed_option_fixture(fixture_name)
-        for bundle_index, fixture_bundle in enumerate(mixed_option.bundles, start=1):
-            if uses_seeded_fixture_ids:
-                bundles.append(fixture_bundle)
-                continue
-            payload = fixture_bundle.to_dict()
-            payload["bundle_id"] = (
-                f"bundle-{assembly_input.trip_id}-runtime-{fixture_index}-{bundle_index}"
-            )
-            bundles.append(InventoryBundle.from_dict(payload))
     return bundles
 
 

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -99,6 +99,37 @@ class InventoryAssemblyInput:
     allow_fixture_fallback: bool
 
 
+@dataclass(frozen=True)
+class PersistedTripInventoryContext:
+    trip_id: str
+    trip_mode: str
+    start_date: str | None
+    end_date: str | None
+    trip_status: str | None
+    primary_regions: tuple[str, ...]
+    duration_days: int | None
+    trip_title: str | None
+    trip_summary: str | None
+    traveler_party_kind: str | None
+    traveler_count: int | None
+
+    @classmethod
+    def from_persisted_trip(cls, record: PersistedTrip) -> PersistedTripInventoryContext:
+        return cls(
+            trip_id=record.trip_id,
+            trip_mode=record.mode,
+            start_date=record.start_date,
+            end_date=record.end_date,
+            trip_status=record.status,
+            primary_regions=tuple(record.primary_regions),
+            duration_days=record.duration_days,
+            trip_title=record.title,
+            trip_summary=record.summary,
+            traveler_party_kind=record.traveler_party_kind,
+            traveler_count=record.traveler_count,
+        )
+
+
 class PersistedTripInventoryFixtureAdapter(SourceAdapter):
     """Expose fixture-backed inventory as an explicit adapter seam for persisted trips."""
 
@@ -298,6 +329,20 @@ class PersistedTripSourceInventoryAdapter(SourceAdapter):
         self.supported_entity_scopes = ("mixed",)
         self.supported_option_kinds = ("mixed", "lodging", "activity", "rail")
         self.capabilities = ("read_file", "supports_normalization_handoff")
+
+    @classmethod
+    def from_persisted_trip(cls, record: PersistedTrip) -> PersistedTripSourceInventoryAdapter:
+        return cls(
+            trip_id=record.trip_id,
+            trip_mode=record.mode,
+            primary_regions=tuple(record.primary_regions),
+            start_date=record.start_date,
+            end_date=record.end_date,
+            duration_days=record.duration_days,
+            trip_title=record.title,
+            traveler_party_kind=record.traveler_party_kind,
+            traveler_count=record.traveler_count,
+        )
 
     @staticmethod
     def _slug(value: str) -> str:
@@ -684,10 +729,27 @@ def _build_inventory_assembly_input(
     trip_summary: str | None = None,
     traveler_party_kind: str | None = None,
     traveler_count: int | None = None,
+    persisted_trip: PersistedTrip | None = None,
     allow_fixture_fallback: bool = True,
 ) -> InventoryAssemblyInput:
+    if persisted_trip is not None:
+        persisted_context = PersistedTripInventoryContext.from_persisted_trip(persisted_trip)
+        trip_id = persisted_context.trip_id
+        trip_mode = persisted_context.trip_mode
+        start_date = persisted_context.start_date
+        end_date = persisted_context.end_date
+        trip_status = persisted_context.trip_status
+        primary_regions = persisted_context.primary_regions
+        duration_days = persisted_context.duration_days
+        trip_title = persisted_context.trip_title
+        trip_summary = persisted_context.trip_summary
+        traveler_party_kind = persisted_context.traveler_party_kind
+        traveler_count = persisted_context.traveler_count
+
     fixture_seed = _FIXTURE_BUNDLE_INPUTS.get(trip_id)
-    use_fixture_seed = fixture_seed is not None and allow_fixture_fallback
+    use_fixture_seed = (
+        fixture_seed is not None and allow_fixture_fallback and persisted_trip is None
+    )
     query = SourceQuery(
         query_id=f"inventory-query:{trip_id}",
         entity_scope="mixed",
@@ -705,6 +767,7 @@ def _build_inventory_assembly_input(
         },
         notes=[
             "Persisted trip inventory assembly",
+            f"persisted_trip:{'yes' if persisted_trip is not None else 'no'}",
             f"trip_title:{trip_title or ''}",
             f"trip_summary:{(trip_summary or '')[:60]}",
             f"start_date:{start_date or ''}",
@@ -720,17 +783,20 @@ def _build_inventory_assembly_input(
             allow_fixture_fallback=allow_fixture_fallback,
         )
     else:
-        adapter = PersistedTripSourceInventoryAdapter(
-            trip_id=trip_id,
-            trip_mode=trip_mode,
-            primary_regions=primary_regions,
-            start_date=start_date,
-            end_date=end_date,
-            duration_days=duration_days,
-            trip_title=trip_title,
-            traveler_party_kind=traveler_party_kind,
-            traveler_count=traveler_count,
-        )
+        if persisted_trip is not None:
+            adapter = PersistedTripSourceInventoryAdapter.from_persisted_trip(persisted_trip)
+        else:
+            adapter = PersistedTripSourceInventoryAdapter(
+                trip_id=trip_id,
+                trip_mode=trip_mode,
+                primary_regions=primary_regions,
+                start_date=start_date,
+                end_date=end_date,
+                duration_days=duration_days,
+                trip_title=trip_title,
+                traveler_party_kind=traveler_party_kind,
+                traveler_count=traveler_count,
+            )
     snapshot = adapter.fetch_snapshot(query)
     handoff = adapter.build_handoff(snapshot)
     return InventoryAssemblyInput(
@@ -914,6 +980,7 @@ def get_inventory_payload(
     assembly_input = _build_inventory_assembly_input(
         trip_id=trip_id,
         trip_mode=trip_mode,
+        persisted_trip=record,
         primary_regions=primary_regions,
         start_date=record.start_date if record is not None else None,
         end_date=record.end_date if record is not None else None,

--- a/trip_planner/app/services/scenarios.py
+++ b/trip_planner/app/services/scenarios.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from copy import deepcopy
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+import unicodedata
 
 from trip_planner.business import (
     ApprovalTargets,
@@ -75,6 +77,10 @@ _SCENARIO_FIXTURE_SEEDS: dict[str, ScenarioFixtureSeed] = {
 _DEFAULT_LEISURE_FIXTURE_ID = "urban-historian"
 _DEFAULT_BUSINESS_PROFILE_FIXTURE = "client_meeting_profile.json"
 _DEFAULT_BUSINESS_CONSTRAINT_FIXTURE = "policy_round_trip_exception.json"
+_RUNTIME_LODGING_KEY = "lodging"
+_RUNTIME_TRANSPORT_KEY = "transport"
+_RUNTIME_ACTIVITIES_KEY = "activities"
+_RUNTIME_DEFAULT_HOME_AIRPORT = "ORD"
 _BUSINESS_HOME_AIRPORT_BY_REGION: dict[str, str] = {
     "austin": "AUS",
     "chicago": "ORD",
@@ -83,6 +89,23 @@ _BUSINESS_HOME_AIRPORT_BY_REGION: dict[str, str] = {
     "seattle": "SEA",
     "tokyo": "HND",
 }
+_RUNTIME_SPENDING_PRIORITIES: dict[str, float] = {
+    _RUNTIME_LODGING_KEY: 0.42,
+    _RUNTIME_TRANSPORT_KEY: 0.36,
+    _RUNTIME_ACTIVITIES_KEY: 0.5,
+}
+_RUNTIME_QUALITY_FLOORS: dict[str, str] = {
+    _RUNTIME_LODGING_KEY: "comfortable local base",
+    _RUNTIME_TRANSPORT_KEY: "low-friction transfers",
+}
+_RUNTIME_COMPARISON_REQUIREMENTS: dict[str, int] = {
+    _RUNTIME_LODGING_KEY: 1,
+    _RUNTIME_TRANSPORT_KEY: 1,
+}
+_RUNTIME_REQUIRED_RECEIPT_CATEGORIES = [_RUNTIME_LODGING_KEY, _RUNTIME_TRANSPORT_KEY]
+_RUNTIME_TRADEOFF_CONFIDENCE = 0.45
+_RUNTIME_TRADEOFF_SALIENCE = 0.35
+_RUNTIME_TRADEOFF_STABILITY = 0.4
 
 
 def _repo_root() -> Path:
@@ -109,7 +132,17 @@ def _default_scenario_title(
 
 
 def _slug(value: str) -> str:
-    return "-".join(part for part in value.lower().split() if part) or "destination"
+    normalized = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    return "-".join(re.findall(r"[a-z0-9]+", normalized.lower())) or "destination"
+
+
+def _home_airport_for_regions(primary_regions: tuple[str, ...]) -> str:
+    for region in primary_regions:
+        region_slug = _slug(region)
+        for candidate in (region_slug, *region_slug.split("-")):
+            if candidate in _BUSINESS_HOME_AIRPORT_BY_REGION:
+                return _BUSINESS_HOME_AIRPORT_BY_REGION[candidate]
+    return _RUNTIME_DEFAULT_HOME_AIRPORT
 
 
 def _runtime_leisure_profile(
@@ -141,18 +174,15 @@ def _runtime_leisure_profile(
     )
     budget_model = BudgetModel(
         total_budget_sensitivity=0.45,
-        spending_priorities={
-            "lodging": 0.42,
-            "transport": 0.36,
-            "activities": 0.5,
-        },
-        quality_floors={
-            "lodging": "comfortable local base",
-            "transport": "low-friction transfers",
-        },
+        spending_priorities=dict(_RUNTIME_SPENDING_PRIORITIES),
+        quality_floors=dict(_RUNTIME_QUALITY_FLOORS),
     )
     tradeoffs = {
-        key: TradeoffDimension(confidence=0.45, salience=0.35, stability=0.4)
+        key: TradeoffDimension(
+            confidence=_RUNTIME_TRADEOFF_CONFIDENCE,
+            salience=_RUNTIME_TRADEOFF_SALIENCE,
+            stability=_RUNTIME_TRADEOFF_STABILITY,
+        )
         for key in leisure_schema.TRADEOFF_DIMENSION_KEYS
     }
     tradeoffs["route_coherence_vs_eclectic_contrast"].value = 0.35
@@ -208,13 +238,12 @@ def _runtime_business_profile(
     primary_regions: tuple[str, ...],
     traveler_party_kind: str | None,
 ) -> BusinessTravelProfile:
-    region_key = _slug(primary_regions[0]) if primary_regions else ""
     purpose_summary = trip_title or ", ".join(primary_regions[:2]) or "Persisted business trip"
     return BusinessTravelProfile(
         traveler_context=TravelerContext(
             employee_type="employee",
             traveler_experience="occasional",
-            home_airport=_BUSINESS_HOME_AIRPORT_BY_REGION.get(region_key, "TBD"),
+            home_airport=_home_airport_for_regions(primary_regions),
             loyalty_programs=[],
             mobility_or_access_needs=[],
         ),
@@ -230,7 +259,7 @@ def _runtime_business_profile(
         ),
         vendor_constraints=VendorConstraints(
             approved_vendors=[],
-            comparison_requirements={"lodging": 1, "transport": 1},
+            comparison_requirements=dict(_RUNTIME_COMPARISON_REQUIREMENTS),
         ),
         schedule_requirements=ScheduleRequirements(
             arrival_buffer_preference="moderate",
@@ -249,7 +278,7 @@ def _runtime_business_profile(
             work_enablers=["reliable wifi"],
         ),
         documentation_requirements=DocumentationRequirements(
-            required_receipt_categories=["lodging", "transport"],
+            required_receipt_categories=list(_RUNTIME_REQUIRED_RECEIPT_CATEGORIES),
             justification_fields=["business purpose", "source-backed option rationale"],
             comparable_capture_required=True,
             booking_link_retention_required=True,

--- a/trip_planner/app/services/scenarios.py
+++ b/trip_planner/app/services/scenarios.py
@@ -7,8 +7,18 @@ from pathlib import Path
 from typing import Any
 
 from trip_planner.business import (
+    ApprovalTargets,
     BusinessTravelProfile,
+    ComfortFloors,
+    CostControls,
+    DocumentationRequirements,
+    ExceptionStrategy,
+    PolicyConstraints,
     PolicyConstraintSet,
+    ScheduleRequirements,
+    TravelerContext,
+    TripPurpose,
+    VendorConstraints,
     derive_business_planning_objectives,
 )
 from trip_planner.itinerary import (
@@ -17,7 +27,19 @@ from trip_planner.itinerary import (
     evaluate_bundle_feasibility,
 )
 from trip_planner.options import InventoryBundle
-from trip_planner.preferences import resolve_leisure_profile
+from trip_planner.preferences import (
+    Anchor,
+    BudgetModel,
+    DateWindow,
+    DurationBounds,
+    HardConstraints,
+    HybridFactor,
+    LeisurePreferenceProfile,
+    TradeoffDimension,
+    TripFrame,
+    resolve_leisure_profile,
+)
+from trip_planner.preferences import schema as leisure_schema
 from trip_planner.ranking import (
     BusinessRankingEngine,
     LeisureRankingEngine,
@@ -53,6 +75,14 @@ _SCENARIO_FIXTURE_SEEDS: dict[str, ScenarioFixtureSeed] = {
 _DEFAULT_LEISURE_FIXTURE_ID = "urban-historian"
 _DEFAULT_BUSINESS_PROFILE_FIXTURE = "client_meeting_profile.json"
 _DEFAULT_BUSINESS_CONSTRAINT_FIXTURE = "policy_round_trip_exception.json"
+_BUSINESS_HOME_AIRPORT_BY_REGION: dict[str, str] = {
+    "austin": "AUS",
+    "chicago": "ORD",
+    "kyoto": "KIX",
+    "lisbon": "LIS",
+    "seattle": "SEA",
+    "tokyo": "HND",
+}
 
 
 def _repo_root() -> Path:
@@ -76,6 +106,164 @@ def _default_scenario_title(
     subject = trip_title or ", ".join(primary_regions[:2]) or "Persisted trip"
     suffix = "ranked scenarios" if trip_mode == "business" else "runtime scenarios"
     return f"{subject} {suffix}"
+
+
+def _slug(value: str) -> str:
+    return "-".join(part for part in value.lower().split() if part) or "destination"
+
+
+def _runtime_leisure_profile(
+    *,
+    primary_regions: tuple[str, ...],
+    duration_days: int | None,
+    traveler_party_kind: str | None,
+) -> LeisurePreferenceProfile:
+    traveler_party = (
+        traveler_party_kind if traveler_party_kind in leisure_schema.TRAVELER_PARTIES else None
+    )
+    trip_frame = TripFrame(
+        duration_days=duration_days,
+        traveler_party=traveler_party,
+        trip_stage="first_visit",
+        regions_in_scope=list(primary_regions),
+    )
+    hard_constraints = HardConstraints(
+        date_window=DateWindow(),
+        duration_bounds=(
+            DurationBounds(
+                min_days=duration_days,
+                max_days=duration_days,
+            )
+            if duration_days is not None
+            else DurationBounds()
+        ),
+        must_include_places=list(primary_regions),
+    )
+    budget_model = BudgetModel(
+        total_budget_sensitivity=0.45,
+        spending_priorities={
+            "lodging": 0.42,
+            "transport": 0.36,
+            "activities": 0.5,
+        },
+        quality_floors={
+            "lodging": "comfortable local base",
+            "transport": "low-friction transfers",
+        },
+    )
+    tradeoffs = {
+        key: TradeoffDimension(confidence=0.45, salience=0.35, stability=0.4)
+        for key in leisure_schema.TRADEOFF_DIMENSION_KEYS
+    }
+    tradeoffs["route_coherence_vs_eclectic_contrast"].value = 0.35
+    tradeoffs["breadth_vs_depth"].value = -0.2 if duration_days and duration_days <= 4 else 0.1
+    tradeoffs["self_reliance_vs_convenience"].value = -0.25
+    tradeoffs["iconic_vs_discovery"].value = -0.15
+    if duration_days and duration_days <= 4:
+        tradeoffs["movement_vs_friction"].value = -0.25
+        tradeoffs["recovery_vs_intensity"].value = 0.25
+
+    anchors: dict[str, list[Anchor]] = {group: [] for group in leisure_schema.ANCHOR_GROUPS}
+    anchors["place_anchors"] = [
+        Anchor(
+            type="primary_region",
+            label=region,
+            strength=0.72,
+            flexibility=0.35,
+            notes="Derived from persisted trip primary region.",
+        )
+        for region in primary_regions[:3]
+    ]
+    anchors["quality_floor_anchors"] = [
+        Anchor(
+            type="workspace_quality_floor",
+            label="comparison-ready runtime inventory",
+            strength=0.62,
+            flexibility=0.45,
+            notes="Protects source-backed workspace review for arbitrary persisted trips.",
+        )
+    ]
+    return LeisurePreferenceProfile(
+        trip_frame=trip_frame,
+        hard_constraints=hard_constraints,
+        budget_model=budget_model,
+        tradeoff_dimensions=tradeoffs,
+        hybrid_factors={
+            "food": HybridFactor(mode="tradeoff", salience=0.35, tradeoff_role="atmosphere"),
+            "rest": HybridFactor(
+                mode="anchor", salience=0.45, anchor_strength=0.5, tradeoff_role="rhythm"
+            ),
+            "music": HybridFactor(mode="tradeoff", salience=0.2, tradeoff_role="atmosphere"),
+            "route_modes": HybridFactor(
+                mode="both", salience=0.45, anchor_strength=0.35, tradeoff_role="route_design"
+            ),
+        },
+        anchors=anchors,
+    )
+
+
+def _runtime_business_profile(
+    *,
+    trip_title: str | None,
+    primary_regions: tuple[str, ...],
+    traveler_party_kind: str | None,
+) -> BusinessTravelProfile:
+    region_key = _slug(primary_regions[0]) if primary_regions else ""
+    purpose_summary = trip_title or ", ".join(primary_regions[:2]) or "Persisted business trip"
+    return BusinessTravelProfile(
+        traveler_context=TravelerContext(
+            employee_type="employee",
+            traveler_experience="occasional",
+            home_airport=_BUSINESS_HOME_AIRPORT_BY_REGION.get(region_key, "TBD"),
+            loyalty_programs=[],
+            mobility_or_access_needs=[],
+        ),
+        trip_purpose=TripPurpose(
+            purpose_type="client_meeting",
+            business_justification=(f"Plan source-backed workspace options for {purpose_summary}."),
+            required_presence_windows=[],
+            trip_criticality="medium",
+        ),
+        policy_constraints=PolicyConstraints(
+            required_booking_channels=[],
+            documentation_rules=["retain runtime inventory provenance"],
+        ),
+        vendor_constraints=VendorConstraints(
+            approved_vendors=[],
+            comparison_requirements={"lodging": 1, "transport": 1},
+        ),
+        schedule_requirements=ScheduleRequirements(
+            arrival_buffer_preference="moderate",
+            meeting_protection_priority=0.7,
+            same_day_return_tolerance=0.4,
+            red_eye_tolerance=0.15,
+        ),
+        cost_controls=CostControls(
+            overall_cost_priority=0.55,
+            policy_compliance_priority=0.65,
+            employee_convenience_priority=0.55,
+        ),
+        comfort_floors=ComfortFloors(
+            lodging_needs=["quiet workspace-ready base"],
+            transport_needs=["low-risk arrival timing"],
+            work_enablers=["reliable wifi"],
+        ),
+        documentation_requirements=DocumentationRequirements(
+            required_receipt_categories=["lodging", "transport"],
+            justification_fields=["business purpose", "source-backed option rationale"],
+            comparable_capture_required=True,
+            booking_link_retention_required=True,
+        ),
+        approval_targets=ApprovalTargets(
+            needs_manager_approval=traveler_party_kind == "team",
+            approval_roles=["manager"] if traveler_party_kind == "team" else [],
+        ),
+        exception_strategy=ExceptionStrategy(
+            fallback_mode="nearest_compliant",
+            require_additional_comparables=False,
+            notes=["Prefer compliant runtime inventory before exception paths."],
+        ),
+    )
 
 
 def _bundle_ranked_results(
@@ -109,9 +297,11 @@ def _bundle_ranked_results(
                 route_sequence=list(
                     result.route_sequence
                     or bundle_map[
-                        result.target_option.option_id
-                        if result.target_option is not None
-                        else result.explanation_records[0].target_id
+                        (
+                            result.target_option.option_id
+                            if result.target_option is not None
+                            else result.explanation_records[0].target_id
+                        )
                     ].destination_ids
                 ),
                 score_breakdown=result.score_breakdown,
@@ -154,23 +344,21 @@ def build_workspace_scenario_search(
     scenario_objectives: object
 
     if trip_mode == "leisure":
-        leisure_fixture_id = (
-            fixture_seed.leisure_fixture_id
-            if fixture_seed is not None and fixture_seed.leisure_fixture_id is not None
-            else _DEFAULT_LEISURE_FIXTURE_ID
-        )
-        traveler_fixture = load_fixture_map()[leisure_fixture_id]
-        leisure_profile = deepcopy(traveler_fixture.profile)
-        if duration_days is not None:
-            leisure_profile.trip_frame.duration_days = duration_days
-        if primary_regions:
-            leisure_profile.trip_frame.regions_in_scope = list(primary_regions)
-        if traveler_party_kind in {"solo", "pair", "family", "friends"}:
-            leisure_profile.trip_frame.traveler_party = traveler_party_kind
-        resolved_profile = resolve_leisure_profile(
-            leisure_profile,
-            traveler_fixture.evidence,
-        )
+        if fixture_seed is not None:
+            leisure_fixture_id = fixture_seed.leisure_fixture_id or _DEFAULT_LEISURE_FIXTURE_ID
+            traveler_fixture = load_fixture_map()[leisure_fixture_id]
+            leisure_profile = deepcopy(traveler_fixture.profile)
+            evidence_records = traveler_fixture.evidence
+            ranking_title = fixture_seed.title
+        else:
+            leisure_profile = _runtime_leisure_profile(
+                primary_regions=primary_regions,
+                duration_days=duration_days,
+                traveler_party_kind=traveler_party_kind,
+            )
+            evidence_records = []
+            ranking_title = title
+        resolved_profile = resolve_leisure_profile(leisure_profile, evidence_records)
         leisure_objectives = derive_itinerary_objectives(
             resolved_profile,
             trip_id=trip_id,
@@ -181,28 +369,32 @@ def build_workspace_scenario_search(
             leisure_objectives,
             bundles,
             trip_id=trip_id,
-            title=fixture_seed.title if fixture_seed is not None else title,
+            title=ranking_title,
             feasibility_outputs=feasibility_outputs,
         )
         scenario_objectives = leisure_objectives
     else:
-        business_profile_fixture = (
-            fixture_seed.business_profile_fixture
-            if fixture_seed is not None and fixture_seed.business_profile_fixture is not None
-            else _DEFAULT_BUSINESS_PROFILE_FIXTURE
-        )
-        business_constraint_fixture = (
-            fixture_seed.business_constraint_fixture
-            if fixture_seed is not None and fixture_seed.business_constraint_fixture is not None
-            else _DEFAULT_BUSINESS_CONSTRAINT_FIXTURE
-        )
-        business_profile = BusinessTravelProfile.from_dict(
-            _load_json(_business_fixture_dir() / business_profile_fixture)
-        )
-        constraint_payload = _load_json(
-            _business_fixture_dir() / business_constraint_fixture
-        )
-        constraint_set = PolicyConstraintSet(**constraint_payload["constraint_set"])
+        if fixture_seed is not None:
+            business_profile_fixture = (
+                fixture_seed.business_profile_fixture or _DEFAULT_BUSINESS_PROFILE_FIXTURE
+            )
+            business_constraint_fixture = (
+                fixture_seed.business_constraint_fixture or _DEFAULT_BUSINESS_CONSTRAINT_FIXTURE
+            )
+            business_profile = BusinessTravelProfile.from_dict(
+                _load_json(_business_fixture_dir() / business_profile_fixture)
+            )
+            constraint_payload = _load_json(_business_fixture_dir() / business_constraint_fixture)
+            constraint_set = PolicyConstraintSet(**constraint_payload["constraint_set"])
+            ranking_title = fixture_seed.title
+        else:
+            business_profile = _runtime_business_profile(
+                trip_title=trip_title,
+                primary_regions=primary_regions,
+                traveler_party_kind=traveler_party_kind,
+            )
+            constraint_set = None
+            ranking_title = title
         business_objectives = derive_business_planning_objectives(
             business_profile,
             trip_id=trip_id,
@@ -213,7 +405,7 @@ def build_workspace_scenario_search(
             business_objectives,
             bundles,
             trip_id=trip_id,
-            title=fixture_seed.title if fixture_seed is not None else title,
+            title=ranking_title,
             constraint_set=constraint_set,
             feasibility_outputs=feasibility_outputs,
         )
@@ -224,7 +416,7 @@ def build_workspace_scenario_search(
         bundles=bundles,
         objectives=scenario_objectives,
         feasibility_outputs=feasibility_outputs,
-        title=fixture_seed.title if fixture_seed is not None else title,
+        title=ranking_title,
     )
 
 
@@ -278,9 +470,11 @@ def build_scenario_ranking_outputs(
                 "tags": [
                     "scenario-ranking",
                     scenario["scenario_summary"]["scenario_kind"],
-                    "recommended"
-                    if scenario["scenario_summary"]["recommended_for_selection"]
-                    else "fallback",
+                    (
+                        "recommended"
+                        if scenario["scenario_summary"]["recommended_for_selection"]
+                        else "fallback"
+                    ),
                 ],
                 "status": _scenario_output_status(scenario),
                 "highlights": [

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -562,6 +562,7 @@ def _build_workspace_inventory_inputs(
     record: PersistedTrip,
 ) -> tuple[list[InventoryBundle], dict[str, Any]]:
     assembly_input = _build_inventory_assembly_input(
+        persisted_trip=record,
         trip_id=record.trip_id,
         trip_mode=record.mode,
         start_date=record.start_date,
@@ -1086,6 +1087,7 @@ def _build_persisted_trip_workspace(
     }
     ordered_saved_scenarios = _ordered_saved_scenarios(saved_scenarios or [])
     inventory_assembly_input = _build_inventory_assembly_input(
+        persisted_trip=record,
         trip_id=record.trip_id,
         trip_mode=record.mode,
         start_date=record.start_date,


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #827

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The current runtime removed fixture fallback from the main persisted workspace path, but it did not replace that fallback with a real source-backed inventory path. That leaves arbitrary newly created trips in an empty or waiting state instead of giving them usable lodging, transport, activity, route, and scenario inputs. This issue closes the inventory gap for arbitrary persisted leisure and business trips without reintroducing seeded trip IDs, bundled demo fixtures, or hidden fallback success paths.

#### Tasks
- [ ] Add or update a persisted-trip source inventory adapter that derives query context from saved `PersistedTrip` records instead of seeded trip IDs or default demo profiles.
- [ ] Route the adapter through the existing source, provenance, normalization, candidate, and inventory bundle contracts instead of reading bundled option fixtures as the main path.
- [x] Update `trip_planner/app/services/inventory.py` so arbitrary persisted trips with primary regions and dates produce non-empty normalized inventory bundles with explicit provenance and adapter metadata.
- [x] Update `trip_planner/app/services/scenarios.py` so scenario search and ranking for arbitrary persisted trips consume the new inventory output and do not fall back to leisure or business fixture profiles.
- [x] Update `trip_planner/app/services/workspace.py` and the workspace route tests so newly created leisure and business trips render runtime inventory, scenario comparison, and bounded degradation state from the new source-backed path.
- [ ] Keep empty or partial workspace behavior only for genuinely missing inputs such as no destination, missing dates, or provider/source degradation, and surface those reasons in `inventory_summary.runtime_state`.
- [ ] Add regression tests that create at least one arbitrary leisure trip and one arbitrary business trip through persisted app routes, then assert inventory bundles, scenario comparison, source references, and route summaries are present without seeded trip IDs.
- [ ] Add regression tests that prove existing fixture bundle identifiers and `PersistedTripInventoryFixtureAdapter` are not used as the main workspace path for those arbitrary persisted trips.
- [ ] Update README or runtime docs if the source-backed local inventory posture changes setup, optional provider env vars, or degraded-state expectations.

#### Acceptance criteria
- [ ] Creating a new leisure trip with destination, dates, and traveler context produces a workspace with `inventory_summary.bundle_count > 0`, non-empty scenario comparison, and source/provenance metadata that is not labeled as fixture-backed inventory.
- [ ] Creating a new business trip with destination, dates, and business purpose produces a workspace with non-empty inventory, scenario comparison, budget/category totals, and business-relevant source/provenance metadata.
- [ ] Arbitrary trip workspace reads do not depend on hard-coded trip IDs such as `trip-leisure-kyoto-draft` or `trip-business-client-summit`.
- [ ] Scenario ranking for arbitrary persisted trips does not silently load the default leisure or business fixture profile when persisted traveler/business context is available.
- [ ] Missing destination or date inputs still produce a coherent partial workspace state with explicit `AdapterIssue` or runtime-state reasons instead of fake inventory.
- [ ] Targeted backend tests pass for inventory, workspace, scenario, and persisted-trip route coverage.
- [ ] `make runtime-check` passes after the implementation.

<!-- auto-status-summary:end -->