### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/agents-guard.js
+++ b/.github/scripts/agents-guard.js
@@ -70,7 +70,11 @@ function isAllowlistedRemoval({ status, current = '', previous = '', repository 
 
 function isArchivePath(filePath) {
   const normalized = normalizePattern(filePath || '').toLowerCase();
-  return normalized.startsWith('archives/') || normalized.startsWith('.github/workflows/archive/');
+  return (
+    normalized.startsWith('archives/') ||
+    normalized.startsWith('.github/workflows/archive/') ||
+    normalized.startsWith('.github/workflows-archive/')
+  );
 }
 
 function isAllowlistedArchiveRename({ status, current = '', previous = '', repository = '' } = {}) {

--- a/.github/workflows/agents-81-gate-followups.yml
+++ b/.github/workflows/agents-81-gate-followups.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
   actions: write
   models: read
 
@@ -75,6 +76,7 @@ jobs:
       security_reason: ${{ steps.security_gate.outputs.reason }}
       fingerprint_should_run: ${{ steps.fingerprint.outputs.should_run || 'true' }}
       fingerprint_reason: ${{ steps.fingerprint.outputs.reason }}
+      fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -277,27 +279,6 @@ jobs:
             }
             // Task appendix needs special handling due to multiline content
             core.setOutput('task_appendix', result.taskAppendix || '');
-
-      - name: Persist state fingerprint
-        if: >-
-          steps.fingerprint.outputs.should_run == 'true' &&
-          steps.fingerprint.outputs.current_hash != '' &&
-          steps.evaluate.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: >-
-            ${{
-              github.event.workflow_run.pull_requests[0].number ||
-              github.event.pull_request.number ||
-              github.event.inputs.pr_number ||
-              ''
-            }}
-        run: |
-          python scripts/state_fingerprint.py store \
-            --workflow "${GITHUB_WORKFLOW}" \
-            --hash "${{ steps.fingerprint.outputs.current_hash }}" \
-            --storage pr-comment
 
   preflight:
     name: Verify secrets available
@@ -634,6 +615,7 @@ jobs:
             core.setOutput('commit_tasks_count', result.sources?.commit || 0);
 
       - name: Update summary comment
+        id: update-summary
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           AGENT_SUMMARY: >-
@@ -712,6 +694,34 @@ jobs:
               llm_analysis_run: llmAnalysisRun,
             };
             await updateKeepaliveLoopSummary({ github, context, core, inputs });
+
+      - name: Persist state fingerprint
+        if: >-
+          needs.evaluate.outputs.fingerprint_should_run == 'true' &&
+          needs.evaluate.outputs.fingerprint_current_hash != '' &&
+          needs.evaluate.outputs.pr_number != '' &&
+          steps.update-summary.outcome == 'success' &&
+          (
+            (
+              needs.evaluate.outputs.action != 'run' &&
+              needs.evaluate.outputs.action != 'fix' &&
+              needs.evaluate.outputs.action != 'conflict'
+            ) ||
+            (
+              needs.preflight.result == 'success' &&
+              (needs.run-codex.result == 'success' || needs.run-codex.result == 'skipped') &&
+              (needs.run-claude.result == 'success' || needs.run-claude.result == 'skipped')
+            )
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.evaluate.outputs.pr_number }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ needs.evaluate.outputs.fingerprint_current_hash }}" \
+            --storage pr-comment
 
   prepare:
     name: Prepare autofix context

--- a/.github/workflows/agents-keepalive-loop-reporter.yml
+++ b/.github/workflows/agents-keepalive-loop-reporter.yml
@@ -79,6 +79,7 @@ jobs:
         run: echo "Skipped - ${{ steps.fingerprint.outputs.reason }}"
 
       - name: Update summary for cancelled/failed runs
+        id: update-summary
         if: steps.fingerprint.outputs.should_run == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
@@ -129,3 +130,17 @@ jobs:
             };
 
             await updateKeepaliveLoopSummary({ github, context, core, inputs });
+
+      - name: Persist state fingerprint
+        if: >-
+          steps.fingerprint.outputs.should_run == 'true' &&
+          steps.fingerprint.outputs.current_hash != '' &&
+          steps.update-summary.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ steps.fingerprint.outputs.current_hash }}" \
+            --storage pr-comment

--- a/.github/workflows/agents-verifier.yml
+++ b/.github/workflows/agents-verifier.yml
@@ -83,6 +83,7 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
       fingerprint_should_run: ${{ steps.fingerprint.outputs.should_run || 'true' }}
       fingerprint_reason: ${{ steps.fingerprint.outputs.reason }}
+      fingerprint_current_hash: ${{ steps.fingerprint.outputs.current_hash }}
     steps:
       - name: Checkout retry helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -313,3 +314,33 @@ jobs:
       # Second model for compare mode (empty string uses default)
       model2: ${{ needs.check.outputs.model2 }}
     secrets: inherit
+
+  persist-fingerprint:
+    name: Persist verifier state fingerprint
+    needs:
+      - check
+      - verifier
+    if: >-
+      always() &&
+      needs.check.outputs.should_run == 'true' &&
+      needs.check.outputs.fingerprint_should_run == 'true' &&
+      needs.check.outputs.fingerprint_current_hash != '' &&
+      needs.verifier.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout state fingerprint helper
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: scripts/state_fingerprint.py
+          sparse-checkout-cone-mode: false
+
+      - name: Persist state fingerprint
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.check.outputs.pr_number }}
+        run: |
+          python scripts/state_fingerprint.py store \
+            --workflow "${GITHUB_WORKFLOW}" \
+            --hash "${{ needs.check.outputs.fingerprint_current_hash }}" \
+            --storage pr-comment

--- a/scripts/langchain/followup_issue_generator.py
+++ b/scripts/langchain/followup_issue_generator.py
@@ -1768,7 +1768,9 @@ def _build_why_section(
     if verification_data.structural_issues:
         parts.append("The original issue had structural problems that may have hindered progress.")
 
-    if _has_mixed_repo_and_workflow_acceptance_criteria(original_issue):
+    if _has_mixed_repo_and_workflow_acceptance_criteria(
+        original_issue
+    ) and not _verification_feedback_mentions_workflow_sync(verification_data):
         parts.append(
             "Workflow-sync acceptance criteria were de-emphasized so this follow-up stays "
             "focused on the repo-local verifier concerns."
@@ -1783,17 +1785,34 @@ def _build_why_section(
 
 
 WORKFLOW_SYNC_ACCEPTANCE_MARKERS = (
-    ".github/",
-    "agent",
-    "autofix",
     "consumer sync",
+    "consumer-sync",
+    ".github/workflows/",
+    "workflow file",
+    "workflow files",
+    "workflow-owned",
+    "workflows-owned",
+    "workflows-owned scripts",
     "gate workflow",
     "maint-68",
+    "synced workflow",
     "sync pr",
     "sync-generated",
-    "template",
-    "workflow",
+    "sync workflow templates",
+    "template sync",
+    "workflow template sync",
+    "workflow-template",
 )
+
+
+def _acceptance_criteria_from_original_issue(
+    original_issue: OriginalIssueData | list[str],
+) -> list[str]:
+    if isinstance(original_issue, OriginalIssueData):
+        raw_criteria = original_issue.acceptance_criteria
+    else:
+        raw_criteria = original_issue
+    return [criterion for criterion in raw_criteria if criterion]
 
 
 def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
@@ -1801,8 +1820,10 @@ def _is_workflow_sync_acceptance_criterion(criterion: str) -> bool:
     return any(marker in normalized for marker in WORKFLOW_SYNC_ACCEPTANCE_MARKERS)
 
 
-def _has_mixed_repo_and_workflow_acceptance_criteria(original_issue: OriginalIssueData) -> bool:
-    criteria = [criterion for criterion in original_issue.acceptance_criteria if criterion]
+def _has_mixed_repo_and_workflow_acceptance_criteria(
+    original_issue: OriginalIssueData | list[str],
+) -> bool:
+    criteria = _acceptance_criteria_from_original_issue(original_issue)
     if not criteria:
         return False
     has_workflow = any(_is_workflow_sync_acceptance_criterion(criterion) for criterion in criteria)
@@ -1812,9 +1833,19 @@ def _has_mixed_repo_and_workflow_acceptance_criteria(original_issue: OriginalIss
     return has_workflow and has_repo_local
 
 
+def _verification_feedback_mentions_workflow_sync(verification_data: VerificationData) -> bool:
+    parts = [
+        *verification_data.concerns,
+        *verification_data.non_pass_output,
+        *verification_data.non_pass_findings,
+        *verification_data.structural_issues,
+    ]
+    return any(_is_workflow_sync_acceptance_criterion(part) for part in parts)
+
+
 def _select_followup_acceptance_criteria(
-    original_issue: OriginalIssueData,
-    verification_data: VerificationData,  # noqa: ARG001 - retained for future signal-aware filtering
+    original_issue: OriginalIssueData | list[str],
+    verification_data: VerificationData,
     *,
     limit: int = 10,
 ) -> list[str]:
@@ -1826,9 +1857,15 @@ def _select_followup_acceptance_criteria(
     avoid restating workflow-sync rollout criteria as if they were local tasks.
     """
 
-    criteria = [criterion for criterion in original_issue.acceptance_criteria if criterion]
+    criteria = _acceptance_criteria_from_original_issue(original_issue)
     if not criteria:
         return []
+
+    if not _has_mixed_repo_and_workflow_acceptance_criteria(original_issue):
+        return criteria[:limit]
+
+    if _verification_feedback_mentions_workflow_sync(verification_data):
+        return criteria[:limit]
 
     filtered = [
         criterion for criterion in criteria if not _is_workflow_sync_acceptance_criterion(criterion)


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-81-gate-followups.yml: Gate followups hub - consolidates keepalive and autofix followups
- agents-keepalive-loop-reporter.yml: Keepalive reporter - posts summary when keepalive run fails or cancels
- agents-verifier.yml: Verifier - validates agent work meets acceptance criteria
- agents-guard.js: Health 45 agents guard logic used by the workflow protections
- followup_issue_generator.py: Follow-up issue generator - creates issues from verification feedback

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `6d24b9a0fd855df3bcec9c55b9fbcd5e26fce02f`
**Template hash:** `756d06aeb176`
**Sync branch:** `sync/workflows-756d06aeb176`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"6d24b9a0fd855df3bcec9c55b9fbcd5e26fce02f","template_hash":"756d06aeb176","sync_branch":"sync/workflows-756d06aeb176","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"25375550497","run_attempt":"1","changes_count":5} -->