### PR TITLE
Issue #1048: Use TPP Python env for live verifier

### DIFF
--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -59,6 +59,9 @@ jobs:
         working-directory: trip-planner
         run: python -m pip install -e ".[dev]"
 
+      - name: Install uv for TPP auto-start fallback
+        run: python -m pip install uv
+
       - name: Install Travel-Plan-Permission dependencies
         working-directory: Travel-Plan-Permission
         run: |

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ runtime-preview-smoke:
 	./scripts/check_production_readiness.sh --preview "${TRIP_PLANNER_PREVIEW_URL}"
 
 full-product-check:
+	@echo "Live TPP auto-start resolves Python as TPP .venv/bin/python, then uv run from uv.lock, then fails fast; set TPP_BASE_URL to skip auto-start."
 	python scripts/check_full_product_verification.py
 
 runtime-full-product-check: full-product-check

--- a/docs/local-testing-plan.md
+++ b/docs/local-testing-plan.md
@@ -45,6 +45,8 @@ make full-product-check
 
 That command creates fresh leisure and business trips through the runtime API, opens their workspaces, asserts runtime/source-backed inventory and scenario comparison identifiers, submits one planner turn, persists a business proposal submission, and ingests an evaluation result. It also reports map-provider and live Travel-Plan-Permission readiness explicitly. Missing map or TPP configuration is reported as `SKIPPED` or `BLOCKED` with the exact missing env var or sibling checkout path; it is never reported as live readiness.
 
+When live TPP auto-start is enabled with `TPP_REPO_PATH`, the verifier runs the sibling service with that repo's own Python environment. Resolution order is `<TPP_REPO_PATH>/.venv/bin/python`, then `uv run --directory <TPP_REPO_PATH> python` when `uv.lock` is present and `uv` is installed, then a fail-fast setup error. If startup does not reach `/readyz`, the verifier includes the resolved command plus the last 50 lines of captured TPP stdout and stderr so missing dependency errors are visible in CI logs. Setting `TPP_BASE_URL` skips auto-start and trusts the externally managed service as before.
+
 ## Critical Journeys Covered
 
 ### Automated Local Checks

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -497,6 +497,7 @@ def _started_tpp_service(
             raise VerificationFailure(
                 "TPP service did not become ready",
                 ready_url=f"{base_url}/readyz",
+                interpreter=" ".join(interpreter),
                 command=" ".join(command),
                 cwd=str(repo_root),
                 returncode=process.poll(),

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -11,6 +11,7 @@ from datetime import date, timedelta
 import json
 import os
 from pathlib import Path
+import shutil
 import socket
 import subprocess
 import sys
@@ -421,6 +422,30 @@ def _free_local_port(preferred: int) -> int:
         return int(sock.getsockname()[1])
 
 
+def _resolve_tpp_interpreter(repo_path: Path) -> list[str]:
+    venv_python = repo_path / ".venv" / "bin" / "python"
+    if venv_python.exists():
+        return [str(venv_python)]
+    if (repo_path / "uv.lock").exists() and shutil.which("uv"):
+        return ["uv", "run", "--directory", str(repo_path), "python"]
+    raise VerificationFailure(
+        "Cannot auto-start TPP: no usable TPP Python environment",
+        venv_python=str(venv_python),
+        uv_lock=str(repo_path / "uv.lock"),
+        remediation=(
+            f"Install TPP dependencies into {repo_path}/.venv, install uv for the repo's "
+            "uv.lock path, or set TPP_BASE_URL to skip auto-start."
+        ),
+    )
+
+
+def _tail_file(path: Path, *, line_count: int = 50) -> str:
+    if not path.exists():
+        return ""
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(lines[-line_count:])
+
+
 @contextmanager
 def _started_tpp_service(
     env: dict[str, str],
@@ -433,39 +458,62 @@ def _started_tpp_service(
 
     port = _free_local_port(TPP_PORT)
     base_url = f"http://127.0.0.1:{port}"
+    repo_root = Path(repo_path)
+    interpreter = _resolve_tpp_interpreter(repo_root)
     service_env = {
         **os.environ,
-        "PYTHONPATH": str(Path(repo_path) / "src"),
+        "PYTHONPATH": str(repo_root / "src"),
         "TPP_BASE_URL": base_url,
         "TPP_AUTH_MODE": "static-token",
         "TPP_ACCESS_TOKEN": env["TPP_ACCESS_TOKEN"],
         "TPP_OIDC_PROVIDER": env["TPP_OIDC_PROVIDER"],
     }
+    stdout_file = tempfile.NamedTemporaryFile(prefix="tpp-service-", suffix=".stdout", delete=False)
+    stderr_file = tempfile.NamedTemporaryFile(prefix="tpp-service-", suffix=".stderr", delete=False)
+    stdout_path = Path(stdout_file.name)
+    stderr_path = Path(stderr_file.name)
+    command = [
+        *interpreter,
+        "-m",
+        "travel_plan_permission.http_service",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
     process = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "travel_plan_permission.http_service",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(port),
-        ],
-        cwd=repo_path,
+        command,
+        cwd=repo_root,
         env=service_env,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=stdout_file,
+        stderr=stderr_file,
     )
+    stdout_file.close()
+    stderr_file.close()
     try:
-        _wait_for_http(f"{base_url}/readyz")
+        try:
+            _wait_for_http(f"{base_url}/readyz")
+        except VerificationFailure as exc:
+            raise VerificationFailure(
+                "TPP service did not become ready",
+                ready_url=f"{base_url}/readyz",
+                command=" ".join(command),
+                cwd=str(repo_root),
+                returncode=process.poll(),
+                stdout_tail=_tail_file(stdout_path),
+                stderr_tail=_tail_file(stderr_path),
+            ) from exc
         yield base_url, process
     finally:
-        process.terminate()
-        try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:  # pragma: no cover - defensive cleanup
-            process.kill()
-            process.wait(timeout=5)
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:  # pragma: no cover - defensive cleanup
+                process.kill()
+                process.wait(timeout=5)
+        stdout_path.unlink(missing_ok=True)
+        stderr_path.unlink(missing_ok=True)
 
 
 def _run_live_tpp_journey(client: TestClient, trip_id: str, env: dict[str, str]) -> dict[str, Any]:

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -446,6 +446,16 @@ def _tail_file(path: Path, *, line_count: int = 50) -> str:
     return "\n".join(lines[-line_count:])
 
 
+def _stop_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover - defensive cleanup
+            process.kill()
+            process.wait(timeout=5)
+
+
 @contextmanager
 def _started_tpp_service(
     env: dict[str, str],
@@ -494,6 +504,7 @@ def _started_tpp_service(
         try:
             _wait_for_http(f"{base_url}/readyz")
         except VerificationFailure as exc:
+            _stop_process(process)
             raise VerificationFailure(
                 "TPP service did not become ready",
                 ready_url=f"{base_url}/readyz",
@@ -506,13 +517,7 @@ def _started_tpp_service(
             ) from exc
         yield base_url, process
     finally:
-        if process.poll() is None:
-            process.terminate()
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:  # pragma: no cover - defensive cleanup
-                process.kill()
-                process.wait(timeout=5)
+        _stop_process(process)
         stdout_path.unlink(missing_ok=True)
         stderr_path.unlink(missing_ok=True)
 

--- a/tests/app/test_full_product_verification.py
+++ b/tests/app/test_full_product_verification.py
@@ -123,6 +123,90 @@ def test_live_tpp_auto_reports_invalid_repo_path_as_blocked(tmp_path) -> None:
     assert check.details["invalid_path"] == {"TPP_REPO_PATH": str(missing_repo)}
 
 
+def test_tpp_interpreter_resolution_prefers_repo_venv(tmp_path) -> None:
+    repo_path = tmp_path / "Travel-Plan-Permission"
+    venv_python = repo_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+
+    assert verifier._resolve_tpp_interpreter(repo_path) == [str(venv_python)]
+
+
+def test_tpp_interpreter_resolution_uses_uv_lock_when_no_venv(monkeypatch, tmp_path) -> None:
+    repo_path = tmp_path / "Travel-Plan-Permission"
+    repo_path.mkdir()
+    (repo_path / "uv.lock").write_text("", encoding="utf-8")
+    monkeypatch.setattr(verifier.shutil, "which", lambda command: "/usr/local/bin/uv")
+
+    assert verifier._resolve_tpp_interpreter(repo_path) == [
+        "uv",
+        "run",
+        "--directory",
+        str(repo_path),
+        "python",
+    ]
+
+
+def test_tpp_interpreter_resolution_fails_with_actionable_message(monkeypatch, tmp_path) -> None:
+    repo_path = tmp_path / "Travel-Plan-Permission"
+    repo_path.mkdir()
+    monkeypatch.setattr(verifier.shutil, "which", lambda command: None)
+
+    try:
+        verifier._resolve_tpp_interpreter(repo_path)
+    except verifier.VerificationFailure as error:
+        message = str(error)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected missing TPP interpreter to fail verification")
+
+    assert "Cannot auto-start TPP" in message
+    assert str(repo_path / ".venv" / "bin" / "python") in message
+    assert "TPP_BASE_URL" in message
+
+
+def test_started_tpp_service_captures_startup_stderr(monkeypatch, tmp_path) -> None:
+    repo_path = tmp_path / "Travel-Plan-Permission"
+    venv_python = repo_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+
+    class FakeProcess:
+        def __init__(self, *args, **kwargs):
+            self.args = args[0]
+            kwargs["stderr"].write(b"ModuleNotFoundError: No module named 'jinja2'\n")
+            kwargs["stderr"].flush()
+
+        def poll(self):
+            return 1
+
+        def terminate(self):  # pragma: no cover - should not terminate exited process
+            raise AssertionError("process already exited")
+
+    def fail_ready(_url: str) -> None:
+        raise verifier.VerificationFailure("not ready")
+
+    monkeypatch.setattr(verifier.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(verifier, "_wait_for_http", fail_ready)
+
+    try:
+        with verifier._started_tpp_service(
+            {
+                "TPP_REPO_PATH": str(repo_path),
+                "TPP_ACCESS_TOKEN": "token",
+                "TPP_OIDC_PROVIDER": "google",
+            }
+        ):
+            raise AssertionError("service should not yield when readiness fails")
+    except verifier.VerificationFailure as error:
+        message = str(error)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("expected readiness failure")
+
+    assert str(venv_python) in message
+    assert "ModuleNotFoundError: No module named 'jinja2'" in message
+    assert "stderr_tail" in message
+
+
 def test_required_live_tpp_accepts_ready_prerequisite_after_success(monkeypatch) -> None:
     for name in (
         "TPP_BASE_URL",

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -56,11 +56,11 @@ def test_started_tpp_service_starts_and_terminates_cleanly(monkeypatch, tmp_path
         assert base_url.startswith("http://127.0.0.1:")
         assert process is process_holder["proc"]
 
-    process = process_holder["proc"]
-    assert process.command[0] == str(repo_path / ".venv" / "bin" / "python")
-    assert process.command[1:3] == ["-m", "travel_plan_permission.http_service"]
-    assert process.terminated is True
-    assert process.wait_calls == 1
+    captured_process = process_holder["proc"]
+    assert captured_process.command[0] == str(repo_path / ".venv" / "bin" / "python")
+    assert captured_process.command[1:3] == ["-m", "travel_plan_permission.http_service"]
+    assert captured_process.terminated is True
+    assert captured_process.wait_calls == 1
 
 
 def test_started_tpp_service_readiness_failure_includes_captured_stderr(

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -71,6 +71,11 @@ def test_started_tpp_service_readiness_failure_includes_captured_stderr(
     class FakeProcess:
         def __init__(self, command, **kwargs):
             self.command = command
+            stdout_lines = "\n".join(f"stdout-{index}" for index in range(60)) + "\n"
+            stderr_lines = "\n".join(f"stderr-{index}" for index in range(60)) + "\n"
+            kwargs["stdout"].write(stdout_lines.encode("utf-8"))
+            kwargs["stdout"].flush()
+            kwargs["stderr"].write(stderr_lines.encode("utf-8"))
             kwargs["stderr"].write(b"ModuleNotFoundError: No module named 'jinja2'\n")
             kwargs["stderr"].flush()
 
@@ -102,4 +107,9 @@ def test_started_tpp_service_readiness_failure_includes_captured_stderr(
     assert str(venv_python) in message
     assert '"interpreter"' in message
     assert "ModuleNotFoundError: No module named 'jinja2'" in message
+    assert "stdout_tail" in message
     assert "stderr_tail" in message
+    assert "stdout-59" in message
+    assert "stderr-59" in message
+    assert "stdout-9" not in message
+    assert "stderr-9" not in message

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -36,12 +36,11 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-""".strip()
-        + "\n",
+""".strip() + "\n",
         encoding="utf-8",
     )
     venv_python.write_text(
-        f"#!/usr/bin/env bash\nexec {verifier.sys.executable} \"$@\"\n",
+        f'#!/usr/bin/env bash\nexec {verifier.sys.executable} "$@"\n',
         encoding="utf-8",
     )
     venv_python.chmod(venv_python.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
@@ -113,7 +112,9 @@ def test_started_tpp_service_starts_known_good_repo_and_tears_down(
     with verifier._started_tpp_service(env) as (_base_url, process):
         assert process is not None
         assert process.poll() is None
-        assert process.args[0] == str(venv_python)
+        process_args = process.args
+        assert isinstance(process_args, (list, tuple))
+        assert process_args[0] == str(venv_python)
 
     assert process.poll() is not None
 

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import stat
+import time
 
 import pytest
 
@@ -36,6 +37,25 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+""".strip() + "\n",
+        encoding="utf-8",
+    )
+    venv_python.write_text(
+        f'#!/usr/bin/env bash\nexec {verifier.sys.executable} "$@"\n',
+        encoding="utf-8",
+    )
+    venv_python.chmod(venv_python.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return repo_path, venv_python
+
+
+def _make_missing_deps_tpp_repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo_path, venv_python = _make_repo_with_venv(tmp_path)
+    package_path = repo_path / "src" / "travel_plan_permission"
+    package_path.mkdir(parents=True)
+    (package_path / "__init__.py").write_text("", encoding="utf-8")
+    (package_path / "http_service.py").write_text(
+        """
+import definitely_missing_dependency
 """.strip() + "\n",
         encoding="utf-8",
     )
@@ -169,3 +189,32 @@ def test_started_tpp_service_readiness_failure_includes_captured_stderr(
     assert "stderr-59" in message
     assert "stdout-9" not in message
     assert "stderr-9" not in message
+
+
+def test_started_tpp_service_missing_deps_failure_includes_stderr(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_path, venv_python = _make_missing_deps_tpp_repo(tmp_path)
+    monkeypatch.setattr(verifier, "_free_local_port", lambda _preferred: 43124)
+
+    def fail_readiness_after_process_boot(_url: str) -> None:
+        time.sleep(0.2)
+        raise verifier.VerificationFailure("not ready")
+
+    monkeypatch.setattr(verifier, "_wait_for_http", fail_readiness_after_process_boot)
+
+    with pytest.raises(verifier.VerificationFailure) as exc_info:
+        with verifier._started_tpp_service(
+            {
+                "TPP_REPO_PATH": str(repo_path),
+                "TPP_ACCESS_TOKEN": "token",
+                "TPP_OIDC_PROVIDER": "google",
+            }
+        ):
+            pass
+
+    message = str(exc_info.value)
+    assert str(venv_python) in message
+    assert "ModuleNotFoundError" in message
+    assert "definitely_missing_dependency" in message
+    assert "stderr_tail" in message

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+
+import pytest
+
+from scripts import check_full_product_verification as verifier
+
+
+def _make_repo_with_venv(tmp_path: Path) -> tuple[Path, Path]:
+    repo_path = tmp_path / "Travel-Plan-Permission"
+    venv_python = repo_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+    return repo_path, venv_python
+
+
+def test_started_tpp_service_starts_and_terminates_cleanly(monkeypatch, tmp_path: Path) -> None:
+    repo_path, _ = _make_repo_with_venv(tmp_path)
+
+    class FakeProcess:
+        def __init__(self, command, **kwargs):
+            self.command = command
+            self.kwargs = kwargs
+            self._poll = None
+            self.terminated = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return self._poll
+
+        def terminate(self):
+            self.terminated = True
+            self._poll = 0
+
+        def wait(self, timeout):
+            self.wait_calls += 1
+            return 0
+
+    process_holder: dict[str, FakeProcess] = {}
+
+    def fake_popen(command, **kwargs):
+        proc = FakeProcess(command, **kwargs)
+        process_holder["proc"] = proc
+        return proc
+
+    monkeypatch.setattr(verifier.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(verifier, "_wait_for_http", lambda _url: None)
+    monkeypatch.setattr(verifier, "_free_local_port", lambda _preferred: 42123)
+
+    with verifier._started_tpp_service(
+        {
+            "TPP_REPO_PATH": str(repo_path),
+            "TPP_ACCESS_TOKEN": "token",
+            "TPP_OIDC_PROVIDER": "google",
+        }
+    ) as (base_url, process):
+        assert base_url.startswith("http://127.0.0.1:")
+        assert process is process_holder["proc"]
+
+    process = process_holder["proc"]
+    assert process.terminated is True
+    assert process.wait_calls == 1
+
+
+def test_started_tpp_service_readiness_failure_includes_captured_stderr(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_path, venv_python = _make_repo_with_venv(tmp_path)
+
+    class FakeProcess:
+        def __init__(self, command, **kwargs):
+            self.command = command
+            kwargs["stderr"].write(b"ModuleNotFoundError: No module named 'jinja2'\n")
+            kwargs["stderr"].flush()
+
+        def poll(self):
+            return 1
+
+        def terminate(self):  # pragma: no cover - process has already exited
+            raise AssertionError("process already exited")
+
+    monkeypatch.setattr(verifier.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(
+        verifier,
+        "_wait_for_http",
+        lambda _url: (_ for _ in ()).throw(verifier.VerificationFailure("not ready")),
+    )
+    monkeypatch.setattr(verifier, "_free_local_port", lambda _preferred: 43123)
+
+    with pytest.raises(verifier.VerificationFailure) as exc_info:
+        with verifier._started_tpp_service(
+            {
+                "TPP_REPO_PATH": str(repo_path),
+                "TPP_ACCESS_TOKEN": "token",
+                "TPP_OIDC_PROVIDER": "google",
+            }
+        ):
+            pass
+
+    message = str(exc_info.value)
+    assert str(venv_python) in message
+    assert "ModuleNotFoundError: No module named 'jinja2'" in message
+    assert "stderr_tail" in message

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -57,6 +57,8 @@ def test_started_tpp_service_starts_and_terminates_cleanly(monkeypatch, tmp_path
         assert process is process_holder["proc"]
 
     process = process_holder["proc"]
+    assert process.command[0] == str(repo_path / ".venv" / "bin" / "python")
+    assert process.command[1:3] == ["-m", "travel_plan_permission.http_service"]
     assert process.terminated is True
     assert process.wait_calls == 1
 
@@ -98,5 +100,6 @@ def test_started_tpp_service_readiness_failure_includes_captured_stderr(
 
     message = str(exc_info.value)
     assert str(venv_python) in message
+    assert '"interpreter"' in message
     assert "ModuleNotFoundError: No module named 'jinja2'" in message
     assert "stderr_tail" in message

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import stat
 
 import pytest
 
@@ -10,6 +11,40 @@ def _make_repo_with_venv(tmp_path: Path) -> tuple[Path, Path]:
     venv_python = repo_path / ".venv" / "bin" / "python"
     venv_python.parent.mkdir(parents=True)
     venv_python.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+    return repo_path, venv_python
+
+
+def _make_runnable_tpp_repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo_path, venv_python = _make_repo_with_venv(tmp_path)
+    package_path = repo_path / "src" / "travel_plan_permission"
+    package_path.mkdir(parents=True)
+    (package_path / "__init__.py").write_text("", encoding="utf-8")
+    (package_path / "http_service.py").write_text(
+        """
+import argparse
+import time
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", required=True)
+    parser.add_argument("--port", type=int, required=True)
+    parser.parse_args()
+    while True:
+        time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    main()
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    venv_python.write_text(
+        f"#!/usr/bin/env bash\nexec {verifier.sys.executable} \"$@\"\n",
+        encoding="utf-8",
+    )
+    venv_python.chmod(venv_python.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return repo_path, venv_python
 
 
@@ -61,6 +96,26 @@ def test_started_tpp_service_starts_and_terminates_cleanly(monkeypatch, tmp_path
     assert captured_process.command[1:3] == ["-m", "travel_plan_permission.http_service"]
     assert captured_process.terminated is True
     assert captured_process.wait_calls == 1
+
+
+def test_started_tpp_service_starts_known_good_repo_and_tears_down(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_path, venv_python = _make_runnable_tpp_repo(tmp_path)
+    env = {
+        "TPP_REPO_PATH": str(repo_path),
+        "TPP_ACCESS_TOKEN": "token",
+        "TPP_OIDC_PROVIDER": "google",
+    }
+    monkeypatch.setattr(verifier, "_wait_for_http", lambda _url: None)
+    monkeypatch.setattr(verifier, "_free_local_port", lambda _preferred: 42124)
+
+    with verifier._started_tpp_service(env) as (_base_url, process):
+        assert process is not None
+        assert process.poll() is None
+        assert process.args[0] == str(venv_python)
+
+    assert process.poll() is not None
 
 
 def test_started_tpp_service_readiness_failure_includes_captured_stderr(

--- a/tests/scripts/test_tpp_migration_guard.py
+++ b/tests/scripts/test_tpp_migration_guard.py
@@ -161,8 +161,7 @@ def test_enforce_guard_accepts_pr_rename_with_recorded_decision(monkeypatch) -> 
         guard,
         "_collect_rename_diff_output",
         lambda: (
-            "R100\ttrip_planner/app/models/tpp.py\t"
-            "trip_planner/integrations/tpp/models.py\n"
+            "R100\ttrip_planner/app/models/tpp.py\t" "trip_planner/integrations/tpp/models.py\n"
         ),
     )
 

--- a/trip_planner/integrations/tpp/contracts.py
+++ b/trip_planner/integrations/tpp/contracts.py
@@ -209,9 +209,7 @@ class TPPResponseEnvelope:
         self.result_payload = _optional_mapping(self.result_payload, "result_payload")
         require_string_mapping(self.result_payload, "result_payload")
         if self.evaluation_result is not None:
-            self.evaluation_result = _require_mapping(
-                self.evaluation_result, "evaluation_result"
-            )
+            self.evaluation_result = _require_mapping(self.evaluation_result, "evaluation_result")
             require_string_mapping(self.evaluation_result, "evaluation_result")
         if self.error is not None and not isinstance(self.error, TPPErrorRecord):
             raise ValueError("error must be a TPPErrorRecord when provided")


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1048 -->
> **Source:** Issue #1048

Closes #1048

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`scripts/check_full_product_verification.py:444-457` starts the sibling
Travel-Plan-Permission service via `subprocess.Popen([sys.executable, "-m",
"travel_plan_permission.http_service", ...])`. The interpreter is
trip-planner's `sys.executable`, and the only path adjustment is
`PYTHONPATH=<tpp_repo>/src`. In a clean trip-planner virtual environment
that does not have TPP runtime dependencies installed (e.g. `jinja2`,
`fastapi` extras, `pydantic` extras), the subprocess fails on import and
`/readyz` never comes up. Because both `stdout` and `stderr` are wired to
`subprocess.DEVNULL` (lines 456–457), the failure is silent: the verifier
just times out waiting for readiness and reports "connection refused"
without surfacing the actual import error.

This means `make full-product-check --live-tpp` is fragile against any
clean environment (developer's first run, CI, the cross-repo CI gate
proposed in #1045) and the failure mode is undiagnosable from the
verifier output. It also undermines the reliability of issue #1045's CI
job before that issue can even land.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1045](https://github.com/stranske/trip-planner/issues/1045)
- [#1044](https://github.com/stranske/trip-planner/issues/1044)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Detect the TPP repo's Python interpreter: prefer `<repo>/.venv/bin/python` if present, else fall back to `uv run python` if a `uv.lock` is present, else fail fast with a clear error message naming both options.
- [x] Replace the `sys.executable` argument in the `subprocess.Popen` call at line 444 with the resolved TPP interpreter.
- [x] Capture `stdout` and `stderr` to a `tempfile.NamedTemporaryFile` per stream rather than `DEVNULL`.
- [x] On readiness timeout, read both temp files, include the last 50 lines of each in the raised error, and surface the resolved interpreter path so the developer can reproduce.
- [x] Add a regression test under `tests/scripts/` that exercises `_started_tpp_service` against a known-good TPP repo path with a venv that has TPP installed, and asserts the service comes up and is torn down cleanly.
- [x] Add a regression test that simulates a missing-deps failure (e.g. by pointing at a repo with an empty venv) and asserts the verifier raises with the captured stderr included in the message.
- [x] Document the resolution order (`.venv` → `uv run` → fail fast) in `docs/local-testing-plan.md` and in the `make full-product-check` help text.

#### Acceptance criteria
- [ ] With `TPP_REPO_PATH` pointing at a TPP checkout that has its own `.venv` with deps installed, `make full-product-check --live-tpp` starts the service through that venv's interpreter and the journey passes.
- [ ] With `TPP_REPO_PATH` pointing at a TPP checkout that has no installed deps, `make full-product-check --live-tpp` fails fast with an error message that names the resolved interpreter and includes the captured TPP stderr (which should reference the missing module).
- [ ] When `TPP_BASE_URL` is set, the auto-start path is skipped entirely (existing behavior, regression-proof).
- [ ] Regression tests covering both the success path and the missing-deps failure path pass in CI.
- [ ] `docs/local-testing-plan.md` documents the resolution order and the failure surface.

<!-- auto-status-summary:end -->