### PR TITLE
ci: gate planner contract with cross-repo smoke against pinned TPP

### DIFF
--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           TPP_REPO_PATH: ${{ github.workspace }}/Travel-Plan-Permission
           TPP_ACCESS_TOKEN: ci-cross-repo-smoke-token
-          TPP_OIDC_PROVIDER: ci-cross-repo-smoke-provider
+          TPP_OIDC_PROVIDER: google
         run: |
           echo "Using TPP_REPO_PATH=${TPP_REPO_PATH}"
           python scripts/check_full_product_verification.py --live-tpp required

--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -81,6 +81,7 @@ jobs:
           TPP_REPO_PATH: ${{ github.workspace }}/Travel-Plan-Permission
           TPP_ACCESS_TOKEN: ci-cross-repo-smoke-token
           TPP_OIDC_PROVIDER: google
+          LIVE_TPP: required
         run: |
           echo "Using TPP_REPO_PATH=${TPP_REPO_PATH}"
-          python scripts/check_full_product_verification.py --live-tpp required
+          make full-product-check

--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  workflow_call:
 
 env:
   TPP_PINNED_REF: d7c5c310018f4242e33f7df3d06c0e76f7b79ee9

--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -1,0 +1,85 @@
+name: Cross-Repo Smoke
+
+# Gate the planner-side cross-repo contract: run `make full-product-check`
+# against a pinned Travel-Plan-Permission checkout via the local subprocess
+# path that `scripts/check_full_product_verification.py` already supports.
+#
+# Bumping the pin: edit TPP_PINNED_REF below and open a paired PR on the
+# TPP-side cross-repo-smoke job that pins the corresponding trip-planner SHA.
+# See docs/CI_SYSTEM_GUIDE.md ("Cross-repo smoke gate").
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  TPP_PINNED_REF: d7c5c310018f4242e33f7df3d06c0e76f7b79ee9
+
+jobs:
+  cross-repo-full-product:
+    name: cross-repo-full-product
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout trip-planner (PR head)
+        uses: actions/checkout@v4
+        with:
+          path: trip-planner
+
+      - name: Checkout Travel-Plan-Permission at pinned ref
+        uses: actions/checkout@v4
+        with:
+          repository: stranske/Travel-Plan-Permission
+          ref: ${{ env.TPP_PINNED_REF }}
+          path: Travel-Plan-Permission
+
+      - name: Log resolved pinned TPP SHA
+        working-directory: Travel-Plan-Permission
+        run: |
+          echo "TPP_PINNED_REF=${TPP_PINNED_REF}"
+          echo "TPP_RESOLVED_SHA=$(git rev-parse HEAD)"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'trip-planner/frontend/package-lock.json'
+
+      - name: Install trip-planner backend dependencies
+        working-directory: trip-planner
+        run: python -m pip install -e ".[dev]"
+
+      - name: Install Travel-Plan-Permission dependencies
+        working-directory: Travel-Plan-Permission
+        run: |
+          if [ -f pyproject.toml ]; then
+            python -m pip install -e ".[dev]" || python -m pip install -e .
+          elif [ -f setup.py ]; then
+            python -m pip install -e .
+          else
+            echo "No installable Python project layout in TPP checkout" >&2
+            exit 1
+          fi
+
+      - name: Install trip-planner frontend dependencies
+        working-directory: trip-planner
+        run: npm --prefix frontend ci
+
+      - name: Run full-product-check against sibling TPP checkout
+        working-directory: trip-planner
+        env:
+          TPP_REPO_PATH: ${{ github.workspace }}/Travel-Plan-Permission
+          TPP_ACCESS_TOKEN: ci-cross-repo-smoke-token
+          TPP_OIDC_PROVIDER: ci-cross-repo-smoke-provider
+        run: |
+          echo "Using TPP_REPO_PATH=${TPP_REPO_PATH}"
+          python scripts/check_full_product_verification.py --live-tpp required

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -50,6 +50,11 @@ jobs:
       enable-soft-gate: true
     secrets: inherit
 
+  cross-repo-smoke:
+    name: Cross-Repo Smoke
+    uses: ./.github/workflows/cross-repo-smoke.yml
+    secrets: inherit
+
   runtime-ci:
     name: Runtime CI
     runs-on: ubuntu-latest
@@ -79,7 +84,7 @@ jobs:
 
   summary:
     name: gate-summary
-    needs: [python-ci, runtime-ci]
+    needs: [python-ci, runtime-ci, cross-repo-smoke]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -102,11 +107,13 @@ jobs:
         env:
           PYTHON_RESULT: ${{ needs.python-ci.result || 'skipped' }}
           RUNTIME_RESULT: ${{ needs.runtime-ci.result || 'skipped' }}
+          CROSS_REPO_RESULT: ${{ needs.cross-repo-smoke.result || 'skipped' }}
         run: |
           set -euo pipefail
 
           python_result="${PYTHON_RESULT:-skipped}"
           runtime_result="${RUNTIME_RESULT:-skipped}"
+          cross_repo_result="${CROSS_REPO_RESULT:-skipped}"
           state="success"
           description="All checks passed"
 
@@ -116,19 +123,22 @@ jobs:
           elif [ "$runtime_result" = "failure" ]; then
             state="failure"
             description="Runtime CI failed"
-          elif [ "$python_result" = "cancelled" ] || [ "$runtime_result" = "cancelled" ]; then
+          elif [ "$cross_repo_result" = "failure" ]; then
+            state="failure"
+            description="Cross-repo smoke check failed"
+          elif [ "$python_result" = "cancelled" ] || [ "$runtime_result" = "cancelled" ] || [ "$cross_repo_result" = "cancelled" ]; then
             state="error"
             description="Checks were cancelled"
-          elif [ "$python_result" = "success" ] && [ "$runtime_result" = "success" ]; then
+          elif [ "$python_result" = "success" ] && [ "$runtime_result" = "success" ] && [ "$cross_repo_result" = "success" ]; then
             state="success"
-            description="Python and runtime CI passed"
-          elif [ "$python_result" = "success" ] && [ "$runtime_result" = "skipped" ]; then
+            description="Python, runtime, and cross-repo CI passed"
+          elif [ "$python_result" = "success" ] && [ "$runtime_result" = "skipped" ] && [ "$cross_repo_result" = "skipped" ]; then
             state="success"
-            description="Python CI passed; runtime CI skipped"
-          elif [ "$python_result" = "skipped" ] && [ "$runtime_result" = "success" ]; then
+            description="Python CI passed; runtime and cross-repo CI skipped"
+          elif [ "$python_result" = "skipped" ] && [ "$runtime_result" = "success" ] && [ "$cross_repo_result" = "skipped" ]; then
             state="success"
-            description="Runtime CI passed; Python CI skipped"
-          elif [ "$python_result" = "skipped" ] && [ "$runtime_result" = "skipped" ]; then
+            description="Runtime CI passed; Python and cross-repo CI skipped"
+          elif [ "$python_result" = "skipped" ] && [ "$runtime_result" = "skipped" ] && [ "$cross_repo_result" = "skipped" ]; then
             state="success"
             description="Checks skipped (no relevant changes)"
           else

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,11 @@ runtime-production-check:
 runtime-preview-smoke:
 	./scripts/check_production_readiness.sh --preview "${TRIP_PLANNER_PREVIEW_URL}"
 
+# LIVE_TPP: pass --live-tpp <mode> (auto|off|required).  Set LIVE_TPP=required
+# in CI (with TPP_REPO_PATH) to gate on the live cross-repo handshake.
+LIVE_TPP ?= auto
+
 full-product-check:
-	python scripts/check_full_product_verification.py
+	python scripts/check_full_product_verification.py --live-tpp $(LIVE_TPP)
 
 runtime-full-product-check: full-product-check

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -147,12 +147,18 @@ racing with `Travel-Plan-Permission@main`. Bump procedure:
 
 #### Required-check on `main`
 
-Once the new job has run green at least once, add `cross-repo-full-product`
-to the required status checks for `main` in repository branch-protection
-settings (Settings → Branches → Branch protection rule for `main` →
-"Require status checks to pass"). Branch protection cannot be edited from a
-workflow file; the toggle must be flipped by a repo admin after the first
-green run.
+The `cross-repo-smoke.yml` workflow exposes a `workflow_call` trigger and is
+called from `pr-00-gate.yml` as the `cross-repo-smoke` job. The gate's
+`summary` job declares `needs: [python-ci, runtime-ci, cross-repo-smoke]`, so
+a failure in the cross-repo smoke check propagates to the `Gate / gate` commit
+status and blocks merge.
+
+Since `Gate / gate` is the required status check on `main`, no additional
+branch-protection configuration is needed for day-to-day use. If a repo admin
+wants the raw `cross-repo-full-product` job to appear as a named required
+check in addition to the gate, they can add it in Settings → Branches →
+Branch protection rule for `main` → "Require status checks to pass" after the
+first green run. That toggle cannot be set from a workflow file.
 
 ---
 

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -106,6 +106,54 @@ To add a domain-specific job:
 2. Add your job with appropriate triggers
 3. Include the job in the Gate aggregation (if using custom Gate)
 
+### Cross-repo smoke gate
+
+The `.github/workflows/cross-repo-smoke.yml` workflow gates the planner-side
+contract with `stranske/Travel-Plan-Permission`. On every PR and on push to
+`main` it:
+
+1. Checks out trip-planner (PR head) into `trip-planner/`.
+2. Checks out `stranske/Travel-Plan-Permission` at a pinned ref into a
+   sibling `Travel-Plan-Permission/` directory.
+3. Installs both repos' dev extras and the trip-planner frontend deps.
+4. Runs `python scripts/check_full_product_verification.py --live-tpp required`
+   with `TPP_REPO_PATH` pointing at the sibling checkout. This is the same
+   path `make full-product-check` uses locally, so a green run proves the
+   live cross-repo handshake (planner → local TPP subprocess) is intact.
+
+The pinned TPP ref is configurable via a single workflow-level env var:
+
+```yaml
+env:
+  TPP_PINNED_REF: <40-char SHA>
+```
+
+CI logs print both `TPP_PINNED_REF` and the resolved SHA so the actually
+checked-out commit is easy to verify.
+
+#### Bumping the pin
+
+The pin is intentionally manual so a TPP-side breakage cannot land green by
+racing with `Travel-Plan-Permission@main`. Bump procedure:
+
+1. Open a paired PR on `stranske/Travel-Plan-Permission` that bumps that
+   repo's `TRIP_PLANNER_PINNED_REF` to the trip-planner SHA you intend to
+   publish.
+2. In this repo, bump `TPP_PINNED_REF` in
+   `.github/workflows/cross-repo-smoke.yml` to the latest known-good TPP
+   `main` SHA.
+3. Land the two PRs together; both `cross-repo-smoke` jobs should be green
+   on the paired branches before merge.
+
+#### Required-check on `main`
+
+Once the new job has run green at least once, add `cross-repo-full-product`
+to the required status checks for `main` in repository branch-protection
+settings (Settings → Branches → Branch protection rule for `main` →
+"Require status checks to pass"). Branch protection cannot be edited from a
+workflow file; the toggle must be flipped by a repo admin after the first
+green run.
+
 ---
 
 ## Agent Automation System

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dev = [
     "pytest-cov==7.1.0",
     "black==26.3.1",
     "httpx==0.28.1",
+    "PyYAML==6.0.3",
+    "types-PyYAML==6.0.12.20250402",
 ]
 [build-system]
 requires = ["setuptools>=82.0.1"]

--- a/requirements.lock
+++ b/requirements.lock
@@ -151,6 +151,8 @@ tiktoken==0.12.0
     # via langchain-openai
 tqdm==4.67.3
     # via openai
+types-pyyaml==6.0.12.20250402
+    # via trip-planner
 typing-extensions==4.15.0
     # via
     #   alembic

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -69,6 +69,7 @@ def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None
     )
     env = run_step.get("env", {})
     assert "${{ github.workspace }}/Travel-Plan-Permission" in str(env.get("TPP_REPO_PATH", ""))
+    assert env.get("TPP_OIDC_PROVIDER") in {"azure_ad", "google", "okta"}
     assert "--live-tpp required" in run_step["run"]
 
 

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -7,6 +7,7 @@ with `pytest tests/scripts/test_cross_repo_smoke_workflow.py`.
 
 from __future__ import annotations
 
+import importlib
 import re
 import subprocess
 from pathlib import Path
@@ -89,3 +90,63 @@ def test_workflow_passes_actionlint() -> None:
     assert (
         result.returncode == 0
     ), f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# Contract-surface guard (AC#2)
+#
+# The cross-repo smoke job exercises the live planner ↔ TPP handshake.  The
+# handshake depends on specific symbols exported from
+# `trip_planner.integrations.tpp`.  If any symbol below is removed from
+# `__init__.py` the import fails here *and* the full-product check script
+# fails in CI — exactly the breakage detection AC#2 requires.
+#
+# Symbols are grouped by the planner service that imports them so the diff
+# that broke the contract is easy to locate.
+# ---------------------------------------------------------------------------
+
+# Symbols consumed by trip_planner/app/services/proposal.py (submission path)
+_PROPOSAL_SERVICE_SYMBOLS = [
+    "BaseTPPIntegrationClient",
+    "EvaluationResultIngestionError",
+    "HTTPTPPIntegrationClient",
+    "TPPCorrelationId",
+    "TPPConfigurationError",
+    "TPPContractError",
+    "TPPErrorRecord",
+    "TPPEvaluationResultIngestionService",
+    "TPPExecutionStatus",
+    "TPPProposalSubmissionService",
+    "TPPRequestEnvelope",
+    "TPPResponseEnvelope",
+    "TPPRetryMetadata",
+    "TPPTransportError",
+]
+
+# Symbols consumed by trip_planner/app/services/policy.py (policy-sync path)
+_POLICY_SERVICE_SYMBOLS = [
+    "BaseTPPIntegrationClient",
+    "HTTPTPPIntegrationClient",
+    "OrganizationContextSnapshot",
+    "PolicyConstraintImport",
+    "PolicyFreshness",
+    "TPPPolicySyncService",
+    "TPPRequestEnvelope",
+    "TPPResponseEnvelope",
+]
+
+
+@pytest.mark.parametrize("symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS)))
+def test_tpp_integration_exports_required_symbol(symbol: str) -> None:
+    """Each symbol must be importable from the public TPP integration package.
+
+    A missing symbol breaks the planner services that depend on it, which in
+    turn causes `make full-product-check --live-tpp required` to exit non-zero
+    and fails the cross-repo-smoke CI job.
+    """
+    mod = importlib.import_module("trip_planner.integrations.tpp")
+    assert hasattr(mod, symbol), (
+        f"trip_planner.integrations.tpp is missing required cross-repo symbol '{symbol}'. "
+        "Removing this export breaks the live planner-TPP handshake and will fail the "
+        "cross-repo-smoke CI job."
+    )

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -64,14 +64,13 @@ def test_workflow_checks_out_both_repos(workflow: dict) -> None:
 def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     run_step = next(
-        step
-        for step in job["steps"]
-        if "scripts/check_full_product_verification.py" in str(step.get("run", ""))
+        step for step in job["steps"] if "make full-product-check" in str(step.get("run", ""))
     )
     env = run_step.get("env", {})
     assert "${{ github.workspace }}/Travel-Plan-Permission" in str(env.get("TPP_REPO_PATH", ""))
     assert env.get("TPP_OIDC_PROVIDER") in {"azure_ad", "google", "okta"}
-    assert "--live-tpp required" in run_step["run"]
+    assert env.get("LIVE_TPP") == "required"
+    assert "make full-product-check" in run_step["run"]
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -1,0 +1,74 @@
+"""Sanity checks for the cross-repo-smoke workflow file.
+
+These keep the issue-#1045 workflow honest in case a future edit accidentally
+drops the pinned ref, the dual checkout, or the live-tpp invocation. Run
+with `pytest tests/scripts/test_cross_repo_smoke_workflow.py`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "cross-repo-smoke.yml"
+)
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW_PATH.read_text())
+
+
+def test_workflow_file_exists() -> None:
+    assert WORKFLOW_PATH.is_file(), f"missing workflow file at {WORKFLOW_PATH}"
+
+
+def test_workflow_defines_cross_repo_full_product_job(workflow: dict) -> None:
+    jobs = workflow.get("jobs", {})
+    assert "cross-repo-full-product" in jobs, jobs.keys()
+
+
+def test_workflow_pins_tpp_ref(workflow: dict) -> None:
+    env = workflow.get("env", {})
+    pinned = env.get("TPP_PINNED_REF", "")
+    assert re.fullmatch(r"[0-9a-f]{40}", pinned), pinned
+
+
+def test_workflow_checks_out_both_repos(workflow: dict) -> None:
+    job = workflow["jobs"]["cross-repo-full-product"]
+    checkout_steps = [
+        step
+        for step in job["steps"]
+        if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
+    ]
+    paths = [step.get("with", {}).get("path") for step in checkout_steps]
+    assert "trip-planner" in paths, paths
+    assert "Travel-Plan-Permission" in paths, paths
+
+    tpp_step = next(
+        step
+        for step in checkout_steps
+        if step.get("with", {}).get("path") == "Travel-Plan-Permission"
+    )
+    with_block = tpp_step["with"]
+    assert with_block.get("repository") == "stranske/Travel-Plan-Permission"
+    assert "${{ env.TPP_PINNED_REF }}" in str(with_block.get("ref", ""))
+
+
+def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None:
+    job = workflow["jobs"]["cross-repo-full-product"]
+    run_step = next(
+        step
+        for step in job["steps"]
+        if "scripts/check_full_product_verification.py" in str(step.get("run", ""))
+    )
+    env = run_step.get("env", {})
+    assert "${{ github.workspace }}/Travel-Plan-Permission" in str(env.get("TPP_REPO_PATH", ""))
+    assert "--live-tpp required" in run_step["run"]

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -8,16 +8,14 @@ with `pytest tests/scripts/test_cross_repo_smoke_workflow.py`.
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
 
 WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2]
-    / ".github"
-    / "workflows"
-    / "cross-repo-smoke.yml"
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "cross-repo-smoke.yml"
 )
 
 
@@ -72,3 +70,21 @@ def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None
     env = run_step.get("env", {})
     assert "${{ github.workspace }}/Travel-Plan-Permission" in str(env.get("TPP_REPO_PATH", ""))
     assert "--live-tpp required" in run_step["run"]
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ACTIONLINT = _REPO_ROOT / ".workflows-lib" / "actionlint"
+
+
+@pytest.mark.skipif(
+    not _ACTIONLINT.is_file(), reason="actionlint binary not present in .workflows-lib/"
+)
+def test_workflow_passes_actionlint() -> None:
+    result = subprocess.run(
+        [str(_ACTIONLINT), str(WORKFLOW_PATH)],
+        capture_output=True,
+        text=True,
+    )
+    assert (
+        result.returncode == 0
+    ), f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -150,3 +150,54 @@ def test_tpp_integration_exports_required_symbol(symbol: str) -> None:
         "Removing this export breaks the live planner-TPP handshake and will fail the "
         "cross-repo-smoke CI job."
     )
+
+
+# ---------------------------------------------------------------------------
+# Client method guards (AC#2 — method-level surface)
+#
+# The cross-repo handshake depends on specific methods of BaseTPPIntegrationClient
+# and HTTPTPPIntegrationClient.  Removing `submit_proposal` (or any method below)
+# from the client class — even if the class itself remains exported — breaks the
+# TPP dispatch path and causes `full-product-check --live-tpp required` to fail.
+# ---------------------------------------------------------------------------
+
+# Operations that form the cross-repo dispatch contract.
+# Grouped to match the four TPP workflow phases: policy-sync, submission,
+# result-ingestion, and status-poll.
+_CLIENT_CONTRACT_METHODS = [
+    "fetch_policy_constraints",  # policy-sync path
+    "submit_proposal",  # submission path (mentioned in AC#2)
+    "fetch_evaluation_result",  # result-ingestion path
+    "poll_execution_status",  # status-poll path
+]
+
+
+@pytest.mark.parametrize("method_name", _CLIENT_CONTRACT_METHODS)
+def test_base_client_exposes_contract_method(method_name: str) -> None:
+    """BaseTPPIntegrationClient must expose every dispatch method.
+
+    Removing any of these breaks the planner → TPP handshake and fails the
+    cross-repo-smoke CI job (AC#2 failure-mode guard).
+    """
+    mod = importlib.import_module("trip_planner.integrations.tpp")
+    cls = mod.BaseTPPIntegrationClient
+    assert callable(getattr(cls, method_name, None)), (
+        f"BaseTPPIntegrationClient.{method_name} is missing or not callable. "
+        "This breaks the cross-repo dispatch contract and will fail the smoke job."
+    )
+
+
+@pytest.mark.parametrize("method_name", _CLIENT_CONTRACT_METHODS)
+def test_http_client_exposes_contract_method(method_name: str) -> None:
+    """HTTPTPPIntegrationClient must expose every dispatch method.
+
+    The HTTP client is the concrete implementation used in production and in
+    the full-product-check subprocess; a missing method causes an AttributeError
+    at runtime and exits the smoke job non-zero.
+    """
+    mod = importlib.import_module("trip_planner.integrations.tpp")
+    cls = mod.HTTPTPPIntegrationClient
+    assert callable(getattr(cls, method_name, None)), (
+        f"HTTPTPPIntegrationClient.{method_name} is missing or not callable. "
+        "This breaks the live cross-repo handshake and will fail the smoke job."
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1045 -->
> **Source:** Issue #1045

Closes #1045

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The cross-repo contract between trip-planner and Travel-Plan-Permission is
already validated locally by `make full-product-check` (with `TPP_REPO_PATH`
set), but no CI job runs that path on every PR. As a result, a planner-side
schema or transport change can land green even if it breaks the live
cross-repo handshake, and only manifests when a developer runs the local
check by hand. With the recent persistence-reload smoke (PR #1007) and
canonical-state-seam test (PR #1009), the contract surface is stable enough
to gate.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1007](https://github.com/stranske/trip-planner/issues/1007)
- [#1009](https://github.com/stranske/trip-planner/issues/1009)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add a new workflow at `.github/workflows/cross-repo-smoke.yml` (or extend `ci.yml`) with a job named `cross-repo-full-product`.
- [x] Use `actions/checkout@v4` twice: once for the PR head and once for `stranske/Travel-Plan-Permission` at the pinned ref into `../Travel-Plan-Permission`.
- [x] Define `TPP_PINNED_REF` as a workflow-level env var; default to a known-good SHA and document how to bump it.
- [x] Install Python deps for trip-planner (`pip install -e .[dev]`) and for the sibling TPP checkout.
- [x] Run `make full-product-check` with `TPP_REPO_PATH=../Travel-Plan-Permission` exported.
- [x] Make the job required for merge to `main`.
- [x] Document the workflow and the pin-bump procedure in `docs/CI_SYSTEM_GUIDE.md` (or the local equivalent).
- [x] Add a smoke test for the workflow itself: a syntax-check pass via `actionlint` or `act` if already present in CI tooling.

#### Acceptance criteria
- [x] A green PR run shows the `cross-repo-full-product` job exercising both repos and `make full-product-check` exits 0.
- [x] A deliberately broken planner-side change (e.g. removing `submit_proposal` from `trip_planner/integrations/tpp/__init__.py`) causes the new job to fail, while existing trip-planner-only checks may still pass.
- [x] `TPP_PINNED_REF` is settable via a single line in the workflow, and the CI logs print the resolved SHA.
- [x] The job is listed as a required check on `main`.
- [x] `docs/CI_SYSTEM_GUIDE.md` documents the new job and the pin-bump procedure.

<!-- auto-status-summary:end -->