### PR TITLE
fix: update prereq error message to use npm ci instead of npm install

### DIFF
--- a/scripts/check_full_stack_runtime.sh
+++ b/scripts/check_full_stack_runtime.sh
@@ -28,7 +28,7 @@ Run once from the repo root:
 Or manually:
   1. python -m venv .venv && source .venv/bin/activate
   2. python -m pip install -e ".[dev]"
-  3. npm --prefix frontend install
+  3. npm --prefix frontend ci
 
 Then rerun `make runtime-check` (or `make runtime-smoke`).
 `make install` creates .venv and installs both backend and frontend deps;


### PR DESCRIPTION
<!-- workflow-source:review_followup -->

## Summary

- The `prereq_failure()` heredoc in `scripts/check_full_stack_runtime.sh` told users to run `npm --prefix frontend install` when frontend dependencies were missing
- The repo standard is `npm --prefix frontend ci` (reproducible lockfile-based installs), enforced in the Makefile and verified by `test_repo_hygiene.py`
- This single-line fix aligns the error message with the actual correct command

## Test plan

- [ ] Verify `scripts/check_full_stack_runtime.sh` line 31 now reads `npm --prefix frontend ci`
- [ ] `make runtime-check` passes (or `make runtime-smoke`)
- [ ] `test_makefile_uses_npm_ci_for_frontend` hygiene test continues to pass

https://claude.ai/code/session_011jppg1sCubx4jd4Y365gKX