### PR TITLE
Issue #1044: Add TPP transport policy with breaker fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Use these env vars only when you are intentionally exercising an integration sea
 - `VITE_GOOGLE_MAPS_EMBED_API_KEY`: legacy key name still accepted as a compatibility fallback when `VITE_GOOGLE_MAPS_BROWSER_API_KEY` is not set.
 - `VITE_GOOGLE_MAPS_PROVIDER_STATE`: optional local/test override for the map adapter load state (`ready`, `loading`, or `error`).
 - `TPP_BASE_URL`, `TPP_ACCESS_TOKEN`, `TPP_OIDC_PROVIDER`: enable the live `Travel-Plan-Permission` transport client. If they are unset, the repo should continue to present stored-policy and passive/local TPP seams rather than implying a real remote policy round-trip.
+- `TPP_TRANSPORT_CONNECT_TIMEOUT_SECONDS`, `TPP_TRANSPORT_READ_TIMEOUT_SECONDS`, `TPP_TRANSPORT_MAX_ATTEMPTS`, `TPP_TRANSPORT_BACKOFF_INITIAL_SECONDS`, `TPP_TRANSPORT_BACKOFF_MAX_SECONDS`, `TPP_TRANSPORT_BREAKER_FAILURE_THRESHOLD`, `TPP_TRANSPORT_BREAKER_RESET_SECONDS`: optional live TPP transport policy overrides. Defaults are 5s connect timeout, 15s read timeout, 3 attempts, 0.5s jittered initial backoff capped at 4s, 5 failures before the per-host breaker opens, and a 30s breaker reset window. `TPP_TIMEOUT_SECONDS` remains accepted as a legacy read-timeout fallback when the newer read-timeout override is unset.
 - `TPP_REPO_PATH`: optional sibling checkout path used by `make full-product-check` when it needs to start a local Travel-Plan-Permission service instead of using `TPP_BASE_URL`.
 
 That distinction matters for docs and verification messaging:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "httpx==0.28.1",
     "PyYAML==6.0.3",
     "types-PyYAML==6.0.12.20250402",
+    "pytest-httpserver==1.1.3",
 ]
 [build-system]
 requires = ["setuptools>=82.0.1"]

--- a/requirements.lock
+++ b/requirements.lock
@@ -120,6 +120,8 @@ pytest==9.0.3
     #   pytest-cov
 pytest-cov==7.1.0
     # via trip-planner (pyproject.toml)
+pytest-httpserver==1.1.3
+    # via trip-planner (pyproject.toml)
 pytokens==0.4.1
     # via black
 pyyaml==6.0.3

--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -55,6 +55,7 @@ STDLIB_MODULES = {
     "gc",
     "glob",
     "hashlib",
+    "http",
     "importlib",
     "inspect",
     "io",

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -308,6 +308,7 @@ def test_workspace_policy_import_surfaces_live_tpp_unavailable_errors(
     monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    monkeypatch.setenv("TPP_TRANSPORT_MAX_ATTEMPTS", "1")
     _install_fake_http(
         monkeypatch,
         [

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -1,4 +1,5 @@
 import json
+import socket
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Literal, cast
@@ -1240,6 +1241,114 @@ def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
         response.json()["detail"]
         == "result_payload.execution_id is required for non-terminal submissions"
     )
+
+
+def test_workspace_proposal_submission_persists_stored_policy_when_live_tpp_times_out(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+    monkeypatch.setenv("TPP_TRANSPORT_MAX_ATTEMPTS", "1")
+    _install_fake_http(monkeypatch, [socket.timeout("slow response")])
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Timeout fallback workspace",
+            "summary": "Persist stored-policy posture when live TPP times out.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    response = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "proposal_version": "proposal-v3",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["proposal_state"]
+    assert payload["submission_status"] == "retry_scheduled"
+    assert payload["summary"]["submission_error"]["code"] == "timeout"
+    assert payload["summary"]["submission_error"]["details"]["error_code"] == "timeout"
+    assert "stored-policy posture" in payload["summary"]["submission_summary"]
+    assert payload["summary"]["submission_retry"]["retryable"] is True
+
+
+def test_workspace_proposal_submission_persists_stored_policy_when_breaker_is_open(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "https://tpp.example.test")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "token-123")
+    monkeypatch.setenv("TPP_OIDC_PROVIDER", "okta")
+
+    def _raise_breaker_open(self, request):
+        del self, request
+        raise tpp_client_module.TPPTransportError(
+            "TPP circuit breaker is open for https://tpp.example.test:443.",
+            error_code="breaker_open",
+            status_code=503,
+            retryable=True,
+        )
+
+    monkeypatch.setattr(
+        tpp_client_module.HTTPTPPIntegrationClient,
+        "submit_proposal",
+        _raise_breaker_open,
+    )
+
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Breaker fallback workspace",
+            "summary": "Persist stored-policy posture when live TPP breaker is open.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = f"proposal:{trip_id}"
+    submission_fixture["request"]["payload"]["proposal_ref"] = f"proposal:{trip_id}"
+
+    response = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": _proposal_payload(trip_id),
+            "request": submission_fixture["request"],
+            "proposal_version": "proposal-v3",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["proposal_state"]
+    assert payload["submission_status"] == "retry_scheduled"
+    assert payload["summary"]["submission_error"]["code"] == "breaker_open"
+    assert payload["summary"]["submission_error"]["details"]["error_code"] == "breaker_open"
+    assert "stored-policy posture" in payload["summary"]["submission_summary"]
 
 
 def test_workspace_proposal_refresh_polls_live_status_and_persists_evaluation(

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -15,6 +15,7 @@ from trip_planner.app.services.feasibility import (
 )
 from trip_planner.app.services.scenarios import _runtime_business_profile
 from trip_planner.app.services.trips import create_trip
+from trip_planner.app.services import workspace as workspace_service
 from trip_planner.app.services.workspace import get_workspace_payload
 from trip_planner.options import InventoryBundle
 from trip_planner.persistence.db import (
@@ -1838,6 +1839,47 @@ def test_workspace_endpoint_hides_other_users_persisted_trips(
     response = client.get(f"/api/workspace/{trip_id}")
 
     assert response.status_code == 404
+
+
+def test_planner_panel_state_surfaces_stored_policy_fallback_notice_for_breaker_open() -> None:
+    panel_state = workspace_service._build_planner_panel_state(
+        trip={
+            "trip_id": "trip-fallback",
+            "title": "Fallback trip",
+            "mode": "business",
+            "trip_frame": {"primary_regions": ["Chicago"]},
+        },
+        scenario_search={"scenarios": [], "explanation": [], "source_refs": []},
+        session={"pending_decisions": [], "interaction_state": {}},
+        saved_scenarios=[],
+        activity_log=[],
+        feasibility_summary={"assessment_count": 0, "assessments": []},
+        policy_context=None,
+        proposal_context={
+            "proposal_state": {
+                "proposal": {"proposal_id": "proposal:trip-fallback"},
+                "summary": {
+                    "submission_error": {
+                        "code": "breaker_open",
+                        "message": "TPP circuit breaker is open for host.",
+                    }
+                },
+            }
+        },
+    )
+
+    fallback_output = next(
+        (
+            item
+            for item in panel_state["outputs"]
+            if item["output_id"].endswith(":proposal-transport-fallback")
+        ),
+        None,
+    )
+    assert fallback_output is not None
+    assert fallback_output["title"] == "Live TPP breaker is open"
+    assert "stored-policy posture" in fallback_output["body"]
+    assert fallback_output["status"] == "caution"
 
 
 def _load_feasibility_fixture(name: str) -> InventoryBundle:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,19 @@
+from collections.abc import Iterator
 from pathlib import Path
 import sys
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 root_str = str(ROOT)
 if root_str not in sys.path:
     sys.path.insert(0, root_str)
+
+
+@pytest.fixture(autouse=True)
+def isolate_tpp_transport_breakers() -> Iterator[None]:
+    from trip_planner.integrations.tpp import client as tpp_client_module
+
+    tpp_client_module.HTTPTPPIntegrationClient._breakers.clear()
+    yield
+    tpp_client_module.HTTPTPPIntegrationClient._breakers.clear()

--- a/tests/integrations/test_tpp_contracts.py
+++ b/tests/integrations/test_tpp_contracts.py
@@ -1,8 +1,13 @@
 import json
+import socket
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Thread
+from urllib import error as urllib_error
 
 import pytest
 
+from trip_planner.integrations.tpp import client as tpp_client_module
 from trip_planner.integrations.tpp import (
     BaseTPPIntegrationClient,
     HTTPTPPIntegrationClient,
@@ -10,6 +15,8 @@ from trip_planner.integrations.tpp import (
     TPPRequestEnvelope,
     TPPResponseEnvelope,
     TPPRuntimeSettings,
+    TPPTransportError,
+    TPPTransportPolicy,
 )
 
 
@@ -146,3 +153,254 @@ def test_http_policy_payload_names_all_trip_id_sources() -> None:
 
     with pytest.raises(TPPContractError, match="payload.trip_plan.trip_id"):
         client._policy_request_payload(request)
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status_code: int, body: dict | list | str) -> None:
+        self.status = status_code
+        self._body = body
+
+    def read(self) -> bytes:
+        if isinstance(self._body, str):
+            return self._body.encode("utf-8")
+        return json.dumps(self._body).encode("utf-8")
+
+    def __enter__(self) -> "_FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        del exc_type, exc, tb
+        return False
+
+
+def _http_client(
+    *,
+    policy: TPPTransportPolicy | None = None,
+    clock=lambda: 0.0,
+    breaker_registry=None,
+) -> HTTPTPPIntegrationClient:
+    return HTTPTPPIntegrationClient(
+        TPPRuntimeSettings(
+            base_url="https://tpp.example.test",
+            access_token="token-123",
+            oidc_provider="okta",
+        ),
+        policy=policy
+        or TPPTransportPolicy(backoff_initial_seconds=0.0, backoff_max_seconds=0.0),
+        sleep=lambda _delay: None,
+        clock=clock,
+        jitter=lambda _start, _end: 0.0,
+        breaker_registry=breaker_registry if breaker_registry is not None else {},
+    )
+
+
+def _install_urlopen(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: list[_FakeHTTPResponse | Exception],
+    *,
+    captured_timeouts: list[float] | None = None,
+) -> None:
+    queue = list(responses)
+
+    def _fake_urlopen(request, timeout=0):
+        del request
+        if captured_timeouts is not None:
+            captured_timeouts.append(timeout)
+        response = queue.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(tpp_client_module.urllib_request, "urlopen", _fake_urlopen)
+
+
+def test_transport_policy_defaults_and_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "TPP_TIMEOUT_SECONDS",
+        "TPP_TRANSPORT_CONNECT_TIMEOUT_SECONDS",
+        "TPP_TRANSPORT_READ_TIMEOUT_SECONDS",
+        "TPP_TRANSPORT_MAX_ATTEMPTS",
+        "TPP_TRANSPORT_BACKOFF_INITIAL_SECONDS",
+        "TPP_TRANSPORT_BACKOFF_MAX_SECONDS",
+        "TPP_TRANSPORT_BREAKER_FAILURE_THRESHOLD",
+        "TPP_TRANSPORT_BREAKER_RESET_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    default_policy = TPPTransportPolicy.from_env()
+
+    assert default_policy.connect_timeout_seconds == 5.0
+    assert default_policy.read_timeout_seconds == 15.0
+    assert default_policy.max_attempts == 3
+    assert default_policy.backoff_initial_seconds == 0.5
+    assert default_policy.backoff_max_seconds == 4.0
+    assert default_policy.breaker_failure_threshold == 5
+    assert default_policy.breaker_reset_seconds == 30.0
+
+    monkeypatch.setenv("TPP_TRANSPORT_CONNECT_TIMEOUT_SECONDS", "2")
+    monkeypatch.setenv("TPP_TRANSPORT_READ_TIMEOUT_SECONDS", "9")
+    monkeypatch.setenv("TPP_TRANSPORT_MAX_ATTEMPTS", "4")
+    monkeypatch.setenv("TPP_TRANSPORT_BACKOFF_INITIAL_SECONDS", "0.1")
+    monkeypatch.setenv("TPP_TRANSPORT_BACKOFF_MAX_SECONDS", "1.5")
+    monkeypatch.setenv("TPP_TRANSPORT_BREAKER_FAILURE_THRESHOLD", "7")
+    monkeypatch.setenv("TPP_TRANSPORT_BREAKER_RESET_SECONDS", "11")
+
+    policy = TPPTransportPolicy.from_env()
+
+    assert policy.connect_timeout_seconds == 2.0
+    assert policy.read_timeout_seconds == 9.0
+    assert policy.max_attempts == 4
+    assert policy.backoff_initial_seconds == 0.1
+    assert policy.backoff_max_seconds == 1.5
+    assert policy.breaker_failure_threshold == 7
+    assert policy.breaker_reset_seconds == 11.0
+
+
+def test_http_transport_retries_server_errors_then_surfaces_typed_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_urlopen(
+        monkeypatch,
+        [
+            _FakeHTTPResponse(503, {"detail": "try later"}),
+            _FakeHTTPResponse(503, {"detail": "still later"}),
+            _FakeHTTPResponse(503, {"detail": "failed"}),
+        ],
+    )
+    client = _http_client(
+        policy=TPPTransportPolicy(
+            max_attempts=3,
+            backoff_initial_seconds=0.0,
+            backoff_max_seconds=0.0,
+            breaker_failure_threshold=5,
+        )
+    )
+
+    with pytest.raises(TPPTransportError) as exc_info:
+        client._request_json(method="POST", path="/api/fail", json_payload={})
+
+    assert exc_info.value.error_code == "server_error"
+    assert exc_info.value.retryable is True
+
+
+def test_http_transport_classifies_connection_timeout_unauthorized_and_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cases: list[tuple[_FakeHTTPResponse | Exception, str]] = [
+        (urllib_error.URLError(ConnectionRefusedError("refused")), "connection_error"),
+        (socket.timeout("slow response"), "timeout"),
+        (_FakeHTTPResponse(401, {"detail": "bad token"}), "unauthorized"),
+        (_FakeHTTPResponse(200, "not-json"), "invalid_response"),
+    ]
+    for response, error_code in cases:
+        _install_urlopen(monkeypatch, [response])
+        client = _http_client(policy=TPPTransportPolicy(max_attempts=1))
+
+        with pytest.raises(TPPTransportError) as exc_info:
+            client._request_json(method="POST", path=f"/api/{error_code}", json_payload={})
+
+        assert exc_info.value.error_code == error_code
+
+
+def test_http_transport_opens_breaker_after_consecutive_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_urlopen(
+        monkeypatch,
+        [urllib_error.URLError(ConnectionRefusedError("refused")) for _ in range(5)],
+    )
+    registry = {}
+    client = _http_client(
+        policy=TPPTransportPolicy(max_attempts=1, breaker_failure_threshold=5),
+        breaker_registry=registry,
+    )
+    for _ in range(5):
+        with pytest.raises(TPPTransportError) as exc_info:
+            client._request_json(method="POST", path="/api/down", json_payload={})
+        assert exc_info.value.error_code == "connection_error"
+
+    with pytest.raises(TPPTransportError) as exc_info:
+        client._request_json(method="POST", path="/api/down", json_payload={})
+
+    assert exc_info.value.error_code == "breaker_open"
+
+
+def test_http_transport_half_open_success_closes_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_time = 0.0
+
+    def _clock() -> float:
+        return current_time
+
+    _install_urlopen(
+        monkeypatch,
+        [
+            urllib_error.URLError(ConnectionRefusedError("refused")),
+            _FakeHTTPResponse(200, {"ok": True}),
+            urllib_error.URLError(ConnectionRefusedError("refused-again")),
+        ],
+    )
+    client = _http_client(
+        policy=TPPTransportPolicy(
+            max_attempts=1,
+            breaker_failure_threshold=1,
+            breaker_reset_seconds=10.0,
+        ),
+        clock=_clock,
+        breaker_registry={},
+    )
+
+    with pytest.raises(TPPTransportError) as first_failure:
+        client._request_json(method="POST", path="/api/down", json_payload={})
+    assert first_failure.value.error_code == "connection_error"
+
+    current_time = 5.0
+    with pytest.raises(TPPTransportError) as open_breaker:
+        client._request_json(method="POST", path="/api/down", json_payload={})
+    assert open_breaker.value.error_code == "breaker_open"
+
+    current_time = 11.0
+    assert client._request_json(method="POST", path="/api/down", json_payload={}) == {
+        "ok": True
+    }
+
+    current_time = 12.0
+    with pytest.raises(TPPTransportError) as after_close:
+        client._request_json(method="POST", path="/api/down", json_payload={})
+    assert after_close.value.error_code == "connection_error"
+
+
+def test_http_transport_integration_against_stub_http_server_reports_server_error() -> None:
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.send_response(503)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"detail": "temporarily unavailable"}')
+
+        def log_message(self, *_args) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        client = HTTPTPPIntegrationClient(
+            TPPRuntimeSettings(
+                base_url=f"http://127.0.0.1:{server.server_port}",
+                access_token="token-123",
+                oidc_provider="okta",
+            ),
+            policy=TPPTransportPolicy(max_attempts=1, breaker_failure_threshold=5),
+            breaker_registry={},
+        )
+
+        with pytest.raises(TPPTransportError) as exc_info:
+            client._request_json(method="POST", path="/stub", json_payload={})
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert exc_info.value.error_code == "server_error"

--- a/tests/integrations/test_tpp_contracts.py
+++ b/tests/integrations/test_tpp_contracts.py
@@ -392,6 +392,48 @@ def test_http_transport_half_open_success_closes_breaker(
     assert after_close.value.error_code == "connection_error"
 
 
+def test_http_transport_half_open_allows_single_trial_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_time = 0.0
+
+    def _clock() -> float:
+        return current_time
+
+    _install_urlopen(
+        monkeypatch,
+        [
+            urllib_error.URLError(ConnectionRefusedError("refused")),
+            _FakeHTTPResponse(200, {"ok": True}),
+        ],
+    )
+    client = _http_client(
+        policy=TPPTransportPolicy(
+            max_attempts=1,
+            breaker_failure_threshold=1,
+            breaker_reset_seconds=10.0,
+        ),
+        clock=_clock,
+        breaker_registry={},
+    )
+
+    with pytest.raises(TPPTransportError):
+        client._request_json(method="POST", path="/api/down", json_payload={})
+
+    current_time = 11.0
+    assert client._request_json(method="POST", path="/api/down", json_payload={}) == {"ok": True}
+
+    breaker = next(iter(client._breaker_registry.values()))
+    breaker.opened_at = 11.0
+    breaker.half_open = True
+    breaker._half_open_trial_in_flight = True
+    current_time = 22.0
+
+    with pytest.raises(TPPTransportError) as exc_info:
+        client._request_json(method="POST", path="/api/down", json_payload={})
+    assert exc_info.value.error_code == "breaker_open"
+
+
 def test_http_transport_integration_against_stub_http_server_reports_server_error() -> None:
     class _Handler(BaseHTTPRequestHandler):
         def do_POST(self) -> None:

--- a/tests/integrations/test_tpp_contracts.py
+++ b/tests/integrations/test_tpp_contracts.py
@@ -403,7 +403,10 @@ def test_http_transport_integration_against_stub_http_server_reports_server_erro
         def log_message(self, *_args) -> None:
             return
 
-    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    try:
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    except PermissionError:
+        pytest.skip("Local socket bind is not permitted in this execution environment.")
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:

--- a/tests/integrations/test_tpp_contracts.py
+++ b/tests/integrations/test_tpp_contracts.py
@@ -3,6 +3,7 @@ import socket
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from threading import Thread
+from typing import Literal
 from urllib import error as urllib_error
 
 import pytest
@@ -168,7 +169,7 @@ class _FakeHTTPResponse:
     def __enter__(self) -> "_FakeHTTPResponse":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> bool:
+    def __exit__(self, exc_type, exc, tb) -> Literal[False]:
         del exc_type, exc, tb
         return False
 
@@ -331,7 +332,7 @@ def test_http_transport_opens_breaker_after_consecutive_failures(
         monkeypatch,
         [urllib_error.URLError(ConnectionRefusedError("refused")) for _ in range(5)],
     )
-    registry = {}
+    registry: dict[str, object] = {}
     client = _http_client(
         policy=TPPTransportPolicy(max_attempts=1, breaker_failure_threshold=5),
         breaker_registry=registry,

--- a/tests/integrations/test_tpp_contracts.py
+++ b/tests/integrations/test_tpp_contracts.py
@@ -185,8 +185,7 @@ def _http_client(
             access_token="token-123",
             oidc_provider="okta",
         ),
-        policy=policy
-        or TPPTransportPolicy(backoff_initial_seconds=0.0, backoff_max_seconds=0.0),
+        policy=policy or TPPTransportPolicy(backoff_initial_seconds=0.0, backoff_max_seconds=0.0),
         sleep=lambda _delay: None,
         clock=clock,
         jitter=lambda _start, _end: 0.0,
@@ -283,6 +282,29 @@ def test_http_transport_retries_server_errors_then_surfaces_typed_error(
     assert exc_info.value.retryable is True
 
 
+def test_http_transport_uses_connect_timeout_policy_for_urlopen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_timeouts: list[float] = []
+    _install_urlopen(
+        monkeypatch,
+        [_FakeHTTPResponse(200, {"ok": True})],
+        captured_timeouts=captured_timeouts,
+    )
+    client = _http_client(
+        policy=TPPTransportPolicy(
+            connect_timeout_seconds=2.5,
+            read_timeout_seconds=9.0,
+            max_attempts=1,
+        )
+    )
+
+    payload = client._request_json(method="POST", path="/api/ok", json_payload={})
+
+    assert payload == {"ok": True}
+    assert captured_timeouts == [2.5]
+
+
 def test_http_transport_classifies_connection_timeout_unauthorized_and_invalid_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -361,9 +383,7 @@ def test_http_transport_half_open_success_closes_breaker(
     assert open_breaker.value.error_code == "breaker_open"
 
     current_time = 11.0
-    assert client._request_json(method="POST", path="/api/down", json_payload={}) == {
-        "ok": True
-    }
+    assert client._request_json(method="POST", path="/api/down", json_payload={}) == {"ok": True}
 
     current_time = 12.0
     with pytest.raises(TPPTransportError) as after_close:

--- a/tests/integrations/test_tpp_contracts.py
+++ b/tests/integrations/test_tpp_contracts.py
@@ -325,6 +325,11 @@ def test_http_transport_classifies_connection_timeout_unauthorized_and_invalid_r
         assert exc_info.value.error_code == error_code
 
 
+def test_transport_error_rejects_unknown_error_code() -> None:
+    with pytest.raises(ValueError, match="error_code must be one of"):
+        TPPTransportError("bad code", error_code="not_a_real_code")  # type: ignore[arg-type]
+
+
 def test_http_transport_opens_breaker_after_consecutive_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/integrations/test_tpp_contracts.py
+++ b/tests/integrations/test_tpp_contracts.py
@@ -199,11 +199,14 @@ def _install_urlopen(
     responses: list[_FakeHTTPResponse | Exception],
     *,
     captured_timeouts: list[float] | None = None,
+    call_counter: list[int] | None = None,
 ) -> None:
     queue = list(responses)
 
     def _fake_urlopen(request, timeout=0):
         del request
+        if call_counter is not None:
+            call_counter[0] += 1
         if captured_timeouts is not None:
             captured_timeouts.append(timeout)
         response = queue.pop(0)
@@ -259,6 +262,7 @@ def test_transport_policy_defaults_and_env_overrides(monkeypatch: pytest.MonkeyP
 def test_http_transport_retries_server_errors_then_surfaces_typed_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    call_counter = [0]
     _install_urlopen(
         monkeypatch,
         [
@@ -266,6 +270,7 @@ def test_http_transport_retries_server_errors_then_surfaces_typed_error(
             _FakeHTTPResponse(503, {"detail": "still later"}),
             _FakeHTTPResponse(503, {"detail": "failed"}),
         ],
+        call_counter=call_counter,
     )
     client = _http_client(
         policy=TPPTransportPolicy(
@@ -281,6 +286,7 @@ def test_http_transport_retries_server_errors_then_surfaces_typed_error(
 
     assert exc_info.value.error_code == "server_error"
     assert exc_info.value.retryable is True
+    assert call_counter[0] == 3
 
 
 def test_http_transport_uses_connect_timeout_policy_for_urlopen(
@@ -388,8 +394,11 @@ def test_http_transport_half_open_success_closes_breaker(
         client._request_json(method="POST", path="/api/down", json_payload={})
     assert open_breaker.value.error_code == "breaker_open"
 
+    breaker = next(iter(client._breaker_registry.values()))
+    assert breaker.state == "open"
     current_time = 11.0
     assert client._request_json(method="POST", path="/api/down", json_payload={}) == {"ok": True}
+    assert breaker.state == "closed"
 
     current_time = 12.0
     with pytest.raises(TPPTransportError) as after_close:

--- a/tests/integrations/test_tpp_transport_httpserver.py
+++ b/tests/integrations/test_tpp_transport_httpserver.py
@@ -1,4 +1,6 @@
+import threading
 import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
@@ -76,14 +78,27 @@ def test_httpserver_surfaces_invalid_response(httpserver: HTTPServer) -> None:
     assert exc_info.value.error_code == "invalid_response"
 
 
-def test_httpserver_surfaces_timeout(httpserver: HTTPServer) -> None:
-    def _slow_response(_request):
-        time.sleep(0.15)
-        return "slow"
+def test_httpserver_surfaces_timeout() -> None:
+    class SlowBodyHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", "12")
+            self.end_headers()
+            time.sleep(0.25)
+            try:
+                self.wfile.write(b'{"ok": true}')
+            except BrokenPipeError:
+                pass
 
-    httpserver.expect_request("/timeout", method="POST").respond_with_handler(_slow_response)
+        def log_message(self, _format: str, *args: object) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), SlowBodyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
     client = _client(
-        httpserver.url_for(""),
+        f"http://127.0.0.1:{server.server_port}",
         policy=TPPTransportPolicy(
             connect_timeout_seconds=1.0,
             read_timeout_seconds=0.05,
@@ -94,8 +109,13 @@ def test_httpserver_surfaces_timeout(httpserver: HTTPServer) -> None:
         ),
     )
 
-    with pytest.raises(TPPTransportError) as exc_info:
-        client._request_json(method="POST", path="/timeout", json_payload={})
+    try:
+        with pytest.raises(TPPTransportError) as exc_info:
+            client._request_json(method="POST", path="/timeout", json_payload={})
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
 
     assert exc_info.value.error_code == "timeout"
 

--- a/tests/integrations/test_tpp_transport_httpserver.py
+++ b/tests/integrations/test_tpp_transport_httpserver.py
@@ -1,0 +1,128 @@
+import time
+
+import pytest
+
+pytest.importorskip("pytest_httpserver")
+from pytest_httpserver import HTTPServer
+
+from trip_planner.integrations.tpp import (
+    HTTPTPPIntegrationClient,
+    TPPRuntimeSettings,
+    TPPTransportError,
+    TPPTransportPolicy,
+)
+
+
+def _client(base_url: str, *, policy: TPPTransportPolicy | None = None) -> HTTPTPPIntegrationClient:
+    return HTTPTPPIntegrationClient(
+        TPPRuntimeSettings(
+            base_url=base_url.rstrip("/"),
+            access_token="token-123",
+            oidc_provider="okta",
+        ),
+        policy=policy
+        or TPPTransportPolicy(
+            max_attempts=1,
+            backoff_initial_seconds=0.0,
+            backoff_max_seconds=0.0,
+            breaker_failure_threshold=5,
+        ),
+        breaker_registry={},
+    )
+
+
+def test_httpserver_surfaces_server_error_after_retry_budget(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/server", method="POST").respond_with_json(
+        {"detail": "temporarily unavailable"}, status=503
+    )
+    client = _client(
+        httpserver.url_for(""),
+        policy=TPPTransportPolicy(
+            max_attempts=3,
+            backoff_initial_seconds=0.0,
+            backoff_max_seconds=0.0,
+            breaker_failure_threshold=5,
+        ),
+    )
+
+    with pytest.raises(TPPTransportError) as exc_info:
+        client._request_json(method="POST", path="/server", json_payload={})
+
+    assert exc_info.value.error_code == "server_error"
+    assert len(httpserver.log) == 3
+
+
+def test_httpserver_surfaces_unauthorized(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/unauthorized", method="POST").respond_with_json(
+        {"detail": "bad token"}, status=401
+    )
+    client = _client(httpserver.url_for(""))
+
+    with pytest.raises(TPPTransportError) as exc_info:
+        client._request_json(method="POST", path="/unauthorized", json_payload={})
+
+    assert exc_info.value.error_code == "unauthorized"
+
+
+def test_httpserver_surfaces_invalid_response(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/invalid", method="POST").respond_with_data(
+        "not-json", status=200, content_type="text/plain"
+    )
+    client = _client(httpserver.url_for(""))
+
+    with pytest.raises(TPPTransportError) as exc_info:
+        client._request_json(method="POST", path="/invalid", json_payload={})
+
+    assert exc_info.value.error_code == "invalid_response"
+
+
+def test_httpserver_surfaces_timeout(httpserver: HTTPServer) -> None:
+    def _slow_response(_request):
+        time.sleep(0.15)
+        return "slow"
+
+    httpserver.expect_request("/timeout", method="POST").respond_with_handler(_slow_response)
+    client = _client(
+        httpserver.url_for(""),
+        policy=TPPTransportPolicy(
+            connect_timeout_seconds=1.0,
+            read_timeout_seconds=0.05,
+            max_attempts=1,
+            backoff_initial_seconds=0.0,
+            backoff_max_seconds=0.0,
+            breaker_failure_threshold=5,
+        ),
+    )
+
+    with pytest.raises(TPPTransportError) as exc_info:
+        client._request_json(method="POST", path="/timeout", json_payload={})
+
+    assert exc_info.value.error_code == "timeout"
+
+
+def test_httpserver_breaker_opens_after_consecutive_failures(httpserver: HTTPServer) -> None:
+    httpserver.expect_request("/down", method="POST").respond_with_json(
+        {"detail": "service down"}, status=503
+    )
+    client = _client(
+        httpserver.url_for(""),
+        policy=TPPTransportPolicy(
+            max_attempts=1,
+            backoff_initial_seconds=0.0,
+            backoff_max_seconds=0.0,
+            breaker_failure_threshold=2,
+            breaker_reset_seconds=60.0,
+        ),
+    )
+
+    with pytest.raises(TPPTransportError) as first:
+        client._request_json(method="POST", path="/down", json_payload={})
+    assert first.value.error_code == "server_error"
+
+    with pytest.raises(TPPTransportError) as second:
+        client._request_json(method="POST", path="/down", json_payload={})
+    assert second.value.error_code == "server_error"
+
+    with pytest.raises(TPPTransportError) as third:
+        client._request_json(method="POST", path="/down", json_payload={})
+    assert third.value.error_code == "breaker_open"

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -211,6 +211,65 @@ def _resolve_submission_response(
     return HTTPTPPIntegrationClient().submit_proposal(live_request)
 
 
+def _transport_error_details(error: Exception, *, source: str) -> dict[str, str]:
+    details: dict[str, str] = {"source": source}
+    error_code = getattr(error, "error_code", None)
+    status_code = getattr(error, "status_code", None)
+    if error_code:
+        details["error_code"] = str(error_code)
+    if status_code is not None:
+        details["status_code"] = str(status_code)
+    return details
+
+
+def _should_persist_stored_policy_fallback(error: TPPTransportError) -> bool:
+    return error.error_code in {"breaker_open", "timeout"}
+
+
+def _fallback_submission_response(
+    *,
+    request: TPPRequestEnvelope,
+    error: TPPTransportError,
+) -> TPPResponseEnvelope:
+    if error.error_code == "breaker_open":
+        summary = (
+            "Live TPP transport circuit breaker is open; the workspace is using stored-policy "
+            "posture until the next retry window."
+        )
+    else:
+        summary = (
+            "Live TPP transport timed out; the workspace is using stored-policy posture until "
+            "the next retry."
+        )
+    return TPPResponseEnvelope(
+        operation=request.operation,
+        request_id=request.request_id,
+        correlation_id=request.correlation_id,
+        transport_pattern="deferred",
+        execution_status=TPPExecutionStatus(
+            state="retry_scheduled",
+            terminal=False,
+            summary=summary,
+            updated_at=_now_iso(),
+        ),
+        result_payload={},
+        error=TPPErrorRecord(
+            code=error.error_code,
+            message=str(error) or summary,
+            category="transport",
+            retryable=True,
+            details=_transport_error_details(error, source="workspace_proposal_submission"),
+        ),
+        retry=TPPRetryMetadata(
+            attempt=1,
+            max_attempts=5,
+            retryable=True,
+            reason=summary,
+        ),
+        received_at=_now_iso(),
+    )
+
+
 def _normalize_evaluation_request(
     request: TPPRequestEnvelope,
     *,
@@ -548,10 +607,7 @@ def _persist_evaluation_refresh_failure(
     request: TPPRequestEnvelope,
     error: Exception,
 ) -> None:
-    status_code = getattr(error, "status_code", None)
-    details: dict[str, str] = {"source": "workspace_proposal_refresh"}
-    if status_code is not None:
-        details["status_code"] = str(status_code)
+    details = _transport_error_details(error, source="workspace_proposal_refresh")
 
     if isinstance(error, TPPTransportError):
         category = "transport"
@@ -607,10 +663,7 @@ def _persist_submission_refresh_failure(
     request: TPPRequestEnvelope,
     error: Exception,
 ) -> None:
-    status_code = getattr(error, "status_code", None)
-    details: dict[str, str] = {"source": "workspace_proposal_refresh"}
-    if status_code is not None:
-        details["status_code"] = str(status_code)
+    details = _transport_error_details(error, source="workspace_proposal_refresh")
 
     if isinstance(error, TPPConfigurationError):
         category = "configuration"
@@ -632,7 +685,7 @@ def _persist_submission_refresh_failure(
         retryable = True
         terminal = False
         summary = "Workspace refresh could not reach the live proposal status endpoint. Retry the status check."
-        code = "submission_refresh_transport_failed"
+        code = f"submission_refresh_{error.error_code}"
     else:
         category = "application"
         state = "failed"
@@ -719,14 +772,19 @@ def save_workspace_proposal_submission(
         raise ValueError("proposal.trip_id must match the workspace trip.")
 
     request = TPPRequestEnvelope.from_dict(request_payload)
-    response = _resolve_submission_response(
-        request,
-        response_payload,
-        proposal_version=proposal_version,
-        trip_record=trip_record,
-        user=user,
-        proposal=proposal,
-    )
+    try:
+        response = _resolve_submission_response(
+            request,
+            response_payload,
+            proposal_version=proposal_version,
+            trip_record=trip_record,
+            user=user,
+            proposal=proposal,
+        )
+    except TPPTransportError as error:
+        if not _should_persist_stored_policy_fallback(error):
+            raise
+        response = _fallback_submission_response(request=request, error=error)
     submission = TPPProposalSubmissionService(_PassiveTPPClient(response)).submit_proposal(
         request,
         proposal,

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1735,6 +1735,32 @@ def _build_planner_panel_state(
                 "highlights": list(summary.get("highlights") or [])[:3],
             }
         )
+        submission_error = summary.get("submission_error")
+        if isinstance(submission_error, dict):
+            error_code = submission_error.get("code")
+            if error_code in {"breaker_open", "timeout"}:
+                if error_code == "breaker_open":
+                    notice_title = "Live TPP breaker is open"
+                    notice_body = (
+                        "Live policy transport is temporarily unavailable. The workspace is using "
+                        "stored-policy posture until the breaker reset window elapses."
+                    )
+                else:
+                    notice_title = "Live TPP request timed out"
+                    notice_body = (
+                        "Live policy transport timed out. The workspace is using stored-policy "
+                        "posture while live transport recovers."
+                    )
+                outputs.append(
+                    {
+                        "output_id": f"output:{trip['trip_id']}:proposal-transport-fallback",
+                        "title": notice_title,
+                        "body": notice_body,
+                        "tags": ["proposal", "transport", "stored-policy", trip["mode"]],
+                        "status": "caution",
+                        "highlights": [str(submission_error.get("message") or "")],
+                    }
+                )
         if follow_up:
             outputs.append(
                 {

--- a/trip_planner/integrations/tpp/__init__.py
+++ b/trip_planner/integrations/tpp/__init__.py
@@ -8,7 +8,9 @@ from .client import (
     TPPIntegrationClient,
     TPPRuntimeSettings,
     TPPServiceUnavailableError,
+    TPPTransportPolicy,
     TPPTransportError,
+    tpp_transport_error_from_exception,
 )
 from .contracts import (
     TPPErrorRecord,
@@ -73,7 +75,9 @@ __all__ = [
     "TPPPolicySyncService",
     "TPPRuntimeSettings",
     "TPPServiceUnavailableError",
+    "TPPTransportPolicy",
     "TPPTransportError",
+    "tpp_transport_error_from_exception",
     "TPPReoptimizationService",
     "TPPRequestEnvelope",
     "TPPResponseEnvelope",

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -8,7 +8,7 @@ import socket
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, ClassVar, Callable, Protocol
+from typing import Any, ClassVar, Callable, Literal, Protocol
 import json
 from urllib import error as urllib_error
 from urllib import parse as urllib_parse
@@ -61,14 +61,39 @@ class BaseTPPIntegrationClient(ABC):
 class TPPTransportError(RuntimeError):
     """Raised when a live TPP transport call cannot be completed safely."""
 
+    VALID_ERROR_CODES = frozenset(
+        {
+            "timeout",
+            "connection_error",
+            "server_error",
+            "breaker_open",
+            "unauthorized",
+            "invalid_response",
+            "unknown",
+        }
+    )
+
     def __init__(
         self,
         message: str,
         *,
-        error_code: str = "unknown",
+        error_code: Literal[
+            "timeout",
+            "connection_error",
+            "server_error",
+            "breaker_open",
+            "unauthorized",
+            "invalid_response",
+            "unknown",
+        ] = "unknown",
         status_code: int = 502,
         retryable: bool = False,
     ) -> None:
+        if error_code not in self.VALID_ERROR_CODES:
+            raise ValueError(
+                "error_code must be one of "
+                f"{sorted(self.VALID_ERROR_CODES)!r}, got {error_code!r}."
+            )
         super().__init__(message)
         self.error_code = error_code
         self.status_code = status_code

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -161,20 +161,14 @@ class TPPTransportPolicy:
     def from_env(cls) -> "TPPTransportPolicy":
         default_read_timeout = _env_float("TPP_TIMEOUT_SECONDS", 15.0)
         return cls(
-            connect_timeout_seconds=_env_float(
-                "TPP_TRANSPORT_CONNECT_TIMEOUT_SECONDS", 5.0
-            ),
+            connect_timeout_seconds=_env_float("TPP_TRANSPORT_CONNECT_TIMEOUT_SECONDS", 5.0),
             read_timeout_seconds=_env_float(
                 "TPP_TRANSPORT_READ_TIMEOUT_SECONDS", default_read_timeout
             ),
             max_attempts=_env_int("TPP_TRANSPORT_MAX_ATTEMPTS", 3),
-            backoff_initial_seconds=_env_float(
-                "TPP_TRANSPORT_BACKOFF_INITIAL_SECONDS", 0.5
-            ),
+            backoff_initial_seconds=_env_float("TPP_TRANSPORT_BACKOFF_INITIAL_SECONDS", 0.5),
             backoff_max_seconds=_env_float("TPP_TRANSPORT_BACKOFF_MAX_SECONDS", 4.0),
-            breaker_failure_threshold=_env_int(
-                "TPP_TRANSPORT_BREAKER_FAILURE_THRESHOLD", 5
-            ),
+            breaker_failure_threshold=_env_int("TPP_TRANSPORT_BREAKER_FAILURE_THRESHOLD", 5),
             breaker_reset_seconds=_env_float("TPP_TRANSPORT_BREAKER_RESET_SECONDS", 30.0),
         )
 
@@ -363,7 +357,9 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         self._sleep = sleep or time.sleep
         self._clock = clock or time.monotonic
         self._jitter = jitter or random.uniform
-        self._breaker_registry = breaker_registry if breaker_registry is not None else self._breakers
+        self._breaker_registry = (
+            breaker_registry if breaker_registry is not None else self._breakers
+        )
 
     def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         if request.operation == "fetch_policy_constraints":
@@ -465,7 +461,11 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             method=method,
         )
         try:
-            with urllib_request.urlopen(request, timeout=self.policy.read_timeout_seconds) as response:
+            with urllib_request.urlopen(
+                request,
+                timeout=self.policy.connect_timeout_seconds,
+            ) as response:
+                self._apply_read_timeout(response)
                 status_code = response.status
                 raw_body = response.read().decode("utf-8")
         except urllib_error.HTTPError as exc:
@@ -478,8 +478,16 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
                 status_code=exc.code,
                 body_excerpt=raw_body,
             ) from exc
-        except (urllib_error.URLError, TimeoutError, socket.timeout, ConnectionError, OSError) as exc:
-            transport_error = tpp_transport_error_from_exception(exc, operation="request", path=path)
+        except (
+            urllib_error.URLError,
+            TimeoutError,
+            socket.timeout,
+            ConnectionError,
+            OSError,
+        ) as exc:
+            transport_error = tpp_transport_error_from_exception(
+                exc, operation="request", path=path
+            )
             if transport_error is None:
                 raise
             raise transport_error from exc
@@ -498,6 +506,16 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         if not isinstance(payload, dict):
             raise TPPContractError(f"TPP request to {path} returned a non-object JSON payload.")
         return payload
+
+    def _apply_read_timeout(self, response: Any) -> None:
+        # urllib does not expose separate connect/read timeout knobs; apply read timeout
+        # on the opened socket when accessible and otherwise fall back silently.
+        sock = getattr(getattr(getattr(response, "fp", None), "raw", None), "_sock", None)
+        if sock is None:
+            return
+        settimeout = getattr(sock, "settimeout", None)
+        if callable(settimeout):
+            settimeout(self.policy.read_timeout_seconds)
 
     def _retry_delay(self, attempt: int) -> float:
         delay = min(

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -178,6 +178,7 @@ class _CircuitBreaker:
         self.failures = 0
         self.opened_at: float | None = None
         self.half_open = False
+        self._half_open_trial_in_flight = False
 
     @property
     def state(self) -> str:
@@ -198,21 +199,32 @@ class _CircuitBreaker:
                 retryable=True,
             )
         self.half_open = True
+        if self._half_open_trial_in_flight:
+            raise TPPTransportError(
+                f"TPP circuit breaker is half-open for {host}; trial already in flight.",
+                error_code="breaker_open",
+                status_code=503,
+                retryable=True,
+            )
+        self._half_open_trial_in_flight = True
 
     def record_success(self) -> None:
         self.failures = 0
         self.opened_at = None
         self.half_open = False
+        self._half_open_trial_in_flight = False
 
     def record_failure(self, *, policy: TPPTransportPolicy, now: float) -> None:
         if self.half_open:
             self.opened_at = now
             self.half_open = False
+            self._half_open_trial_in_flight = False
             return
         self.failures += 1
         if self.failures >= policy.breaker_failure_threshold:
             self.opened_at = now
             self.half_open = False
+            self._half_open_trial_in_flight = False
 
 
 def tpp_transport_error_from_exception(

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import os
+import random
+import socket
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, ClassVar, Callable, Protocol
 import json
 from urllib import error as urllib_error
+from urllib import parse as urllib_parse
 from urllib import request as urllib_request
 
 from .contracts import TPPRequestEnvelope, TPPResponseEnvelope
@@ -57,27 +61,238 @@ class BaseTPPIntegrationClient(ABC):
 class TPPTransportError(RuntimeError):
     """Raised when a live TPP transport call cannot be completed safely."""
 
-    def __init__(self, message: str, *, status_code: int = 502) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_code: str = "unknown",
+        status_code: int = 502,
+        retryable: bool = False,
+    ) -> None:
         super().__init__(message)
+        self.error_code = error_code
         self.status_code = status_code
+        self.retryable = retryable
 
 
 class TPPConfigurationError(TPPTransportError):
     """Raised when live TPP transport is requested without runtime config."""
 
     def __init__(self, message: str) -> None:
-        super().__init__(message, status_code=503)
+        super().__init__(message, error_code="unknown", status_code=503, retryable=True)
 
 
 class TPPContractError(TPPTransportError):
     """Raised when the upstream TPP service returns an invalid contract."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message,
+            error_code="invalid_response",
+            status_code=502,
+            retryable=False,
+        )
 
 
 class TPPServiceUnavailableError(TPPTransportError):
     """Raised when the upstream TPP service cannot be reached."""
 
     def __init__(self, message: str) -> None:
-        super().__init__(message, status_code=503)
+        super().__init__(
+            message,
+            error_code="connection_error",
+            status_code=503,
+            retryable=True,
+        )
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise TPPConfigurationError(f"{name} must be a numeric value when provided.") from exc
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise TPPConfigurationError(f"{name} must be an integer value when provided.") from exc
+
+
+@dataclass(slots=True)
+class TPPTransportPolicy:
+    connect_timeout_seconds: float = 5.0
+    read_timeout_seconds: float = 15.0
+    max_attempts: int = 3
+    backoff_initial_seconds: float = 0.5
+    backoff_max_seconds: float = 4.0
+    breaker_failure_threshold: int = 5
+    breaker_reset_seconds: float = 30.0
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "connect_timeout_seconds",
+            "read_timeout_seconds",
+            "breaker_reset_seconds",
+        ):
+            value = float(getattr(self, field_name))
+            if value <= 0:
+                raise TPPConfigurationError(f"{field_name} must be greater than 0.")
+            setattr(self, field_name, value)
+        for field_name in ("backoff_initial_seconds", "backoff_max_seconds"):
+            value = float(getattr(self, field_name))
+            if value < 0:
+                raise TPPConfigurationError(f"{field_name} must not be negative.")
+            setattr(self, field_name, value)
+        for field_name in ("max_attempts", "breaker_failure_threshold"):
+            value = int(getattr(self, field_name))
+            if value <= 0:
+                raise TPPConfigurationError(f"{field_name} must be greater than 0.")
+            setattr(self, field_name, value)
+
+    @classmethod
+    def from_env(cls) -> "TPPTransportPolicy":
+        default_read_timeout = _env_float("TPP_TIMEOUT_SECONDS", 15.0)
+        return cls(
+            connect_timeout_seconds=_env_float(
+                "TPP_TRANSPORT_CONNECT_TIMEOUT_SECONDS", 5.0
+            ),
+            read_timeout_seconds=_env_float(
+                "TPP_TRANSPORT_READ_TIMEOUT_SECONDS", default_read_timeout
+            ),
+            max_attempts=_env_int("TPP_TRANSPORT_MAX_ATTEMPTS", 3),
+            backoff_initial_seconds=_env_float(
+                "TPP_TRANSPORT_BACKOFF_INITIAL_SECONDS", 0.5
+            ),
+            backoff_max_seconds=_env_float("TPP_TRANSPORT_BACKOFF_MAX_SECONDS", 4.0),
+            breaker_failure_threshold=_env_int(
+                "TPP_TRANSPORT_BREAKER_FAILURE_THRESHOLD", 5
+            ),
+            breaker_reset_seconds=_env_float("TPP_TRANSPORT_BREAKER_RESET_SECONDS", 30.0),
+        )
+
+
+class _CircuitBreaker:
+    def __init__(self) -> None:
+        self.failures = 0
+        self.opened_at: float | None = None
+        self.half_open = False
+
+    @property
+    def state(self) -> str:
+        if self.opened_at is None:
+            return "closed"
+        if self.half_open:
+            return "half-open"
+        return "open"
+
+    def before_request(self, *, policy: TPPTransportPolicy, now: float, host: str) -> None:
+        if self.opened_at is None:
+            return
+        if now - self.opened_at < policy.breaker_reset_seconds:
+            raise TPPTransportError(
+                f"TPP circuit breaker is open for {host}; retry after the reset window.",
+                error_code="breaker_open",
+                status_code=503,
+                retryable=True,
+            )
+        self.half_open = True
+
+    def record_success(self) -> None:
+        self.failures = 0
+        self.opened_at = None
+        self.half_open = False
+
+    def record_failure(self, *, policy: TPPTransportPolicy, now: float) -> None:
+        if self.half_open:
+            self.opened_at = now
+            self.half_open = False
+            return
+        self.failures += 1
+        if self.failures >= policy.breaker_failure_threshold:
+            self.opened_at = now
+            self.half_open = False
+
+
+def tpp_transport_error_from_exception(
+    exc: BaseException,
+    *,
+    operation: str,
+    path: str | None = None,
+) -> TPPTransportError | None:
+    target = path or operation
+    if isinstance(exc, TPPTransportError):
+        return exc
+    if isinstance(exc, urllib_error.HTTPError):
+        try:
+            body_excerpt = exc.read().decode("utf-8", errors="replace").strip()
+        except OSError:
+            body_excerpt = ""
+        return _http_status_error(path=target, status_code=exc.code, body_excerpt=body_excerpt)
+    if isinstance(exc, urllib_error.URLError):
+        reason = exc.reason
+        if isinstance(reason, (TimeoutError, socket.timeout)):
+            return TPPTransportError(
+                f"TPP request for {target} timed out: {reason}.",
+                error_code="timeout",
+                status_code=504,
+                retryable=True,
+            )
+        return TPPTransportError(
+            f"TPP request for {target} failed: {exc}.",
+            error_code="connection_error",
+            status_code=503,
+            retryable=True,
+        )
+    if isinstance(exc, (TimeoutError, socket.timeout)):
+        return TPPTransportError(
+            f"TPP request for {target} timed out: {exc}.",
+            error_code="timeout",
+            status_code=504,
+            retryable=True,
+        )
+    if isinstance(exc, (ConnectionError, OSError)):
+        return TPPTransportError(
+            f"TPP request for {target} failed: {exc}.",
+            error_code="connection_error",
+            status_code=503,
+            retryable=True,
+        )
+    return None
+
+
+def _http_status_error(*, path: str, status_code: int, body_excerpt: str) -> TPPTransportError:
+    excerpt = body_excerpt.strip()
+    if len(excerpt) > 280:
+        excerpt = f"{excerpt[:277]}..."
+    message = f"TPP request to {path} returned HTTP {status_code}: {excerpt or 'no response body'}"
+    if status_code in {401, 403}:
+        return TPPTransportError(
+            message,
+            error_code="unauthorized",
+            status_code=401,
+            retryable=False,
+        )
+    if 500 <= status_code <= 599:
+        return TPPTransportError(
+            message,
+            error_code="server_error",
+            status_code=503,
+            retryable=True,
+        )
+    return TPPTransportError(
+        message,
+        error_code="unknown",
+        status_code=502,
+        retryable=False,
+    )
 
 
 @dataclass(slots=True)
@@ -131,8 +346,24 @@ class TPPRuntimeSettings:
 class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
     """Executes TPP operations over the planner-facing HTTP seam."""
 
-    def __init__(self, settings: TPPRuntimeSettings | None = None) -> None:
+    _breakers: ClassVar[dict[tuple[str, str, int], _CircuitBreaker]] = {}
+
+    def __init__(
+        self,
+        settings: TPPRuntimeSettings | None = None,
+        *,
+        policy: TPPTransportPolicy | None = None,
+        sleep: Callable[[float], None] | None = None,
+        clock: Callable[[], float] | None = None,
+        jitter: Callable[[float, float], float] | None = None,
+        breaker_registry: dict[tuple[str, str, int], _CircuitBreaker] | None = None,
+    ) -> None:
         self.settings = settings or TPPRuntimeSettings.from_env()
+        self.policy = policy or TPPTransportPolicy.from_env()
+        self._sleep = sleep or time.sleep
+        self._clock = clock or time.monotonic
+        self._jitter = jitter or random.uniform
+        self._breaker_registry = breaker_registry if breaker_registry is not None else self._breakers
 
     def execute(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         if request.operation == "fetch_policy_constraints":
@@ -174,6 +405,58 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         json_payload: dict[str, Any],
     ) -> dict[str, Any]:
         url = f"{self.settings.base_url}{path}"
+        breaker_key = self._breaker_key(url)
+        breaker = self._breaker_registry.setdefault(breaker_key, _CircuitBreaker())
+        host_label = self._host_label(breaker_key)
+        last_error: TPPTransportError | None = None
+
+        for attempt in range(1, self.policy.max_attempts + 1):
+            try:
+                breaker.before_request(
+                    policy=self.policy,
+                    now=self._clock(),
+                    host=host_label,
+                )
+                payload = self._send_json_request(
+                    method=method,
+                    path=path,
+                    url=url,
+                    json_payload=json_payload,
+                )
+            except TPPTransportError as exc:
+                last_error = exc
+                if exc.error_code != "breaker_open":
+                    breaker.record_failure(policy=self.policy, now=self._clock())
+                if (
+                    exc.error_code == "breaker_open"
+                    or not exc.retryable
+                    or attempt >= self.policy.max_attempts
+                ):
+                    raise
+                delay = self._retry_delay(attempt)
+                if delay > 0:
+                    self._sleep(delay)
+                continue
+            breaker.record_success()
+            return payload
+
+        if last_error is not None:
+            raise last_error
+        raise TPPTransportError(
+            f"TPP request to {path} failed without a typed transport result.",
+            error_code="unknown",
+            status_code=502,
+            retryable=False,
+        )
+
+    def _send_json_request(
+        self,
+        *,
+        method: str,
+        path: str,
+        url: str,
+        json_payload: dict[str, Any],
+    ) -> dict[str, Any]:
         body = json.dumps(json_payload).encode("utf-8")
         request = urllib_request.Request(
             url,
@@ -182,28 +465,30 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             method=method,
         )
         try:
-            with urllib_request.urlopen(request, timeout=self.settings.timeout_seconds) as response:
+            with urllib_request.urlopen(request, timeout=self.policy.read_timeout_seconds) as response:
                 status_code = response.status
                 raw_body = response.read().decode("utf-8")
         except urllib_error.HTTPError as exc:
-            raw_body = exc.read().decode("utf-8", errors="replace")
-            body_excerpt = raw_body.strip()
-            if len(body_excerpt) > 280:
-                body_excerpt = f"{body_excerpt[:277]}..."
-            raise TPPTransportError(
-                f"TPP request to {path} returned HTTP {exc.code}: {body_excerpt or 'no response body'}",
-                status_code=502,
+            try:
+                raw_body = exc.read().decode("utf-8", errors="replace")
+            except OSError:
+                raw_body = ""
+            raise _http_status_error(
+                path=path,
+                status_code=exc.code,
+                body_excerpt=raw_body,
             ) from exc
-        except urllib_error.URLError as exc:
-            raise TPPServiceUnavailableError(f"TPP request to {path} failed: {exc}.") from exc
+        except (urllib_error.URLError, TimeoutError, socket.timeout, ConnectionError, OSError) as exc:
+            transport_error = tpp_transport_error_from_exception(exc, operation="request", path=path)
+            if transport_error is None:
+                raise
+            raise transport_error from exc
 
         if status_code >= 400:
-            body_excerpt = raw_body.strip()
-            if len(body_excerpt) > 280:
-                body_excerpt = f"{body_excerpt[:277]}..."
-            raise TPPTransportError(
-                f"TPP request to {path} returned HTTP {status_code}: {body_excerpt or 'no response body'}",
-                status_code=502,
+            raise _http_status_error(
+                path=path,
+                status_code=status_code,
+                body_excerpt=raw_body,
             )
 
         try:
@@ -213,6 +498,30 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
         if not isinstance(payload, dict):
             raise TPPContractError(f"TPP request to {path} returned a non-object JSON payload.")
         return payload
+
+    def _retry_delay(self, attempt: int) -> float:
+        delay = min(
+            self.policy.backoff_initial_seconds * (2 ** max(attempt - 1, 0)),
+            self.policy.backoff_max_seconds,
+        )
+        if delay <= 0:
+            return 0.0
+        return self._jitter(0.0, delay)
+
+    @staticmethod
+    def _breaker_key(url: str) -> tuple[str, str, int]:
+        parsed = urllib_parse.urlsplit(url)
+        scheme = parsed.scheme or "http"
+        host = parsed.hostname or ""
+        if not host:
+            raise TPPContractError("TPP_BASE_URL must include a host.")
+        port = parsed.port or (443 if scheme == "https" else 80)
+        return (scheme, host, port)
+
+    @staticmethod
+    def _host_label(key: tuple[str, str, int]) -> str:
+        scheme, host, port = key
+        return f"{scheme}://{host}:{port}"
 
     def _policy_request_payload(self, request: TPPRequestEnvelope) -> dict[str, Any]:
         payload = dict(request.payload)

--- a/trip_planner/integrations/tpp/results.py
+++ b/trip_planner/integrations/tpp/results.py
@@ -8,7 +8,11 @@ from typing import Any
 from trip_planner._validators import require_non_empty
 from trip_planner.business.policy_contracts import PolicyEvaluationResult
 
-from .client import TPPIntegrationClient
+from .client import (
+    TPPIntegrationClient,
+    TPPTransportError,
+    tpp_transport_error_from_exception,
+)
 from .contracts import (
     TPPErrorRecord,
     TPPExecutionStatus,
@@ -136,7 +140,18 @@ class TPPEvaluationResultIngestionService:
         proposal_version: str,
         scenario_id: str | None = None,
     ) -> PersistedEvaluationResult:
-        response = self.client.fetch_evaluation_result(request)
+        try:
+            response = self.client.fetch_evaluation_result(request)
+        except TPPTransportError:
+            raise
+        except Exception as exc:
+            transport_error = tpp_transport_error_from_exception(
+                exc,
+                operation="fetch_evaluation_result",
+            )
+            if transport_error is None:
+                raise
+            raise transport_error from exc
         return self.normalize_response(
             request,
             response,

--- a/trip_planner/integrations/tpp/submission.py
+++ b/trip_planner/integrations/tpp/submission.py
@@ -8,7 +8,11 @@ from typing import Any
 from trip_planner._validators import require_non_empty
 from trip_planner.business.policy_contracts import TripPlanProposal
 
-from .client import TPPIntegrationClient
+from .client import (
+    TPPIntegrationClient,
+    TPPTransportError,
+    tpp_transport_error_from_exception,
+)
 from .contracts import (
     TPPErrorRecord,
     TPPExecutionStatus,
@@ -139,7 +143,18 @@ class TPPProposalSubmissionService:
         proposal_version: str,
         scenario_id: str | None = None,
     ) -> ProposalSubmissionRecord:
-        response = self.client.submit_proposal(request)
+        try:
+            response = self.client.submit_proposal(request)
+        except TPPTransportError:
+            raise
+        except Exception as exc:
+            transport_error = tpp_transport_error_from_exception(
+                exc,
+                operation="submit_proposal",
+            )
+            if transport_error is None:
+                raise
+            raise transport_error from exc
         return self.normalize_response(
             request,
             proposal,


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1044 -->
> **Source:** Issue #1044

Closes #1044

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The TPP integration client at `trip_planner/integrations/tpp/client.py`
implements `submit_proposal` and `fetch_evaluation_result` and dispatches
through `_dispatch`. It does not yet apply a documented timeout policy,
retry budget, or circuit-breaker. The result is that any live TPP transport
failure (network blip, 503, transient timeout) propagates raw and there is
no fallback posture for the planner workspace. The README explicitly notes
that "live remote `Travel-Plan-Permission` execution remains deferred unless
you deliberately configure that seam" — hardening this client is the work
that lifts that deferral.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1031](https://github.com/stranske/trip-planner/issues/1031)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add `TPPTransportPolicy` (dataclass) with fields: `connect_timeout_seconds`, `read_timeout_seconds`, `max_attempts`, `backoff_initial_seconds`, `backoff_max_seconds`, `breaker_failure_threshold`, `breaker_reset_seconds`.
- [x] Add a per-host `_CircuitBreaker` with closed/open/half-open states.
- [x] Wrap `_dispatch` in `client.py` to apply timeout, retry, and breaker logic.
- [x] Define `TPPTransportError` with `error_code` values: `timeout`, `connection_error`, `server_error`, `breaker_open`, `unauthorized`, `invalid_response`, `unknown`.
- [x] Update `submission.py` and `results.py` to convert raw transport errors into `TPPTransportError` with a typed code while preserving original cause via `__cause__`.
- [x] Plumb a typed-error fallback into the planner workspace so a `breaker_open` or `timeout` error renders the stored-policy posture instead of an opaque failure.
- [x] Add unit tests covering: 503 → retried up to `max_attempts` then surfaces `server_error`; connection refused → `connection_error`; consecutive failures → breaker opens; breaker reset window → half-open trial; successful response in half-open → breaker closes.
- [x] Add an integration test against a stub HTTP server using `pytest-httpserver` simulating each error class.
- [x] Document the policy and its env-var overrides (`TPP_TRANSPORT_*`) in `README.md` near the existing `TPP_BASE_URL` block.

#### Acceptance criteria
- [x] Default policy: 5s connect, 15s read, 3 attempts, 0.5s initial backoff capped at 4s, 5 failures opens the breaker, 30s reset.
- [x] Each policy field is overridable via env (`TPP_TRANSPORT_CONNECT_TIMEOUT_SECONDS`, etc.) and via constructor argument.
- [x] On three consecutive 503s a single call surfaces `TPPTransportError(error_code="server_error")` after the third attempt.
- [x] On five consecutive failures the breaker opens and subsequent calls immediately return `TPPTransportError(error_code="breaker_open")` until the reset window elapses.
- [x] The planner workspace renders stored-policy posture (with a typed error notice) when the client surfaces `breaker_open` or `timeout`, not an unhandled exception.
- [x] Unit and integration tests covering all listed error codes pass in CI.
- [x] `make full-product-check` continues to pass with `TPP_BASE_URL` unset (no live transport configured).
- [x] No new public method is added to the TPP client interface that pre-empts the canonical-method-name decision still pending in #1031; the policy is applied at the existing `_dispatch` layer rather than at the per-method surface.

<!-- auto-status-summary:end -->