### PR TITLE
fix(preferences): distinguish balanced-conflict from no-evidence in dimension resolver

### DIFF
--- a/tests/preferences/test_resolution.py
+++ b/tests/preferences/test_resolution.py
@@ -185,7 +185,7 @@ def test_dimension_resolution_explicit_override_beats_behavioral_signal() -> Non
     ]
     resolved = resolve_dimension_evidence("movement_vs_friction", 0.6, records)
     assert resolved.final_value < 0.0
-    assert resolved.explanation_code in {"explicit_override", "conflict_low_confidence"}
+    assert resolved.explanation_code == "explicit_override"
     assert "ev-explicit" in resolved.contributing_evidence_ids
 
 
@@ -214,6 +214,37 @@ def test_dimension_resolution_tie_keeps_seed_value() -> None:
     ]
     resolved = resolve_dimension_evidence("movement_vs_friction", 0.25, records)
     assert resolved.final_value == 0.25
+    assert resolved.explanation_code == "balanced_conflict"
+    assert {"ev-left", "ev-right"}.issubset(set(resolved.contributing_evidence_ids))
+
+
+def test_dimension_resolution_pure_behavioral_conflict_emits_balanced_code() -> None:
+    records = [
+        PreferenceEvidence(
+            id="ev-bpos",
+            evidence_type="scenario_reaction",
+            source_type="scenario_prompt",
+            affected_dimensions=["movement_vs_friction"],
+            signal_direction="positive",
+            confidence_hint=0.85,
+            salience_hint=0.7,
+            sequence=10,
+        ),
+        PreferenceEvidence(
+            id="ev-bneg",
+            evidence_type="scenario_reaction",
+            source_type="scenario_prompt",
+            affected_dimensions=["movement_vs_friction"],
+            signal_direction="negative",
+            confidence_hint=0.85,
+            salience_hint=0.7,
+            sequence=10,
+        ),
+    ]
+    resolved = resolve_dimension_evidence("movement_vs_friction", 0.0, records)
+    assert resolved.final_value == 0.0
+    assert resolved.explanation_code == "balanced_conflict"
+    assert {"ev-bpos", "ev-bneg"}.issubset(set(resolved.contributing_evidence_ids))
 
 
 def test_dimension_resolution_stale_behavior_is_discounted() -> None:

--- a/tests/preferences/test_resolution.py
+++ b/tests/preferences/test_resolution.py
@@ -247,6 +247,30 @@ def test_dimension_resolution_pure_behavioral_conflict_emits_balanced_code() -> 
     assert {"ev-bpos", "ev-bneg"}.issubset(set(resolved.contributing_evidence_ids))
 
 
+def test_dimension_resolution_contradiction_only_evidence_uses_default_seed() -> None:
+    # Contradiction-direction signals carry no directional weight on their own,
+    # so a record-set containing only contradictions must NOT be labelled
+    # "balanced_conflict" — there is no opposing directional support to balance.
+    # Confidence/salience are kept low so contradiction_support stays under
+    # the 0.18 conflict_low_confidence override threshold and we exercise the
+    # default_seed branch.
+    records = [
+        PreferenceEvidence(
+            id="ev-contradicting",
+            evidence_type="direct_statement",
+            source_type="user_message",
+            affected_dimensions=["movement_vs_friction"],
+            signal_direction="contradiction",
+            confidence_hint=0.0,
+            salience_hint=0.0,
+            sequence=5,
+        ),
+    ]
+    resolved = resolve_dimension_evidence("movement_vs_friction", 0.25, records)
+    assert resolved.final_value == 0.25
+    assert resolved.explanation_code == "default_seed"
+
+
 def test_dimension_resolution_stale_behavior_is_discounted() -> None:
     records = [
         PreferenceEvidence(

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -239,7 +239,12 @@ def resolve_dimension_evidence(
                 precedence_score = explicit_support
     if precedence_score == 0.0:
         final_value = seed_value
-        if contributions:
+        # ``contributions`` includes every applicable record (including
+        # contradiction-only ones with ``signed_weight == 0``). We only call this
+        # a "balanced_conflict" when at least one record carried directional
+        # weight that was then cancelled by an opposing signal.
+        has_directional_support = any(abs_w > 0.0 for abs_w, _ in contributions)
+        if has_directional_support:
             code = "balanced_conflict"
             text = "Opposing evidence netted to neutral; retained seed value."
         else:

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -70,7 +70,12 @@ BEHAVIORAL_EVIDENCE_TYPES: tuple[str, ...] = (
     "option_rejection",
     "trip_revision",
 )
+# Behavioral evidence whose ``sequence`` is older than the most recent applicable
+# record by more than this many sequence steps is treated as "stale" and discounted.
+# Sized to roughly span a single planning iteration's worth of recent activity.
 STALE_SEQUENCE_WINDOW = 12
+# Stale behavioral evidence still contributes, but at this fraction of fresh weight.
+STALE_BEHAVIOR_DISCOUNT = 0.6
 
 
 @dataclass(slots=True)
@@ -212,7 +217,7 @@ def resolve_dimension_evidence(
                 and (max_sequence - record.sequence) > stale_sequence_window
             )
             if is_stale:
-                older_behavior_support += signed_weight * 0.6
+                older_behavior_support += signed_weight * STALE_BEHAVIOR_DISCOUNT
             else:
                 recent_behavior_support += signed_weight
         salience_boost += max(0.0, weight) * record.salience_hint * 0.45
@@ -234,8 +239,12 @@ def resolve_dimension_evidence(
                 precedence_score = explicit_support
     if precedence_score == 0.0:
         final_value = seed_value
-        code = "default_seed"
-        text = "Evidence netted to neutral; retained seed value."
+        if contributions:
+            code = "balanced_conflict"
+            text = "Opposing evidence netted to neutral; retained seed value."
+        else:
+            code = "default_seed"
+            text = "Evidence had no directional support; retained seed value."
     elif precedence_score > 0.0:
         direction = 1.0
         magnitude = _clamp_probability(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:973 -->
> **Source:** Issue #973

Closes #973

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Once multiple evidence signals exist, the planner needs deterministic resolution logic for explicit answers, inferred preferences, defaults, stale evidence, and conflicts.

#### Tasks
- [ ] Review preference evidence schema, fixture corpus, and ranking consumers.
- [ ] Define precedence rules for explicit answers, recent behavior, older behavior, defaults, and contradictory signals.
- [ ] Implement a resolver that emits final value, confidence, contributing evidence ids, and explanation text/code.
- [ ] Add tests for tie, conflict, stale evidence, missing evidence, and explicit override cases.

#### Acceptance criteria
- [ ] Resolution is deterministic for the same evidence set regardless of input order.
- [ ] Explicit user answers override weaker inferred/default evidence according to documented rules.
- [ ] The resolver emits explanation/provenance fields used by ranking or UI.
- [ ] Tests cover stale, conflicting, missing, and explicit-override cases.

**Head SHA:** cf950c91bef4481a53f4af39a245439323282a34
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/25090376962) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/25090376955) |
<!-- auto-status-summary:end -->