### PR TITLE
fix: close TPP polling verifier concerns

### DIFF
--- a/tests/planner/test_tpp_polling_service.py
+++ b/tests/planner/test_tpp_polling_service.py
@@ -140,14 +140,15 @@ def test_poll_pending_until_timeout_returns_timeout_envelope() -> None:
     assert response.request_id == "request-1"
     assert response.correlation_id.value == "corr-1"
     assert response.result_payload == {}
-    assert response.result_payload.get("evaluation_result", {}) == {}
+    assert response.evaluation_result == {}
     assert response.error is None
     assert payload["execution_status"]["state"] == "timeout"
     assert payload["result_payload"] == {}
-    assert payload.get("evaluation_result", {}) == {}
+    assert payload["evaluation_result"] == {}
     round_tripped = TPPResponseEnvelope.from_dict(payload)
     assert round_tripped.execution_status.state == "timeout"
     assert round_tripped.result_payload == {}
+    assert round_tripped.evaluation_result == {}
     assert call_count == 3
     assert sleeps == [1.0, 2.0, 2.0]
 
@@ -182,7 +183,8 @@ def test_poll_timeout_returns_empty_payload_and_evaluation_result_lookup() -> No
 
     assert response.execution_status.state == "timeout"
     assert response.result_payload == {}
-    assert payload.get("evaluation_result", {}) == {}
+    assert response.evaluation_result == {}
+    assert payload["evaluation_result"] == {}
     assert response.error is None
 
 
@@ -206,7 +208,7 @@ def test_poll_truncates_first_sleep_to_remaining_timeout() -> None:
 
     assert response.execution_status.state == "timeout"
     assert response.result_payload == {}
-    assert response.result_payload.get("evaluation_result", {}) == {}
+    assert response.evaluation_result == {}
     assert sleeps == [0.5]
     assert call_count == 1
 
@@ -232,3 +234,8 @@ def test_poll_uses_capped_cadence_and_truncates_final_sleep_to_timeout_remaining
     assert response.execution_status.state == "timeout"
     assert sleeps == [1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 30.0, 4.0]
     assert calls == 8
+
+
+def test_polling_service_rejects_non_callable_provider() -> None:
+    with pytest.raises(ValueError, match="poll_response_provider must be callable"):
+        TPPPollingService(None, timeout_seconds=1.0)  # type: ignore[arg-type]

--- a/trip_planner/integrations/tpp/contracts.py
+++ b/trip_planner/integrations/tpp/contracts.py
@@ -190,6 +190,7 @@ class TPPResponseEnvelope:
     transport_pattern: str
     execution_status: TPPExecutionStatus
     result_payload: dict[str, Any] = field(default_factory=dict)
+    evaluation_result: dict[str, Any] | None = None
     error: TPPErrorRecord | None = None
     retry: TPPRetryMetadata | None = None
     received_at: str | None = None
@@ -207,6 +208,11 @@ class TPPResponseEnvelope:
             raise ValueError("execution_status must be a TPPExecutionStatus")
         self.result_payload = _optional_mapping(self.result_payload, "result_payload")
         require_string_mapping(self.result_payload, "result_payload")
+        if self.evaluation_result is not None:
+            self.evaluation_result = _require_mapping(
+                self.evaluation_result, "evaluation_result"
+            )
+            require_string_mapping(self.evaluation_result, "evaluation_result")
         if self.error is not None and not isinstance(self.error, TPPErrorRecord):
             raise ValueError("error must be a TPPErrorRecord when provided")
         if self.retry is not None and not isinstance(self.retry, TPPRetryMetadata):
@@ -222,6 +228,8 @@ class TPPResponseEnvelope:
         payload = asdict(self)
         payload["correlation_id"] = self.correlation_id.to_dict()
         payload["execution_status"] = self.execution_status.to_dict()
+        if self.evaluation_result is None:
+            payload.pop("evaluation_result", None)
         if self.error is not None:
             payload["error"] = self.error.to_dict()
         if self.retry is not None:
@@ -238,6 +246,11 @@ class TPPResponseEnvelope:
             transport_pattern=response.get("transport_pattern", "sync"),
             execution_status=TPPExecutionStatus(**response["execution_status"]),
             result_payload=_optional_mapping(response.get("result_payload"), "result_payload"),
+            evaluation_result=(
+                _require_mapping(response["evaluation_result"], "evaluation_result")
+                if "evaluation_result" in response
+                else None
+            ),
             error=(
                 TPPErrorRecord(**response["error"]) if response.get("error") is not None else None
             ),

--- a/trip_planner/integrations/tpp/services/tpp_polling_service.py
+++ b/trip_planner/integrations/tpp/services/tpp_polling_service.py
@@ -34,6 +34,8 @@ class TPPPollingService:
         sleeper: Callable[[float], None] = time.sleep,
         now: Callable[[], float] = time.monotonic,
     ) -> None:
+        if not callable(poll_response_provider):
+            raise ValueError("poll_response_provider must be callable")
         if timeout_seconds <= 0:
             raise ValueError("timeout_seconds must be > 0")
         self._poll_response_provider = poll_response_provider
@@ -97,4 +99,5 @@ class TPPPollingService:
                 external_status="timeout",
             ),
             result_payload={},
+            evaluation_result={},
         )


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1050 -->
> **Source:** Issue #1050

Closes #1050

<!-- pr-preamble:end -->

## Summary
- Add an explicit top-level `evaluation_result` field to timeout `TPPResponseEnvelope` serialization while preserving empty `result_payload`.
- Reject non-callable polling providers during `TPPPollingService` construction with a controlled `ValueError`.
- Tighten timeout tests so `evaluation_result == {}` must exist and round-trip instead of being masked by `.get(..., {})`.

## Verifier disposition
This addresses the OpenAI verifier concerns on #1055. The contract file change is intentional and bounded because the explicit timeout envelope field lives on `TPPResponseEnvelope`; the service and polling tests are the only runtime behavior changes.

## Validation
- `/opt/anaconda3/bin/python3.12 -m pytest tests/planner/test_tpp_polling_service.py tests/integrations/test_tpp_contracts.py -q`
- `/opt/anaconda3/bin/ruff check trip_planner/integrations/tpp/contracts.py trip_planner/integrations/tpp/services/tpp_polling_service.py tests/planner/test_tpp_polling_service.py`

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #1023's verifier flagged that the polling service relied on the caller re-invoking it across multiple external poll calls to detect timeout, meaning timeout state lived in caller-side state and the service could not return a deterministic timeout result on its own. This refactor makes a single public method call drive the full pending → terminal-state-or-timeout flow internally, returning a uniform `TPPResponseEnvelope` (including a synthetic timeout envelope) without raising.

This is PR-C in a 3-part split (siblings: PR-A interface unification + contracts #1031; PR-B module migration #1049). PR-C depends on PR-A landing first (centralized envelope validation) and PR-B's sub-decision being settled (canonical file path fixed before behavior changes). It is the highest-risk PR in the series because it changes runtime behavior.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1023](https://github.com/stranske/trip-planner/issues/1023)
- [#1031](https://github.com/stranske/trip-planner/issues/1031)
- [#1049](https://github.com/stranske/trip-planner/issues/1049)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Use `time.monotonic()` for timeout measurement. Make cadence calculation a pure function for testability (e.g., `_next_wait(attempt: int) -> float = min(2 ** (attempt - 1), 30)` for attempt ≥ 1). Truncate sleeps to remaining timeout (e.g., if 5s remain and next wait is 8s, sleep 5s). Implement sleeping via an injected `sleeper` (default `time.sleep`) so tests can provide a fake sleeper and a deterministic monotonic clock. The "no second external poll call needed" test can count fake client calls and assert they match expectations for a given `timeout_seconds` and cadence.

#### Acceptance criteria
- [ ] `tpp_polling_service.py` exposes a single public method that accepts the polling request and returns a `TPPResponseEnvelope` with a terminal state or `execution_status.state == "timeout"` without requiring any caller-side polling loop.
- [ ] The polling service constructor in `tpp_polling_service.py` accepts `timeout_seconds: float` and `sleeper: Callable[[float], None]` and the module contains no hardcoded production default timeout value.
- [ ] When the client returns non-terminal responses until the configured timeout elapses, the service returns a `TPPResponseEnvelope` where `execution_status.state == "timeout"`, `result_payload == {}`, and `evaluation_result == {}`, and no exception is raised.
- [ ] When the client returns pending then success, a single `service.poll(...)` call returns the success envelope and the recorded sleeper durations equal `[1.0, 2.0]`.
- [ ] When the client returns pending then failure, a single `service.poll(...)` call returns the failure envelope and the recorded sleeper durations equal `[1.0]`.
- [ ] Cadence inside the loop produces sleeper durations matching the doubling-with-30s-cap pattern: `[1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 30.0, ...]`.
- [ ] `tests/planner/test_tpp_polling_service.py` (or canonical path after PR-B) contains tests covering pending→success, pending→failure, pending→timeout, no second external poll call needed, and cadence verification, and all tests pass.
- [ ] CI test suite passes with all existing tests green and only the following files modified: `tpp_polling_service.py`, `test_tpp_polling_service.py`, and files containing import statements for these modules (no logic changes in other modules).

<!-- auto-status-summary:end -->