### PR TITLE
Hotfix: mark deferred-implementation acceptance tests as xfail

### DIFF
--- a/tests/planner/test_planner_turn_acceptance.py
+++ b/tests/planner/test_planner_turn_acceptance.py
@@ -31,6 +31,14 @@ import inspect
 import pytest
 
 
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Runtime-planning-services-epic #677 (children #690-#693) outputs are "
+        "not yet wired through the planner-turn → workspace path. Expected to "
+        "pass once the contract is implemented; tracked under the parent epic."
+    ),
+)
 def test_planner_turn_surfaces_runtime_planning_services_outputs() -> None:
     """Runtime-planning-services-epic #677 (children #690-#693) acceptance contract.
 
@@ -66,6 +74,15 @@ def test_planner_turn_surfaces_runtime_planning_services_outputs() -> None:
     )
 
 
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Live TPP approval-flow entry points (request_approval / "
+        "poll_approval_status) are not yet wired into "
+        "trip_planner.integrations.tpp. Expected to pass once the live TPP "
+        "execution/reoptimization epic implements the round-trip."
+    ),
+)
 def test_tpp_approval_flow_round_trip_from_planner_turn() -> None:
     """Live-tpp-execution-reoptimization-epic acceptance contract.
 
@@ -101,6 +118,14 @@ def test_tpp_approval_flow_round_trip_from_planner_turn() -> None:
         )
 
 
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Maps-timeline-comparison-epic #679 (child #699) typed route-context "
+        "contract is not yet exported from trip_planner.contracts. Expected "
+        "to pass once the route-context map surface lands."
+    ),
+)
 def test_map_target_uses_typed_route_context_contract() -> None:
     """Maps-timeline-comparison-epic #679 (child #699) acceptance contract.
 


### PR DESCRIPTION
## Hotfix — main is currently red

After [#1005](https://github.com/stranske/trip-planner/pull/1005) merged, the three failing acceptance tests in \`tests/planner/test_planner_turn_acceptance.py\` started breaking the Python 3.12 / 3.13 CI jobs on main and on every subsequent PR. The tests are intentionally failing (they assert design contracts that haven't been implemented yet), but unmarked failures fail the suite.

The issue body for #956 explicitly allows expected-failing tests with linked implementation issues:

> "Tests run through the documented local command or are marked expected-failing with linked implementation issues."

I should have added the markers in #1005. This PR does that.

## What changes

\`tests/planner/test_planner_turn_acceptance.py\` — adds \`@pytest.mark.xfail(strict=False, reason=...)\` to each of the three tests:

| Test | Linked epic |
|---|---|
| \`test_planner_turn_surfaces_runtime_planning_services_outputs\` | runtime-planning-services-epic #677 (children #690-#693) |
| \`test_tpp_approval_flow_round_trip_from_planner_turn\` | live-tpp-execution-reoptimization-epic |
| \`test_map_target_uses_typed_route_context_contract\` | maps-timeline-comparison-epic #679 (child #699) |

\`strict=False\` means each test reports as XFAILED (expected failure) when the contract isn't implemented, but if the contract lands, the test will report as XPASSED (unexpected pass) — a clear signal to remove the marker.

## Local validation

\`\`\`
pytest -q tests/planner/test_planner_turn_acceptance.py
\`\`\`

Result: **3 xfailed in 0.52s** (exit code 0).

## Why this happened

When I authored #1005 I tested locally with the file as the only argument to pytest, which exits non-zero on failure but doesn't visibly impact CI. CI runs the full suite, and unmarked failures fail the suite. The xfail marker is the documented way to encode "expected to fail until the implementation lands" without breaking CI.

## Non-goals

- No change to test logic — the contracts asserted are identical
- No change to other test files