### PR TITLE
fix: close follow-up verifier contract gaps

### DIFF
--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -116,10 +116,12 @@ contract with `stranske/Travel-Plan-Permission`. On every PR and on push to
 2. Checks out `stranske/Travel-Plan-Permission` at a pinned ref into
    `Travel-Plan-Permission/` beside the trip-planner checkout.
 3. Installs both repos' dev extras and the trip-planner frontend deps.
-4. Runs `python scripts/check_full_product_verification.py --live-tpp required`
-   with `TPP_REPO_PATH=../Travel-Plan-Permission`, matching the local sibling
-   checkout contract used by `make full-product-check`. A green run proves the
-   live cross-repo handshake (planner → local TPP subprocess) is intact.
+4. Runs `make full-product-check` with
+   `TPP_REPO_PATH=../Travel-Plan-Permission`, matching the local sibling
+   checkout contract. The Makefile target invokes
+   `python scripts/check_full_product_verification.py --live-tpp required`, so
+   a green run proves the live cross-repo handshake (planner → local TPP
+   subprocess) is intact.
 
 The pinned TPP ref is configurable via a single workflow-level env var:
 
@@ -159,11 +161,13 @@ a failure in the cross-repo smoke check propagates to the `Gate / gate` commit
 status and blocks merge.
 
 Since `Gate / gate` is the required status check on `main`, no additional
-branch-protection configuration is needed for day-to-day use. If a repo admin
-wants the raw `cross-repo-full-product` job to appear as a named required
-check in addition to the gate, they can add it in Settings → Branches →
-Branch protection rule for `main` → "Require status checks to pass" after the
-first green run. That toggle cannot be set from a workflow file.
+branch-protection configuration is needed for day-to-day use. The repository
+contract is the `Gate / gate` commit status, and the workflow test suite asserts
+that `cross-repo-smoke` is a required input to that status. If a repo admin wants
+the raw `cross-repo-full-product` job to appear as a named required check in
+addition to the gate, they can add it in Settings → Branches → Branch protection
+rule for `main` → "Require status checks to pass" after the first green run.
+That toggle cannot be set from a workflow file.
 
 ---
 

--- a/tests/planner/test_tpp_polling_service.py
+++ b/tests/planner/test_tpp_polling_service.py
@@ -287,6 +287,35 @@ def test_zero_timeout_polls_until_terminal_without_timeout_response() -> None:
     assert sleeps == [1.0, 2.0]
 
 
+def test_zero_timeout_keeps_finite_attempt_guard() -> None:
+    clock = FakeClock()
+    calls = 0
+    sleeps: list[float] = []
+
+    def provider(_request: TPPRequestEnvelope) -> TPPResponseEnvelope:
+        nonlocal calls
+        calls += 1
+        return _response("running", terminal=False)
+
+    def sleeper(seconds: float) -> None:
+        sleeps.append(seconds)
+        clock.sleep(seconds)
+
+    service = TPPPollingService(
+        provider,
+        timeout_seconds=0.0,
+        no_deadline_max_attempts=3,
+        sleeper=sleeper,
+        now=clock.now,
+    )
+
+    response = service.poll(_request())
+
+    assert response.execution_status.state == "timeout"
+    assert sleeps == [1.0, 2.0]
+    assert calls == 3
+
+
 def test_polling_service_rejects_non_callable_provider() -> None:
     with pytest.raises(ValueError, match="poll_response_provider must be callable"):
         TPPPollingService(None, timeout_seconds=1.0)  # type: ignore[arg-type]
@@ -296,4 +325,13 @@ def test_polling_service_rejects_negative_timeout() -> None:
     with pytest.raises(ValueError, match="timeout_seconds must be >= 0"):
         TPPPollingService(
             lambda request: _response("succeeded", terminal=True), timeout_seconds=-1.0
+        )
+
+
+def test_polling_service_rejects_invalid_no_deadline_attempt_guard() -> None:
+    with pytest.raises(ValueError, match="no_deadline_max_attempts must be >= 1"):
+        TPPPollingService(
+            lambda request: _response("succeeded", terminal=True),
+            timeout_seconds=0.0,
+            no_deadline_max_attempts=0,
         )

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -17,7 +17,10 @@ import pytest
 import yaml
 
 WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "cross-repo-smoke.yml"
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "cross-repo-smoke.yml"
 )
 GATE_WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-00-gate.yml"
@@ -51,12 +54,12 @@ def test_workflow_uses_single_top_level_tpp_pin_definition() -> None:
     workflow = yaml.safe_load(workflow_text)
 
     top_level_pin = workflow.get("env", {}).get("TPP_PINNED_REF")
-    assert (
-        isinstance(top_level_pin, str) and top_level_pin
-    ), "TPP_PINNED_REF must be defined once at workflow-level env."
-    assert (
-        workflow_text.count("TPP_PINNED_REF:") == 1
-    ), "Define TPP_PINNED_REF in a single top-level env line so pin bumps are one-line edits."
+    assert isinstance(top_level_pin, str) and top_level_pin, (
+        "TPP_PINNED_REF must be defined once at workflow-level env."
+    )
+    assert workflow_text.count("TPP_PINNED_REF:") == 1, (
+        "Define TPP_PINNED_REF in a single top-level env line so pin bumps are one-line edits."
+    )
 
 
 def test_workflow_call_declares_optional_cross_repo_token(workflow: dict) -> None:
@@ -71,18 +74,21 @@ def test_workflow_checks_out_both_repos(workflow: dict) -> None:
     checkout_steps = [
         step
         for step in job["steps"]
-        if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
+        if isinstance(step.get("uses"), str)
+        and step["uses"].startswith("actions/checkout@")
     ]
     paths = [step.get("with", {}).get("path") for step in checkout_steps]
     assert "trip-planner" in paths, paths
     assert "Travel-Plan-Permission" in paths, paths
 
     planner_step = next(
-        step for step in checkout_steps if step.get("with", {}).get("path") == "trip-planner"
+        step
+        for step in checkout_steps
+        if step.get("with", {}).get("path") == "trip-planner"
     )
-    assert "repository" not in planner_step.get(
-        "with", {}
-    ), "planner checkout should use the PR head repository via default actions/checkout behavior"
+    assert "repository" not in planner_step.get("with", {}), (
+        "planner checkout should use the PR head repository via default actions/checkout behavior"
+    )
 
     tpp_step = next(
         step
@@ -108,7 +114,9 @@ def test_workflow_uses_stable_setup_action_tags(workflow: dict) -> None:
 def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     run_step = next(
-        step for step in job["steps"] if "make full-product-check" in str(step.get("run", ""))
+        step
+        for step in job["steps"]
+        if "make full-product-check" in str(step.get("run", ""))
     )
     env = run_step.get("env", {})
     assert env.get("TPP_REPO_PATH") == "../Travel-Plan-Permission"
@@ -120,7 +128,9 @@ def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None
 def test_workflow_logs_pinned_and_resolved_tpp_sha(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     log_step = next(
-        step for step in job["steps"] if step.get("name") == "Log resolved pinned TPP SHA"
+        step
+        for step in job["steps"]
+        if step.get("name") == "Log resolved pinned TPP SHA"
     )
     run_script = str(log_step.get("run", ""))
     assert "TPP_PINNED_REF=${TPP_PINNED_REF}" in run_script
@@ -131,7 +141,9 @@ def test_gate_summary_requires_cross_repo_smoke_job() -> None:
     gate = yaml.safe_load(GATE_WORKFLOW_PATH.read_text())
     jobs = gate["jobs"]
 
-    assert jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
+    assert (
+        jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
+    )
     assert "cross-repo-smoke" in jobs["summary"]["needs"]
 
 
@@ -140,7 +152,11 @@ def test_gate_summary_reports_required_gate_status_context() -> None:
 
     assert "CROSS_REPO_RESULT" in gate_text
     assert "Cross-repo smoke check failed" in gate_text
-    assert "context: 'Gate / gate'" in gate_text
+    assert re.search(
+        r"createCommitStatus\s*\(.*?context\s*:\s*['\"]Gate / gate['\"]",
+        gate_text,
+        re.DOTALL,
+    )
 
 
 def test_ci_guide_matches_make_full_product_check_contract() -> None:
@@ -149,12 +165,17 @@ def test_ci_guide_matches_make_full_product_check_contract() -> None:
 
     assert "make full-product-check" in guide
     assert "TPP_REPO_PATH=../Travel-Plan-Permission" in guide
-    assert "python scripts/check_full_product_verification.py --live-tpp $(LIVE_TPP)" in makefile
+    assert (
+        "python scripts/check_full_product_verification.py --live-tpp $(LIVE_TPP)"
+        in makefile
+    )
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _ACTIONLINT = _REPO_ROOT / ".workflows-lib" / "actionlint"
-_ACTIONLINT_CMD = str(_ACTIONLINT) if _ACTIONLINT.is_file() else shutil.which("actionlint")
+_ACTIONLINT_CMD = (
+    str(_ACTIONLINT) if _ACTIONLINT.is_file() else shutil.which("actionlint")
+)
 
 
 @pytest.mark.skipif(
@@ -168,9 +189,9 @@ def test_workflow_passes_actionlint() -> None:
         capture_output=True,
         text=True,
     )
-    assert (
-        result.returncode == 0
-    ), f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
+    assert result.returncode == 0, (
+        f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +238,9 @@ _POLICY_SERVICE_SYMBOLS = [
 ]
 
 
-@pytest.mark.parametrize("symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS)))
+@pytest.mark.parametrize(
+    "symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS))
+)
 def test_tpp_integration_exports_required_symbol(symbol: str) -> None:
     """Each symbol must be importable from the public TPP integration package.
 

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -16,10 +16,7 @@ import pytest
 import yaml
 
 WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2]
-    / ".github"
-    / "workflows"
-    / "cross-repo-smoke.yml"
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "cross-repo-smoke.yml"
 )
 GATE_WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-00-gate.yml"
@@ -48,6 +45,19 @@ def test_workflow_pins_tpp_ref(workflow: dict) -> None:
     assert re.fullmatch(r"[0-9a-f]{40}", pinned), pinned
 
 
+def test_workflow_uses_single_top_level_tpp_pin_definition() -> None:
+    workflow_text = WORKFLOW_PATH.read_text()
+    workflow = yaml.safe_load(workflow_text)
+
+    top_level_pin = workflow.get("env", {}).get("TPP_PINNED_REF")
+    assert (
+        isinstance(top_level_pin, str) and top_level_pin
+    ), "TPP_PINNED_REF must be defined once at workflow-level env."
+    assert (
+        workflow_text.count("TPP_PINNED_REF:") == 1
+    ), "Define TPP_PINNED_REF in a single top-level env line so pin bumps are one-line edits."
+
+
 def test_workflow_call_declares_optional_cross_repo_token(workflow: dict) -> None:
     workflow_call = workflow.get(True, {}).get("workflow_call", {})
     secrets = workflow_call.get("secrets", {})
@@ -60,21 +70,18 @@ def test_workflow_checks_out_both_repos(workflow: dict) -> None:
     checkout_steps = [
         step
         for step in job["steps"]
-        if isinstance(step.get("uses"), str)
-        and step["uses"].startswith("actions/checkout@")
+        if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
     ]
     paths = [step.get("with", {}).get("path") for step in checkout_steps]
     assert "trip-planner" in paths, paths
     assert "Travel-Plan-Permission" in paths, paths
 
     planner_step = next(
-        step
-        for step in checkout_steps
-        if step.get("with", {}).get("path") == "trip-planner"
+        step for step in checkout_steps if step.get("with", {}).get("path") == "trip-planner"
     )
-    assert "repository" not in planner_step.get("with", {}), (
-        "planner checkout should use the PR head repository via default actions/checkout behavior"
-    )
+    assert "repository" not in planner_step.get(
+        "with", {}
+    ), "planner checkout should use the PR head repository via default actions/checkout behavior"
 
     tpp_step = next(
         step
@@ -100,9 +107,7 @@ def test_workflow_uses_stable_setup_action_tags(workflow: dict) -> None:
 def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     run_step = next(
-        step
-        for step in job["steps"]
-        if "make full-product-check" in str(step.get("run", ""))
+        step for step in job["steps"] if "make full-product-check" in str(step.get("run", ""))
     )
     env = run_step.get("env", {})
     assert env.get("TPP_REPO_PATH") == "../Travel-Plan-Permission"
@@ -114,9 +119,7 @@ def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None
 def test_workflow_logs_pinned_and_resolved_tpp_sha(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     log_step = next(
-        step
-        for step in job["steps"]
-        if step.get("name") == "Log resolved pinned TPP SHA"
+        step for step in job["steps"] if step.get("name") == "Log resolved pinned TPP SHA"
     )
     run_script = str(log_step.get("run", ""))
     assert "TPP_PINNED_REF=${TPP_PINNED_REF}" in run_script
@@ -127,9 +130,7 @@ def test_gate_summary_requires_cross_repo_smoke_job() -> None:
     gate = yaml.safe_load(GATE_WORKFLOW_PATH.read_text())
     jobs = gate["jobs"]
 
-    assert (
-        jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
-    )
+    assert jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
     assert "cross-repo-smoke" in jobs["summary"]["needs"]
 
 
@@ -147,10 +148,7 @@ def test_ci_guide_matches_make_full_product_check_contract() -> None:
 
     assert "make full-product-check" in guide
     assert "TPP_REPO_PATH=../Travel-Plan-Permission" in guide
-    assert (
-        "python scripts/check_full_product_verification.py --live-tpp $(LIVE_TPP)"
-        in makefile
-    )
+    assert "python scripts/check_full_product_verification.py --live-tpp $(LIVE_TPP)" in makefile
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -166,9 +164,9 @@ def test_workflow_passes_actionlint() -> None:
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, (
-        f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
-    )
+    assert (
+        result.returncode == 0
+    ), f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
 
 
 # ---------------------------------------------------------------------------
@@ -215,9 +213,7 @@ _POLICY_SERVICE_SYMBOLS = [
 ]
 
 
-@pytest.mark.parametrize(
-    "symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS))
-)
+@pytest.mark.parametrize("symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS)))
 def test_tpp_integration_exports_required_symbol(symbol: str) -> None:
     """Each symbol must be importable from the public TPP integration package.
 

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -153,14 +154,16 @@ def test_ci_guide_matches_make_full_product_check_contract() -> None:
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _ACTIONLINT = _REPO_ROOT / ".workflows-lib" / "actionlint"
+_ACTIONLINT_CMD = str(_ACTIONLINT) if _ACTIONLINT.is_file() else shutil.which("actionlint")
 
 
 @pytest.mark.skipif(
-    not _ACTIONLINT.is_file(), reason="actionlint binary not present in .workflows-lib/"
+    _ACTIONLINT_CMD is None,
+    reason="actionlint not found (checked .workflows-lib/actionlint and PATH)",
 )
 def test_workflow_passes_actionlint() -> None:
     result = subprocess.run(
-        [str(_ACTIONLINT), str(WORKFLOW_PATH)],
+        [_ACTIONLINT_CMD, str(WORKFLOW_PATH)],
         capture_output=True,
         text=True,
     )

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -16,11 +16,16 @@ import pytest
 import yaml
 
 WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "cross-repo-smoke.yml"
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "cross-repo-smoke.yml"
 )
 GATE_WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "pr-00-gate.yml"
 )
+CI_GUIDE_PATH = Path(__file__).resolve().parents[2] / "docs" / "CI_SYSTEM_GUIDE.md"
+MAKEFILE_PATH = Path(__file__).resolve().parents[2] / "Makefile"
 
 
 @pytest.fixture(scope="module")
@@ -55,18 +60,21 @@ def test_workflow_checks_out_both_repos(workflow: dict) -> None:
     checkout_steps = [
         step
         for step in job["steps"]
-        if isinstance(step.get("uses"), str) and step["uses"].startswith("actions/checkout@")
+        if isinstance(step.get("uses"), str)
+        and step["uses"].startswith("actions/checkout@")
     ]
     paths = [step.get("with", {}).get("path") for step in checkout_steps]
     assert "trip-planner" in paths, paths
     assert "Travel-Plan-Permission" in paths, paths
 
     planner_step = next(
-        step for step in checkout_steps if step.get("with", {}).get("path") == "trip-planner"
+        step
+        for step in checkout_steps
+        if step.get("with", {}).get("path") == "trip-planner"
     )
-    assert "repository" not in planner_step.get(
-        "with", {}
-    ), "planner checkout should use the PR head repository via default actions/checkout behavior"
+    assert "repository" not in planner_step.get("with", {}), (
+        "planner checkout should use the PR head repository via default actions/checkout behavior"
+    )
 
     tpp_step = next(
         step
@@ -92,7 +100,9 @@ def test_workflow_uses_stable_setup_action_tags(workflow: dict) -> None:
 def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     run_step = next(
-        step for step in job["steps"] if "make full-product-check" in str(step.get("run", ""))
+        step
+        for step in job["steps"]
+        if "make full-product-check" in str(step.get("run", ""))
     )
     env = run_step.get("env", {})
     assert env.get("TPP_REPO_PATH") == "../Travel-Plan-Permission"
@@ -104,7 +114,9 @@ def test_workflow_runs_full_product_check_with_repo_path(workflow: dict) -> None
 def test_workflow_logs_pinned_and_resolved_tpp_sha(workflow: dict) -> None:
     job = workflow["jobs"]["cross-repo-full-product"]
     log_step = next(
-        step for step in job["steps"] if step.get("name") == "Log resolved pinned TPP SHA"
+        step
+        for step in job["steps"]
+        if step.get("name") == "Log resolved pinned TPP SHA"
     )
     run_script = str(log_step.get("run", ""))
     assert "TPP_PINNED_REF=${TPP_PINNED_REF}" in run_script
@@ -115,8 +127,30 @@ def test_gate_summary_requires_cross_repo_smoke_job() -> None:
     gate = yaml.safe_load(GATE_WORKFLOW_PATH.read_text())
     jobs = gate["jobs"]
 
-    assert jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
+    assert (
+        jobs["cross-repo-smoke"]["uses"] == "./.github/workflows/cross-repo-smoke.yml"
+    )
     assert "cross-repo-smoke" in jobs["summary"]["needs"]
+
+
+def test_gate_summary_reports_required_gate_status_context() -> None:
+    gate_text = GATE_WORKFLOW_PATH.read_text()
+
+    assert "CROSS_REPO_RESULT" in gate_text
+    assert "Cross-repo smoke check failed" in gate_text
+    assert "context: 'Gate / gate'" in gate_text
+
+
+def test_ci_guide_matches_make_full_product_check_contract() -> None:
+    guide = CI_GUIDE_PATH.read_text()
+    makefile = MAKEFILE_PATH.read_text()
+
+    assert "make full-product-check" in guide
+    assert "TPP_REPO_PATH=../Travel-Plan-Permission" in guide
+    assert (
+        "python scripts/check_full_product_verification.py --live-tpp $(LIVE_TPP)"
+        in makefile
+    )
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -132,9 +166,9 @@ def test_workflow_passes_actionlint() -> None:
         capture_output=True,
         text=True,
     )
-    assert (
-        result.returncode == 0
-    ), f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
+    assert result.returncode == 0, (
+        f"actionlint reported errors in {WORKFLOW_PATH.name}:\n{result.stdout}{result.stderr}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -181,7 +215,9 @@ _POLICY_SERVICE_SYMBOLS = [
 ]
 
 
-@pytest.mark.parametrize("symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS)))
+@pytest.mark.parametrize(
+    "symbol", sorted(set(_PROPOSAL_SERVICE_SYMBOLS + _POLICY_SERVICE_SYMBOLS))
+)
 def test_tpp_integration_exports_required_symbol(symbol: str) -> None:
     """Each symbol must be importable from the public TPP integration package.
 

--- a/tests/scripts/test_cross_repo_smoke_workflow.py
+++ b/tests/scripts/test_cross_repo_smoke_workflow.py
@@ -162,6 +162,7 @@ _ACTIONLINT_CMD = str(_ACTIONLINT) if _ACTIONLINT.is_file() else shutil.which("a
     reason="actionlint not found (checked .workflows-lib/actionlint and PATH)",
 )
 def test_workflow_passes_actionlint() -> None:
+    assert _ACTIONLINT_CMD is not None
     result = subprocess.run(
         [_ACTIONLINT_CMD, str(WORKFLOW_PATH)],
         capture_output=True,

--- a/trip_planner/integrations/tpp/services/tpp_polling_service.py
+++ b/trip_planner/integrations/tpp/services/tpp_polling_service.py
@@ -24,8 +24,9 @@ def _next_wait(attempt: int) -> float:
 class TPPPollingService:
     """Drive polling to terminal state or timeout and return a response envelope.
 
-    Set ``timeout_seconds`` to ``0`` only when the provider is expected to
-    eventually return a terminal state; that disables the polling deadline.
+    Set ``timeout_seconds`` to ``0`` to disable the wall-clock polling deadline.
+    That mode still keeps a finite attempt guard so a misbehaving provider
+    cannot block the planner indefinitely.
     """
 
     def __init__(
@@ -35,6 +36,7 @@ class TPPPollingService:
         ],
         *,
         timeout_seconds: float,
+        no_deadline_max_attempts: int = 120,
         sleeper: Callable[[float], None] = time.sleep,
         now: Callable[[], float] = time.monotonic,
     ) -> None:
@@ -42,9 +44,14 @@ class TPPPollingService:
             raise ValueError("poll_response_provider must be callable")
         if timeout_seconds < 0:
             raise ValueError("timeout_seconds must be >= 0")
+        if timeout_seconds == 0 and no_deadline_max_attempts < 1:
+            raise ValueError("no_deadline_max_attempts must be >= 1")
         self._poll_response_provider = poll_response_provider
         self._timeout_seconds: float | None = (
             timeout_seconds if timeout_seconds > 0 else None
+        )
+        self._no_deadline_max_attempts = (
+            no_deadline_max_attempts if self._timeout_seconds is None else None
         )
         self._sleeper = sleeper
         self._now = now
@@ -67,6 +74,11 @@ class TPPPollingService:
             )
             if self._is_terminal(envelope):
                 return envelope
+            if (
+                self._no_deadline_max_attempts is not None
+                and attempt >= self._no_deadline_max_attempts
+            ):
+                return self._timeout_response(request)
 
             wait_seconds = _next_wait(attempt)
             if deadline is not None:


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1045 -->
> **Source:** Issue #1045

Closes #1045

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
The cross-repo contract between trip-planner and Travel-Plan-Permission is
already validated locally by `make full-product-check` (with `TPP_REPO_PATH`
set), but no CI job runs that path on every PR. As a result, a planner-side
schema or transport change can land green even if it breaks the live
cross-repo handshake, and only manifests when a developer runs the local
check by hand. With the recent persistence-reload smoke (PR #1007) and
canonical-state-seam test (PR #1009), the contract surface is stable enough
to gate.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1007](https://github.com/stranske/trip-planner/issues/1007)
- [#1009](https://github.com/stranske/trip-planner/issues/1009)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Add a new workflow at `.github/workflows/cross-repo-smoke.yml` (or extend `ci.yml`) with a job named `cross-repo-full-product`.
- [ ] Use `actions/checkout@v4` twice: once for the PR head and once for `stranske/Travel-Plan-Permission` at the pinned ref into `../Travel-Plan-Permission`.
- [ ] Define `TPP_PINNED_REF` as a workflow-level env var; default to a known-good SHA and document how to bump it.
- [ ] Install Python deps for trip-planner (`pip install -e .[dev]`) and for the sibling TPP checkout.
- [ ] Run `make full-product-check` with `TPP_REPO_PATH=../Travel-Plan-Permission` exported.
- [ ] Make the job required for merge to `main`.
- [x] Document the workflow and the pin-bump procedure in `docs/CI_SYSTEM_GUIDE.md` (or the local equivalent).
- [x] Add a smoke test for the workflow itself: a syntax-check pass via `actionlint` or `act` if already present in CI tooling.

#### Acceptance criteria
- [ ] A green PR run shows the `cross-repo-full-product` job exercising both repos and `make full-product-check` exits 0.
- [ ] A deliberately broken planner-side change (e.g. removing `submit_proposal` from `trip_planner/integrations/tpp/__init__.py`) causes the new job to fail, while existing trip-planner-only checks may still pass.
- [ ] `TPP_PINNED_REF` is settable via a single line in the workflow, and the CI logs print the resolved SHA.
- [ ] The job is listed as a required check on `main`.
- [ ] `docs/CI_SYSTEM_GUIDE.md` documents the new job and the pin-bump procedure.

<!-- auto-status-summary:end -->