### PR TITLE
Claude bootstrap for #1034

### DIFF
--- a/agents/claude-1034.md
+++ b/agents/claude-1034.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for claude on issue #1034 -->

--- a/docs/leisure-preference-engine.md
+++ b/docs/leisure-preference-engine.md
@@ -657,3 +657,53 @@ Once `LeisurePreferenceProfile` exists, the next layers should be:
 3. itinerary objective mapping
 4. ranking
 5. explanation
+
+## Explanation and Provenance Integration
+
+### Design
+
+`resolve_dimension_evidence` produces three provenance fields per dimension:
+
+- `explanation_code` — a short machine-readable tag indicating how evidence resolved:
+  `default_seed`, `explicit_override`, `behavioral_inference`, `conflict_override`,
+  `conflict_low_confidence`
+- `explanation_text` — a human-readable sentence describing the resolution outcome
+- `contributing_evidence_ids` — the top-5 evidence IDs by weight that drove the result
+
+### Integration Approach: Augment
+
+`_apply_dimension_resolution` retains its own value-update logic (it uses the seed direction
+and accumulated positive/weakening support rather than `resolve_dimension_evidence`'s
+precedence-score approach).  After processing each dimension's evidence it calls
+`resolve_dimension_evidence` a second time — solely to obtain the provenance fields — and
+writes them onto `DimensionResolutionExplanation`.
+
+This means `DimensionResolutionExplanation` carries:
+- the existing influence list, tension references, and interaction rule IDs
+- the new `explanation_code`, `explanation_text`, and `contributing_evidence_ids`
+
+### Consumer: `_build_explanations` in `objective_derivation.py`
+
+The itinerary-objective derivation layer already builds a structured explanation list from
+`ResolvedLeisureProfile`.  Each tradeoff-dimension line is augmented with the evidence code:
+
+```
+movement_vs_friction: value=0.40, confidence=0.52, salience=0.45, evidence_code=explicit_override
+```
+
+This gives the downstream ranking and UI layers a stable, auditable signal about how
+confident the resolver was for each dimension and why.
+
+### Unused Fields on `DimensionEvidenceResolution`
+
+`DimensionEvidenceResolution` also carries `explicit_support`, `recent_behavior_support`,
+`older_behavior_support`, and `contradiction_support`.  These are intermediate computation
+values used inside `resolve_dimension_evidence` to derive `confidence`, `salience_boost`, and
+`stability_bonus`.  They are retained as first-class fields because:
+
+- they make the stale-recency test (`test_dimension_resolution_stale_behavior_is_discounted`)
+  directly assertable
+- they aid debugging when a confidence score looks wrong
+
+They are NOT expected to propagate into `DimensionResolutionExplanation`; the already-computed
+`confidence` on that object is the downstream surface.

--- a/docs/leisure-preference-engine.md
+++ b/docs/leisure-preference-engine.md
@@ -694,16 +694,21 @@ movement_vs_friction: value=0.40, confidence=0.52, salience=0.45, evidence_code=
 This gives the downstream ranking and UI layers a stable, auditable signal about how
 confident the resolver was for each dimension and why.
 
-### Unused Fields on `DimensionEvidenceResolution`
+### Fields on `DimensionEvidenceResolution`
 
-`DimensionEvidenceResolution` also carries `explicit_support`, `recent_behavior_support`,
-`older_behavior_support`, and `contradiction_support`.  These are intermediate computation
-values used inside `resolve_dimension_evidence` to derive `confidence`, `salience_boost`, and
-`stability_bonus`.  They are retained as first-class fields because:
+`DimensionEvidenceResolution` exposes only fields that are consumed by callers:
 
-- they make the stale-recency test (`test_dimension_resolution_stale_behavior_is_discounted`)
-  directly assertable
-- they aid debugging when a confidence score looks wrong
+| Field | Consumer |
+|-------|----------|
+| `final_value` | tests and direct callers of `resolve_dimension_evidence` |
+| `confidence` | tests; factored from `explicit_support` and `contradiction_support` internally |
+| `explanation_code` | `_apply_dimension_resolution` → `DimensionResolutionExplanation` |
+| `explanation_text` | `_apply_dimension_resolution` → `DimensionResolutionExplanation` |
+| `contributing_evidence_ids` | `_apply_dimension_resolution` → `DimensionResolutionExplanation` |
+| `recent_behavior_support` | `test_dimension_resolution_stale_behavior_is_discounted` |
+| `older_behavior_support` | `test_dimension_resolution_stale_behavior_is_discounted` |
 
-They are NOT expected to propagate into `DimensionResolutionExplanation`; the already-computed
-`confidence` on that object is the downstream surface.
+Intermediate scalars (`explicit_support`, `contradiction_support`, `salience_boost`,
+`stability_bonus`, `stage_boosts`) were dropped from the dataclass; they remain local
+variables inside `resolve_dimension_evidence` and their effect is already captured in
+`confidence` and the explanation fields.

--- a/tests/itinerary/test_objective_derivation.py
+++ b/tests/itinerary/test_objective_derivation.py
@@ -433,3 +433,62 @@ def test_pre_fix_path_would_fail_for_unsorted_tensions() -> None:
     assert (
         raw_forward_lines != raw_reversed_lines
     ), "pre-fix simulation: raw iteration order differs, confirming sorted() is necessary"
+
+
+VALID_EVIDENCE_CODES = {
+    "default_seed",
+    "explicit_override",
+    "behavioral_inference",
+    "conflict_override",
+    "conflict_low_confidence",
+}
+
+
+def test_derivation_explanations_carry_evidence_codes() -> None:
+    """_build_explanations must embed explanation_code from DimensionResolutionExplanation.
+
+    This verifies that the provenance fields emitted by resolve_dimension_evidence are
+    wired through _apply_dimension_resolution into DimensionResolutionExplanation, and
+    then consumed by the objective-derivation layer.
+    """
+    fixture = load_fixture_map()["scenic-rail-nomad"]
+    resolved = resolve_leisure_profile(fixture.profile, fixture.evidence)
+
+    objectives = derive_itinerary_objectives(resolved, trip_id="trip-provenance")
+
+    dimension_lines = [
+        line for line in objectives.explanations if ": value=" in line and "evidence_code=" in line
+    ]
+    assert len(dimension_lines) == 6, f"expected 6 dimension lines, got: {dimension_lines}"
+
+    for line in dimension_lines:
+        code = line.split("evidence_code=")[-1]
+        assert code in VALID_EVIDENCE_CODES, f"unexpected evidence_code {code!r} in line: {line}"
+
+    # Confirm the resolved explanation object carries the same codes.
+    for key in (
+        "movement_vs_friction",
+        "recovery_vs_intensity",
+        "structure_vs_elasticity",
+        "breadth_vs_depth",
+        "iconic_vs_discovery",
+        "route_coherence_vs_eclectic_contrast",
+    ):
+        dim_expl = resolved.explanation.dimension_explanations[key]
+        assert dim_expl.explanation_code in VALID_EVIDENCE_CODES
+        assert isinstance(dim_expl.explanation_text, str)
+        assert isinstance(dim_expl.contributing_evidence_ids, list)
+
+
+def test_derivation_no_evidence_yields_default_seed_code() -> None:
+    """With no evidence, every dimension explanation_code is 'default_seed'."""
+    profile = build_profile_from_overrides({})
+    resolved = resolve_leisure_profile(profile, [])
+
+    objectives = derive_itinerary_objectives(resolved, trip_id="trip-no-evidence")
+
+    dimension_lines = [line for line in objectives.explanations if "evidence_code=" in line]
+    assert dimension_lines
+    for line in dimension_lines:
+        code = line.split("evidence_code=")[-1]
+        assert code == "default_seed", f"expected default_seed, got {code!r} in: {line}"

--- a/trip_planner/itinerary/objective_derivation.py
+++ b/trip_planner/itinerary/objective_derivation.py
@@ -314,10 +314,11 @@ def _build_explanations(resolved: ResolvedLeisureProfile) -> list[str]:
         "route_coherence_vs_eclectic_contrast",
     ):
         dimension = resolved.profile.tradeoff_dimensions[key]
+        evidence_code = resolved.explanation.dimension_explanations[key].explanation_code
         explanations.append(
             (
                 f"{key}: value={dimension.value:.2f}, confidence={dimension.confidence:.2f}, "
-                f"salience={dimension.salience:.2f}"
+                f"salience={dimension.salience:.2f}, evidence_code={evidence_code}"
             )
         )
     for tension in sorted(resolved.profile.tension_flags, key=lambda t: t.id):

--- a/trip_planner/preferences/explanations.py
+++ b/trip_planner/preferences/explanations.py
@@ -30,6 +30,9 @@ class DimensionResolutionExplanation:
     interaction_rule_ids: list[str] = field(default_factory=list)
     tension_flag_ids: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
+    explanation_code: str = "default_seed"
+    explanation_text: str = ""
+    contributing_evidence_ids: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -324,6 +324,7 @@ def _apply_dimension_resolution(
 ) -> None:
     for dimension_key in schema.TRADEOFF_DIMENSION_KEYS:
         dimension = profile.tradeoff_dimensions[dimension_key]
+        seed_value = dimension.value
         base_direction = _base_direction(dimension.value)
         base_magnitude = abs(dimension.value)
         positive_support = 0.0
@@ -419,6 +420,11 @@ def _apply_dimension_resolution(
             profile.evidence_summary.confidence_notes.append(
                 f"{dimension_key} includes contradictory evidence that should remain visible downstream."
             )
+        provenance = resolve_dimension_evidence(dimension_key, seed_value, evidence_records)
+        dim_expl = explanation.dimension_explanations[dimension_key]
+        dim_expl.explanation_code = provenance.explanation_code
+        dim_expl.explanation_text = provenance.explanation_text
+        dim_expl.contributing_evidence_ids = provenance.contributing_evidence_ids
 
 
 def _apply_hybrid_resolution(

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -81,13 +81,8 @@ class DimensionEvidenceResolution:
     contributing_evidence_ids: list[str] = field(default_factory=list)
     explanation_code: str = "default_seed"
     explanation_text: str = ""
-    explicit_support: float = 0.0
     recent_behavior_support: float = 0.0
     older_behavior_support: float = 0.0
-    contradiction_support: float = 0.0
-    salience_boost: float = 0.0
-    stability_bonus: float = 0.0
-    stage_boosts: dict[str, float] = field(default_factory=dict)
 
 
 def _clamp_probability(value: float) -> float:
@@ -171,7 +166,6 @@ def resolve_dimension_evidence(
             confidence=0.0,
             explanation_code="default_seed",
             explanation_text="No evidence found; retained seed value.",
-            stage_boosts={stage: 0.0 for stage in schema.PLANNING_STAGES},
         )
 
     max_sequence = max(
@@ -278,13 +272,8 @@ def resolve_dimension_evidence(
         contributing_evidence_ids=ordered_ids,
         explanation_code=code,
         explanation_text=text,
-        explicit_support=explicit_support,
         recent_behavior_support=recent_behavior_support,
         older_behavior_support=older_behavior_support,
-        contradiction_support=contradiction_support,
-        salience_boost=salience_boost,
-        stability_bonus=stability_bonus,
-        stage_boosts=stage_boosts,
     )
 
 


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #1029 (closes #973) added a standalone `resolve_dimension_evidence` helper that emits `explanation_code`, `explanation_text`, and `contributing_evidence_ids`, but it is currently only used by tests. The main pipeline `resolve_leisure_profile` still uses the older `_apply_dimension_resolution` path, and the `DimensionResolutionExplanation` dataclass exposed to consumers (`trip_planner/ranking/leisure.py`, `trip_planner/itinerary/objective_derivation.py`) does not carry the new explanation/provenance fields.

The provider comparison review on PR #1029 flagged this as the largest gap against the original acceptance criteria:

"The resolver emits explanation/provenance fields used by ranking or UI."

The fields are emitted by the helper, but no ranking/UI consumer reads them.

PR #1033 fixed the smaller, isolated concerns from the same review.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1029](https://github.com/stranske/trip-planner/issues/1029)
- [#973](https://github.com/stranske/trip-planner/issues/973)
- [#1033](https://github.com/stranske/trip-planner/issues/1033)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Audit consumers (`trip_planner/ranking/leisure.py`, `trip_planner/itinerary/objective_derivation.py`, frontend) to enumerate which provenance fields would actually be used.
- [x] Decide and document the integration approach (replace / augment / standalone) in `docs/leisure-preference-engine.md`.
- [x] Implement the integration so `resolve_leisure_profile` produces explanation/provenance for every dimension, not just the influences list.
- [x] Update at least one consumer to read the new provenance fields and add a test asserting that consumption.
- [x] Resolve the unused-fields question on `DimensionEvidenceResolution`: either factor them into confidence or drop them.

#### Acceptance criteria
- [x] `resolve_leisure_profile` produces `explanation_code`, `explanation_text`, and `contributing_evidence_ids` per dimension (or a documented alternative surface).
- [x] At least one ranking or UI consumer reads at least one of the new fields, with a test covering that path.
- [x] No regression in the existing 173 preferences tests or 14 `tests/itinerary/test_objective_derivation.py` tests.
- [x] `DimensionEvidenceResolution` has no fields that are computed but never consumed.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

PR #1029 (closes #973) added a standalone `resolve_dimension_evidence` helper that emits `explanation_code`, `explanation_text`, and `contributing_evidence_ids`, but it is currently only used by tests. The main pipeline `resolve_leisure_profile` still uses the older `_apply_dimension_resolution` path, and the `DimensionResolutionExplanation` dataclass exposed to consumers (`trip_planner/ranking/leisure.py`, `trip_planner/itinerary/objective_derivation.py`) does not carry the new explanation/provenance fields.

The provider comparison review on PR #1029 flagged this as the largest gap against the original acceptance criteria:

> "The resolver emits explanation/provenance fields used by ranking or UI."

The fields are emitted by the helper, but no ranking/UI consumer reads them.

PR #1033 fixed the smaller, isolated concerns from the same review.

## Scope

- Decide whether `resolve_dimension_evidence` should replace the per-dimension logic in `_apply_dimension_resolution`, augment it (e.g., compute alongside and merge), or remain a standalone utility documented as such.
- Surface `explanation_code`, `explanation_text`, `contributing_evidence_ids` (and the currently-unused `older_behavior_support`, `salience_boost`, `stability_bonus`, `stage_boosts`) on `DimensionResolutionExplanation` — or document why each is intentionally internal.
- Update at least one consumer (ranking or UI) to read the new provenance fields, so the acceptance criterion "used by ranking or UI" is materially met.
- Decide whether the final-confidence formula in `resolve_dimension_evidence` should incorporate `older_behavior_support`, `salience_boost`, `stability_bonus`, and `stage_boosts` (currently computed and returned but not factored into `confidence`).

## Non-Goals

- Do not introduce live external travel providers in tests.
- Do not redesign the unrelated `_apply_anchor_and_constraint_precedence` or hybrid factor paths in this issue.

## Tasks

- [ ] Audit consumers (`trip_planner/ranking/leisure.py`, `trip_planner/itinerary/objective_derivation.py`, frontend) to enumerate which provenance fields would actually be used.
- [ ] Decide and document the integration approach (replace / augment / standalone) in `docs/leisure-preference-engine.md`.
- [ ] Implement the integration so `resolve_leisure_profile` produces explanation/provenance for every dimension, not just the influences list.
- [x] Update at least one consumer to read the new provenance fields and add a test asserting that consumption.
- [ ] Resolve the unused-fields question on `DimensionEvidenceResolution`: either factor them into confidence or drop them.

## Acceptance Criteria

- [ ] `resolve_leisure_profile` produces `explanation_code`, `explanation_text`, and `contributing_evidence_ids` per dimension (or a documented alternative surface).
- [ ] At least one ranking or UI consumer reads at least one of the new fields, with a test covering that path.
- [x] No regression in the existing 173 preferences tests or 14 `tests/itinerary/test_objective_derivation.py` tests.
- [ ] `DimensionEvidenceResolution` has no fields that are computed but never consumed.

## References

- PR #1029 — initial implementation (merged with split provider verdict)
- PR #1033 — small follow-up addressing review concerns A, B, D, E
- Issue #973 — original spec



</details>

—
PR created automatically to engage Claude.

<!-- pr-preamble:start -->
<!-- meta:issue:1034 -->
> **Source:** Issue #1034

Closes #1034

<!-- pr-preamble:end -->