### PR TITLE
Claude bootstrap for #961

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: runtime-backend runtime-frontend runtime-dev runtime-check runtime-smoke runtime-production-check runtime-preview-smoke runtime-full-product-check full-product-check
+.PHONY: install runtime-backend runtime-frontend runtime-dev runtime-check runtime-smoke runtime-production-check runtime-preview-smoke runtime-full-product-check full-product-check
+
+install:
+	python -m venv .venv
+	.venv/bin/pip install -e ".[dev]"
+	npm --prefix frontend install
 
 runtime-backend:
 	python -m uvicorn trip_planner.app.main:app --reload --host 127.0.0.1 --port 8000

--- a/README.md
+++ b/README.md
@@ -101,21 +101,24 @@ python scripts/build_html.py
 
 ## App Runtime Quick Start
 
-Create and activate a repo-local virtualenv first:
+Install all backend and frontend dependencies once from a clean checkout:
+
+```bash
+make install
+```
+
+This creates `.venv`, installs the Python dev extras into it, and installs `frontend/node_modules`. No manual venv activation is needed before running `make runtime-check` afterward — the script detects `.venv` automatically.
+
+If you prefer to manage the virtualenv yourself:
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-```
-
-Then install the backend and frontend dependencies once:
-
-```bash
 python -m pip install -e ".[dev]"
 npm --prefix frontend install
 ```
 
-`make runtime-check` and `make runtime-smoke` assume those installs have already completed inside the active `.venv` and `frontend/node_modules`. If either the backend dev extras or frontend dependencies are missing, the check script exits early and points back to these commands.
+`make runtime-check` and `make runtime-smoke` require those installs to have completed. If either the backend dev extras or frontend dependencies are missing, the check script exits early with instructions pointing back to `make install`.
 
 Repo dependency layout:
 

--- a/agents/claude-961.md
+++ b/agents/claude-961.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for claude on issue #961 -->

--- a/docs/local-testing-plan.md
+++ b/docs/local-testing-plan.md
@@ -16,7 +16,7 @@ That baseline is still required, but it is not the whole production-readiness st
 
 ## Canonical Local Sequence
 
-Run these commands from the repo root after activating `.venv` and installing `frontend/node_modules`:
+Run `make install` once from a clean checkout to create `.venv` and install all deps, then run these commands from the repo root:
 
 ```bash
 make runtime-production-check

--- a/scripts/check_full_stack_runtime.sh
+++ b/scripts/check_full_stack_runtime.sh
@@ -3,6 +3,14 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Use .venv if present (created by `make install`), otherwise fall back to $PATH python.
+if [ -x "${repo_root}/.venv/bin/python" ]; then
+  PYTHON="${repo_root}/.venv/bin/python"
+else
+  PYTHON="python"
+fi
+
 backend_host="${BACKEND_HOST:-127.0.0.1}"
 backend_port="${BACKEND_PORT:-8000}"
 backend_url="http://${backend_host}:${backend_port}"
@@ -12,12 +20,19 @@ backend_pid=""
 
 prereq_failure() {
   cat >&2 <<'EOF'
-Full-stack runtime checks require an active virtualenv plus both dependency installs:
+Full-stack runtime checks require a virtualenv and both dependency installs.
+Run once from the repo root:
+
+  make install
+
+Or manually:
   1. python -m venv .venv && source .venv/bin/activate
   2. python -m pip install -e ".[dev]"
   3. npm --prefix frontend install
 
 Then rerun `make runtime-check` (or `make runtime-smoke`).
+`make install` creates .venv and installs both backend and frontend deps;
+no manual activation is needed before running make runtime-check afterward.
 These commands validate the local FastAPI + Vite MVP in this repo; they do not
 prove live Google Maps rendering or remote Travel-Plan-Permission transport.
 Do not create a repo-root `node_modules/`; local frontend tooling should live
@@ -29,8 +44,8 @@ EOF
 }
 
 require_backend_prereqs() {
-  if ! python -m pytest --version >/dev/null 2>&1; then
-    echo "Missing backend test dependencies (`python -m pytest` is unavailable)." >&2
+  if ! "${PYTHON}" -m pytest --version >/dev/null 2>&1; then
+    echo "Missing backend test dependencies (pytest is unavailable under ${PYTHON})." >&2
     prereq_failure
   fi
 }
@@ -62,7 +77,7 @@ cleanup() {
 }
 
 wait_for_backend() {
-  python - "${backend_url}" <<'PY'
+  "${PYTHON}" - "${backend_url}" <<'PY'
 import json
 import sys
 import time
@@ -92,12 +107,12 @@ require_backend_prereqs
 require_frontend_prereqs
 
 if [ "${smoke_only}" != "true" ]; then
-  python -m pytest tests/app/test_health.py tests/app/test_workspace.py
+  "${PYTHON}" -m pytest tests/app/test_health.py tests/app/test_workspace.py
   npm --prefix frontend test
   npm --prefix frontend run build
 fi
 
-python -m uvicorn trip_planner.app.main:app \
+"${PYTHON}" -m uvicorn trip_planner.app.main:app \
   --host "${backend_host}" \
   --port "${backend_port}" \
   >"${backend_log}" 2>&1 &

--- a/trip_planner.egg-info/PKG-INFO
+++ b/trip_planner.egg-info/PKG-INFO
@@ -6,7 +6,7 @@ Requires-Dist: anyio==4.13.0
 Requires-Dist: fastapi==0.136.0
 Requires-Dist: langchain-core==1.3.0
 Requires-Dist: langchain-openai==1.1.14
-Requires-Dist: starlette==0.47.3
+Requires-Dist: starlette==1.0.0
 Requires-Dist: sqlalchemy==2.0.49
 Requires-Dist: uvicorn==0.44.0
 Provides-Extra: dev

--- a/trip_planner.egg-info/SOURCES.txt
+++ b/trip_planner.egg-info/SOURCES.txt
@@ -1,10 +1,12 @@
 README.md
 pyproject.toml
 scripts/__init__.py
+scripts/aggregate_agent_metrics.py
 scripts/autopilot_metrics_collector.py
 scripts/autopilot_step_timer.py
 scripts/build_html.py
 scripts/calc_penalty.py
+scripts/check_full_product_verification.py
 scripts/ci_coverage_delta.py
 scripts/ci_history.py
 scripts/ci_metrics.py

--- a/trip_planner.egg-info/requires.txt
+++ b/trip_planner.egg-info/requires.txt
@@ -3,7 +3,7 @@ anyio==4.13.0
 fastapi==0.136.0
 langchain-core==1.3.0
 langchain-openai==1.1.14
-starlette==0.47.3
+starlette==1.0.0
 sqlalchemy==2.0.49
 uvicorn==0.44.0
 


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
A repo is not ready for agents if the documented runtime path depends on a stale or broken local `.venv`. `make runtime-check` should be reproducible from a clean checkout.

#### Tasks
- [x] Inspect `Makefile`, `pyproject.toml`, lock/dependency files, and local testing docs.
- [x] Ensure `.venv` is ignored/untracked and not required before setup.
- [x] Update `make runtime-check` or prerequisites to create/use the documented environment reliably.
- [x] Run the documented clean-checkout path after removing stale environment state.

#### Acceptance criteria
- [x] `make runtime-check` succeeds from a clean checkout after documented setup.
- [x] The repo does not rely on committed `.venv` contents.
- [x] Failure messages identify missing dependencies or setup steps clearly.
- [x] Docs and Makefile agree on the runtime-check command.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

A repo is not ready for agents if the documented runtime path depends on a stale or broken local `.venv`. `make runtime-check` should be reproducible from a clean checkout.

## Scope

- Repair local/runtime setup instructions and scripts so `make runtime-check` works from a clean checkout.
- Remove dependence on the current broken `.venv` state.
- Document how agents should rebuild local envs safely.

## Non-Goals

- Do not make unrelated visual redesigns.
- Do not use live external travel providers in required tests.
- Do not move Workflows automation maintenance into trip-planner issues.

## Tasks

- [x] Inspect `Makefile`, `pyproject.toml`, lock/dependency files, and local testing docs.
- [x] Ensure `.venv` is ignored/untracked and not required before setup.
- [x] Update `make runtime-check` or prerequisites to create/use the documented environment reliably.
- [x] Run the documented clean-checkout path after removing stale environment state.

## Acceptance Criteria

- [x] `make runtime-check` succeeds from a clean checkout after documented setup.
- [x] The repo does not rely on committed `.venv` contents.
- [x] Failure messages identify missing dependencies or setup steps clearly.
- [x] Docs and Makefile agree on the runtime-check command.

## Implementation Notes

Relevant files: `Makefile`, `pyproject.toml`, `.gitignore`, `docs/local-testing-plan.md`, `docs/CI_SYSTEM_GUIDE.md`, `tests/test_dependency_version_alignment.py`, `tests/test_repo_hygiene.py`, `frontend/package.json`, `frontend/package-lock.json`.



</details>

—
PR created automatically to engage Claude.

<!-- pr-preamble:start -->
<!-- meta:issue:961 -->
> **Source:** Issue #961

Closes #961

<!-- pr-preamble:end -->