### PR TITLE
Follow-up: harden TPP verifier process diagnostics

### DIFF
--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -69,10 +69,11 @@ jobs:
       - name: Install Travel-Plan-Permission dependencies
         working-directory: Travel-Plan-Permission
         run: |
+          python -m venv .venv
           if [ -f pyproject.toml ]; then
-            python -m pip install -e ".[dev]" || python -m pip install -e .
+            .venv/bin/python -m pip install -e ".[dev]" || .venv/bin/python -m pip install -e .
           elif [ -f setup.py ]; then
-            python -m pip install -e .
+            .venv/bin/python -m pip install -e .
           else
             echo "No installable Python project layout in TPP checkout" >&2
             exit 1

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -447,7 +447,11 @@ def _resolve_tpp_interpreter(repo_path: Path) -> list[str]:
     if (repo_path / "uv.lock").exists() and shutil.which("uv"):
         return ["uv", "run", "--directory", str(repo_path), "python"]
     raise VerificationFailure(
-        "Cannot auto-start TPP: no usable TPP Python environment",
+        (
+            "Cannot auto-start TPP: expected either "
+            f"{venv_python} or `uv run --directory {repo_path} python` "
+            "(with uv.lock present and uv installed)."
+        ),
         venv_python=str(venv_python),
         uv_lock=str(repo_path / "uv.lock"),
         remediation=(

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -467,8 +467,15 @@ def _tail_file(path: Path, *, line_count: int = 50, max_bytes: int = 64 * 1024) 
     with path.open("rb") as handle:
         handle.seek(0, os.SEEK_END)
         size = handle.tell()
-        handle.seek(max(size - max_bytes, 0))
-        lines = handle.read(max_bytes).decode("utf-8", errors="replace").splitlines()
+        start = max(size - max_bytes - 1, 0)
+        handle.seek(start)
+        text = handle.read(max_bytes + 1).decode("utf-8", errors="replace")
+    if start > 0:
+        first_newline = text.find("\n")
+        if first_newline == -1:
+            return ""
+        text = text[first_newline + 1 :]
+    lines = text.splitlines()
     return "\n".join(lines[-line_count:])
 
 

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -12,6 +12,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+import shlex
 import socket
 import subprocess
 import sys
@@ -456,10 +457,14 @@ def _resolve_tpp_interpreter(repo_path: Path) -> list[str]:
     )
 
 
-def _tail_file(path: Path, *, line_count: int = 50) -> str:
+def _tail_file(path: Path, *, line_count: int = 50, max_bytes: int = 64 * 1024) -> str:
     if not path.exists():
         return ""
-    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    with path.open("rb") as handle:
+        handle.seek(0, os.SEEK_END)
+        size = handle.tell()
+        handle.seek(max(size - max_bytes, 0))
+        lines = handle.read(max_bytes).decode("utf-8", errors="replace").splitlines()
     return "\n".join(lines[-line_count:])
 
 
@@ -508,15 +513,23 @@ def _started_tpp_service(
         "--port",
         str(port),
     ]
-    process = subprocess.Popen(
-        command,
-        cwd=repo_root,
-        env=service_env,
-        stdout=stdout_file,
-        stderr=stderr_file,
-    )
-    stdout_file.close()
-    stderr_file.close()
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=repo_root,
+            env=service_env,
+            stdout=stdout_file,
+            stderr=stderr_file,
+        )
+    except Exception:
+        stdout_file.close()
+        stderr_file.close()
+        stdout_path.unlink(missing_ok=True)
+        stderr_path.unlink(missing_ok=True)
+        raise
+    else:
+        stdout_file.close()
+        stderr_file.close()
     try:
         try:
             _wait_for_http(f"{base_url}/readyz")
@@ -525,8 +538,8 @@ def _started_tpp_service(
             raise VerificationFailure(
                 "TPP service did not become ready",
                 ready_url=f"{base_url}/readyz",
-                interpreter=" ".join(interpreter),
-                command=" ".join(command),
+                interpreter=shlex.join(interpreter),
+                command=shlex.join(command),
                 cwd=str(repo_root),
                 returncode=process.poll(),
                 stdout_tail=_tail_file(stdout_path),

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -191,6 +191,89 @@ def test_started_tpp_service_readiness_failure_includes_captured_stderr(
     assert "stderr-9" not in message
 
 
+def test_started_tpp_service_launch_failure_cleans_temp_files(monkeypatch, tmp_path: Path) -> None:
+    repo_path, _ = _make_repo_with_venv(tmp_path)
+    created_paths: list[Path] = []
+    real_named_temporary_file = verifier.tempfile.NamedTemporaryFile
+
+    def tracked_named_temporary_file(*args, **kwargs):
+        temp_file = real_named_temporary_file(*args, **kwargs)
+        created_paths.append(Path(temp_file.name))
+        return temp_file
+
+    def fail_popen(*_args, **_kwargs):
+        raise OSError("cannot start")
+
+    monkeypatch.setattr(verifier.tempfile, "NamedTemporaryFile", tracked_named_temporary_file)
+    monkeypatch.setattr(verifier.subprocess, "Popen", fail_popen)
+    monkeypatch.setattr(verifier, "_free_local_port", lambda _preferred: 43125)
+
+    with pytest.raises(OSError, match="cannot start"):
+        with verifier._started_tpp_service(
+            {
+                "TPP_REPO_PATH": str(repo_path),
+                "TPP_ACCESS_TOKEN": "token",
+                "TPP_OIDC_PROVIDER": "google",
+            }
+        ):
+            pass
+
+    assert len(created_paths) == 2
+    assert all(not path.exists() for path in created_paths)
+
+
+def test_tail_file_limits_bytes_before_splitting_lines(tmp_path: Path) -> None:
+    output_path = tmp_path / "service.log"
+    output_path.write_text("prefix\n" + ("x" * 70000) + "\nlast\n", encoding="utf-8")
+
+    tail = verifier._tail_file(output_path, line_count=2, max_bytes=32)
+
+    assert "prefix" not in tail
+    assert "last" in tail
+    assert len(tail) < 40
+
+
+def test_started_tpp_service_readiness_failure_quotes_command(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_path = tmp_path / "Travel Plan Permission"
+    venv_python = repo_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+
+    class FakeProcess:
+        def __init__(self, _command, **_kwargs):
+            pass
+
+        def poll(self):
+            return 1
+
+        def terminate(self):  # pragma: no cover - process has already exited
+            raise AssertionError("process already exited")
+
+    monkeypatch.setattr(verifier.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(
+        verifier,
+        "_wait_for_http",
+        lambda _url: (_ for _ in ()).throw(verifier.VerificationFailure("not ready")),
+    )
+    monkeypatch.setattr(verifier, "_free_local_port", lambda _preferred: 43126)
+
+    with pytest.raises(verifier.VerificationFailure) as exc_info:
+        with verifier._started_tpp_service(
+            {
+                "TPP_REPO_PATH": str(repo_path),
+                "TPP_ACCESS_TOKEN": "token",
+                "TPP_OIDC_PROVIDER": "google",
+            }
+        ):
+            pass
+
+    message = str(exc_info.value)
+    assert f"'{venv_python}'" in message
+    assert f"'{venv_python}' -m travel_plan_permission.http_service" in message
+
+
 def test_started_tpp_service_missing_deps_failure_includes_stderr(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -198,7 +281,7 @@ def test_started_tpp_service_missing_deps_failure_includes_stderr(
     monkeypatch.setattr(verifier, "_free_local_port", lambda _preferred: 43124)
 
     def fail_readiness_after_process_boot(_url: str) -> None:
-        time.sleep(0.2)
+        time.sleep(1.0)
         raise verifier.VerificationFailure("not ready")
 
     monkeypatch.setattr(verifier, "_wait_for_http", fail_readiness_after_process_boot)

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -233,9 +233,7 @@ def test_tail_file_limits_bytes_before_splitting_lines(tmp_path: Path) -> None:
     assert len(tail) < 40
 
 
-def test_started_tpp_service_readiness_failure_quotes_command(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_started_tpp_service_readiness_failure_quotes_command(monkeypatch, tmp_path: Path) -> None:
     repo_path = tmp_path / "Travel Plan Permission"
     venv_python = repo_path / ".venv" / "bin" / "python"
     venv_python.parent.mkdir(parents=True)
@@ -301,3 +299,32 @@ def test_started_tpp_service_missing_deps_failure_includes_stderr(
     assert "ModuleNotFoundError" in message
     assert "definitely_missing_dependency" in message
     assert "stderr_tail" in message
+
+
+def test_resolve_tpp_interpreter_prefers_repo_venv(tmp_path: Path) -> None:
+    repo_path, venv_python = _make_repo_with_venv(tmp_path)
+    (repo_path / "uv.lock").write_text("", encoding="utf-8")
+    resolved = verifier._resolve_tpp_interpreter(repo_path)
+    assert resolved == [str(venv_python)]
+
+
+def test_resolve_tpp_interpreter_uses_uv_when_lock_present(monkeypatch, tmp_path: Path) -> None:
+    repo_path = tmp_path / "Travel-Plan-Permission"
+    repo_path.mkdir(parents=True)
+    (repo_path / "uv.lock").write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        verifier.shutil, "which", lambda command: "/usr/bin/uv" if command == "uv" else None
+    )
+    resolved = verifier._resolve_tpp_interpreter(repo_path)
+    assert resolved == ["uv", "run", "--directory", str(repo_path), "python"]
+
+
+def test_resolve_tpp_interpreter_fails_fast_when_no_venv_or_uv(monkeypatch, tmp_path: Path) -> None:
+    repo_path = tmp_path / "Travel-Plan-Permission"
+    repo_path.mkdir(parents=True)
+    monkeypatch.setattr(verifier.shutil, "which", lambda _command: None)
+    with pytest.raises(verifier.VerificationFailure) as exc_info:
+        verifier._resolve_tpp_interpreter(repo_path)
+    message = str(exc_info.value)
+    assert str(repo_path / ".venv" / "bin" / "python") in message
+    assert f"uv run --directory {repo_path} python" in message

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -233,6 +233,18 @@ def test_tail_file_limits_bytes_before_splitting_lines(tmp_path: Path) -> None:
     assert len(tail) < 40
 
 
+def test_tail_file_drops_partial_first_line(tmp_path: Path) -> None:
+    output_path = tmp_path / "service.log"
+    output_path.write_text(
+        "header\n" + ("x" * 80) + "\ncomplete-1\ncomplete-2\n",
+        encoding="utf-8",
+    )
+
+    tail = verifier._tail_file(output_path, line_count=2, max_bytes=24)
+
+    assert tail == "complete-1\ncomplete-2"
+
+
 def test_started_tpp_service_readiness_failure_quotes_command(monkeypatch, tmp_path: Path) -> None:
     repo_path = tmp_path / "Travel Plan Permission"
     venv_python = repo_path / ".venv" / "bin" / "python"


### PR DESCRIPTION
<!-- pr-preamble:start -->
<!-- meta:issue:1048 -->
> **Source:** Issue #1048

Closes #1048

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
`scripts/check_full_product_verification.py:444-457` starts the sibling
Travel-Plan-Permission service via `subprocess.Popen([sys.executable, "-m",
"travel_plan_permission.http_service", ...])`. The interpreter is
trip-planner's `sys.executable`, and the only path adjustment is
`PYTHONPATH=<tpp_repo>/src`. In a clean trip-planner virtual environment
that does not have TPP runtime dependencies installed (e.g. `jinja2`,
`fastapi` extras, `pydantic` extras), the subprocess fails on import and
`/readyz` never comes up. Because both `stdout` and `stderr` are wired to
`subprocess.DEVNULL` (lines 456–457), the failure is silent: the verifier
just times out waiting for readiness and reports "connection refused"
without surfacing the actual import error.

This means `make full-product-check --live-tpp` is fragile against any
clean environment (developer's first run, CI, the cross-repo CI gate
proposed in #1045) and the failure mode is undiagnosable from the
verifier output. It also undermines the reliability of issue #1045's CI
job before that issue can even land.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#1045](https://github.com/stranske/trip-planner/issues/1045)
- [#1044](https://github.com/stranske/trip-planner/issues/1044)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Detect the TPP repo's Python interpreter: prefer `<repo>/.venv/bin/python` if present, else fall back to `uv run python` if a `uv.lock` is present, else fail fast with a clear error message naming both options.
- [ ] Replace the `sys.executable` argument in the `subprocess.Popen` call at line 444 with the resolved TPP interpreter.
- [ ] Capture `stdout` and `stderr` to a `tempfile.NamedTemporaryFile` per stream rather than `DEVNULL`.
- [ ] On readiness timeout, read both temp files, include the last 50 lines of each in the raised error, and surface the resolved interpreter path so the developer can reproduce.
- [ ] Add a regression test under `tests/scripts/` that exercises `_started_tpp_service` against a known-good TPP repo path with a venv that has TPP installed, and asserts the service comes up and is torn down cleanly.
- [ ] Add a regression test that simulates a missing-deps failure (e.g. by pointing at a repo with an empty venv) and asserts the verifier raises with the captured stderr included in the message.
- [ ] Document the resolution order (`.venv` → `uv run` → fail fast) in `docs/local-testing-plan.md` and in the `make full-product-check` help text.

#### Acceptance criteria
- [ ] With `TPP_REPO_PATH` pointing at a TPP checkout that has its own `.venv` with deps installed, `make full-product-check --live-tpp` starts the service through that venv's interpreter and the journey passes.
- [ ] With `TPP_REPO_PATH` pointing at a TPP checkout that has no installed deps, `make full-product-check --live-tpp` fails fast with an error message that names the resolved interpreter and includes the captured TPP stderr (which should reference the missing module).
- [ ] When `TPP_BASE_URL` is set, the auto-start path is skipped entirely (existing behavior, regression-proof).
- [ ] Regression tests covering both the success path and the missing-deps failure path pass in CI.
- [ ] `docs/local-testing-plan.md` documents the resolution order and the failure surface.

<!-- auto-status-summary:end -->