### PR TITLE
Claude bootstrap for #972

### DIFF
--- a/agents/claude-972.md
+++ b/agents/claude-972.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for claude on issue #972 -->

--- a/docs/preference-learning-model.md
+++ b/docs/preference-learning-model.md
@@ -116,6 +116,14 @@ Use:
 
 Not all evidence should count equally.
 
+Confidence should start from a signal-family baseline before other weighting rules are applied:
+
+- `revealed_behavior` (for concrete option selections/rejections and trip revisions): `0.85`
+- `explicit_answer` (for direct statements and structured answers): `0.70`
+- `default_assumption` (for fallback/inferred assumptions with no direct user signal): `0.10`
+
+These baselines are implemented in `trip_planner.preferences.evidence.baseline_confidence_hint`.
+
 The first pass should score evidence strength using:
 
 - `explicitness`: how directly the user expressed the preference
@@ -126,6 +134,12 @@ The first pass should score evidence strength using:
 - `conflict_penalty`: whether later evidence materially contradicts earlier evidence
 
 Revealed preference and resource-allocation evidence should usually outrank abstract self-description when the two conflict, unless the higher-level preference is anchored or constrained explicitly.
+
+Freshness rules:
+
+- evidence older than the current planning cycle should be down-weighted relative to fresh evidence
+- stale default assumptions should decay fastest because they are the weakest class
+- repeated, recent revealed behavior can override older explicit self-description unless blocked by hard constraints or anchors
 
 ## Preference Resolution Rules
 

--- a/docs/preference-learning-model.md
+++ b/docs/preference-learning-model.md
@@ -141,6 +141,30 @@ Freshness rules:
 - stale default assumptions should decay fastest because they are the weakest class
 - repeated, recent revealed behavior can override older explicit self-description unless blocked by hard constraints or anchors
 
+### Per-Dimension Evidence Sources And Confidence Rules
+
+All first-tier dimensions use the same signal-family baseline confidence rules:
+
+- `explicit_answer`: `0.70`
+- `revealed_behavior`: `0.85`
+- `default_assumption`: `0.10`
+
+Dimension-specific support strength defines how strongly each evidence type should influence scoring (`strong > medium > weak`). Canonical mapping lives in `trip_planner.preferences.evidence_catalog.DIMENSION_EVIDENCE_STRENGTH`.
+
+| Dimension | Strong evidence types | Medium evidence types |
+|---|---|---|
+| `movement_vs_friction` | `forced_tradeoff_choice`, `scenario_reaction`, `option_selection`, `trip_revision` | `direct_statement`, `option_rejection` |
+| `recovery_vs_intensity` | `forced_tradeoff_choice`, `scenario_reaction`, `option_selection`, `trip_revision` | `direct_statement`, `option_rejection` |
+| `nature_vs_culture` | `forced_tradeoff_choice`, `scenario_reaction`, `option_selection` | `direct_statement`, `option_rejection`, `trip_revision` |
+| `structure_vs_elasticity` | `scenario_reaction`, `forced_tradeoff_choice`, `trip_revision` | `direct_statement`, `option_selection` |
+| `breadth_vs_depth` | `forced_tradeoff_choice`, `scenario_reaction`, `trip_revision` | `direct_statement`, `option_selection` |
+| `self_reliance_vs_convenience` | `forced_tradeoff_choice`, `scenario_reaction`, `option_selection` | `direct_statement`, `option_rejection`, `trip_revision` |
+| `historic_vs_contemporary` | `forced_tradeoff_choice`, `scenario_reaction` | `direct_statement`, `option_selection`, `trip_revision` |
+| `scenic_transit_vs_destination_time` | `forced_tradeoff_choice`, `scenario_reaction`, `option_selection` | `direct_statement`, `option_rejection` |
+| `route_coherence_vs_eclectic_contrast` | `forced_tradeoff_choice`, `scenario_reaction`, `trip_revision` | `direct_statement`, `option_selection` |
+| `social_energy_vs_solitude` | `forced_tradeoff_choice`, `scenario_reaction` | `direct_statement`, `option_selection`, `trip_revision` |
+| `iconic_vs_discovery` | `forced_tradeoff_choice`, `scenario_reaction`, `option_selection` | `direct_statement`, `option_rejection` |
+
 ## Preference Resolution Rules
 
 The resolver should compute each first-tier dimension using four layers.

--- a/tests/fixtures/preferences/evidence_records.json
+++ b/tests/fixtures/preferences/evidence_records.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "0.1.0",
+  "records": [
+    {
+      "name": "explicit-answer",
+      "dimension": "structure_vs_elasticity",
+      "signal_type": "explicit_answer",
+      "value": -0.62,
+      "source": "user_message",
+      "confidence": 0.7,
+      "observed_at": "2026-04-20T14:00:00Z",
+      "provenance": {
+        "source_id": "msg-001",
+        "channel": "chat",
+        "captured_by": "planner-turn-1"
+      },
+      "evidence_type": "direct_statement"
+    },
+    {
+      "name": "revealed-behavior",
+      "dimension": "movement_vs_friction",
+      "signal_type": "revealed_behavior",
+      "value": -0.74,
+      "source": "option_menu",
+      "confidence": 0.86,
+      "observed_at": "2026-04-24T10:30:00Z",
+      "provenance": {
+        "source_id": "choice-775",
+        "channel": "option-comparison",
+        "captured_by": "planner-turn-3"
+      },
+      "evidence_type": "option_selection"
+    },
+    {
+      "name": "default-assumption",
+      "dimension": "historic_vs_contemporary",
+      "signal_type": "default_assumption",
+      "value": 0.15,
+      "source": "planner_inference_review",
+      "confidence": 0.1,
+      "observed_at": "2026-01-05T09:00:00Z",
+      "provenance": {
+        "source_id": "inference-42",
+        "channel": "model-inference",
+        "captured_by": "normalization-pass"
+      },
+      "evidence_type": "scenario_reaction"
+    },
+    {
+      "name": "conflicting-explicit",
+      "dimension": "movement_vs_friction",
+      "signal_type": "explicit_answer",
+      "value": 0.58,
+      "source": "structured_input",
+      "confidence": 0.67,
+      "observed_at": "2026-04-26T08:00:00Z",
+      "provenance": {
+        "source_id": "form-88",
+        "channel": "questionnaire",
+        "captured_by": "planner-turn-4"
+      },
+      "evidence_type": "direct_statement"
+    }
+  ]
+}

--- a/tests/preferences/test_evidence.py
+++ b/tests/preferences/test_evidence.py
@@ -2,6 +2,8 @@ from trip_planner.preferences.evidence import (
     ContradictionMarker,
     OptionEvidence,
     PreferenceEvidence,
+    baseline_confidence_hint,
+    evidence_signal_family,
 )
 
 
@@ -152,3 +154,36 @@ def test_option_rejection_cannot_have_positive_signal_direction() -> None:
         assert "cannot use a positive signal_direction" in str(exc)
     else:
         raise AssertionError("Option rejection should not allow positive signal direction")
+
+
+def test_signal_family_classification_for_explicit_revealed_and_default() -> None:
+    assert (
+        evidence_signal_family(evidence_type="direct_statement", source_type="user_message")
+        == "explicit_answer"
+    )
+    assert (
+        evidence_signal_family(evidence_type="option_selection", source_type="option_menu")
+        == "revealed_behavior"
+    )
+    assert (
+        evidence_signal_family(
+            evidence_type="scenario_reaction", source_type="planner_inference_review"
+        )
+        == "default_assumption"
+    )
+
+
+def test_baseline_confidence_prefers_revealed_then_explicit_then_default() -> None:
+    explicit = baseline_confidence_hint(
+        evidence_type="direct_statement",
+        source_type="user_message",
+    )
+    revealed = baseline_confidence_hint(
+        evidence_type="option_selection",
+        source_type="option_menu",
+    )
+    default = baseline_confidence_hint(
+        evidence_type="scenario_reaction",
+        source_type="planner_inference_review",
+    )
+    assert revealed > explicit > default

--- a/tests/preferences/test_evidence_fixtures.py
+++ b/tests/preferences/test_evidence_fixtures.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+from trip_planner.preferences.evidence import DimensionEvidenceRecord, EvidenceProvenance
+from trip_planner.preferences.schema import SCHEMA_VERSION
+
+
+def _fixture_payload() -> dict:
+    path = Path("tests/fixtures/preferences/evidence_records.json")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _record(entry: dict) -> DimensionEvidenceRecord:
+    return DimensionEvidenceRecord(
+        dimension=entry["dimension"],
+        signal_type=entry["signal_type"],
+        value=entry["value"],
+        source=entry["source"],
+        confidence=entry["confidence"],
+        observed_at=entry["observed_at"],
+        provenance=EvidenceProvenance(**entry["provenance"]),
+        evidence_type=entry.get("evidence_type"),
+        evidence_id=entry.get("evidence_id", ""),
+    )
+
+
+def test_evidence_fixture_records_validate_against_schema() -> None:
+    payload = _fixture_payload()
+    assert payload["schema_version"] == SCHEMA_VERSION
+
+    records = [_record(entry) for entry in payload["records"]]
+
+    assert len(records) >= 4
+    assert all(record.dimension for record in records)
+    assert all(record.source for record in records)
+
+
+def test_evidence_fixtures_cover_explicit_revealed_and_default_signals() -> None:
+    records = {entry["name"]: _record(entry) for entry in _fixture_payload()["records"]}
+
+    assert records["explicit-answer"].signal_type == "explicit_answer"
+    assert records["revealed-behavior"].signal_type == "revealed_behavior"
+    assert records["default-assumption"].signal_type == "default_assumption"
+
+
+def test_default_assumption_fixture_is_stale() -> None:
+    records = {entry["name"]: _record(entry) for entry in _fixture_payload()["records"]}
+
+    assert records["default-assumption"].is_stale(
+        as_of="2026-04-28T00:00:00Z",
+        max_age_days=30,
+    )
+
+
+def test_conflicting_fixture_records_detect_directional_conflict() -> None:
+    records = {entry["name"]: _record(entry) for entry in _fixture_payload()["records"]}
+
+    assert records["revealed-behavior"].conflicts_with(records["conflicting-explicit"])

--- a/tests/preferences/test_resolution.py
+++ b/tests/preferences/test_resolution.py
@@ -84,6 +84,21 @@ def test_resolution_flags_dimensions_that_need_directional_seed() -> None:
     )
 
 
+def test_resolution_explanation_reports_value_delta_from_seed() -> None:
+    fixture = next(item for item in load_fixture_corpus() if item.id == "scenic-rail-nomad")
+    seed = _resolution_seed(fixture.profile)
+    seed.tradeoff_dimensions["movement_vs_friction"].value = 0.2
+
+    result = resolve_leisure_profile(seed, fixture.evidence)
+
+    detail = result.explanation.dimension_explanations["movement_vs_friction"]
+    assert detail.initial_value == 0.2
+    assert detail.resolved_value == result.profile.tradeoff_dimensions["movement_vs_friction"].value
+    assert detail.value_delta == detail.resolved_value - detail.initial_value
+    assert detail.value_delta > 0.0
+    assert any(influence.source_kind == "evidence" for influence in detail.influences)
+
+
 def test_directional_seed_artifacts_removed_after_interaction_moves_off_zero() -> None:
     fixture = next(item for item in load_fixture_corpus() if item.id == "discovery-wanderer")
     seed = _resolution_seed(fixture.profile)

--- a/trip_planner/preferences/evidence.py
+++ b/trip_planner/preferences/evidence.py
@@ -26,6 +26,11 @@ EVIDENCE_SOURCE_TYPES: tuple[str, ...] = (
     "trip_revision",
     "imported_trip_notes",
 )
+EVIDENCE_SIGNAL_FAMILIES: tuple[str, ...] = (
+    "explicit_answer",
+    "revealed_behavior",
+    "default_assumption",
+)
 EVIDENCE_SUPPORT_LEVELS: tuple[str, ...] = ("weak", "medium", "strong")
 SIGNAL_DIRECTIONS: tuple[str, ...] = ("positive", "negative", "contradiction")
 OPTION_KINDS: tuple[str, ...] = (
@@ -35,6 +40,24 @@ OPTION_KINDS: tuple[str, ...] = (
     "destination_bundle",
     "mixed_bundle",
 )
+_BASELINE_CONFIDENCE_BY_SIGNAL_FAMILY: dict[str, float] = {
+    "explicit_answer": 0.7,
+    "revealed_behavior": 0.85,
+    "default_assumption": 0.1,
+}
+
+
+def evidence_signal_family(*, evidence_type: str, source_type: str) -> str:
+    if evidence_type in {"option_selection", "option_rejection", "trip_revision"}:
+        return "revealed_behavior"
+    if source_type in {"user_message", "structured_input", "scenario_prompt"}:
+        return "explicit_answer"
+    return "default_assumption"
+
+
+def baseline_confidence_hint(*, evidence_type: str, source_type: str) -> float:
+    family = evidence_signal_family(evidence_type=evidence_type, source_type=source_type)
+    return _BASELINE_CONFIDENCE_BY_SIGNAL_FAMILY[family]
 
 
 def _require_probability(value: float, field_name: str) -> None:

--- a/trip_planner/preferences/evidence.py
+++ b/trip_planner/preferences/evidence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 from . import schema
@@ -45,6 +46,16 @@ _BASELINE_CONFIDENCE_BY_SIGNAL_FAMILY: dict[str, float] = {
     "revealed_behavior": 0.85,
     "default_assumption": 0.1,
 }
+
+
+def _parse_iso8601_utc(value: str, field_name: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field_name} must include timezone information")
+    return parsed.astimezone(UTC)
 
 
 def evidence_signal_family(*, evidence_type: str, source_type: str) -> str:
@@ -107,6 +118,70 @@ class ContradictionMarker:
         if not self.reason:
             raise ValueError("reason is required")
         _require_probability(self.weakening_strength, "weakening_strength")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class EvidenceProvenance:
+    source_id: str
+    channel: str
+    captured_by: str
+
+    def __post_init__(self) -> None:
+        if not self.source_id:
+            raise ValueError("source_id is required")
+        if not self.channel:
+            raise ValueError("channel is required")
+        if not self.captured_by:
+            raise ValueError("captured_by is required")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class DimensionEvidenceRecord:
+    dimension: str
+    signal_type: str
+    value: float
+    source: str
+    confidence: float
+    observed_at: str
+    provenance: EvidenceProvenance
+    evidence_type: str | None = None
+    evidence_id: str = ""
+
+    def __post_init__(self) -> None:
+        if self.dimension not in schema.TRADEOFF_DIMENSION_KEYS:
+            raise ValueError(f"dimension must be one of {schema.TRADEOFF_DIMENSION_KEYS}")
+        if self.signal_type not in EVIDENCE_SIGNAL_FAMILIES:
+            raise ValueError(f"signal_type must be one of {EVIDENCE_SIGNAL_FAMILIES}")
+        if not -1.0 <= self.value <= 1.0:
+            raise ValueError("value must be between -1.0 and 1.0")
+        if not self.source:
+            raise ValueError("source is required")
+        _require_probability(self.confidence, "confidence")
+        _parse_iso8601_utc(self.observed_at, "observed_at")
+        if not isinstance(self.provenance, EvidenceProvenance):
+            raise ValueError("provenance must be an EvidenceProvenance")
+        if self.evidence_type is not None and self.evidence_type not in EVIDENCE_TYPES:
+            raise ValueError(f"evidence_type must be one of {EVIDENCE_TYPES}")
+
+    def is_stale(self, *, as_of: str, max_age_days: int) -> bool:
+        observed = _parse_iso8601_utc(self.observed_at, "observed_at")
+        cutoff = _parse_iso8601_utc(as_of, "as_of")
+        age_days = (cutoff - observed).days
+        return age_days > max_age_days
+
+    def conflicts_with(self, other: "DimensionEvidenceRecord") -> bool:
+        return (
+            self.dimension == other.dimension
+            and self.value != 0.0
+            and other.value != 0.0
+            and (self.value > 0 > other.value or self.value < 0 < other.value)
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/trip_planner/preferences/explanations.py
+++ b/trip_planner/preferences/explanations.py
@@ -20,10 +20,12 @@ class MaterialInfluence:
 @dataclass(slots=True)
 class DimensionResolutionExplanation:
     dimension_key: str
+    initial_value: float
     resolved_value: float
     confidence: float
     salience: float
     stability: float
+    value_delta: float = 0.0
     influences: list[MaterialInfluence] = field(default_factory=list)
     interaction_rule_ids: list[str] = field(default_factory=list)
     tension_flag_ids: list[str] = field(default_factory=list)

--- a/trip_planner/preferences/fixture_corpus.py
+++ b/trip_planner/preferences/fixture_corpus.py
@@ -10,6 +10,7 @@ from trip_planner.preferences.evidence import (
     ContradictionMarker,
     OptionEvidence,
     PreferenceEvidence,
+    baseline_confidence_hint,
 )
 from trip_planner.preferences.models import (
     Anchor,
@@ -260,7 +261,13 @@ def build_evidence_record(payload: dict[str, Any]) -> PreferenceEvidence:
         affected_hybrid_factors=list(payload.get("affected_hybrid_factors", [])),
         anchor_groups=list(payload.get("anchor_groups", [])),
         signal_direction=payload.get("signal_direction", "positive"),
-        confidence_hint=payload.get("confidence_hint", 0.5),
+        confidence_hint=payload.get(
+            "confidence_hint",
+            baseline_confidence_hint(
+                evidence_type=payload["evidence_type"],
+                source_type=payload["source_type"],
+            ),
+        ),
         salience_hint=payload.get("salience_hint", 0.5),
         observed_at=payload.get("observed_at"),
         sequence=payload.get("sequence"),

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -105,6 +105,7 @@ def _new_dimension_explanation(
     dimension = profile.tradeoff_dimensions[dimension_key]
     return DimensionResolutionExplanation(
         dimension_key=dimension_key,
+        initial_value=dimension.value,
         resolved_value=dimension.value,
         confidence=dimension.confidence,
         salience=dimension.salience,
@@ -369,6 +370,7 @@ def _finalize_explanations(
             explanation.tension_explanations.pop(directional_seed_tension_id, None)
             confidence_notes = [note for note in confidence_notes if note != directional_seed_note]
         detail.resolved_value = dimension.value
+        detail.value_delta = _clamp_axis(dimension.value - detail.initial_value)
         detail.confidence = dimension.confidence
         detail.salience = dimension.salience
         detail.stability = dimension.stability


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Preference scores should be explainable. Each dimension needs evidence inputs, provenance, confidence, and freshness rules so the planner can justify why one option fits better than another.

#### Tasks
- [x] Review `docs/preference-learning-model.md`, `docs/preferences-fixture-corpus.md`, and `tests/preferences/`.
- [x] Define an evidence schema with dimension, signal type, value, source, confidence, observed_at, and provenance fields.
- [x] Document how explicit answers, revealed behavior, and defaults differ in confidence.
- [x] Add fixtures and validation tests for evidence records.

#### Acceptance criteria
- [x] Each preference dimension has documented evidence sources and confidence rules.
- [x] Evidence fixtures validate against the schema.
- [x] Tests cover explicit answer, revealed behavior, default, stale, and conflicting evidence examples.
- [x] The model supports explaining why a score changed.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

Preference scores should be explainable. Each dimension needs evidence inputs, provenance, confidence, and freshness rules so the planner can justify why one option fits better than another.

## Scope

- Define evidence records for each preference dimension.
- Specify provenance, confidence, source, timestamp/freshness, and conflict behavior.
- Connect evidence to existing preference tests and fixture corpus.

## Non-Goals

- Do not make unrelated visual redesigns.
- Do not use live external travel providers in required tests.
- Do not move Workflows automation maintenance into trip-planner issues.

## Tasks

- [ ] Review `docs/preference-learning-model.md`, `docs/preferences-fixture-corpus.md`, and `tests/preferences/`.
- [ ] Define an evidence schema with dimension, signal type, value, source, confidence, observed_at, and provenance fields.
- [ ] Document how explicit answers, revealed behavior, and defaults differ in confidence.
- [ ] Add fixtures and validation tests for evidence records.

## Acceptance Criteria

- [ ] Each preference dimension has documented evidence sources and confidence rules.
- [ ] Evidence fixtures validate against the schema.
- [ ] Tests cover explicit answer, revealed behavior, default, stale, and conflicting evidence examples.
- [ ] The model supports explaining why a score changed.

## Implementation Notes

Relevant files: `trip_planner/preferences/evidence.py`, `trip_planner/preferences/evidence_catalog.py`, `trip_planner/preferences/explanations.py`, `docs/preference-learning-model.md`, `docs/leisure-preference-contract.md`, `tests/preferences/test_evidence.py`, `tests/preferences/test_evidence_catalog.py`.



</details>

—
PR created automatically to engage Claude.

<!-- pr-preamble:start -->
<!-- meta:issue:972 -->
> **Source:** Issue #972

Closes #972

<!-- pr-preamble:end -->