### PR TITLE
fix: document TPP migration verifier disposition

### DIFF
--- a/.agents/issue-1049-ledger.yml
+++ b/.agents/issue-1049-ledger.yml
@@ -2,6 +2,13 @@ version: 1
 issue: 1049
 base: main
 branch: codex/issue-1049
+disposition:
+  status: verifier-follow-up-opened
+  updated_at: '2026-04-30T10:31:18Z'
+  evidence: docs/verification/issue-1049-tpp-migration-disposition.md
+  notes:
+    - PR #1054 completed the migration and merged, but the ledger was left stale.
+    - This follow-up reconciles the task statuses and records durable verifier evidence.
 tasks:
   - id: task-01
     title: Implement a guard in this PR so no `git mv` occurs until the sub-decision
@@ -14,7 +21,7 @@ tasks:
   - id: task-02
     title: Create the destination package directory for the chosen option (e.g., for
       B-1 create `trip_planner/integrations/tpp/services/`).
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -22,7 +29,7 @@ tasks:
   - id: task-03
     title: Move TPP service files matching `trip_planner/app/services/*tpp*.py` to
       the chosen canonical location using `git mv`.
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -30,7 +37,7 @@ tasks:
   - id: task-04
     title: 'Move `trip_planner/app/models/tpp.py` to the chosen canonical location
       using `git mv` (B-1 target: `trip_planner/integrations/tpp/models.py` or `trip_planner/integrations/tpp/models/tpp.py`).'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -39,7 +46,7 @@ tasks:
     title: Update production imports across the codebase to reference the new module
       paths (remove TPP-related imports from `trip_planner.app.services` / `trip_planner.app.models`
       / `trip_planner.app.clients` namespaces).
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -47,7 +54,7 @@ tasks:
   - id: task-06
     title: 'Define scope for: Identify all production files that import from trip_planner.app.services
       with TPP-related modules using grep (verify: confirm completion in repo)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -56,7 +63,7 @@ tasks:
     title: 'Implement focused slice for: Identify all production files that import
       from trip_planner.app.services with TPP-related modules using grep (verify:
       confirm completion in repo)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -65,7 +72,7 @@ tasks:
     title: 'Validate focused slice for: Identify all production files that import
       from trip_planner.app.services with TPP-related modules using grep (verify:
       confirm completion in repo)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -73,7 +80,7 @@ tasks:
   - id: task-09
     title: 'Define scope for: Update imports in identified production files to reference
       the new canonical TPP module paths (verify: confirm completion in repo)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -82,7 +89,7 @@ tasks:
     title: 'Implement focused slice for: Update imports in identified production files
       to reference the new canonical TPP module paths (verify: confirm completion
       in repo)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -91,7 +98,7 @@ tasks:
     title: 'Validate focused slice for: Update imports in identified production files
       to reference the new canonical TPP module paths (verify: confirm completion
       in repo)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -99,7 +106,7 @@ tasks:
   - id: task-12
     title: 'Define scope for: Verify that all production imports resolve correctly
       by running static type checking with mypy'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -107,7 +114,7 @@ tasks:
   - id: task-13
     title: 'Implement focused slice for: Verify that all production imports resolve
       correctly by running static type checking with mypy'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -115,7 +122,7 @@ tasks:
   - id: task-14
     title: 'Validate focused slice for: Verify that all production imports resolve
       correctly by running static type checking with mypy'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -123,7 +130,7 @@ tasks:
   - id: task-15
     title: 'Define scope for: Document any import conflicts or circular dependencies
       discovered during the migration (verify: dependencies updated)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -131,7 +138,7 @@ tasks:
   - id: task-16
     title: 'Implement focused slice for: Document any import conflicts or circular
       dependencies discovered during the migration (verify: dependencies updated)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -139,7 +146,7 @@ tasks:
   - id: task-17
     title: 'Validate focused slice for: Document any import conflicts or circular
       dependencies discovered during the migration (verify: dependencies updated)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -147,7 +154,7 @@ tasks:
   - id: task-18
     title: Update test imports in `tests/planner/test_tpp_*.py` and `tests/integrations/test_*.py`
       to reference the new module paths.
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -155,7 +162,7 @@ tasks:
   - id: task-19
     title: 'Define scope for: Identify all test files matching tests/planner/test_tpp_*.py
       that import TPP modules (verify: tests pass)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -163,7 +170,7 @@ tasks:
   - id: task-20
     title: 'Implement focused slice for: Identify all test files matching tests/planner/test_tpp_*.py
       that import TPP modules (verify: tests pass)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -171,7 +178,7 @@ tasks:
   - id: task-21
     title: 'Validate focused slice for: Identify all test files matching tests/planner/test_tpp_*.py
       that import TPP modules (verify: tests pass)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -179,7 +186,7 @@ tasks:
   - id: task-22
     title: 'Define scope for: Update imports in tests/planner/test_tpp_*.py files
       to reference the new canonical paths (verify: tests pass)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -187,7 +194,7 @@ tasks:
   - id: task-23
     title: 'Implement focused slice for: Update imports in tests/planner/test_tpp_*.py
       files to reference the new canonical paths (verify: tests pass)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -195,7 +202,7 @@ tasks:
   - id: task-24
     title: 'Validate focused slice for: Update imports in tests/planner/test_tpp_*.py
       files to reference the new canonical paths (verify: tests pass)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -203,14 +210,14 @@ tasks:
   - id: task-25
     title: 'Update imports in tests/integrations/test_*.py files that reference TPP
       modules (verify: tests pass)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
     notes: []
   - id: task-26
     title: Run the affected test suite to verify all test imports resolve correctly
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -219,7 +226,7 @@ tasks:
     title: Add/update any minimal shim/legacy stubs under `trip_planner/app/` only
       if required to keep non-TPP imports working, and document any intentional leftovers
       in the PR body.
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -227,7 +234,7 @@ tasks:
   - id: task-28
     title: "Write a PR body inventory listing every renamed file (old path \u2192\
       \ new path) to demonstrate 1:1 moves."
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -235,7 +242,7 @@ tasks:
   - id: task-29
     title: The PR body records the chosen sub-decision (B-1 / B-2 / B-3) before any
       file is moved.
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -243,7 +250,7 @@ tasks:
   - id: task-30
     title: All TPP-related production files are located under one canonical sub-tree
       (per the chosen option) and no additional production TPP files remain elsewhere.
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -252,7 +259,7 @@ tasks:
     title: Running `find trip_planner/app -name "*tpp*"` returns zero results, or
       only intentional shim/legacy stubs that are explicitly documented in the PR
       body.
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -260,7 +267,7 @@ tasks:
   - id: task-32
     title: Running `grep -rE "from trip_planner\.app\.(services|models|clients)" --include="*.py"`
       returns zero TPP-related imports.
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -268,14 +275,14 @@ tasks:
   - id: task-33
     title: All tests pass with only import-path updates (no behavioral changes required
       to make tests pass).
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
     notes: []
   - id: task-34
     title: CI is green (Gate, ruff, mypy, all test jobs).
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -283,7 +290,7 @@ tasks:
   - id: task-35
     title: "The PR body includes an inventory of every renamed file (old path \u2192\
       \ new path)."
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -291,7 +298,7 @@ tasks:
   - id: task-36
     title: Sub-decision (B-1 / B-2 / B-3) is recorded in the PR body before any file
       is moved.
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -299,7 +306,7 @@ tasks:
   - id: task-37
     title: All TPP-related production files live under one canonical sub-tree (whichever
       B-1/B-2/B-3 picked).
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -307,7 +314,7 @@ tasks:
   - id: task-38
     title: '`find trip_planner/app -name "*tpp*"` returns either zero results or only
       intentional shim/legacy stubs documented in the PR body.'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -315,7 +322,7 @@ tasks:
   - id: task-39
     title: '`grep -rE "from trip_planner\.app\.(services|models|clients)" --include="*.py"`
       returns zero TPP-related imports.'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -323,14 +330,14 @@ tasks:
   - id: task-40
     title: "All existing tests pass without behavioral changes \u2014 only import\
       \ paths updated."
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
     notes: []
   - id: task-41
     title: 'CI green: Gate, ruff, mypy, all test jobs.'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -338,7 +345,7 @@ tasks:
   - id: task-42
     title: PR body inventory of every renamed file is included (so reviewers can confirm
       1:1 moves and no accidental rewrites).
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -353,7 +360,7 @@ tasks:
       reviewer has documented the chosen option (B-1, B-2, or B-3) in a comment before
       any file moves begin.'' Remove this from the task list and add a note that the
       agent should pause and request human input if the decision is not present.)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''
@@ -364,7 +371,7 @@ tasks:
       to fail, but cannot control or guarantee CI execution. | Rephrase as: ''Fix
       any linting, type-checking, or test failures reported by CI'' and move ''CI
       is green'' to a human verification step in acceptance criteria.)'
-    status: todo
+    status: done
     started_at: null
     finished_at: null
     commit: ''

--- a/docs/verification/issue-1049-tpp-migration-disposition.md
+++ b/docs/verification/issue-1049-tpp-migration-disposition.md
@@ -1,0 +1,46 @@
+# Issue 1049 TPP Migration Verifier Disposition
+
+Source PR: https://github.com/stranske/trip-planner/pull/1054
+Verifier report: https://github.com/stranske/trip-planner/pull/1054#issuecomment-4351273331
+
+## Scope
+
+PR #1054 moved TPP-specific production modules out of `trip_planner/app/*` and into the canonical `trip_planner/integrations/tpp/*` tree. The provider comparison agreed the functional migration was correct, but Anthropic returned `CONCERNS` because several tracking and verifier-evidence checks were not durable after merge.
+
+This follow-up records the durable disposition for those concerns and tightens the guard so it is only treated as an enforcing check when a pull-request diff is available.
+
+## Canonical Choice
+
+Chosen sub-decision: B-1.
+
+The canonical TPP package location is `trip_planner/integrations/tpp/`, with services under `trip_planner/integrations/tpp/services/` and models under `trip_planner/integrations/tpp/models.py`.
+
+## Rename Inventory
+
+| Old path | New path |
+| --- | --- |
+| `trip_planner/app/models/tpp.py` | `trip_planner/integrations/tpp/models.py` |
+| `trip_planner/app/services/tpp_polling_service.py` | `trip_planner/integrations/tpp/services/tpp_polling_service.py` |
+| `trip_planner/app/services/tpp_proposal_submission_service.py` | `trip_planner/integrations/tpp/services/tpp_proposal_submission_service.py` |
+| `trip_planner/app/services/tpp_result_service.py` | `trip_planner/integrations/tpp/services/tpp_result_service.py` |
+| `trip_planner/app/services/workspace_state.py` | `trip_planner/integrations/tpp/services/workspace_state.py` |
+
+No legacy shim is required on current `main`: production imports resolve through `trip_planner.integrations.tpp.*`, and the repo hygiene tests reject new production TPP imports from `trip_planner.app.services`, `trip_planner.app.models`, or `trip_planner.app.clients`.
+
+## Guard Disposition
+
+`scripts/tpp_migration_guard.py` enforces the PR-body decision requirement from pull-request diff context. It is intentionally skipped outside PR context because a post-merge main checkout no longer exposes the original rename diff.
+
+Post-merge protection is covered by separate canonical-layout checks:
+
+- `tests/test_repo_hygiene.py::test_no_tpp_files_remain_under_legacy_app_tree`
+- `tests/test_repo_hygiene.py::test_no_production_tpp_imports_from_legacy_app_namespaces`
+
+The guard-specific tests cover both failure and success in PR context:
+
+- missing PR body + guarded rename is rejected
+- PR body with a single recorded B-1/B-2/B-3 choice is accepted
+
+## Cross-Repo Smoke Disposition
+
+`tests/integrations/test_tpp_cross_repo_smoke.py` closes its first `TestClient` before binding a second app instance to the same persisted database. The fixture context remains responsible for final cleanup. This keeps the same persistence boundary the smoke is intended to verify while avoiding hidden shared in-memory app state.

--- a/scripts/tpp_migration_guard.py
+++ b/scripts/tpp_migration_guard.py
@@ -207,7 +207,7 @@ def load_pr_body() -> str:
     return os.getenv("PR_BODY", "") or _read_pr_body_from_event()
 
 
-def _is_pr_context() -> bool:
+def is_pr_context() -> bool:
     event_name = os.getenv("GITHUB_EVENT_NAME", "").strip().lower()
     if event_name in {"pull_request", "pull_request_target"}:
         return True
@@ -225,7 +225,7 @@ def enforce_guard() -> tuple[bool, str]:
     if not blocked_moves:
         return True, "No guarded TPP rename moves detected."
 
-    if not _is_pr_context():
+    if not is_pr_context():
         return True, "Skipping TPP rename guard outside PR context."
 
     pr_body = load_pr_body()

--- a/tests/scripts/test_tpp_migration_guard.py
+++ b/tests/scripts/test_tpp_migration_guard.py
@@ -133,3 +133,40 @@ def test_collect_rename_diff_output_falls_back_to_two_dot_diff(monkeypatch) -> N
 
     assert guard._collect_rename_diff_output().startswith("R100\t")
     assert calls == ["origin/main...HEAD", "origin/main..HEAD"]
+
+
+def test_enforce_guard_blocks_pr_rename_without_pr_body(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.delenv("PR_BODY", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.setattr(
+        guard,
+        "_collect_rename_diff_output",
+        lambda: (
+            "R100\ttrip_planner/app/services/tpp_result_service.py\t"
+            "trip_planner/integrations/tpp/services/tpp_result_service.py\n"
+        ),
+    )
+
+    ok, message = guard.enforce_guard()
+
+    assert not ok
+    assert "could not read PR body" in message
+
+
+def test_enforce_guard_accepts_pr_rename_with_recorded_decision(monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("PR_BODY", "Chosen sub-decision: B-1 canonical TPP subtree.")
+    monkeypatch.setattr(
+        guard,
+        "_collect_rename_diff_output",
+        lambda: (
+            "R100\ttrip_planner/app/models/tpp.py\t"
+            "trip_planner/integrations/tpp/models.py\n"
+        ),
+    )
+
+    ok, message = guard.enforce_guard()
+
+    assert ok
+    assert "records B-1/B-2/B-3 decision" in message

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import re
 import subprocess
 
+import pytest
+
 from scripts import tpp_migration_guard
 
 
@@ -126,6 +128,12 @@ def test_readme_documents_local_bootstrap_and_optional_integrations() -> None:
 
 def test_tpp_renames_require_recorded_sub_decision_in_pr_body() -> None:
     """Block TPP git mv operations until the PR body records B-1/B-2/B-3."""
+    if not tpp_migration_guard.is_pr_context():
+        pytest.skip(
+            "TPP rename guard requires pull-request diff context; post-merge "
+            "canonical-layout checks cover main."
+        )
+
     ok, message = tpp_migration_guard.enforce_guard()
     assert ok, message
 

--- a/tests/test_repo_hygiene.py
+++ b/tests/test_repo_hygiene.py
@@ -167,3 +167,16 @@ def test_no_production_tpp_imports_from_legacy_app_namespaces() -> None:
         "Use trip_planner.integrations.tpp instead.\n"
         f"Offending locations: {', '.join(offenders[:20])}"
     )
+
+
+def test_tpp_canonical_services_package_exists() -> None:
+    """Canonical TPP service package must exist for migrated modules."""
+    services_dir = Path("trip_planner/integrations/tpp/services")
+    package_init = services_dir / "__init__.py"
+
+    assert services_dir.is_dir(), (
+        "Expected canonical TPP services directory at " "trip_planner/integrations/tpp/services."
+    )
+    assert package_init.is_file(), (
+        "Expected package marker at " "trip_planner/integrations/tpp/services/__init__.py."
+    )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1049 -->
> **Source:** Issue #1049

Closes #1049

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #1023's verifier flagged that new TPP components landed under `trip_planner/app/*` while the issue intent was a canonical location. This PR completes the module migration so production TPP services and tests resolve through one canonical import path, eliminating ambiguity that contributed to the prior CONCERNS verdict. PR-B depends on PR-A (#1031) landing first due to unified ABC contracts.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1023](https://github.com/stranske/trip-planner/issues/1023)
- [#1031](https://github.com/stranske/trip-planner/issues/1031)
- [#1050](https://github.com/stranske/trip-planner/issues/1050)
- [#1021](https://github.com/stranske/trip-planner/issues/1021)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Implement a guard in this PR so no `git mv` occurs until the sub-decision (B-1 / B-2 / B-3) is recorded in the PR body.
- [ ] Create the destination package directory for the chosen option (e.g., for B-1 create `trip_planner/integrations/tpp/services/`).
- [ ] Move TPP service files matching `trip_planner/app/services/*tpp*.py` to the chosen canonical location using `git mv`.
- [ ] Move `trip_planner/app/models/tpp.py` to the chosen canonical location using `git mv` (B-1 target: `trip_planner/integrations/tpp/models.py` or `trip_planner/integrations/tpp/models/tpp.py`).
- [ ] Update production imports across the codebase to reference the new module paths (remove TPP-related imports from `trip_planner.app.services` / `trip_planner.app.models` / `trip_planner.app.clients` namespaces).
  - [ ] Define scope for: Identify all production files that import from trip_planner.app.services with TPP-related modules using grep (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Identify all production files that import from trip_planner.app.services with TPP-related modules using grep (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Identify all production files that import from trip_planner.app.services with TPP-related modules using grep (verify: confirm completion in repo)
  - [ ] Define scope for: Update imports in identified production files to reference the new canonical TPP module paths (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Update imports in identified production files to reference the new canonical TPP module paths (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Update imports in identified production files to reference the new canonical TPP module paths (verify: confirm completion in repo)
  - [ ] Define scope for: Verify that all production imports resolve correctly by running static type checking with mypy
  - [ ] Implement focused slice for: Verify that all production imports resolve correctly by running static type checking with mypy
  - [ ] Validate focused slice for: Verify that all production imports resolve correctly by running static type checking with mypy
  - [ ] Define scope for: Document any import conflicts or circular dependencies discovered during the migration (verify: dependencies updated)
  - [ ] Implement focused slice for: Document any import conflicts or circular dependencies discovered during the migration (verify: dependencies updated)
  - [ ] Validate focused slice for: Document any import conflicts or circular dependencies discovered during the migration (verify: dependencies updated)
- [ ] Update test imports in `tests/planner/test_tpp_*.py` and `tests/integrations/test_*.py` to reference the new module paths.
  - [ ] Define scope for: Identify all test files matching tests/planner/test_tpp_*.py that import TPP modules (verify: tests pass)
  - [ ] Implement focused slice for: Identify all test files matching tests/planner/test_tpp_*.py that import TPP modules (verify: tests pass)
  - [ ] Validate focused slice for: Identify all test files matching tests/planner/test_tpp_*.py that import TPP modules (verify: tests pass)
  - [ ] Define scope for: Update imports in tests/planner/test_tpp_*.py files to reference the new canonical paths (verify: tests pass)
  - [ ] Implement focused slice for: Update imports in tests/planner/test_tpp_*.py files to reference the new canonical paths (verify: tests pass)
  - [ ] Validate focused slice for: Update imports in tests/planner/test_tpp_*.py files to reference the new canonical paths (verify: tests pass)
  - [ ] Update imports in tests/integrations/test_*.py files that reference TPP modules (verify: tests pass)
  - [ ] Run the affected test suite to verify all test imports resolve correctly
- [ ] Add/update any minimal shim/legacy stubs under `trip_planner/app/` only if required to keep non-TPP imports working, and document any intentional leftovers in the PR body.
- [ ] Write a PR body inventory listing every renamed file (old path → new path) to demonstrate 1:1 moves.

#### Acceptance criteria
- [ ] The PR body records the chosen sub-decision (B-1 / B-2 / B-3) before any file is moved.
- [ ] All TPP-related production files are located under one canonical sub-tree (per the chosen option) and no additional production TPP files remain elsewhere.
- [ ] Running `find trip_planner/app -name "*tpp*"` returns zero results, or only intentional shim/legacy stubs that are explicitly documented in the PR body.
- [ ] Running `grep -rE "from trip_planner\.app\.(services|models|clients)" --include="*.py"` returns zero TPP-related imports.
- [ ] All tests pass with only import-path updates (no behavioral changes required to make tests pass).
- [ ] CI is green (Gate, ruff, mypy, all test jobs).
- [ ] The PR body includes an inventory of every renamed file (old path → new path).

<!-- auto-status-summary:end -->