### PR TITLE
Issue #959: Define route-context map target contract

### DIFF
--- a/docs/contracts/route-context-map-target.md
+++ b/docs/contracts/route-context-map-target.md
@@ -1,0 +1,149 @@
+# Route-Context Map Target Contract
+
+This document is the source-of-truth contract for the **first map target** in the
+trip-planner application: the route-and-context map surface for the active
+scenario in the trip workspace. It consolidates the design rules in
+[maps-timeline-comparison-epic.md](../maps-timeline-comparison-epic.md) and
+[frontend-route-visualization.md](../frontend-route-visualization.md) into a
+fielded contract that a coding agent can implement against without re-reading
+the upstream design narrative.
+
+## Why this exists
+
+The map work was previously described across two design narratives plus a
+TypeScript surface module, with no single doc naming the first artifact, the
+required input shape, or the offline/fallback behavior in one place. Issue
+[#959](https://github.com/stranske/trip-planner/issues/959) called for that
+consolidation so subsequent map work has a single contract to extend.
+
+## First map target
+
+**Component:** [`frontend/src/components/maps/TripMap.tsx`](../../frontend/src/components/maps/TripMap.tsx)
+
+**Surface module:** [`frontend/src/components/maps/mapSurface.ts`](../../frontend/src/components/maps/mapSurface.ts)
+(canonical TypeScript types — `TripMapSurfaceModel`, `MapSurfaceProvider`,
+`RouteStop`, `RouteSegment`, `MapMarker`, `MapMarkerKind`,
+`MapProviderLoadState`).
+
+The first map target renders **route context for the active scenario** in the
+trip workspace. It does not render timeline structure, scenario comparison, or
+saved-trip overviews — those are separate surfaces in this epic
+([#698](https://github.com/stranske/trip-planner/issues/698) and
+[#700](https://github.com/stranske/trip-planner/issues/700) respectively) and
+are explicitly deferred from this contract.
+
+## Required input fields
+
+The map target consumes pre-shaped route data from the workspace payload
+produced by `trip_planner/app/services/workspace.py`. No browser-only planning
+state is permitted; every visualizable signal must come from the workspace
+contract below.
+
+### From `runtime_scenario_comparison.scenarios[*]`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `scenario_id` | string | yes | Selects the active scenario. |
+| `route_sequence` | string[] | yes | Ordered destination/anchor identifiers driving stop generation. |
+| `route_summary` | string | yes | Single-line route description shown when the provider adapter is unavailable. |
+| `route_segments` | object[] | yes when adapter is live | Pre-shaped segments (origin, destination, geometry hints, warning text). |
+| `metrics.estimated_total` | object \| null | optional | Currency-typed total surfaced under route summary. |
+| `metrics.travel_burden_score` | number \| null | optional | Drives the burden warning highlight. |
+| `policy_posture` | string | yes | Mirrored as the policy-posture chip on the map. |
+
+### From `feasibility_summary`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `assessments` | object[] | yes | Source of route-attention and bundle-readiness signals; map summarizes only — does not recompute. |
+| `summary_text` | string | optional | Used when no per-scenario summary is available. |
+
+### From `inventory_summary.bundles[*]`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `destination_names` | string[] | yes | Anchors the destination context list and stop labels. |
+| `bundle_id` | string | yes | Stable identifier for marker provenance. |
+
+### Trip-level context (workspace payload root)
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `trip.primary_regions` | string[] | yes | Drives the destination anchors when route_sequence is sparse. |
+| `policy_evaluation.posture` | string | optional | Used as the displayed policy posture if the active scenario lacks one. |
+
+## Provider and offline behavior
+
+The map target supports two provider modes, selected by environment
+configuration in the frontend bundle. The contract treats both as legitimate
+runtime states; neither is permitted to blank the workspace.
+
+| Mode | Trigger | UI behavior |
+|---|---|---|
+| **Live (`google-maps-js`)** | `VITE_GOOGLE_MAPS_BROWSER_API_KEY` set; provider loaded successfully | Renders the Google Maps JavaScript adapter with the pre-shaped route segments, stop markers, option markers, and selected-marker detail. |
+| **Fallback** | Key missing, provider load error, sparse route, or `VITE_GOOGLE_MAPS_PROVIDER_STATE=loading\|error` | Renders the bounded route schematic with the same route context (anchors, segments, markers, summaries, posture chip, feasibility highlights) using SVG/CSS only. |
+
+### Required fallback fields on `MapSurfaceProvider` (kind: `fallback`)
+
+| Field | Required | Notes |
+|---|---|---|
+| `kind` | yes | Literal `"fallback"`. |
+| `label` | yes | Human-readable name of the fallback surface. |
+| `status` | yes | One of `"fallback"`, `"misconfigured"`, `"provider-error"`, `"loading"`, `"sparse-route"`. |
+| `summary` | yes | Single-line explanation of why fallback is active (used in the surface header). |
+
+The contract requires fallback rendering to remain feature-equivalent for
+**route-context comprehension**: stop list, marker list, segment list, posture
+chip, and feasibility summary all visible. Provider-native interactions
+(zoom/pan/native-tile) are intentionally unavailable in fallback.
+
+## Test mode
+
+`make runtime-check` and `make runtime-smoke` validate the shipped map adapter
+seam and fallback states without requiring a real Google Maps key. The
+fallback surface is the **default test mode**; live adapter rendering requires
+an explicit env var. Tests must not assume live provider rendering and must
+assert against the documented fields produced by `buildTripMapSurfaceModel` in
+`mapSurface.ts`.
+
+## Deferred map features (non-goals for this contract)
+
+Each of the following is explicitly **out of scope** for the first map target.
+They are tracked as separate issues or future contract additions; do not
+extend the route-context map to absorb them without a new contract.
+
+- **Timeline-only views.** Owned by [#698](https://github.com/stranske/trip-planner/issues/698)
+  and rendered via `frontend/src/components/timeline/`.
+- **Scenario comparison maps.** Owned by [#700](https://github.com/stranske/trip-planner/issues/700);
+  comparison reuses route-context outputs but is a separate surface in
+  `frontend/src/components/workspace/`.
+- **Geography-first state model.** The route-context map must not introduce a
+  parallel browser-only model for trips, routes, or scenarios. All inputs come
+  from `trip_planner/app/` workspace contracts.
+- **Live route recomputation in the browser.** Movement scoring, meeting
+  feasibility, and route shape are produced by backend ranking/feasibility
+  services. The map summarizes only.
+- **Directions-iframe fallback.** When the live adapter is unavailable, the
+  fallback is the bounded route schematic, not a directions iframe.
+- **Real-time updates from external map providers.** Out of scope for the
+  workspace surface; would belong to an in-trip adjustment epic.
+- **Multiple simultaneous provider adapters.** Only `google-maps-js` is wired
+  today. Adding a second provider requires extending `MapSurfaceProvider`'s
+  discriminated union explicitly.
+
+## Validation
+
+This contract has two validation layers:
+
+1. **Existing TypeScript test:** [`frontend/src/components/maps/mapSurface.test.ts`](../../frontend/src/components/maps/mapSurface.test.ts)
+   exercises `buildTripMapSurfaceModel` against representative scenario inputs.
+2. **Backend payload schema test:** [`tests/contracts/test_route_context_map_target.py`](../../tests/contracts/test_route_context_map_target.py)
+   asserts the workspace payload produced by `trip_planner/app/services/workspace.py`
+   exposes the fields this contract requires, against a fixture in
+   [`tests/fixtures/maps/route_context_map_target.json`](../../tests/fixtures/maps/route_context_map_target.json).
+   The fixture is the canonical "what the map consumes" example for the
+   route-context surface.
+
+Any change that drops a field listed above must update both the contract here
+and the schema test, or the test fails with an explicit "missing required map
+target field" message.

--- a/tests/contracts/test_route_context_map_target.py
+++ b/tests/contracts/test_route_context_map_target.py
@@ -1,0 +1,206 @@
+"""Schema test for the route-context map target contract.
+
+Validates the canonical fixture in
+``tests/fixtures/maps/route_context_map_target.json`` against the documented
+contract in ``docs/contracts/route-context-map-target.md`` (issue #959).
+
+If the workspace payload schema drops a documented field, this test fails with
+an explicit "missing required map target field" message naming the missing
+field. If a fallback provider field shape changes incompatibly, the test
+fails likewise.
+
+Run with::
+
+    pytest -q tests/contracts/test_route_context_map_target.py
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "maps"
+    / "route_context_map_target.json"
+)
+
+
+def _load_fixture() -> dict:
+    return json.loads(_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+# ---- Documented required field sets (mirrored from the contract doc) ----
+
+_REQUIRED_TRIP_FIELDS = ("trip_id", "primary_regions")
+_REQUIRED_FEASIBILITY_FIELDS = ("assessments",)
+_REQUIRED_BUNDLE_FIELDS = ("bundle_id", "destination_names")
+_REQUIRED_SCENARIO_FIELDS = (
+    "scenario_id",
+    "route_sequence",
+    "route_summary",
+    "policy_posture",
+)
+_REQUIRED_SEGMENT_FIELDS = ("id", "fromLabel", "toLabel", "x1", "y1", "x2", "y2")
+
+
+def _missing(payload: dict, fields: tuple[str, ...], label: str) -> list[str]:
+    return [f"{label}.{name}" for name in fields if name not in payload]
+
+
+def test_route_context_map_target_fixture_exposes_required_fields() -> None:
+    """The canonical fixture carries every field the contract requires."""
+    fixture = _load_fixture()
+    missing: list[str] = []
+
+    trip = fixture.get("trip") or {}
+    missing += _missing(trip, _REQUIRED_TRIP_FIELDS, "trip")
+
+    feasibility = fixture.get("feasibility_summary") or {}
+    missing += _missing(feasibility, _REQUIRED_FEASIBILITY_FIELDS, "feasibility_summary")
+
+    bundles = (fixture.get("inventory_summary") or {}).get("bundles") or []
+    assert bundles, (
+        "Fixture is missing inventory_summary.bundles. The route-context map "
+        "target requires at least one bundle to anchor destination context per "
+        "docs/contracts/route-context-map-target.md."
+    )
+    for index, bundle in enumerate(bundles):
+        missing += _missing(bundle, _REQUIRED_BUNDLE_FIELDS, f"bundles[{index}]")
+
+    scenarios = (fixture.get("runtime_scenario_comparison") or {}).get("scenarios") or []
+    assert scenarios, (
+        "Fixture is missing runtime_scenario_comparison.scenarios. The "
+        "route-context map target requires at least one scenario to render."
+    )
+    for index, scenario in enumerate(scenarios):
+        missing += _missing(scenario, _REQUIRED_SCENARIO_FIELDS, f"scenarios[{index}]")
+        for seg_index, segment in enumerate(scenario.get("route_segments") or []):
+            missing += _missing(
+                segment,
+                _REQUIRED_SEGMENT_FIELDS,
+                f"scenarios[{index}].route_segments[{seg_index}]",
+            )
+
+    assert not missing, (
+        f"Route-context map target fixture is missing required fields: {missing}. "
+        f"Required by docs/contracts/route-context-map-target.md. Either restore "
+        f"the fields in the fixture, or update the contract doc and this test "
+        f"if the requirement is intentionally being relaxed."
+    )
+
+
+def test_route_context_map_target_segments_use_normalized_coordinates() -> None:
+    """Segments use 0-1 normalized coordinates so the fallback schematic renders.
+
+    The contract specifies that fallback rendering must remain feature-
+    equivalent without provider-native tiles. The route segments therefore
+    carry normalized geometry (x1/y1/x2/y2 in [0, 1]) rather than provider-
+    specific projections, so the SVG/CSS fallback can position them directly.
+    """
+    fixture = _load_fixture()
+    out_of_range: list[str] = []
+
+    for scenario in fixture["runtime_scenario_comparison"]["scenarios"]:
+        for segment in scenario.get("route_segments") or []:
+            for axis in ("x1", "y1", "x2", "y2"):
+                value = segment.get(axis)
+                if value is None or not (0.0 <= float(value) <= 1.0):
+                    out_of_range.append(
+                        f"scenario={scenario.get('scenario_id')!r} "
+                        f"segment={segment.get('id')!r} {axis}={value!r}"
+                    )
+
+    assert not out_of_range, (
+        "Route segments must use normalized 0..1 coordinates so the fallback "
+        f"map schematic can render without provider tiles. Out-of-range: {out_of_range}. "
+        "See docs/contracts/route-context-map-target.md."
+    )
+
+
+def test_route_context_map_target_segments_emit_optional_warning_field() -> None:
+    """The contract reserves ``warning`` (string|null) on each segment.
+
+    The fallback schematic uses this to highlight policy-debt segments. Tests
+    enforce that even null is present so consumers can rely on the key existing.
+    """
+    fixture = _load_fixture()
+    for scenario in fixture["runtime_scenario_comparison"]["scenarios"]:
+        for segment in scenario.get("route_segments") or []:
+            assert "warning" in segment, (
+                f"Segment {segment.get('id')!r} on scenario "
+                f"{scenario.get('scenario_id')!r} is missing the documented "
+                "``warning`` field (may be null). The fallback schematic "
+                "consumes this field to render policy-exception highlights."
+            )
+            warning_value = segment["warning"]
+            assert warning_value is None or isinstance(warning_value, str), (
+                f"Segment {segment.get('id')!r} warning value is not a string|null: "
+                f"{warning_value!r}."
+            )
+
+
+def test_route_context_map_target_scenarios_carry_metrics_estimated_total_currency_when_present() -> None:
+    """``metrics.estimated_total`` is optional, but if present must carry currency + amounts.
+
+    The map surface formats this via Intl.NumberFormat. A scenario carrying a
+    non-null estimated_total without a currency code would crash the formatter,
+    so the contract requires the currency field whenever the object is present.
+    """
+    fixture = _load_fixture()
+    for scenario in fixture["runtime_scenario_comparison"]["scenarios"]:
+        metrics = scenario.get("metrics") or {}
+        total = metrics.get("estimated_total")
+        if total is None:
+            continue
+        for required in ("currency", "typical_amount"):
+            assert required in total, (
+                f"scenario={scenario.get('scenario_id')!r} "
+                f"metrics.estimated_total is missing required field {required!r}. "
+                "The route-context map formatter requires both fields whenever the "
+                "estimated_total object is non-null. See "
+                "docs/contracts/route-context-map-target.md."
+            )
+
+
+@pytest.mark.parametrize(
+    "deferred_feature",
+    [
+        "timeline_only_view",
+        "scenario_comparison_map",
+        "geography_first_state_model",
+        "directions_iframe_fallback",
+    ],
+)
+def test_route_context_map_target_does_not_absorb_deferred_features(
+    deferred_feature: str,
+) -> None:
+    """The fixture must not include deferred features (sanity guard).
+
+    Each deferred feature is owned by a separate epic/issue per the contract.
+    If a future change starts hanging timeline blocks, comparison cards, or
+    iframe URLs off the map fixture, this test fails — that is the signal to
+    extend a separate contract rather than overload route-context.
+    """
+    fixture = _load_fixture()
+    serialized = json.dumps(fixture).lower()
+
+    forbidden_substrings = {
+        "timeline_only_view": ("timeline_blocks", "timeline_only"),
+        "scenario_comparison_map": ("comparison_card", "scenario_comparison_map"),
+        "geography_first_state_model": ("browser_geography_state",),
+        "directions_iframe_fallback": ("iframe", "directions_iframe"),
+    }[deferred_feature]
+
+    for substring in forbidden_substrings:
+        assert substring not in serialized, (
+            f"Route-context map target fixture contains '{substring}', which "
+            f"belongs to the deferred feature '{deferred_feature}'. Per "
+            "docs/contracts/route-context-map-target.md, deferred features "
+            "must live in their own contract surfaces (timeline, comparison, "
+            "etc.) rather than be absorbed into the route-context fixture."
+        )

--- a/tests/fixtures/maps/route_context_map_target.json
+++ b/tests/fixtures/maps/route_context_map_target.json
@@ -1,0 +1,87 @@
+{
+  "_doc": "Canonical fixture for the route-context map target contract (issue #959).\nMirrors the workspace payload subset that frontend/src/components/maps/TripMap.tsx consumes. See docs/contracts/route-context-map-target.md.",
+  "trip": {
+    "trip_id": "trip-route-context-001",
+    "primary_regions": ["Chicago", "Madison"]
+  },
+  "policy_evaluation": {
+    "posture": "approval-ready"
+  },
+  "feasibility_summary": {
+    "summary_text": "All scenarios meet baseline meeting-timing constraints.",
+    "assessments": [
+      {
+        "scenario_id": "scenario-best-approval",
+        "route_attention": "low",
+        "bundle_readiness": "ready",
+        "notes": ["Direct ORD-MSN segment under burden cap."]
+      }
+    ]
+  },
+  "inventory_summary": {
+    "bundles": [
+      {
+        "bundle_id": "bundle-001",
+        "destination_names": ["Chicago", "Madison"]
+      }
+    ]
+  },
+  "runtime_scenario_comparison": {
+    "scenarios": [
+      {
+        "scenario_id": "scenario-best-approval",
+        "policy_posture": "approval-ready",
+        "route_sequence": ["dest-city-chicago", "dest-city-madison"],
+        "route_summary": "ORD → MSN with direct rental and policy-aligned lodging.",
+        "route_segments": [
+          {
+            "id": "seg-1",
+            "fromLabel": "Chicago",
+            "toLabel": "Madison",
+            "x1": 0.18,
+            "y1": 0.42,
+            "x2": 0.62,
+            "y2": 0.31,
+            "warning": null
+          }
+        ],
+        "metrics": {
+          "estimated_total": {
+            "currency": "USD",
+            "typical_amount": 1840.0,
+            "min_amount": 1820.0,
+            "max_amount": 1880.0
+          },
+          "travel_burden_score": 0.32
+        }
+      },
+      {
+        "scenario_id": "scenario-faster-with-debt",
+        "policy_posture": "approval-debt",
+        "route_sequence": ["dest-city-chicago", "dest-city-madison"],
+        "route_summary": "Premium fare with policy exception path.",
+        "route_segments": [
+          {
+            "id": "seg-1b",
+            "fromLabel": "Chicago",
+            "toLabel": "Madison",
+            "x1": 0.18,
+            "y1": 0.42,
+            "x2": 0.62,
+            "y2": 0.31,
+            "warning": "Requires exception approval before booking."
+          }
+        ],
+        "metrics": {
+          "estimated_total": {
+            "currency": "USD",
+            "typical_amount": 2410.0,
+            "min_amount": 2380.0,
+            "max_amount": 2480.0
+          },
+          "travel_burden_score": 0.18
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:959 -->
> **Source:** Issue #959

Closes #959

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The map work has remained ambiguous. Agents need to know whether they are building a route map, destination comparison, timeline, option explorer, or workspace visualization before implementing UI or data contracts.

#### Tasks
- [ ] Audit route visualization and maps/timeline docs plus existing frontend route/map code.
- [ ] Choose the first map target and explicitly defer other map ideas.
- [ ] Define the data contract consumed by the map component: coordinates, route segments, itinerary events, and provenance fields.
- [ ] Define offline/test mode versus real map provider behavior.
- [ ] Add fixture/schema tests or docs examples validating the contract.

#### Acceptance criteria
- [ ] A coding agent can identify the exact first map artifact/component to build.
- [ ] The map contract includes required fields and offline/test behavior.
- [ ] Deferred map features are listed as non-goals or future issues.
- [ ] A fixture or schema test validates the target map payload.

**Head SHA:** 42d6a73f275367a94bafc59b0f2f1b191b77e5b0
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/25052348841) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/25052348755) |
<!-- auto-status-summary:end -->