### PR TITLE
fix(tpp): deepcopy persisted result payload and tighten submission test

### DIFF
--- a/tests/planner/test_tpp_proposal_submission_service.py
+++ b/tests/planner/test_tpp_proposal_submission_service.py
@@ -17,8 +17,9 @@ from trip_planner.integrations.tpp.contracts import (
 
 
 class _FakeTPPClient(BaseTPPIntegrationClient):
-    def __init__(self) -> None:
+    def __init__(self, *, response_proposal_id: str = "proposal-from-response") -> None:
         self.last_request: TPPRequestEnvelope | None = None
+        self._response_proposal_id = response_proposal_id
 
     def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         self.last_request = request
@@ -28,18 +29,20 @@ class _FakeTPPClient(BaseTPPIntegrationClient):
             correlation_id=request.correlation_id,
             transport_pattern="sync",
             execution_status=TPPExecutionStatus(state="accepted", terminal=False),
-            result_payload={"proposal_id": request.proposal_id or "proposal-fallback"},
+            result_payload={"proposal_id": self._response_proposal_id},
         )
 
 
 def test_submit_builds_submit_proposal_request_from_workspace_data() -> None:
-    client = _FakeTPPClient()
+    # Use distinct request and response proposal_ids so the assertion proves the
+    # persisted value comes from the response (not coincidentally from the request).
+    client = _FakeTPPClient(response_proposal_id="proposal-from-tpp-server")
     service = TPPWorkspaceProposalSubmissionService(client)
     workspace_state: dict[str, object] = {}
     workspace_data = {
         "organization_id": "org-123",
         "trip_id": "trip-123",
-        "proposal_id": "proposal-123",
+        "proposal_id": "proposal-from-workspace",
         "request_id": "req-123",
         "correlation_id": "corr-123",
         "custom": {"priority": "high"},
@@ -53,10 +56,12 @@ def test_submit_builds_submit_proposal_request_from_workspace_data() -> None:
     assert client.last_request.correlation_id == TPPCorrelationId(value="corr-123")
     assert client.last_request.organization_id == "org-123"
     assert client.last_request.trip_id == "trip-123"
-    assert client.last_request.proposal_id == "proposal-123"
+    assert client.last_request.proposal_id == "proposal-from-workspace"
     assert client.last_request.payload == workspace_data
-    assert response == ProposalSubmissionResult(proposal_id="proposal-123", success=True)
-    assert workspace_state["tpp_proposal_id"] == "proposal-123"
+    assert response == ProposalSubmissionResult(
+        proposal_id="proposal-from-tpp-server", success=True
+    )
+    assert workspace_state["tpp_proposal_id"] == "proposal-from-tpp-server"
 
 
 def test_submit_raises_domain_error_and_does_not_persist_proposal_id_for_bad_contract() -> None:

--- a/tests/planner/test_workspace_state.py
+++ b/tests/planner/test_workspace_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
@@ -49,9 +50,10 @@ def test_load_tpp_result_rehydrates_payload_with_exact_structure_preservation() 
 
 
 def test_persist_tpp_result_isolates_persisted_snapshot_from_caller_mutation() -> None:
-    # Mutating the original payload after persisting must not leak into workspace state,
-    # and mutating the persisted snapshot must not leak back into the caller's payload.
-    original_payload = {
+    # Mutating the caller's payload after persisting must not leak into workspace state.
+    # (The reverse direction — mutating the persisted snapshot leaking into the caller —
+    # is covered by ``test_load_tpp_result_returns_independent_copy`` below.)
+    original_payload: dict[str, Any] = {
         "execution_status": {"state": "succeeded", "terminal": True},
         "result_payload": {
             "trip_id": "trip-100",
@@ -59,7 +61,7 @@ def test_persist_tpp_result_isolates_persisted_snapshot_from_caller_mutation() -
             "nested": {"flag": True, "items": [1, 2, 3]},
         },
     }
-    workspace_state: dict[str, object] = {}
+    workspace_state: dict[str, Any] = {}
 
     persist_tpp_result(workspace_state, original_payload)
     snapshot_before_mutation = json.dumps(workspace_state["tpp_result"], sort_keys=True)
@@ -73,7 +75,7 @@ def test_persist_tpp_result_isolates_persisted_snapshot_from_caller_mutation() -
 
 
 def test_load_tpp_result_returns_independent_copy() -> None:
-    original_result = {
+    original_result: dict[str, Any] = {
         "execution_status": {"state": "succeeded", "terminal": True},
         "result_payload": {
             "trip_id": "trip-100",
@@ -81,7 +83,7 @@ def test_load_tpp_result_returns_independent_copy() -> None:
             "nested": {"items": [1, 2, 3]},
         },
     }
-    workspace_state: dict[str, object] = {}
+    workspace_state: dict[str, Any] = {}
     persist_tpp_result(workspace_state, original_result)
 
     rehydrated = load_tpp_result(workspace_state)

--- a/tests/planner/test_workspace_state.py
+++ b/tests/planner/test_workspace_state.py
@@ -4,7 +4,11 @@ import json
 
 import pytest
 
-from trip_planner.app.services.workspace_state import load_tpp_result, persist_tpp_proposal_id
+from trip_planner.app.services.workspace_state import (
+    load_tpp_result,
+    persist_tpp_proposal_id,
+    persist_tpp_result,
+)
 
 
 def test_persist_tpp_proposal_id_sets_workspace_state_field() -> None:
@@ -42,3 +46,49 @@ def test_load_tpp_result_rehydrates_payload_with_exact_structure_preservation() 
     assert json.dumps(rehydrated_result, sort_keys=True) == json.dumps(
         original_result, sort_keys=True
     )
+
+
+def test_persist_tpp_result_isolates_persisted_snapshot_from_caller_mutation() -> None:
+    # Mutating the original payload after persisting must not leak into workspace state,
+    # and mutating the persisted snapshot must not leak back into the caller's payload.
+    original_payload = {
+        "execution_status": {"state": "succeeded", "terminal": True},
+        "result_payload": {
+            "trip_id": "trip-100",
+            "proposal_id": "proposal-123",
+            "nested": {"flag": True, "items": [1, 2, 3]},
+        },
+    }
+    workspace_state: dict[str, object] = {}
+
+    persist_tpp_result(workspace_state, original_payload)
+    snapshot_before_mutation = json.dumps(workspace_state["tpp_result"], sort_keys=True)
+
+    # Mutate caller's nested structures.
+    original_payload["result_payload"]["nested"]["flag"] = False
+    original_payload["result_payload"]["nested"]["items"].append(4)
+
+    snapshot_after_mutation = json.dumps(workspace_state["tpp_result"], sort_keys=True)
+    assert snapshot_before_mutation == snapshot_after_mutation
+
+
+def test_load_tpp_result_returns_independent_copy() -> None:
+    original_result = {
+        "execution_status": {"state": "succeeded", "terminal": True},
+        "result_payload": {
+            "trip_id": "trip-100",
+            "proposal_id": "proposal-123",
+            "nested": {"items": [1, 2, 3]},
+        },
+    }
+    workspace_state: dict[str, object] = {}
+    persist_tpp_result(workspace_state, original_result)
+
+    rehydrated = load_tpp_result(workspace_state)
+    assert rehydrated is not None
+    rehydrated["result_payload"]["nested"]["items"].append(99)
+
+    # Mutating the loaded copy must not affect the persisted snapshot.
+    second_load = load_tpp_result(workspace_state)
+    assert second_load is not None
+    assert second_load["result_payload"]["nested"]["items"] == [1, 2, 3]

--- a/trip_planner/app/services/workspace_state.py
+++ b/trip_planner/app/services/workspace_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, Mapping, MutableMapping
 
 
@@ -16,8 +17,13 @@ def persist_tpp_proposal_id(workspace_state: MutableMapping[str, Any], proposal_
 def persist_tpp_result(
     workspace_state: MutableMapping[str, Any], result_payload: Mapping[str, Any]
 ) -> None:
-    """Persist a TPP evaluation/result payload exactly as received."""
-    workspace_state["tpp_result"] = dict(result_payload)
+    """Persist a TPP evaluation/result payload exactly as received.
+
+    Uses ``deepcopy`` so that later mutations of the caller's payload (or of
+    the stored copy) cannot leak through nested structures and corrupt the
+    persisted snapshot.
+    """
+    workspace_state["tpp_result"] = deepcopy(dict(result_payload))
 
 
 def load_tpp_result(workspace_state: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -27,4 +33,4 @@ def load_tpp_result(workspace_state: Mapping[str, Any]) -> dict[str, Any] | None
         return None
     if not isinstance(result_payload, dict):
         raise ValueError("workspace_state.tpp_result must be a mapping when present")
-    return dict(result_payload)
+    return deepcopy(result_payload)

--- a/trip_planner/app/services/workspace_state.py
+++ b/trip_planner/app/services/workspace_state.py
@@ -32,5 +32,5 @@ def load_tpp_result(workspace_state: Mapping[str, Any]) -> dict[str, Any] | None
     if result_payload is None:
         return None
     if not isinstance(result_payload, dict):
-        raise ValueError("workspace_state.tpp_result must be a mapping when present")
+        raise ValueError("workspace_state.tpp_result must be a dict when present")
     return deepcopy(result_payload)


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1021 -->
> **Source:** Issue #1021

Closes #1021

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #1017 addressed issue #967 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure, focusing on completing the missing production TPP submission, polling, validation, and result-persistence behavior that current tests expect.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1017](https://github.com/stranske/trip-planner/issues/1017)
- [#967](https://github.com/stranske/trip-planner/issues/967)
- [#966](https://github.com/stranske/trip-planner/issues/966)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
### TPP Proposal Submission
- [ ] Create the TPP proposal submission service method in `planner/services/tpp_proposal_submission_service.py` that calls `planner/clients/tpp_client.py` with workspace data
- [ ] Implement extraction logic in `planner/services/tpp_proposal_submission_service.py` to parse the `proposal_id` from the TPP client response
- [ ] Add workspace state persistence method in `planner/services/workspace_state.py` to store the extracted `proposal_id`
- [ ] Write unit tests in `tests/planner/test_tpp_proposal_submission_service.py` verifying the submission service calls the TPP client with correct parameters
- [ ] Write unit tests in `tests/planner/test_tpp_proposal_submission_service.py` verifying `proposal_id` extraction handles valid response structures
- [ ] Write unit tests in `tests/planner/test_tpp_proposal_submission_service.py` verifying `proposal_id` is correctly persisted to workspace state

### TPP Polling Workflow
- [ ] Define the application outcome enumeration or types in `planner/models/tpp.py` for `approved`, `rejected`, `failed`, `pending`, and `timeout` states
- [ ] Implement the state mapping function in `planner/services/tpp_polling_service.py` that converts TPP poll response states to application outcomes
- [ ] Implement the routing logic in `planner/services/tpp_polling_service.py` that directs each application outcome to its corresponding handler branch
- [ ] Implement the timeout detection mechanism in `planner/services/tpp_polling_service.py` that triggers when polling exceeds configured duration
- [ ] Write unit tests in `tests/planner/test_tpp_polling_service.py` verifying each TPP state (`approved`, `rejected`, `failed`, `pending`) maps to the correct application outcome
- [ ] Write unit tests in `tests/planner/test_tpp_polling_service.py` verifying timeout condition triggers the timeout outcome without terminal state

### TPP Result Persistence and Rehydration
- [ ] Implement the workspace state method in `planner/services/workspace_state.py` to persist TPP evaluation result payloads without transformation
- [ ] Implement the workspace state method in `planner/services/workspace_state.py` to reload persisted TPP result payloads during rehydration
- [ ] Write unit tests in `tests/planner/test_tpp_result_service.py` verifying result payloads are stored with exact structure preservation
- [ ] Write unit tests in `tests/planner/test_workspace_state.py` verifying reloaded payloads match originally stored values including nested structures

### TPP Contract Validation
- [ ] Define the contract schema in `planner/contracts/tpp.py` for TPP submit responses including required `proposal_id` field
- [ ] Define the contract schema in `planner/contracts/tpp.py` for TPP poll responses including required `state` field
- [ ] Define the contract schema in `planner/contracts/tpp.py` for TPP result responses including required evaluation fields
- [ ] Implement validation logic in `planner/services/tpp_proposal_submission_service.py` for submit responses that raises domain error on contract violations
- [ ] Implement validation logic in `planner/services/tpp_polling_service.py` for poll responses that raises domain error on contract violations
- [ ] Implement validation logic in `planner/services/tpp_result_service.py` for result responses that raises domain error on contract violations
- [ ] Write unit tests in `tests/planner/test_tpp_proposal_submission_service.py` verifying domain error is raised for malformed submit responses
- [ ] Write unit tests in `tests/planner/test_tpp_polling_service.py` verifying domain error is raised for malformed poll responses
- [ ] Write unit tests in `tests/planner/test_tpp_result_service.py` verifying domain error is raised for malformed result responses

### Cleanup
- [ ] Fix the branch diff by reverting or removing modifications to `tests/planner/test_inventory_provenance.py` from this work

#### Acceptance criteria
### Proposal Submission
- [ ] Calling the production TPP proposal submission service with a valid workspace and a mocked TPP submit response containing `proposal_id='test-123'` persists the value `'test-123'` into `workspace.state.tpp_proposal_id` and returns a result object where `result.proposal_id == 'test-123'` and `result.success == True`
- [ ] If the TPP submit response is missing `proposal_id` or otherwise violates the submit response contract, the submission service raises the existing domain error and does not write any proposal id into workspace state

### Polling State Mapping
- [ ] The production polling service maps a poll response with `state='approved'` to return `PollingOutcome.APPROVED` (or equivalent enum value) and does not return `PollingOutcome.PENDING`, `PollingOutcome.REJECTED`, `PollingOutcome.FAILED`, or `PollingOutcome.TIMEOUT`
- [ ] The production polling service maps a poll response with `state='rejected'` to return `PollingOutcome.REJECTED`, and `tests/planner/test_tpp_polling_service.py` contains an assertion verifying `polling_service.poll(proposal_id) == PollingOutcome.REJECTED` for that exact outcome
- [ ] The production polling service maps a poll response with `state='pending'` to return `PollingOutcome.PENDING`, and `tests/planner/test_tpp_polling_service.py` contains an assertion verifying `polling_service.poll(proposal_id) == PollingOutcome.PENDING` for that exact outcome
- [ ] The production polling service maps a poll response with `state='failed'` to return `PollingOutcome.FAILED` and does not return `PollingOutcome.APPROVED`, `PollingOutcome.PENDING`, `PollingOutcome.REJECTED`, or `PollingOutcome.TIMEOUT`
- [ ] When the polling workflow reaches its configured timeout condition without receiving a terminal poll state, it returns `PollingOutcome.TIMEOUT` and does not persist an approved or rejected result
- [ ] If a poll response payload is malformed or missing required contract fields, the polling service raises the existing domain error instead of returning any `PollingOutcome` value

### Result Persistence and Rehydration
- [ ] When a contract-valid TPP evaluation/result payload is received, the production result service persists it into `workspace.state.tpp_result` such that `json.dumps(workspace.state.tpp_result, sort_keys=True)` equals `json.dumps(original_payload, sort_keys=True)`, preserving all keys and nested structures
- [ ] Reloading or rehydrating a workspace after a TPP result has been persisted returns the same result payload shape and values that were originally stored, verified by `json.dumps(rehydrated_result, sort_keys=True) == json.dumps(original_result, sort_keys=True)`
- [ ] If a TPP result payload is malformed or missing required contract fields, the result-processing path raises the existing domain error and does not persist the malformed payload into workspace state

### Cleanup
- [ ] The TPP follow-up change set does not modify `tests/planner/test_inventory_provenance.py`, verified by `git diff --name-only` not listing that file

**Head SHA:** 56ce8e087661dd9102316ff499d08f5ade0702e9
**Latest Runs:** ⏭️ skipped — Agents PR Event Hub
**Required:** gate: ⏸️ not started

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/stranske/trip-planner/actions/runs/25090281969) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/stranske/trip-planner/actions/runs/25090281977) |
<!-- auto-status-summary:end -->