### PR TITLE
fix: close cross-repo smoke verifier gaps

### DIFF
--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -36,6 +36,7 @@ jobs:
           repository: stranske/Travel-Plan-Permission
           ref: ${{ env.TPP_PINNED_REF }}
           path: Travel-Plan-Permission
+          token: ${{ secrets.CROSS_REPO_TOKEN || github.token }}
 
       - name: Log resolved pinned TPP SHA
         working-directory: Travel-Plan-Permission
@@ -44,12 +45,12 @@ jobs:
           echo "TPP_RESOLVED_SHA=$(git rev-parse HEAD)"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -78,7 +79,7 @@ jobs:
       - name: Run full-product-check against sibling TPP checkout
         working-directory: trip-planner
         env:
-          TPP_REPO_PATH: ${{ github.workspace }}/Travel-Plan-Permission
+          TPP_REPO_PATH: ../Travel-Plan-Permission
           TPP_ACCESS_TOKEN: ci-cross-repo-smoke-token
           TPP_OIDC_PROVIDER: google
           LIVE_TPP: required

--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -15,6 +15,9 @@ on:
     branches: [main]
   workflow_dispatch:
   workflow_call:
+    secrets:
+      CROSS_REPO_TOKEN:
+        required: false
 
 env:
   TPP_PINNED_REF: d7c5c310018f4242e33f7df3d06c0e76f7b79ee9

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -131,6 +131,11 @@ env:
 CI logs print both `TPP_PINNED_REF` and the resolved SHA so the actually
 checked-out commit is easy to verify.
 
+When this workflow runs through `workflow_call`, the optional `CROSS_REPO_TOKEN`
+secret is preferred for the pinned TPP checkout and falls back to `github.token`.
+Callers should pass it with `secrets: inherit` when the default token cannot read
+the pinned repo or ref.
+
 #### Bumping the pin
 
 The pin is intentionally manual so a TPP-side breakage cannot land green by

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -113,12 +113,12 @@ contract with `stranske/Travel-Plan-Permission`. On every PR and on push to
 `main` it:
 
 1. Checks out trip-planner (PR head) into `trip-planner/`.
-2. Checks out `stranske/Travel-Plan-Permission` at a pinned ref into a
-   sibling `Travel-Plan-Permission/` directory.
+2. Checks out `stranske/Travel-Plan-Permission` at a pinned ref into
+   `Travel-Plan-Permission/` beside the trip-planner checkout.
 3. Installs both repos' dev extras and the trip-planner frontend deps.
 4. Runs `python scripts/check_full_product_verification.py --live-tpp required`
-   with `TPP_REPO_PATH` pointing at the sibling checkout. This is the same
-   path `make full-product-check` uses locally, so a green run proves the
+   with `TPP_REPO_PATH=../Travel-Plan-Permission`, matching the local sibling
+   checkout contract used by `make full-product-check`. A green run proves the
    live cross-repo handshake (planner → local TPP subprocess) is intact.
 
 The pinned TPP ref is configurable via a single workflow-level env var:

--- a/tests/planner/test_tpp_polling_service.py
+++ b/tests/planner/test_tpp_polling_service.py
@@ -40,7 +40,9 @@ def _request() -> TPPRequestEnvelope:
 def _response(
     state: str, *, terminal: bool, result_payload: dict[str, object] | None = None
 ) -> TPPResponseEnvelope:
-    error = TPPErrorRecord(code="failed", message="failed") if state == "failed" else None
+    error = (
+        TPPErrorRecord(code="failed", message="failed") if state == "failed" else None
+    )
     return TPPResponseEnvelope(
         operation="poll_execution_status",
         request_id="request-1",
@@ -68,7 +70,9 @@ def test_poll_pending_then_success_records_expected_sleeps() -> None:
             _response("running", terminal=False),
             _response("running", terminal=False),
             _response(
-                "succeeded", terminal=True, result_payload={"trip_id": "t-1", "proposal_id": "p-1"}
+                "succeeded",
+                terminal=True,
+                result_payload={"trip_id": "t-1", "proposal_id": "p-1"},
             ),
         ]
     )
@@ -80,7 +84,9 @@ def test_poll_pending_then_success_records_expected_sleeps() -> None:
         sleeps.append(seconds)
         clock.sleep(seconds)
 
-    service = TPPPollingService(provider, timeout_seconds=20.0, sleeper=sleeper, now=clock.now)
+    service = TPPPollingService(
+        provider, timeout_seconds=20.0, sleeper=sleeper, now=clock.now
+    )
 
     response = service.poll(_request())
 
@@ -105,7 +111,9 @@ def test_poll_pending_then_failure_records_expected_sleeps() -> None:
         sleeps.append(seconds)
         clock.sleep(seconds)
 
-    service = TPPPollingService(provider, timeout_seconds=20.0, sleeper=sleeper, now=clock.now)
+    service = TPPPollingService(
+        provider, timeout_seconds=20.0, sleeper=sleeper, now=clock.now
+    )
 
     response = service.poll(_request())
 
@@ -127,7 +135,9 @@ def test_poll_pending_until_timeout_returns_timeout_envelope() -> None:
         sleeps.append(seconds)
         clock.sleep(seconds)
 
-    service = TPPPollingService(provider, timeout_seconds=5.0, sleeper=sleeper, now=clock.now)
+    service = TPPPollingService(
+        provider, timeout_seconds=5.0, sleeper=sleeper, now=clock.now
+    )
 
     response = service.poll(_request())
     payload = response.to_dict()
@@ -162,7 +172,9 @@ def test_poll_does_not_require_second_external_call_to_detect_timeout() -> None:
         call_count += 1
         return _response("running", terminal=False)
 
-    service = TPPPollingService(provider, timeout_seconds=1.0, sleeper=clock.sleep, now=clock.now)
+    service = TPPPollingService(
+        provider, timeout_seconds=1.0, sleeper=clock.sleep, now=clock.now
+    )
 
     response = service.poll(_request())
 
@@ -176,7 +188,9 @@ def test_poll_timeout_returns_empty_payload_and_evaluation_result_lookup() -> No
     def provider(_request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         return _response("running", terminal=False)
 
-    service = TPPPollingService(provider, timeout_seconds=1.0, sleeper=clock.sleep, now=clock.now)
+    service = TPPPollingService(
+        provider, timeout_seconds=1.0, sleeper=clock.sleep, now=clock.now
+    )
 
     response = service.poll(_request())
     payload = response.to_dict()
@@ -202,7 +216,9 @@ def test_poll_truncates_first_sleep_to_remaining_timeout() -> None:
         sleeps.append(seconds)
         clock.sleep(seconds)
 
-    service = TPPPollingService(provider, timeout_seconds=0.5, sleeper=sleeper, now=clock.now)
+    service = TPPPollingService(
+        provider, timeout_seconds=0.5, sleeper=sleeper, now=clock.now
+    )
 
     response = service.poll(_request())
 
@@ -213,7 +229,9 @@ def test_poll_truncates_first_sleep_to_remaining_timeout() -> None:
     assert call_count == 1
 
 
-def test_poll_uses_capped_cadence_and_truncates_final_sleep_to_timeout_remaining() -> None:
+def test_poll_uses_capped_cadence_and_truncates_final_sleep_to_timeout_remaining() -> (
+    None
+):
     clock = FakeClock()
     sleeps: list[float] = []
     calls = 0
@@ -227,7 +245,9 @@ def test_poll_uses_capped_cadence_and_truncates_final_sleep_to_timeout_remaining
         sleeps.append(seconds)
         clock.sleep(seconds)
 
-    service = TPPPollingService(provider, timeout_seconds=95.0, sleeper=sleeper, now=clock.now)
+    service = TPPPollingService(
+        provider, timeout_seconds=95.0, sleeper=sleeper, now=clock.now
+    )
 
     response = service.poll(_request())
 
@@ -236,6 +256,44 @@ def test_poll_uses_capped_cadence_and_truncates_final_sleep_to_timeout_remaining
     assert calls == 8
 
 
+def test_zero_timeout_polls_until_terminal_without_timeout_response() -> None:
+    clock = FakeClock()
+    sleeps: list[float] = []
+    responses = iter(
+        [
+            _response("running", terminal=False),
+            _response("running", terminal=False),
+            _response(
+                "succeeded", terminal=True, result_payload={"proposal_id": "p-1"}
+            ),
+        ]
+    )
+
+    def provider(_request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        return next(responses)
+
+    def sleeper(seconds: float) -> None:
+        sleeps.append(seconds)
+        clock.sleep(seconds)
+
+    service = TPPPollingService(
+        provider, timeout_seconds=0.0, sleeper=sleeper, now=clock.now
+    )
+
+    response = service.poll(_request())
+
+    assert response.execution_status.state == "succeeded"
+    assert response.result_payload == {"proposal_id": "p-1"}
+    assert sleeps == [1.0, 2.0]
+
+
 def test_polling_service_rejects_non_callable_provider() -> None:
     with pytest.raises(ValueError, match="poll_response_provider must be callable"):
         TPPPollingService(None, timeout_seconds=1.0)  # type: ignore[arg-type]
+
+
+def test_polling_service_rejects_negative_timeout() -> None:
+    with pytest.raises(ValueError, match="timeout_seconds must be >= 0"):
+        TPPPollingService(
+            lambda request: _response("succeeded", terminal=True), timeout_seconds=-1.0
+        )

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -16,10 +16,7 @@ import pytest
 import yaml
 
 WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2]
-    / ".github"
-    / "workflows"
-    / "cross-repo-smoke.yml"
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "cross-repo-smoke.yml"
 )
 GATE_WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-00-gate.yml"
@@ -58,8 +55,7 @@ def test_workflow_checks_out_both_repos(workflow: dict) -> None:
     checkout_steps = [
         step
         for step in job["steps"]
-        if isinstance(step.get("uses"), str)
-        and step["uses"].startswith("actions/checkout@")
+        if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
     ]
     paths = [step.get("with", {}).get("path") for step in checkout_steps]
     assert "trip-planner" in paths, paths
@@ -89,9 +85,7 @@ def test_workflow_uses_stable_setup_action_tags(workflow: dict) -> None:
 def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     run_step = next(
-        step
-        for step in job["steps"]
-        if "make full-product-check" in str(step.get("run", ""))
+        step for step in job["steps"] if "make full-product-check" in str(step.get("run", ""))
     )
     env = run_step.get("env", {})
     assert env.get("TPP_REPO_PATH") == "../Travel-Plan-Permission"
@@ -100,13 +94,21 @@ def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None
     assert "make full-product-check" in run_step["run"]
 
 
+def test_workflow_logs_pinned_and_resolved_tpp_sha(workflow: dict) -> None:
+    job = workflow["jobs"]["cross-repo-full-product"]
+    log_step = next(
+        step for step in job["steps"] if step.get("name") == "Log resolved pinned TPP SHA"
+    )
+    run_script = str(log_step.get("run", ""))
+    assert "TPP_PINNED_REF=${TPP_PINNED_REF}" in run_script
+    assert "git rev-parse HEAD" in run_script
+
+
 def test_gate_summary_requires_cross_repo_smoke_job() -> None:
     gate = yaml.safe_load(GATE_WORKFLOW_PATH.read_text())
     jobs = gate["jobs"]
 
-    assert (
-        jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
-    )
+    assert jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
     assert "cross-repo-smoke" in jobs["summary"]["needs"]
 
 
@@ -123,9 +125,9 @@ def test_workflow_passes_actionlint() -> None:
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
-    )
+    assert (
+        result.returncode == 0
+    ), f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
 
 
 # ---------------------------------------------------------------------------
@@ -172,9 +174,7 @@ _POLICY_SERVICE_SYMBOLS = [
 ]
 
 
-@pytest.mark.parametrize(
-    "symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS))
-)
+@pytest.mark.parametrize("symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS)))
 def test_tpp_integration_exports_required_symbol(symbol: str) -> None:
     """Each symbol must be importable from the public TPP integration package.
 

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -16,7 +16,13 @@ import pytest
 import yaml
 
 WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "cross-repo-smoke.yml"
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "cross-repo-smoke.yml"
+)
+GATE_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-00-gate.yml"
 )
 
 
@@ -45,7 +51,8 @@ def test_workflow_checks_out_both_repos(workflow: dict) -> None:
     checkout_steps = [
         step
         for step in job["steps"]
-        if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
+        if isinstance(step.get("uses"), str)
+        and step["uses"].startswith("actions/checkout@")
     ]
     paths = [step.get("with", {}).get("path") for step in checkout_steps]
     assert "trip-planner" in paths, paths
@@ -59,18 +66,41 @@ def test_workflow_checks_out_both_repos(workflow: dict) -> None:
     with_block = tpp_step["with"]
     assert with_block.get("repository") == "stranske/Travel-Plan-Permission"
     assert "${{ env.TPP_PINNED_REF }}" in str(with_block.get("ref", ""))
+    assert "CROSS_REPO_TOKEN" in str(with_block.get("token", ""))
+
+
+def test_workflow_uses_stable_setup_action_tags(workflow: dict) -> None:
+    job = workflow["jobs"]["cross-repo-full-product"]
+    uses_values = [str(step.get("uses", "")) for step in job["steps"]]
+
+    assert "actions/setup-python@v5" in uses_values
+    assert "actions/setup-node@v4" in uses_values
+    assert "actions/setup-python@v6" not in uses_values
+    assert "actions/setup-node@v6" not in uses_values
 
 
 def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     run_step = next(
-        step for step in job["steps"] if "make full-product-check" in str(step.get("run", ""))
+        step
+        for step in job["steps"]
+        if "make full-product-check" in str(step.get("run", ""))
     )
     env = run_step.get("env", {})
-    assert "${{ github.workspace }}/Travel-Plan-Permission" in str(env.get("TPP_REPO_PATH", ""))
+    assert env.get("TPP_REPO_PATH") == "../Travel-Plan-Permission"
     assert env.get("TPP_OIDC_PROVIDER") in {"azure_ad", "google", "okta"}
     assert env.get("LIVE_TPP") == "required"
     assert "make full-product-check" in run_step["run"]
+
+
+def test_gate_summary_requires_cross_repo_smoke_job() -> None:
+    gate = yaml.safe_load(GATE_WORKFLOW_PATH.read_text())
+    jobs = gate["jobs"]
+
+    assert (
+        jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
+    )
+    assert "cross-repo-smoke" in jobs["summary"]["needs"]
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -86,9 +116,9 @@ def test_workflow_passes_actionlint() -> None:
         capture_output=True,
         text=True,
     )
-    assert (
-        result.returncode == 0
-    ), f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
+    assert result.returncode == 0, (
+        f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -135,7 +165,9 @@ _POLICY_SERVICE_SYMBOLS = [
 ]
 
 
-@pytest.mark.parametrize("symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS)))
+@pytest.mark.parametrize(
+    "symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS))
+)
 def test_tpp_integration_exports_required_symbol(symbol: str) -> None:
     """Each symbol must be importable from the public TPP integration package.
 

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -46,6 +46,13 @@ def test_workflow_pins_tpp_ref(workflow: dict) -> None:
     assert re.fullmatch(r"[0-9a-f]{40}", pinned), pinned
 
 
+def test_workflow_call_declares_optional_cross_repo_token(workflow: dict) -> None:
+    workflow_call = workflow.get(True, {}).get("workflow_call", {})
+    secrets = workflow_call.get("secrets", {})
+
+    assert secrets.get("CROSS_REPO_TOKEN") == {"required": False}
+
+
 def test_workflow_checks_out_both_repos(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     checkout_steps = [

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -61,6 +61,13 @@ def test_workflow_checks_out_both_repos(workflow: dict) -> None:
     assert "trip-planner" in paths, paths
     assert "Travel-Plan-Permission" in paths, paths
 
+    planner_step = next(
+        step for step in checkout_steps if step.get("with", {}).get("path") == "trip-planner"
+    )
+    assert "repository" not in planner_step.get(
+        "with", {}
+    ), "planner checkout should use the PR head repository via default actions/checkout behavior"
+
     tpp_step = next(
         step
         for step in checkout_steps

--- a/trip_planner/integrations/tpp/services/tpp_polling_service.py
+++ b/trip_planner/integrations/tpp/services/tpp_polling_service.py
@@ -22,7 +22,11 @@ def _next_wait(attempt: int) -> float:
 
 
 class TPPPollingService:
-    """Drive polling to terminal state or timeout and return a response envelope."""
+    """Drive polling to terminal state or timeout and return a response envelope.
+
+    Set ``timeout_seconds`` to ``0`` only when the provider is expected to
+    eventually return a terminal state; that disables the polling deadline.
+    """
 
     def __init__(
         self,

--- a/trip_planner/integrations/tpp/services/tpp_polling_service.py
+++ b/trip_planner/integrations/tpp/services/tpp_polling_service.py
@@ -36,10 +36,12 @@ class TPPPollingService:
     ) -> None:
         if not callable(poll_response_provider):
             raise ValueError("poll_response_provider must be callable")
-        if timeout_seconds <= 0:
-            raise ValueError("timeout_seconds must be > 0")
+        if timeout_seconds < 0:
+            raise ValueError("timeout_seconds must be >= 0")
         self._poll_response_provider = poll_response_provider
-        self._timeout_seconds = timeout_seconds
+        self._timeout_seconds: float | None = (
+            timeout_seconds if timeout_seconds > 0 else None
+        )
         self._sleeper = sleeper
         self._now = now
 
@@ -48,23 +50,31 @@ class TPPPollingService:
             raise ValueError("request must be a TPPRequestEnvelope")
 
         started_at = self._now()
-        deadline = started_at + self._timeout_seconds
+        deadline = (
+            None
+            if self._timeout_seconds is None
+            else started_at + self._timeout_seconds
+        )
         attempt = 1
 
         while True:
-            envelope = self._normalize_poll_response(self._poll_response_provider(request))
+            envelope = self._normalize_poll_response(
+                self._poll_response_provider(request)
+            )
             if self._is_terminal(envelope):
                 return envelope
 
-            remaining = deadline - self._now()
-            if remaining <= 0:
-                return self._timeout_response(request)
+            wait_seconds = _next_wait(attempt)
+            if deadline is not None:
+                remaining = deadline - self._now()
+                if remaining <= 0:
+                    return self._timeout_response(request)
+                wait_seconds = min(wait_seconds, remaining)
 
-            wait_seconds = min(_next_wait(attempt), remaining)
             self._sleeper(wait_seconds)
             attempt += 1
 
-            if self._now() >= deadline:
+            if deadline is not None and self._now() >= deadline:
                 return self._timeout_response(request)
 
     def _normalize_poll_response(


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1045 -->
> **Source:** Issue #1045

Closes #1045

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The cross-repo contract between trip-planner and Travel-Plan-Permission is
already validated locally by `make full-product-check` (with `TPP_REPO_PATH`
set), but no CI job runs that path on every PR. As a result, a planner-side
schema or transport change can land green even if it breaks the live
cross-repo handshake, and only manifests when a developer runs the local
check by hand. With the recent persistence-reload smoke (PR #1007) and
canonical-state-seam test (PR #1009), the contract surface is stable enough
to gate.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1007](https://github.com/stranske/trip-planner/issues/1007)
- [#1009](https://github.com/stranske/trip-planner/issues/1009)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add a new workflow at `.github/workflows/cross-repo-smoke.yml` (or extend `ci.yml`) with a job named `cross-repo-full-product`.
- [x] Use `actions/checkout@v4` twice: once for the PR head and once for `stranske/Travel-Plan-Permission` at the pinned ref into `../Travel-Plan-Permission`.
- [x] Define `TPP_PINNED_REF` as a workflow-level env var; default to a known-good SHA and document how to bump it.
- [x] Install Python deps for trip-planner (`pip install -e .[dev]`) and for the sibling TPP checkout.
- [x] Run `make full-product-check` with `TPP_REPO_PATH=../Travel-Plan-Permission` exported.
- [ ] Make the job required for merge to `main`.
- [x] Document the workflow and the pin-bump procedure in `docs/CI_SYSTEM_GUIDE.md` (or the local equivalent).
- [x] Add a smoke test for the workflow itself: a syntax-check pass via `actionlint` or `act` if already present in CI tooling.

#### Acceptance criteria
- [ ] A green PR run shows the `cross-repo-full-product` job exercising both repos and `make full-product-check` exits 0.
- [ ] A deliberately broken planner-side change (e.g. removing `submit_proposal` from `trip_planner/integrations/tpp/__init__.py`) causes the new job to fail, while existing trip-planner-only checks may still pass.
- [x] `TPP_PINNED_REF` is settable via a single line in the workflow, and the CI logs print the resolved SHA.
- [ ] The job is listed as a required check on `main`.
- [ ] `docs/CI_SYSTEM_GUIDE.md` documents the new job and the pin-bump procedure.

<!-- auto-status-summary:end -->