### PR TITLE
fix(preferences): reclassify scenario_reaction as behavioral and unclamp value_delta

### DIFF
--- a/docs/preference-learning-model.md
+++ b/docs/preference-learning-model.md
@@ -165,6 +165,33 @@ Dimension-specific support strength defines how strongly each evidence type shou
 | `social_energy_vs_solitude` | `forced_tradeoff_choice`, `scenario_reaction` | `direct_statement`, `option_selection`, `trip_revision` |
 | `iconic_vs_discovery` | `forced_tradeoff_choice`, `scenario_reaction`, `option_selection` | `direct_statement`, `option_rejection` |
 
+#### Hybrid Factor Evidence Sources
+
+Hybrid factors (food, rest, music, route_modes) carry both directional and anchor-strength
+signals. Canonical mapping lives in `trip_planner.preferences.evidence_catalog.HYBRID_FACTOR_EVIDENCE_STRENGTH`.
+
+| Hybrid factor | Strong evidence types | Medium evidence types |
+|---|---|---|
+| `food` | `anchor_declaration`, `option_selection`, `option_rejection` | `direct_statement`, `scenario_reaction`, `trip_revision` |
+| `rest` | `anchor_declaration`, `scenario_reaction`, `option_selection`, `trip_revision` | `direct_statement`, `option_rejection` |
+| `music` | `anchor_declaration`, `option_selection` | `direct_statement`, `scenario_reaction`, `trip_revision` |
+| `route_modes` | `anchor_declaration`, `option_selection`, `option_rejection` | `direct_statement`, `forced_tradeoff_choice`, `trip_revision` |
+
+#### Anchor Group Evidence Sources
+
+Anchor groups carry commitment-like signals about what the trip must protect or organize
+around. Canonical mapping lives in `trip_planner.preferences.evidence_catalog.ANCHOR_GROUP_EVIDENCE_STRENGTH`.
+
+| Anchor group | Strong evidence types | Medium evidence types |
+|---|---|---|
+| `place_anchors` | `hard_constraint_declaration`, `anchor_declaration` | `trip_revision`, `option_selection` |
+| `experience_anchors` | `anchor_declaration`, `option_selection`, `trip_revision` | `direct_statement`, `scenario_reaction` |
+| `mode_anchors` | `anchor_declaration`, `option_selection` | `forced_tradeoff_choice`, `option_rejection` |
+| `rhythm_anchors` | `anchor_declaration`, `trip_revision` | `scenario_reaction`, `option_selection` |
+| `calendar_anchors` | `hard_constraint_declaration`, `anchor_declaration` | `trip_revision` |
+| `quality_floor_anchors` | `hard_constraint_declaration`, `anchor_declaration`, `option_rejection` | `trip_revision` |
+| `regional_adjacency_preferences` | `option_selection` | `anchor_declaration`, `scenario_reaction`, `trip_revision` |
+
 ## Preference Resolution Rules
 
 The resolver should compute each first-tier dimension using four layers.

--- a/tests/preferences/test_evidence.py
+++ b/tests/preferences/test_evidence.py
@@ -173,6 +173,25 @@ def test_signal_family_classification_for_explicit_revealed_and_default() -> Non
     )
 
 
+def test_signal_family_classifies_scenario_reactions_as_revealed_behavior() -> None:
+    # scenario_reaction is behavioral evidence (the user reacted to a presented scenario);
+    # it should not be reclassified as an explicit_answer just because the source_type is
+    # 'scenario_prompt'.
+    assert (
+        evidence_signal_family(evidence_type="scenario_reaction", source_type="scenario_prompt")
+        == "revealed_behavior"
+    )
+
+
+def test_signal_family_treats_planner_inference_as_default_for_any_evidence_type() -> None:
+    assert (
+        evidence_signal_family(
+            evidence_type="option_selection", source_type="planner_inference_review"
+        )
+        == "default_assumption"
+    )
+
+
 def test_baseline_confidence_prefers_revealed_then_explicit_then_default() -> None:
     explicit = baseline_confidence_hint(
         evidence_type="direct_statement",

--- a/tests/preferences/test_resolution.py
+++ b/tests/preferences/test_resolution.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from tests.preferences.fixture_corpus import load_fixture_corpus
 from trip_planner.preferences import EvidenceSummary, resolve_leisure_profile
 from trip_planner.preferences.evidence import PreferenceEvidence
-from trip_planner.preferences.resolution import _finalize_explanations, resolve_dimension_evidence
+from trip_planner.preferences.resolution import resolve_dimension_evidence
 
 EXPECTED_TENSION_IDS = {
     "social-recovery-balancer": {"social-energy-recovery-conflict"},
@@ -102,18 +102,22 @@ def test_resolution_explanation_reports_value_delta_from_seed() -> None:
 
 
 def test_value_delta_is_not_clamped_for_full_axis_swings() -> None:
-    # Both endpoints of the axis are valid: a swing from -1.0 to +1.0 is a delta of 2.0
-    # and must not be silently clamped to 1.0.
-    fixture = next(item for item in load_fixture_corpus() if item.id == "scenic-rail-nomad")
+    # ``self_reliance_vs_convenience`` is force-raised to at least 0.35 by the
+    # quality-floor guardrail in ``_apply_anchor_and_constraint_precedence``.
+    # Seeding it at -1.0 and letting the public resolver run produces a natural
+    # delta of 1.35, which would be silently truncated to 1.0 if value_delta
+    # were ever clamped to the [-1, 1] axis range again.
+    fixture = next(item for item in load_fixture_corpus() if item.id == "comfort-floor-traveler")
     seed = _resolution_seed(fixture.profile)
+    seed.tradeoff_dimensions["self_reliance_vs_convenience"].value = -1.0
+
     result = resolve_leisure_profile(seed, fixture.evidence)
 
-    detail = result.explanation.dimension_explanations["movement_vs_friction"]
-    detail.initial_value = -1.0
-    result.profile.tradeoff_dimensions["movement_vs_friction"].value = 1.0
-    _finalize_explanations(result.profile, result.explanation)
-
-    assert detail.value_delta == 2.0
+    detail = result.explanation.dimension_explanations["self_reliance_vs_convenience"]
+    assert detail.initial_value == -1.0
+    assert detail.resolved_value >= 0.35
+    assert detail.value_delta == detail.resolved_value - detail.initial_value
+    assert detail.value_delta > 1.0
 
 
 def test_directional_seed_artifacts_removed_after_interaction_moves_off_zero() -> None:

--- a/tests/preferences/test_resolution.py
+++ b/tests/preferences/test_resolution.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from tests.preferences.fixture_corpus import load_fixture_corpus
 from trip_planner.preferences import EvidenceSummary, resolve_leisure_profile
 from trip_planner.preferences.evidence import PreferenceEvidence
-from trip_planner.preferences.resolution import resolve_dimension_evidence
+from trip_planner.preferences.resolution import _finalize_explanations, resolve_dimension_evidence
 
 EXPECTED_TENSION_IDS = {
     "social-recovery-balancer": {"social-energy-recovery-conflict"},
@@ -99,6 +99,21 @@ def test_resolution_explanation_reports_value_delta_from_seed() -> None:
     assert detail.value_delta == detail.resolved_value - detail.initial_value
     assert detail.value_delta > 0.0
     assert any(influence.source_kind == "evidence" for influence in detail.influences)
+
+
+def test_value_delta_is_not_clamped_for_full_axis_swings() -> None:
+    # Both endpoints of the axis are valid: a swing from -1.0 to +1.0 is a delta of 2.0
+    # and must not be silently clamped to 1.0.
+    fixture = next(item for item in load_fixture_corpus() if item.id == "scenic-rail-nomad")
+    seed = _resolution_seed(fixture.profile)
+    result = resolve_leisure_profile(seed, fixture.evidence)
+
+    detail = result.explanation.dimension_explanations["movement_vs_friction"]
+    detail.initial_value = -1.0
+    result.profile.tradeoff_dimensions["movement_vs_friction"].value = 1.0
+    _finalize_explanations(result.profile, result.explanation)
+
+    assert detail.value_delta == 2.0
 
 
 def test_directional_seed_artifacts_removed_after_interaction_moves_off_zero() -> None:

--- a/trip_planner/preferences/evidence.py
+++ b/trip_planner/preferences/evidence.py
@@ -58,10 +58,22 @@ def _parse_iso8601_utc(value: str, field_name: str) -> datetime:
     return parsed.astimezone(UTC)
 
 
+_BEHAVIORAL_EVIDENCE_TYPES_FOR_FAMILY: frozenset[str] = frozenset(
+    {"option_selection", "option_rejection", "trip_revision", "scenario_reaction"}
+)
+_EXPLICIT_SOURCE_TYPES_FOR_FAMILY: frozenset[str] = frozenset(
+    {"user_message", "structured_input", "scenario_prompt"}
+)
+
+
 def evidence_signal_family(*, evidence_type: str, source_type: str) -> str:
-    if evidence_type in {"option_selection", "option_rejection", "trip_revision"}:
+    # Planner-inferred records are treated as default assumptions regardless of evidence_type;
+    # they represent the system's prior, not a user signal.
+    if source_type == "planner_inference_review":
+        return "default_assumption"
+    if evidence_type in _BEHAVIORAL_EVIDENCE_TYPES_FOR_FAMILY:
         return "revealed_behavior"
-    if source_type in {"user_message", "structured_input", "scenario_prompt"}:
+    if source_type in _EXPLICIT_SOURCE_TYPES_FOR_FAMILY:
         return "explicit_answer"
     return "default_assumption"
 

--- a/trip_planner/preferences/resolution.py
+++ b/trip_planner/preferences/resolution.py
@@ -533,7 +533,10 @@ def _finalize_explanations(
             explanation.tension_explanations.pop(directional_seed_tension_id, None)
             confidence_notes = [note for note in confidence_notes if note != directional_seed_note]
         detail.resolved_value = dimension.value
-        detail.value_delta = _clamp_axis(dimension.value - detail.initial_value)
+        # Both ``initial_value`` and ``dimension.value`` are clamped to [-1, 1], so the
+        # delta naturally lies in [-2, 2]. Clamping it to [-1, 1] would silently lose
+        # information for full-axis swings (e.g. -1 -> +1).
+        detail.value_delta = dimension.value - detail.initial_value
         detail.confidence = dimension.confidence
         detail.salience = dimension.salience
         detail.stability = dimension.stability


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:972 -->
> **Source:** Issue #972

Closes #972

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Preference scores should be explainable. Each dimension needs evidence inputs, provenance, confidence, and freshness rules so the planner can justify why one option fits better than another.

#### Tasks
- [ ] Review `docs/preference-learning-model.md`, `docs/preferences-fixture-corpus.md`, and `tests/preferences/`.
- [ ] Define an evidence schema with dimension, signal type, value, source, confidence, observed_at, and provenance fields.
- [ ] Document how explicit answers, revealed behavior, and defaults differ in confidence.
- [ ] Add fixtures and validation tests for evidence records.

#### Acceptance criteria
- [ ] Each preference dimension has documented evidence sources and confidence rules.
- [ ] Evidence fixtures validate against the schema.
- [ ] Tests cover explicit answer, revealed behavior, default, stale, and conflicting evidence examples.
- [ ] The model supports explaining why a score changed.

**Head SHA:** 2d67f5434da5bf1136ac2c4175745b4b4b2fb7df
**Latest Runs:** ✅ success — Gate
**Required:** gate: ✅ success

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/25088424461) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/25088424464) |
| CI | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/25087922055) |
| Claude Code Review (Opt-in) | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/25087921919) |
| Gate | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/25087922050) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/stranske/trip-planner/actions/runs/25087921924) |
<!-- auto-status-summary:end -->