### PR TITLE
Codex bootstrap for #1129

### DIFF
--- a/agents/codex-1129.md
+++ b/agents/codex-1129.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1129 -->

--- a/docs/contracts/route-context-map-target.md
+++ b/docs/contracts/route-context-map-target.md
@@ -25,9 +25,18 @@ consolidation so subsequent map work has a single contract to extend.
 `RouteStop`, `RouteSegment`, `MapMarker`, `MapMarkerKind`,
 `MapProviderLoadState`).
 
-The first map target renders **route context for the active scenario** in the
-trip workspace. It does not render timeline structure, scenario comparison, or
-saved-trip overviews — those are separate surfaces in this epic
+The first map target renders **route context for the active route option** in
+the trip workspace. It supports three traveler-facing scopes without changing
+the selected route option:
+
+| Scope | User intent | Map behavior |
+|---|---|---|
+| `global` | Understand the whole trip outline. | Keeps the main anchors and complete rough route visible. Labels the shape as approximate. |
+| `regional` | Compare the selected route option. | Shows all legs for the active route option and remains synchronized with route-option selection. |
+| `local` | Focus on one travel leg. | Narrows the visible route to a selected segment and nearby planning markers. If a route has fewer than two stops, the UI explains that segment detail is pending. |
+
+It does not render timeline-only structure, saved-trip overviews, or multiple
+simultaneous geography overlays. Those are separate surfaces in this epic
 ([#698](https://github.com/stranske/trip-planner/issues/698) and
 [#700](https://github.com/stranske/trip-planner/issues/700) respectively) and
 are explicitly deferred from this contract.
@@ -44,12 +53,26 @@ contract below.
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `scenario_id` | string | yes | Selects the active scenario. |
+| `route_option_id` | string | recommended | Stable route-option identifier when it differs from `scenario_id`. |
 | `route_sequence` | string[] | yes | Ordered destination/anchor identifiers driving stop generation. |
 | `route_summary` | string | yes | Single-line route description shown when the provider adapter is unavailable. |
-| `route_segments` | object[] | yes when adapter is live | Pre-shaped segments (origin, destination, geometry hints, warning text). |
+| `map_view` | object | yes | Traveler-facing map state. This is the normal UI source for scope, active route option, selected segment, markers, rough geometry, and confidence copy. |
+| `map_diagnostics` | object | yes | Provider/debug details. Normal traveler UI must not render this payload directly. |
 | `metrics.estimated_total` | object \| null | optional | Currency-typed total surfaced under route summary. |
 | `metrics.travel_burden_score` | number \| null | optional | Drives the burden warning highlight. |
 | `policy_posture` | string | yes | Mirrored as the policy-posture chip on the map. |
+
+### `map_view` fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `active_scope` | `global`\|`regional`\|`local` | yes | Initial scope for the route option. The frontend can change scope locally without changing `active_route_option_id`. |
+| `active_route_option_id` | string | yes | Route option currently driving the map. |
+| `selected_segment_id` | string \| null | yes | Segment focus for local mode. Null is valid when geometry is sparse. |
+| `place_markers` | object[] | yes | User-facing route anchors with label and normalized fallback coordinates. |
+| `rough_route_geometry` | object[] | yes | Approximate route segments. These are planning shapes, not turn-by-turn directions. |
+| `confidence.level` | `high`\|`medium`\|`low` | yes | Coarse confidence label for route precision. |
+| `confidence.summary` | string | yes | Traveler-facing copy explaining approximate versus more detailed map state. |
 
 ### From `feasibility_summary`
 
@@ -76,7 +99,10 @@ contract below.
 
 The map target supports two provider modes, selected by environment
 configuration in the frontend bundle. The contract treats both as legitimate
-runtime states; neither is permitted to blank the workspace.
+runtime states; neither is permitted to blank the workspace. Provider state
+belongs in `map_diagnostics` and the internal `MapSurfaceProvider`; the normal
+traveler UI should show route confidence and scope language instead of raw
+provider labels such as API adapter names, load errors, or key configuration.
 
 | Mode | Trigger | UI behavior |
 |---|---|---|
@@ -88,9 +114,9 @@ runtime states; neither is permitted to blank the workspace.
 | Field | Required | Notes |
 |---|---|---|
 | `kind` | yes | Literal `"fallback"`. |
-| `label` | yes | Human-readable name of the fallback surface. |
+| `label` | yes | Human-readable internal name of the fallback surface. Do not render this directly in normal traveler mode. |
 | `status` | yes | One of `"fallback"`, `"misconfigured"`, `"provider-error"`, `"loading"`, `"sparse-route"`. |
-| `summary` | yes | Single-line explanation of why fallback is active (used in the surface header). |
+| `summary` | yes | Single-line diagnostic explanation of why fallback is active. Use for debug/advanced surfaces, not the normal map header. |
 
 The contract requires fallback rendering to remain feature-equivalent for
 **route-context comprehension**: stop list, marker list, segment list, posture

--- a/docs/contracts/route-context-map-target.md
+++ b/docs/contracts/route-context-map-target.md
@@ -23,7 +23,7 @@ consolidation so subsequent map work has a single contract to extend.
 **Surface module:** [`frontend/src/components/maps/mapSurface.ts`](../../frontend/src/components/maps/mapSurface.ts)
 (canonical TypeScript types — `TripMapSurfaceModel`, `MapSurfaceProvider`,
 `RouteStop`, `RouteSegment`, `MapMarker`, `MapMarkerKind`,
-`MapProviderLoadState`).
+`MapFocusCue`, `MapProviderLoadState`).
 
 The first map target renders **route context for the active route option** in
 the trip workspace. It supports three traveler-facing scopes without changing
@@ -34,6 +34,13 @@ the selected route option:
 | `global` | Understand the whole trip outline. | Keeps the main anchors and complete rough route visible. Labels the shape as approximate. |
 | `regional` | Compare the selected route option. | Shows all legs for the active route option and remains synchronized with route-option selection. |
 | `local` | Focus on one travel leg. | Narrows the visible route to a selected segment and nearby planning markers. If a route has fewer than two stops, the UI explains that segment detail is pending. |
+
+When the workspace payload includes planning-ledger entries with explicit map
+links, the target also surfaces those as **map focus cues**. Focus cues do not
+invent geography from free text. They attach only when a ledger entry names a
+route option, route segment, marker, bundle, or destination through
+`related_option_id`, `source_refs`, or metadata keys such as `route_segment_id`,
+`map_marker_id`, `bundle_id`, or `destination`.
 
 It does not render timeline-only structure, saved-trip overviews, or multiple
 simultaneous geography overlays. Those are separate surfaces in this epic
@@ -73,6 +80,24 @@ contract below.
 | `rough_route_geometry` | object[] | yes | Approximate route segments. These are planning shapes, not turn-by-turn directions. |
 | `confidence.level` | `high`\|`medium`\|`low` | yes | Coarse confidence label for route precision. |
 | `confidence.summary` | string | yes | Traveler-facing copy explaining approximate versus more detailed map state. |
+
+### From `planning_ledger`
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `entries[*].ledger_entry_id` | string | yes, when ledger present | Stable identifier for the linked planning note. |
+| `entries[*].summary` | string | yes, when ledger present | Traveler-facing note copy shown in the map sidebar when linked. |
+| `entries[*].status` | string | yes, when ledger present | Superseded entries are ignored by the map focus layer. |
+| `entries[*].item_type` | string | yes, when ledger present | Rendered as a short note type label such as route option, open question, or source. |
+| `entries[*].related_option_id` | string \| null | optional | Links a note to the active route option when it equals `scenario_id` or `route_option_id`. |
+| `entries[*].source_refs` | string[] | optional | May link a note to a route option, route segment, marker, bundle, or destination. |
+| `entries[*].metadata` | object | optional | May carry `route_segment_id`, `map_segment_id`, `selected_segment_id`, `map_marker_id`, `marker_id`, `bundle_id`, `destination`, or `route_option_id`. |
+
+Linked ledger entries are rendered as `MapFocusCue` values in
+`buildTripMapSurfaceModel`. The normal UI uses those cues to emphasize the
+linked marker or segment and to show a compact "Linked planning notes" list.
+Unlinked ledger text stays in the planning ledger panel; the map should not
+guess links by broad keyword matching.
 
 ### From `feasibility_summary`
 

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -265,6 +265,28 @@ export type RuntimeScenarioComparison = {
       estimated_total_delta: number | null;
     };
     highlights: string[];
+    map_view?: {
+      active_scope: "global" | "regional" | "local";
+      active_route_option_id: string;
+      selected_segment_id: string | null;
+      place_markers: string[];
+      rough_route_geometry: Array<Record<string, unknown>>;
+      confidence: {
+        level: "high" | "medium" | "low";
+        summary: string;
+      };
+    };
+    map_diagnostics?: {
+      provider: {
+        kind: string;
+        status: string;
+        details: string;
+      };
+      route_state: "ready" | "sparse";
+      route_warning: string | null;
+      source_result_id: string;
+      objective_refs: string[];
+    };
   }>;
   source_refs: string[];
 };

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -269,8 +269,26 @@ export type RuntimeScenarioComparison = {
       active_scope: "global" | "regional" | "local";
       active_route_option_id: string;
       selected_segment_id: string | null;
-      place_markers: string[];
-      rough_route_geometry: Array<Record<string, unknown>>;
+      place_markers: Array<{
+        id: string;
+        source_id: string;
+        label: string;
+        route_index: number;
+        x: number;
+        y: number;
+      }>;
+      rough_route_geometry: Array<{
+        id: string;
+        from_marker_id: string;
+        to_marker_id: string;
+        from_label: string;
+        to_label: string;
+        x1: number;
+        y1: number;
+        x2: number;
+        y2: number;
+        warning: string | null;
+      }>;
       confidence: {
         level: "high" | "medium" | "low";
         summary: string;

--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -1,0 +1,166 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { FeasibilitySummary, RuntimeScenarioComparison, WorkspaceData } from "../../api/workspace";
+import { TripMap } from "./TripMap";
+
+const comparison: RuntimeScenarioComparison = {
+  title: "Scandinavia route comparison",
+  summary: "Three route options are ready for side-by-side review.",
+  lead_scenario_id: "route-option:rail-first",
+  comparison_axes: [
+    { key: "score", label: "Planner score", direction: "higher_better" },
+    { key: "travel_minutes", label: "Travel minutes", direction: "lower_better" },
+  ],
+  scenarios: [
+    {
+      scenario_id: "route-option:rail-first",
+      route_option_id: "route-option:rail-first",
+      title: "Rail-first route",
+      rank: 1,
+      status: "recommended",
+      state: "baseline",
+      purpose: "Use Rail-first route as the route everything else is compared against.",
+      confidence: 0.88,
+      unresolved_questions: [],
+      available_actions: [],
+      summary: "A low-friction rail sequence through the main cities.",
+      comparison_note: "Lead route for the current workspace comparison set.",
+      option_count: 3,
+      route_sequence: ["stockholm", "oslo", "bergen"],
+      route_summary: "stockholm -> oslo -> bergen",
+      recommended_for_selection: true,
+      feasible: true,
+      metrics: {
+        score: 0.88,
+        travel_minutes: 420,
+        transfers: 3,
+        estimated_total: { currency: "USD", typical_amount: 3600 },
+      },
+      delta: {
+        score_delta: 0,
+        travel_minutes_delta: 0,
+        transfers_delta: 0,
+        estimated_total_delta: 0,
+      },
+      highlights: ["Balanced movement with clear rail legs."],
+    },
+    {
+      scenario_id: "route-option:fjord-focus",
+      route_option_id: "route-option:fjord-focus",
+      title: "Fjord-focus route",
+      rank: 2,
+      status: "alternative",
+      state: "active",
+      purpose: "Compare Fjord-focus route as an active alternative.",
+      confidence: 0.74,
+      unresolved_questions: ["Can the scenic transfer still fit the trip pace?"],
+      available_actions: [],
+      summary: "A scenic route with more time near Bergen.",
+      comparison_note: "Alternative route preserved for direct scenario comparison.",
+      option_count: 4,
+      route_sequence: ["oslo", "flam", "bergen"],
+      route_summary: "oslo -> flam -> bergen",
+      recommended_for_selection: false,
+      feasible: true,
+      metrics: {
+        score: 0.74,
+        travel_minutes: 510,
+        transfers: 5,
+        estimated_total: { currency: "USD", typical_amount: 3900 },
+      },
+      delta: {
+        score_delta: -0.14,
+        travel_minutes_delta: 90,
+        transfers_delta: 2,
+        estimated_total_delta: 300,
+      },
+      highlights: ["More scenery with more transfers."],
+    },
+  ],
+  source_refs: ["scenario-search:scandinavia"],
+};
+
+const bundles: WorkspaceData["inventory_summary"]["bundles"] = [
+  {
+    bundle_id: "bundle-rail",
+    title: "Rail transfer anchors",
+    bundle_context: "transport_route",
+    summary: "Rail transfers attached to the current route.",
+    destination_names: ["Stockholm", "Oslo", "Bergen"],
+    option_count: 3,
+    strengths: [],
+    tradeoffs: [],
+  },
+];
+
+const feasibilitySummary: FeasibilitySummary = {
+  assessment_count: 1,
+  recommended_bundle_count: 1,
+  blocking_bundle_count: 0,
+  attention_bundle_count: 0,
+  notes: [],
+  assessments: [],
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderTripMap(onSelectScenario = vi.fn()) {
+  render(
+    <TripMap
+      comparison={comparison}
+      scenarioComparisonSummary="Rail-first stays the easiest route to compare against."
+      scenarioFocusAreas={["route_pace"]}
+      activeScenarioId="route-option:rail-first"
+      onSelectScenario={onSelectScenario}
+      bundles={bundles}
+      feasibilitySummary={feasibilitySummary}
+      tripPrimaryRegions={["Sweden", "Norway"]}
+      policyPosture="No approval packet yet"
+      compactLayout={false}
+    />
+  );
+  return onSelectScenario;
+}
+
+describe("TripMap", () => {
+  it("switches map scopes without changing the selected route option", () => {
+    const onSelectScenario = renderTripMap();
+
+    const scopeControls = screen.getByLabelText("Map view scope");
+    expect(within(scopeControls).getByRole("button", { name: "Route" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    fireEvent.click(within(scopeControls).getByRole("button", { name: "Segment" }));
+
+    expect(screen.getByLabelText("Local segment selector")).toBeInTheDocument();
+    expect(screen.getByText("Segment-level planning view")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Oslo to Bergen" }));
+    expect(screen.getByLabelText("Oslo to Bergen route drawing")).toHaveTextContent(
+      "1 shown segment"
+    );
+
+    fireEvent.click(within(scopeControls).getByRole("button", { name: "Whole trip" }));
+    expect(screen.getByText("Approximate trip outline")).toBeInTheDocument();
+    expect(onSelectScenario).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "2. Fjord-focus route" }));
+    expect(onSelectScenario).toHaveBeenCalledWith("route-option:fjord-focus");
+  });
+
+  it("keeps provider diagnostics out of the normal traveler map", () => {
+    renderTripMap();
+
+    expect(screen.getByLabelText("Map view confidence")).toHaveTextContent(
+      "Approximate route shape"
+    );
+    expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Provider misconfigured/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Provider error/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -103,11 +103,64 @@ const feasibilitySummary: FeasibilitySummary = {
   assessments: [],
 };
 
+const planningLedger: WorkspaceData["planning_ledger"] = {
+  entries: [
+    {
+      ledger_entry_id: "ledger:route-baseline",
+      trip_id: "trip:scandinavia",
+      session_state_id: "session:scandinavia",
+      item_type: "option_considered",
+      status: "active",
+      category: "route_options",
+      summary: "Keep rail-first route as the baseline until ferry timing is known.",
+      detail: "",
+      source_message_ids: [],
+      source_refs: [],
+      related_option_id: "route-option:rail-first",
+      related_decision_id: null,
+      supersedes_entry_id: null,
+      metadata: {},
+      created_at: "2026-05-10T00:00:00Z",
+      updated_at: "2026-05-10T00:00:00Z",
+    },
+    {
+      ledger_entry_id: "ledger:oslo-transfer",
+      trip_id: "trip:scandinavia",
+      session_state_id: "session:scandinavia",
+      item_type: "open_question",
+      status: "active",
+      category: "questions",
+      summary: "Remember Oslo rail transfer timing.",
+      detail: "",
+      source_message_ids: [],
+      source_refs: [],
+      related_option_id: null,
+      related_decision_id: null,
+      supersedes_entry_id: null,
+      metadata: { bundle_id: "bundle-rail" },
+      created_at: "2026-05-10T00:00:00Z",
+      updated_at: "2026-05-10T00:00:00Z",
+    },
+  ],
+  summary: {
+    active_decisions: [],
+    open_questions: [],
+    active_options: [],
+    rejected_options: [],
+    constraints: [],
+    assumptions: [],
+    source_references: [],
+  },
+};
+
 afterEach(() => {
   cleanup();
 });
 
-function renderTripMap(onSelectScenario = vi.fn()) {
+function renderTripMap(
+  onSelectScenario = vi.fn(),
+  ledger?: WorkspaceData["planning_ledger"]
+) {
   render(
     <TripMap
       comparison={comparison}
@@ -119,6 +172,7 @@ function renderTripMap(onSelectScenario = vi.fn()) {
       feasibilitySummary={feasibilitySummary}
       tripPrimaryRegions={["Sweden", "Norway"]}
       policyPosture="No approval packet yet"
+      planningLedger={ledger}
       compactLayout={false}
     />
   );
@@ -162,5 +216,24 @@ describe("TripMap", () => {
     expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Provider misconfigured/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Provider error/i)).not.toBeInTheDocument();
+  });
+
+  it("surfaces linked planning ledger entries as map focus cues", () => {
+    renderTripMap(vi.fn(), planningLedger);
+
+    expect(screen.getByLabelText("Route context map")).toHaveTextContent(
+      "2 linked planning note"
+    );
+    expect(screen.getByLabelText("Linked planning notes")).toHaveTextContent(
+      "Keep rail-first route as the baseline until ferry timing is known."
+    );
+    expect(screen.getByLabelText("Linked planning notes for selected marker")).toHaveTextContent(
+      "Remember Oslo rail transfer timing."
+    );
+    expect(
+      screen.getByRole("button", {
+        name: /transport marker: Rail transfer anchors.*1 linked planning note/i,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -5,6 +5,7 @@ import {
   formatEstimatedTotal,
   type MapMarker,
   type MapProviderLoadState,
+  type MapViewScope,
 } from "./mapSurface";
 
 type InventoryBundle = WorkspaceData["inventory_summary"]["bundles"][number];
@@ -94,6 +95,8 @@ function ActiveTripMap({
     import.meta.env.VITE_GOOGLE_MAPS_EMBED_API_KEY;
   const providerLoadState =
     (import.meta.env.VITE_GOOGLE_MAPS_PROVIDER_STATE as MapProviderLoadState | undefined) ?? "ready";
+  const [activeScope, setActiveScope] = useState<MapViewScope>("regional");
+  const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
   const mapSurface = buildTripMapSurfaceModel({
     activeScenario,
     bundles,
@@ -104,36 +107,83 @@ function ActiveTripMap({
     policyPosture,
     googleMapsApiKey,
     providerLoadState,
+    activeScope,
+    selectedSegmentId,
   });
-  const initialMarkerId = mapSurface.markers[0]?.id ?? null;
+  const initialMarkerId = mapSurface.visibleMarkers[0]?.id ?? null;
   const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(initialMarkerId);
   const selectedMarker = useMemo(
     () =>
-      mapSurface.markers.find((marker) => marker.id === selectedMarkerId) ??
-      mapSurface.markers[0] ??
+      mapSurface.visibleMarkers.find((marker) => marker.id === selectedMarkerId) ??
+      mapSurface.visibleMarkers[0] ??
       null,
-    [mapSurface.markers, selectedMarkerId]
+    [mapSurface.visibleMarkers, selectedMarkerId]
   );
 
   useEffect(() => {
     setSelectedMarkerId(initialMarkerId);
   }, [activeScenario.scenario_id, initialMarkerId]);
 
+  useEffect(() => {
+    setSelectedSegmentId(null);
+  }, [activeScenario.scenario_id]);
+
+  function handleScopeChange(nextScope: MapViewScope) {
+    setActiveScope(nextScope);
+    if (nextScope === "local" && selectedSegmentId == null) {
+      setSelectedSegmentId(mapSurface.routeSegments[0]?.id ?? null);
+    }
+  }
+
   return (
     <section className="status-card map-card">
-      <p className="status-label">Map surface</p>
-      <h2>Map preview for {activeScenario.title}</h2>
+      <p className="status-label">Trip map</p>
+      <h2>Map for {activeScenario.title}</h2>
       <p>{activeScenario.summary}</p>
-      <div className="map-provider-banner" aria-label="Map provider status">
-        <span className={`map-provider-pill map-provider-pill-${mapSurface.provider.status}`}>
-          {mapSurface.provider.label}
+      <div className="map-provider-banner" aria-label="Map view confidence">
+        <span
+          className={`map-provider-pill map-confidence-pill-${mapSurface.workspaceView.confidence.level}`}
+        >
+          {mapSurface.scope.precisionLabel}
         </span>
-        <p className="muted-copy">
-          {compactLayout ? "Compact" : "Full"} review keeps the provider state and fallback path
-          visible before the traveler studies the route.
-        </p>
+        <p className="muted-copy">{mapSurface.scope.summary}</p>
       </div>
-      <p className="muted-copy">{mapSurface.provider.summary}</p>
+      <p className="muted-copy">{mapSurface.workspaceView.confidence.summary}</p>
+      <div className="map-scope-controls" aria-label="Map view scope">
+        {mapSurface.scopeOptions.map((option) => (
+          <button
+            key={option.scope}
+            type="button"
+            title={option.title}
+            className={`map-scope-button${
+              option.scope === mapSurface.scope.activeScope ? " map-scope-button-active" : ""
+            }`}
+            aria-pressed={option.scope === mapSurface.scope.activeScope}
+            onClick={() => handleScopeChange(option.scope)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+      {activeScope === "local" && mapSurface.routeSegments.length > 0 ? (
+        <div className="map-segment-selector" aria-label="Local segment selector">
+          {mapSurface.routeSegments.map((segment) => (
+            <button
+              key={segment.id}
+              type="button"
+              className={`map-segment-button${
+                segment.id === mapSurface.workspaceView.selectedSegmentId
+                  ? " map-segment-button-active"
+                  : ""
+              }`}
+              aria-pressed={segment.id === mapSurface.workspaceView.selectedSegmentId}
+              onClick={() => setSelectedSegmentId(segment.id)}
+            >
+              {segment.fromLabel} to {segment.toLabel}
+            </button>
+          ))}
+        </div>
+      ) : null}
       <div className="map-scenario-toggle" aria-label="Map scenario previews">
         {comparison.scenarios.map((scenario) => (
           <button
@@ -152,26 +202,26 @@ function ActiveTripMap({
       <div className="map-surface" aria-label="Route context map">
         <div
           className={`map-route map-route-${mapSurface.provider.kind}`}
-          aria-label={`${mapSurface.provider.label} route overlay`}
+          aria-label={`${mapSurface.scope.label} route drawing`}
         >
           <div className="map-provider-toolbar">
-            <span className="map-provider-name">{mapSurface.provider.label}</span>
-            <span>{mapSurface.routeSegments.length} segment(s)</span>
-            <span>{mapSurface.markers.length} marker(s)</span>
+            <span className="map-provider-name">{mapSurface.scope.label}</span>
+            <span>{mapSurface.visibleRouteSegments.length} shown segment(s)</span>
+            <span>{mapSurface.visibleMarkers.length} shown marker(s)</span>
           </div>
           {mapSurface.provider.kind === "google-maps-js" ? (
             <InteractiveProviderMap
               title={activeScenario.title}
-              markers={mapSurface.markers}
+              markers={mapSurface.visibleMarkers}
               selectedMarker={selectedMarker}
-              routeSegments={mapSurface.routeSegments}
+              routeSegments={mapSurface.visibleRouteSegments}
               onSelectMarker={setSelectedMarkerId}
             />
           ) : (
             <FallbackRouteSchematic
-              markers={mapSurface.markers}
+              markers={mapSurface.visibleMarkers}
               selectedMarker={selectedMarker}
-              routeStops={mapSurface.routeStops}
+              routeStops={mapSurface.visibleRouteStops}
               onSelectMarker={setSelectedMarkerId}
             />
           )}
@@ -183,8 +233,9 @@ function ActiveTripMap({
         </div>
         <div className="map-sidebar">
           <article className="decision-card">
-            <h3>{providerPathHeading(mapSurface.provider)}</h3>
-            <p>{mapSurface.provider.summary}</p>
+            <h3>Map view</h3>
+            <p>{mapSurface.scope.summary}</p>
+            <p className="muted-copy">{mapSurface.workspaceView.confidence.summary}</p>
           </article>
           {selectedMarker ? (
             <article className="decision-card map-marker-detail" aria-live="polite">
@@ -413,24 +464,5 @@ function markerLabel(kind: MapMarker["kind"]): string {
     case "stop":
     default:
       return "S";
-  }
-}
-
-function providerPathHeading(provider: ReturnType<typeof buildTripMapSurfaceModel>["provider"]): string {
-  if (provider.kind === "google-maps-js") {
-    return "Live provider path";
-  }
-
-  switch (provider.status) {
-    case "loading":
-      return "Provider loading fallback path";
-    case "provider-error":
-      return "Provider error fallback path";
-    case "sparse-route":
-      return "Sparse route fallback path";
-    case "misconfigured":
-      return "Textual fallback route path";
-    default:
-      return "Fallback route path";
   }
 }

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -21,6 +21,7 @@ export function TripMap({
   feasibilitySummary,
   tripPrimaryRegions,
   policyPosture,
+  planningLedger,
   compactLayout,
 }: {
   comparison: RuntimeScenarioComparison;
@@ -32,6 +33,7 @@ export function TripMap({
   feasibilitySummary: FeasibilitySummary;
   tripPrimaryRegions: string[];
   policyPosture: string | null;
+  planningLedger?: WorkspaceData["planning_ledger"];
   compactLayout: boolean;
 }) {
   const activeScenario =
@@ -62,6 +64,7 @@ export function TripMap({
       scenarioFocusAreas={scenarioFocusAreas}
       tripPrimaryRegions={tripPrimaryRegions}
       policyPosture={policyPosture}
+      planningLedger={planningLedger}
       compactLayout={compactLayout}
     />
   );
@@ -77,6 +80,7 @@ function ActiveTripMap({
   scenarioFocusAreas,
   tripPrimaryRegions,
   policyPosture,
+  planningLedger,
   compactLayout,
 }: {
   activeScenario: TripMapScenario;
@@ -88,6 +92,7 @@ function ActiveTripMap({
   scenarioFocusAreas?: string[];
   tripPrimaryRegions: string[];
   policyPosture: string | null;
+  planningLedger?: WorkspaceData["planning_ledger"];
   compactLayout: boolean;
 }) {
   const googleMapsApiKey =
@@ -109,8 +114,12 @@ function ActiveTripMap({
     providerLoadState,
     activeScope,
     selectedSegmentId,
+    planningLedger,
   });
-  const initialMarkerId = mapSurface.visibleMarkers[0]?.id ?? null;
+  const initialMarkerId =
+    mapSurface.visibleMarkers.find((marker) => marker.focusCues.length > 0)?.id ??
+    mapSurface.visibleMarkers[0]?.id ??
+    null;
   const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(initialMarkerId);
   const selectedMarker = useMemo(
     () =>
@@ -208,6 +217,9 @@ function ActiveTripMap({
             <span className="map-provider-name">{mapSurface.scope.label}</span>
             <span>{mapSurface.visibleRouteSegments.length} shown segment(s)</span>
             <span>{mapSurface.visibleMarkers.length} shown marker(s)</span>
+            {mapSurface.visibleFocusCues.length > 0 ? (
+              <span>{mapSurface.visibleFocusCues.length} linked planning note(s)</span>
+            ) : null}
           </div>
           {mapSurface.provider.kind === "google-maps-js" ? (
             <InteractiveProviderMap
@@ -236,6 +248,16 @@ function ActiveTripMap({
             <h3>Map view</h3>
             <p>{mapSurface.scope.summary}</p>
             <p className="muted-copy">{mapSurface.workspaceView.confidence.summary}</p>
+            {mapSurface.visibleFocusCues.length > 0 ? (
+              <ul className="map-ledger-focus-list" aria-label="Linked planning notes">
+                {mapSurface.visibleFocusCues.slice(0, 4).map((cue) => (
+                  <li key={cue.ledgerEntryId}>
+                    <span>{cue.label}</span>
+                    {cue.summary}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
           </article>
           {selectedMarker ? (
             <article className="decision-card map-marker-detail" aria-live="polite">
@@ -243,6 +265,19 @@ function ActiveTripMap({
               <h3>{selectedMarker.label}</h3>
               <p>{selectedMarker.summary}</p>
               <p className="muted-copy">{selectedMarker.detail}</p>
+              {selectedMarker.focusCues.length > 0 ? (
+                <ul
+                  className="map-ledger-focus-list"
+                  aria-label="Linked planning notes for selected marker"
+                >
+                  {selectedMarker.focusCues.map((cue) => (
+                    <li key={cue.ledgerEntryId}>
+                      <span>{cue.label}</span>
+                      {cue.summary}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
             </article>
           ) : null}
           <dl className="workspace-meta map-metrics">
@@ -368,7 +403,9 @@ function InteractiveProviderMap({
             y1={segment.y1}
             x2={segment.x2}
             y2={segment.y2}
-            className={segment.warning ? "map-route-line map-route-line-warning" : "map-route-line"}
+            className={`map-route-line${segment.warning ? " map-route-line-warning" : ""}${
+              segment.focusCues.length > 0 ? " map-route-line-focused" : ""
+            }`}
           />
         ))}
       </svg>
@@ -410,11 +447,14 @@ function FallbackRouteSchematic({
       <div className="map-fallback-route">
         {routeStops.map((stop, index) => {
           const markerId = `${stop.id}-marker`;
+          const marker = markers.find((candidate) => candidate.id === markerId);
           return (
             <button
               key={stop.id}
               type="button"
-              className={`map-stop${selectedMarker?.id === markerId ? " map-stop-selected" : ""}`}
+              className={`map-stop${selectedMarker?.id === markerId ? " map-stop-selected" : ""}${
+                marker?.focusCues.length ? " map-stop-focused" : ""
+              }`}
               aria-pressed={selectedMarker?.id === markerId}
               onClick={() => onSelectMarker(markerId)}
             >
@@ -434,7 +474,8 @@ function FallbackRouteSchematic({
             type="button"
             className={`map-option-marker map-option-marker-${marker.kind}${
               selectedMarker?.id === marker.id ? " map-option-marker-selected" : ""
-            }`}
+            }${marker.focusCues.length > 0 ? " map-option-marker-focused" : ""}`}
+            aria-label={markerAccessibleLabel(marker)}
             aria-pressed={selectedMarker?.id === marker.id}
             onClick={() => onSelectMarker(marker.id)}
           >
@@ -448,7 +489,13 @@ function FallbackRouteSchematic({
 }
 
 function markerAccessibleLabel(marker: MapMarker): string {
-  return `${marker.kind} marker: ${marker.label}. ${marker.summary}`;
+  const focusSummary =
+    marker.focusCues.length === 0
+      ? ""
+      : ` ${marker.focusCues.length} linked planning note${
+          marker.focusCues.length === 1 ? "" : "s"
+        }.`;
+  return `${marker.kind} marker: ${marker.label}. ${marker.summary}${focusSummary}`;
 }
 
 function markerLabel(kind: MapMarker["kind"]): string {

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -159,6 +159,145 @@ describe("mapSurface", () => {
     expect(localModel.scope.precisionLabel).toBe("Segment-level planning view");
   });
 
+  it("connects directly linked ledger entries to map markers and route segments", () => {
+    const baseInput = {
+      activeScenario: {
+        scenario_id: "scenario:focus",
+        route_option_id: "route-option:focus",
+        title: "Kyoto route focus",
+        rank: 1,
+        status: "lead",
+        summary: "Baseline",
+        comparison_note: "Lead route",
+        option_count: 2,
+        route_sequence: ["kyoto", "uji", "nara"],
+        route_summary: "kyoto -> uji -> nara",
+        recommended_for_selection: true,
+        feasible: true,
+        metrics: {
+          score: 0.91,
+          travel_minutes: 180,
+          transfers: 2,
+          estimated_total: null,
+        },
+        delta: {
+          score_delta: 0,
+          travel_minutes_delta: 0,
+          transfers_delta: 0,
+          estimated_total_delta: null,
+        },
+        highlights: ["Short regional route."],
+      },
+      bundles: [
+        {
+          bundle_id: "bundle-uji-tea",
+          title: "Uji tea anchors",
+          bundle_context: "activity_route",
+          summary: "Tea stops that should stay near the Uji leg.",
+          destination_names: ["Uji"],
+          option_count: 2,
+          strengths: [],
+          tradeoffs: [],
+        },
+      ],
+      feasibilitySummary: {
+        assessment_count: 0,
+        recommended_bundle_count: 0,
+        blocking_bundle_count: 0,
+        attention_bundle_count: 0,
+        notes: [],
+        assessments: [],
+      },
+      googleMapsApiKey: "test-key",
+    };
+    const initialModel = buildTripMapSurfaceModel(baseInput);
+    const focusedSegmentId = initialModel.routeSegments[1].id;
+
+    const model = buildTripMapSurfaceModel({
+      ...baseInput,
+      planningLedger: {
+        entries: [
+          {
+            ledger_entry_id: "ledger:route",
+            trip_id: "trip:kyoto",
+            session_state_id: "session:kyoto",
+            item_type: "option_considered",
+            status: "active",
+            category: "route_options",
+            summary: "Keep this route in view while checking lodging.",
+            detail: "",
+            source_message_ids: [],
+            source_refs: [],
+            related_option_id: "route-option:focus",
+            related_decision_id: null,
+            supersedes_entry_id: null,
+            metadata: {},
+            created_at: "2026-05-10T00:00:00Z",
+            updated_at: "2026-05-10T00:00:00Z",
+          },
+          {
+            ledger_entry_id: "ledger:segment",
+            trip_id: "trip:kyoto",
+            session_state_id: "session:kyoto",
+            item_type: "open_question",
+            status: "active",
+            category: "questions",
+            summary: "Check whether Uji to Nara is too much in one day.",
+            detail: "",
+            source_message_ids: [],
+            source_refs: [],
+            related_option_id: null,
+            related_decision_id: null,
+            supersedes_entry_id: null,
+            metadata: { route_segment_id: focusedSegmentId },
+            created_at: "2026-05-10T00:00:00Z",
+            updated_at: "2026-05-10T00:00:00Z",
+          },
+          {
+            ledger_entry_id: "ledger:marker",
+            trip_id: "trip:kyoto",
+            session_state_id: "session:kyoto",
+            item_type: "assumption",
+            status: "active",
+            category: "assumption",
+            summary: "Uji tea anchors should remain visible on the map.",
+            detail: "",
+            source_message_ids: [],
+            source_refs: [],
+            related_option_id: null,
+            related_decision_id: null,
+            supersedes_entry_id: null,
+            metadata: { bundle_id: "bundle-uji-tea" },
+            created_at: "2026-05-10T00:00:00Z",
+            updated_at: "2026-05-10T00:00:00Z",
+          },
+        ],
+        summary: {
+          active_decisions: [],
+          open_questions: [],
+          active_options: [],
+          rejected_options: [],
+          constraints: [],
+          assumptions: [],
+          source_references: [],
+        },
+      },
+    });
+
+    expect(model.focusCues.map((cue) => cue.targetKind)).toEqual([
+      "route",
+      "segment",
+      "marker",
+    ]);
+    expect(model.workspaceView.focusCues).toEqual(model.visibleFocusCues);
+    expect(model.routeSegments[1].focusCues[0].summary).toContain("Uji to Nara");
+    expect(
+      model.markers.find(
+        (marker) => marker.sourceId === "bundle-uji-tea" && marker.focusCues.length > 0
+      )?.focusCues[0].summary
+    ).toContain("Uji tea anchors");
+  });
+
   it("falls back when Google Maps is not configured", () => {
     const model = buildTripMapSurfaceModel({
       activeScenario: {

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -79,6 +79,14 @@ describe("mapSurface", () => {
     ]);
     expect(model.routeStops.map((stop) => stop.label)).toEqual(["Kyoto", "Uji", "Kyoto"]);
     expect(model.routeSegments).toHaveLength(2);
+    expect(model.workspaceView.activeScope).toBe("regional");
+    expect(model.workspaceView.activeRouteOptionId).toBe("scenario:1");
+    expect(model.workspaceView.selectedSegmentId).toBe(model.routeSegments[0].id);
+    expect(model.workspaceView.placeMarkers).toEqual(model.markers);
+    expect(model.workspaceView.roughRouteGeometry).toEqual(model.routeSegments);
+    expect(model.workspaceView.confidence.level).toBe("high");
+    expect(model.workspaceView.diagnostics.provider).toEqual(model.provider);
+    expect(model.workspaceView.diagnostics.routeState).toBe("ready");
     expect(model.markers.map((marker) => marker.kind)).toEqual([
       "stop",
       "stop",
@@ -130,6 +138,7 @@ describe("mapSurface", () => {
     expect(model.provider.kind).toBe("fallback");
     expect(model.provider.summary).toContain("bounded textual route fallback");
     expect(model.provider.status).toBe("misconfigured");
+    expect(model.workspaceView.confidence.level).toBe("medium");
     expect(model.scenarioComparisonSummary).toBe(
       "Scenario comparison summary is still syncing to this workspace review surface."
     );
@@ -271,6 +280,7 @@ describe("mapSurface", () => {
     expect(model.routeState).toBe("sparse");
     expect(model.provider.kind).toBe("fallback");
     expect(model.provider.status).toBe("sparse-route");
+    expect(model.workspaceView.confidence.level).toBe("low");
     expect(model.routeSegments).toHaveLength(0);
     expect(model.markers).toHaveLength(1);
   });

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -96,6 +96,69 @@ describe("mapSurface", () => {
     ]);
   });
 
+  it("switches between whole-trip and local map scopes without losing the route option", () => {
+    const baseInput = {
+      activeScenario: {
+        scenario_id: "scenario:scope",
+        title: "Kyoto local detail",
+        rank: 1,
+        status: "lead",
+        summary: "Baseline",
+        comparison_note: "Lead route",
+        option_count: 2,
+        route_sequence: ["kyoto", "uji", "nara"],
+        route_summary: "kyoto -> uji -> nara",
+        recommended_for_selection: true,
+        feasible: true,
+        metrics: {
+          score: 0.91,
+          travel_minutes: 180,
+          transfers: 2,
+          estimated_total: null,
+        },
+        delta: {
+          score_delta: 0,
+          travel_minutes_delta: 0,
+          transfers_delta: 0,
+          estimated_total_delta: null,
+        },
+        highlights: ["Short regional route."],
+      },
+      bundles: [],
+      feasibilitySummary: {
+        assessment_count: 0,
+        recommended_bundle_count: 0,
+        blocking_bundle_count: 0,
+        attention_bundle_count: 0,
+        notes: [],
+        assessments: [],
+      },
+      googleMapsApiKey: "test-key",
+    };
+    const globalModel = buildTripMapSurfaceModel({
+      ...baseInput,
+      activeScope: "global",
+    });
+    const secondSegmentId = globalModel.routeSegments[1].id;
+    const localModel = buildTripMapSurfaceModel({
+      ...baseInput,
+      activeScope: "local",
+      selectedSegmentId: secondSegmentId,
+    });
+
+    expect(globalModel.workspaceView.activeScope).toBe("global");
+    expect(globalModel.workspaceView.activeRouteOptionId).toBe("scenario:scope");
+    expect(globalModel.visibleRouteSegments).toHaveLength(2);
+    expect(globalModel.scope.precisionLabel).toBe("Approximate trip outline");
+
+    expect(localModel.workspaceView.activeScope).toBe("local");
+    expect(localModel.workspaceView.activeRouteOptionId).toBe("scenario:scope");
+    expect(localModel.workspaceView.selectedSegmentId).toBe(secondSegmentId);
+    expect(localModel.visibleRouteSegments).toHaveLength(1);
+    expect(localModel.visibleRouteStops.map((stop) => stop.label)).toEqual(["Uji", "Nara"]);
+    expect(localModel.scope.precisionLabel).toBe("Segment-level planning view");
+  });
+
   it("falls back when Google Maps is not configured", () => {
     const model = buildTripMapSurfaceModel({
       activeScenario: {

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -47,6 +47,8 @@ export type MapMarker = {
 
 export type RouteSegment = {
   id: string;
+  fromStopId: string;
+  toStopId: string;
   fromLabel: string;
   toLabel: string;
   x1: number;
@@ -76,11 +78,43 @@ export type MapWorkspaceView = {
   };
 };
 
+export type MapScopePresentation = {
+  activeScope: MapViewScope;
+  label: string;
+  summary: string;
+  precisionLabel: string;
+};
+
+export const MAP_SCOPE_OPTIONS: Array<{
+  scope: MapViewScope;
+  label: string;
+  title: string;
+}> = [
+  {
+    scope: "global",
+    label: "Whole trip",
+    title: "Show the broad outline across all trip anchors.",
+  },
+  {
+    scope: "regional",
+    label: "Route",
+    title: "Show the selected route option and its main travel legs.",
+  },
+  {
+    scope: "local",
+    label: "Segment",
+    title: "Focus on one travel leg and nearby planning markers.",
+  },
+];
+
 export type TripMapSurfaceModel = {
   provider: MapSurfaceProvider;
   routeStops: RouteStop[];
   routeSegments: RouteSegment[];
   markers: MapMarker[];
+  visibleRouteStops: RouteStop[];
+  visibleRouteSegments: RouteSegment[];
+  visibleMarkers: MapMarker[];
   destinationAnchors: string[];
   destinationContext: string[];
   scenarioFocusAreas: string[];
@@ -90,6 +124,8 @@ export type TripMapSurfaceModel = {
   feasibilitySummary: string;
   routeState: "ready" | "sparse";
   routeWarning: string | null;
+  scope: MapScopePresentation;
+  scopeOptions: typeof MAP_SCOPE_OPTIONS;
   workspaceView: MapWorkspaceView;
 };
 
@@ -233,6 +269,8 @@ function buildRouteSegments(routeStops: RouteStop[], routeWarning: string | null
     const nextStop = routeStops[index + 1];
     return {
       id: `${stop.id}-${nextStop.id}`,
+      fromStopId: stop.id,
+      toStopId: nextStop.id,
       fromLabel: stop.label,
       toLabel: nextStop.label,
       x1: stop.x,
@@ -337,6 +375,86 @@ function buildScenarioAffordances({
   return affordances;
 }
 
+function scopePresentationFor({
+  activeScope,
+  selectedSegment,
+}: {
+  activeScope: MapViewScope;
+  selectedSegment: RouteSegment | null;
+}): MapScopePresentation {
+  if (activeScope === "global") {
+    return {
+      activeScope,
+      label: "Whole-trip outline",
+      summary: "Shows the broad shape of the trip so the main anchors stay visible.",
+      precisionLabel: "Approximate trip outline",
+    };
+  }
+
+  if (activeScope === "local") {
+    return {
+      activeScope,
+      label: selectedSegment
+        ? `${selectedSegment.fromLabel} to ${selectedSegment.toLabel}`
+        : "Local segment",
+      summary: selectedSegment
+        ? `Focuses on the ${selectedSegment.fromLabel} to ${selectedSegment.toLabel} travel leg and nearby planning markers.`
+        : "Add another route stop before the map can focus on a local segment.",
+      precisionLabel: selectedSegment ? "Segment-level planning view" : "Segment detail pending",
+    };
+  }
+
+  return {
+    activeScope,
+    label: "Selected route option",
+    summary: "Shows the route option currently selected in the comparison workbench.",
+    precisionLabel: "Approximate route shape",
+  };
+}
+
+function visibleMapContentFor({
+  activeScope,
+  routeStops,
+  routeSegments,
+  markers,
+  selectedSegmentId,
+}: {
+  activeScope: MapViewScope;
+  routeStops: RouteStop[];
+  routeSegments: RouteSegment[];
+  markers: MapMarker[];
+  selectedSegmentId: string | null | undefined;
+}): {
+  routeStops: RouteStop[];
+  routeSegments: RouteSegment[];
+  markers: MapMarker[];
+  selectedSegment: RouteSegment | null;
+} {
+  if (activeScope !== "local" || routeSegments.length === 0) {
+    return {
+      routeStops,
+      routeSegments,
+      markers,
+      selectedSegment: selectedSegmentId
+        ? routeSegments.find((segment) => segment.id === selectedSegmentId) ?? routeSegments[0] ?? null
+        : routeSegments[0] ?? null,
+    };
+  }
+
+  const selectedSegment =
+    routeSegments.find((segment) => segment.id === selectedSegmentId) ?? routeSegments[0];
+  const visibleStopIds = new Set([selectedSegment.fromStopId, selectedSegment.toStopId]);
+  const visibleStops = routeStops.filter((stop) => visibleStopIds.has(stop.id));
+  const visibleStopMarkerIds = new Set(visibleStops.map((stop) => `${stop.id}-marker`));
+
+  return {
+    routeStops: visibleStops.length > 0 ? visibleStops : routeStops,
+    routeSegments: [selectedSegment],
+    markers: markers.filter((marker) => marker.kind !== "stop" || visibleStopMarkerIds.has(marker.id)),
+    selectedSegment,
+  };
+}
+
 function deriveMapConfidence({
   routeState,
   provider,
@@ -347,18 +465,18 @@ function deriveMapConfidence({
   if (routeState === "sparse") {
     return {
       level: "low",
-      summary: "Low confidence: route geometry is incomplete and shown as a rough preview.",
+      summary: "Low confidence: the route needs more stops before the map can show its shape.",
     };
   }
   if (provider.kind === "fallback") {
     return {
       level: "medium",
-      summary: "Medium confidence: route geometry is approximate while the map provider is unavailable.",
+      summary: "Medium confidence: this is an approximate sketch from the current route stops.",
     };
   }
   return {
     level: "high",
-    summary: "High confidence: route geometry is backed by live provider rendering.",
+    summary: "High confidence: the route has enough map detail for close review.",
   };
 }
 
@@ -372,6 +490,8 @@ export function buildTripMapSurfaceModel({
   policyPosture = null,
   googleMapsApiKey,
   providerLoadState = "ready",
+  activeScope = "regional",
+  selectedSegmentId,
 }: {
   activeScenario: TripMapScenario;
   bundles: InventoryBundle[];
@@ -382,6 +502,8 @@ export function buildTripMapSurfaceModel({
   policyPosture?: string | null;
   googleMapsApiKey?: string | null;
   providerLoadState?: MapProviderLoadState;
+  activeScope?: MapViewScope;
+  selectedSegmentId?: string | null;
 }): TripMapSurfaceModel {
   const routeStops = activeScenario.route_sequence.map((stop, index) => {
     const coordinate = coordinateForRouteIndex(index, activeScenario.route_sequence.length);
@@ -467,12 +589,23 @@ export function buildTripMapSurfaceModel({
         "Google Maps JavaScript is the active presentation adapter; route, marker, and warning state still comes from workspace runtime data.",
     };
   }
+  const visibleMapContent = visibleMapContentFor({
+    activeScope,
+    routeStops,
+    routeSegments,
+    markers,
+    selectedSegmentId,
+  });
+  const scope = scopePresentationFor({
+    activeScope,
+    selectedSegment: visibleMapContent.selectedSegment,
+  });
   const workspaceView: MapWorkspaceView = {
-    activeScope: "regional",
+    activeScope,
     activeRouteOptionId: activeScenario.scenario_id,
-    selectedSegmentId: routeSegments[0]?.id ?? null,
-    placeMarkers: markers,
-    roughRouteGeometry: routeSegments,
+    selectedSegmentId: visibleMapContent.selectedSegment?.id ?? null,
+    placeMarkers: visibleMapContent.markers,
+    roughRouteGeometry: visibleMapContent.routeSegments,
     confidence: deriveMapConfidence({ routeState, provider }),
     diagnostics: {
       provider,
@@ -486,6 +619,9 @@ export function buildTripMapSurfaceModel({
     routeStops,
     routeSegments,
     markers,
+    visibleRouteStops: visibleMapContent.routeStops,
+    visibleRouteSegments: visibleMapContent.routeSegments,
+    visibleMarkers: visibleMapContent.markers,
     destinationAnchors,
     destinationContext,
     scenarioFocusAreas: scenarioFocusAreas?.filter(Boolean) ?? [],
@@ -497,6 +633,8 @@ export function buildTripMapSurfaceModel({
     feasibilitySummary: summarizeFeasibility(feasibilitySummary, destinationAnchors),
     routeState,
     routeWarning,
+    scope,
+    scopeOptions: MAP_SCOPE_OPTIONS,
     workspaceView,
   };
 }

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -6,6 +6,8 @@ import type {
 
 type TripMapScenario = RuntimeScenarioComparison["scenarios"][number];
 type InventoryBundle = WorkspaceData["inventory_summary"]["bundles"][number];
+type PlanningLedgerState = NonNullable<WorkspaceData["planning_ledger"]>;
+type PlanningLedgerEntry = PlanningLedgerState["entries"][number];
 
 export type MapProviderLoadState = "ready" | "loading" | "error";
 
@@ -26,6 +28,7 @@ export type MapSurfaceProvider =
 
 export type RouteStop = {
   id: string;
+  sourceId: string;
   label: string;
   description: string;
   x: number;
@@ -34,8 +37,21 @@ export type RouteStop = {
 
 export type MapMarkerKind = "stop" | "lodging" | "activity" | "transport" | "policy";
 
+export type MapFocusCue = {
+  ledgerEntryId: string;
+  label: string;
+  summary: string;
+  status: PlanningLedgerEntry["status"];
+  itemType: PlanningLedgerEntry["item_type"];
+  targetKind: "route" | "segment" | "marker";
+  targetId: string;
+  markerId: string | null;
+  segmentId: string | null;
+};
+
 export type MapMarker = {
   id: string;
+  sourceId: string;
   kind: MapMarkerKind;
   label: string;
   summary: string;
@@ -43,6 +59,7 @@ export type MapMarker = {
   x: number;
   y: number;
   emphasized: boolean;
+  focusCues: MapFocusCue[];
 };
 
 export type RouteSegment = {
@@ -56,6 +73,7 @@ export type RouteSegment = {
   x2: number;
   y2: number;
   warning: string | null;
+  focusCues: MapFocusCue[];
 };
 
 export type MapViewScope = "global" | "regional" | "local";
@@ -67,6 +85,7 @@ export type MapWorkspaceView = {
   selectedSegmentId: string | null;
   placeMarkers: MapMarker[];
   roughRouteGeometry: RouteSegment[];
+  focusCues: MapFocusCue[];
   confidence: {
     level: MapGeometryConfidence;
     summary: string;
@@ -115,6 +134,8 @@ export type TripMapSurfaceModel = {
   visibleRouteStops: RouteStop[];
   visibleRouteSegments: RouteSegment[];
   visibleMarkers: MapMarker[];
+  focusCues: MapFocusCue[];
+  visibleFocusCues: MapFocusCue[];
   destinationAnchors: string[];
   destinationContext: string[];
   scenarioFocusAreas: string[];
@@ -278,6 +299,7 @@ function buildRouteSegments(routeStops: RouteStop[], routeWarning: string | null
       x2: nextStop.x,
       y2: nextStop.y,
       warning: index === 0 ? routeWarning : null,
+      focusCues: [],
     };
   });
 }
@@ -297,6 +319,7 @@ function buildMarkers({
 }): MapMarker[] {
   const stopMarkers = routeStops.map((stop, index) => ({
     id: `${stop.id}-marker`,
+    sourceId: stop.sourceId,
     kind: "stop" as const,
     label: stop.label,
     summary: index === 0 ? "Route origin" : index === routeStops.length - 1 ? "Route destination" : "Route stop",
@@ -304,6 +327,7 @@ function buildMarkers({
     x: stop.x,
     y: stop.y,
     emphasized: index === 0 || index === routeStops.length - 1,
+    focusCues: [],
   }));
   const bundleMarkers = bundles.flatMap((bundle, index) => {
     const coordinate = coordinateForMarker(index, bundles.length);
@@ -311,6 +335,7 @@ function buildMarkers({
     const destinations = bundle.destination_names.filter(Boolean).join(", ") || "No destination anchors";
     return markerKinds.map((kind, markerIndex) => ({
       id: `bundle-${bundle.bundle_id}-${kind}`,
+      sourceId: bundle.bundle_id,
       kind,
       label: bundle.title,
       summary: `${bundle.option_count} option(s) anchored to ${destinations}`,
@@ -318,6 +343,7 @@ function buildMarkers({
       x: coordinate.x + markerIndex * 3,
       y: coordinate.y + markerIndex * 3,
       emphasized: activeScenario.recommended_for_selection && index === 0 && markerIndex === 0,
+      focusCues: [],
     }));
   });
   const policyMarker =
@@ -326,6 +352,7 @@ function buildMarkers({
       : [
           {
             id: `${activeScenario.scenario_id}-policy-warning`,
+            sourceId: activeScenario.scenario_id,
             kind: "policy" as const,
             label: "Route burden warning",
             summary: routeWarning,
@@ -338,6 +365,7 @@ function buildMarkers({
             x: 82,
             y: 18,
             emphasized: true,
+            focusCues: [],
           },
         ];
 
@@ -455,6 +483,241 @@ function visibleMapContentFor({
   };
 }
 
+function normalizedRef(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function normalizeRefList(values: unknown): string[] {
+  if (typeof values === "string") {
+    return [values];
+  }
+  if (Array.isArray(values)) {
+    return values.filter((value): value is string => typeof value === "string");
+  }
+  return [];
+}
+
+function entryMapRefs(entry: PlanningLedgerEntry): string[] {
+  const metadata = entry.metadata ?? {};
+  const refs = [
+    entry.related_option_id,
+    entry.related_decision_id,
+    ...entry.source_refs,
+    ...entry.source_message_ids,
+    metadata["map_marker_id"],
+    metadata["marker_id"],
+    metadata["map_marker_ids"],
+    metadata["marker_ids"],
+    metadata["route_segment_id"],
+    metadata["map_segment_id"],
+    metadata["selected_segment_id"],
+    metadata["route_segment_ids"],
+    metadata["map_segment_ids"],
+    metadata["route_option_id"],
+    metadata["scenario_id"],
+    metadata["bundle_id"],
+    metadata["destination"],
+    metadata["destination_id"],
+    metadata["place_id"],
+  ];
+  return Array.from(
+    new Set(refs.flatMap(normalizeRefList).map((ref) => ref.trim()).filter(Boolean))
+  );
+}
+
+function labelForLedgerEntry(entry: PlanningLedgerEntry): string {
+  switch (entry.item_type) {
+    case "option_rejected":
+      return "Rejected option";
+    case "option_considered":
+      return "Route option";
+    case "decision":
+      return "Decision";
+    case "assumption":
+      return "Assumption";
+    case "constraint":
+      return "Constraint";
+    case "open_question":
+      return "Open question";
+    case "source_reference":
+      return "Source";
+    default:
+      return "Planning note";
+  }
+}
+
+function buildMapFocusCues({
+  activeScenario,
+  markers,
+  routeSegments,
+  planningLedger,
+}: {
+  activeScenario: TripMapScenario;
+  markers: MapMarker[];
+  routeSegments: RouteSegment[];
+  planningLedger?: PlanningLedgerState | null;
+}): MapFocusCue[] {
+  const entries = planningLedger?.entries ?? [];
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const routeIds = new Set(
+    [activeScenario.scenario_id, activeScenario.route_option_id].filter(
+      (value): value is string => Boolean(value)
+    )
+  );
+  const markerById = new Map(markers.map((marker) => [marker.id, marker]));
+  const markerBySourceId = new Map(markers.map((marker) => [marker.sourceId, marker]));
+  const markerByLabel = new Map(markers.map((marker) => [normalizedRef(marker.label), marker]));
+  const segmentById = new Map(routeSegments.map((segment) => [segment.id, segment]));
+  const cues: MapFocusCue[] = [];
+  const seen = new Set<string>();
+
+  for (const entry of entries) {
+    if (entry.status === "superseded") {
+      continue;
+    }
+    const summary = entry.summary.trim();
+    if (summary === "") {
+      continue;
+    }
+
+    const refs = entryMapRefs(entry);
+    let target:
+      | { targetKind: "marker"; targetId: string; markerId: string; segmentId: null }
+      | { targetKind: "segment"; targetId: string; markerId: null; segmentId: string }
+      | { targetKind: "route"; targetId: string; markerId: null; segmentId: null }
+      | null = null;
+
+    for (const ref of refs) {
+      const marker =
+        markerById.get(ref) ??
+        markerBySourceId.get(ref) ??
+        markerByLabel.get(normalizedRef(ref));
+      if (marker) {
+        target = {
+          targetKind: "marker",
+          targetId: marker.id,
+          markerId: marker.id,
+          segmentId: null,
+        };
+        break;
+      }
+    }
+
+    if (target == null) {
+      for (const ref of refs) {
+        const segment = segmentById.get(ref);
+        if (segment) {
+          target = {
+            targetKind: "segment",
+            targetId: segment.id,
+            markerId: null,
+            segmentId: segment.id,
+          };
+          break;
+        }
+      }
+    }
+
+    if (target == null) {
+      for (const ref of refs) {
+        if (routeIds.has(ref)) {
+          target = {
+            targetKind: "route",
+            targetId: ref,
+            markerId: null,
+            segmentId: null,
+          };
+          break;
+        }
+      }
+    }
+
+    if (target == null) {
+      continue;
+    }
+
+    const key = `${entry.ledger_entry_id}:${target.targetKind}:${target.targetId}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    cues.push({
+      ledgerEntryId: entry.ledger_entry_id,
+      label: labelForLedgerEntry(entry),
+      summary,
+      status: entry.status,
+      itemType: entry.item_type,
+      ...target,
+    });
+  }
+
+  return cues.slice(0, 8);
+}
+
+function attachFocusCues({
+  markers,
+  routeSegments,
+  focusCues,
+}: {
+  markers: MapMarker[];
+  routeSegments: RouteSegment[];
+  focusCues: MapFocusCue[];
+}): { markers: MapMarker[]; routeSegments: RouteSegment[] } {
+  const cuesByMarkerId = new Map<string, MapFocusCue[]>();
+  const cuesBySegmentId = new Map<string, MapFocusCue[]>();
+  for (const cue of focusCues) {
+    if (cue.markerId) {
+      cuesByMarkerId.set(cue.markerId, [...(cuesByMarkerId.get(cue.markerId) ?? []), cue]);
+    }
+    if (cue.segmentId) {
+      cuesBySegmentId.set(cue.segmentId, [...(cuesBySegmentId.get(cue.segmentId) ?? []), cue]);
+    }
+  }
+
+  return {
+    markers: markers.map((marker) => {
+      const markerFocusCues = cuesByMarkerId.get(marker.id) ?? [];
+      return {
+        ...marker,
+        emphasized: marker.emphasized || markerFocusCues.length > 0,
+        focusCues: markerFocusCues,
+      };
+    }),
+    routeSegments: routeSegments.map((segment) => ({
+      ...segment,
+      focusCues: cuesBySegmentId.get(segment.id) ?? [],
+    })),
+  };
+}
+
+function visibleFocusCuesFor({
+  focusCues,
+  visibleMarkers,
+  visibleRouteSegments,
+}: {
+  focusCues: MapFocusCue[];
+  visibleMarkers: MapMarker[];
+  visibleRouteSegments: RouteSegment[];
+}): MapFocusCue[] {
+  const visibleMarkerIds = new Set(visibleMarkers.map((marker) => marker.id));
+  const visibleSegmentIds = new Set(visibleRouteSegments.map((segment) => segment.id));
+  return focusCues.filter((cue) => {
+    if (cue.targetKind === "route") {
+      return true;
+    }
+    if (cue.markerId) {
+      return visibleMarkerIds.has(cue.markerId);
+    }
+    if (cue.segmentId) {
+      return visibleSegmentIds.has(cue.segmentId);
+    }
+    return false;
+  });
+}
+
 function deriveMapConfidence({
   routeState,
   provider,
@@ -492,6 +755,7 @@ export function buildTripMapSurfaceModel({
   providerLoadState = "ready",
   activeScope = "regional",
   selectedSegmentId,
+  planningLedger,
 }: {
   activeScenario: TripMapScenario;
   bundles: InventoryBundle[];
@@ -504,11 +768,13 @@ export function buildTripMapSurfaceModel({
   providerLoadState?: MapProviderLoadState;
   activeScope?: MapViewScope;
   selectedSegmentId?: string | null;
+  planningLedger?: PlanningLedgerState | null;
 }): TripMapSurfaceModel {
   const routeStops = activeScenario.route_sequence.map((stop, index) => {
     const coordinate = coordinateForRouteIndex(index, activeScenario.route_sequence.length);
     return {
       id: `${activeScenario.scenario_id}-${stop}-${index}`,
+      sourceId: stop,
       label: humanizeStop(stop),
       description: describeStop(index, activeScenario.route_sequence.length),
       x: coordinate.x,
@@ -531,13 +797,26 @@ export function buildTripMapSurfaceModel({
   const trimmedApiKey = googleMapsApiKey?.trim() ?? "";
   const routeWarning = deriveRouteWarning(activeScenario, feasibilitySummary);
   const routeSegments = buildRouteSegments(routeStops, routeWarning);
-  const markers = buildMarkers({
+  const baseMarkers = buildMarkers({
     activeScenario,
     bundles,
     routeStops,
     routeWarning,
     policyPosture,
   });
+  const focusCues = buildMapFocusCues({
+    activeScenario,
+    markers: baseMarkers,
+    routeSegments,
+    planningLedger,
+  });
+  const focusedMapContent = attachFocusCues({
+    markers: baseMarkers,
+    routeSegments,
+    focusCues,
+  });
+  const markers = focusedMapContent.markers;
+  const focusedRouteSegments = focusedMapContent.routeSegments;
   const routeState = routeStops.length >= 2 ? "ready" : "sparse";
   const scenarioAffordances = buildScenarioAffordances({
     activeScenario,
@@ -592,9 +871,14 @@ export function buildTripMapSurfaceModel({
   const visibleMapContent = visibleMapContentFor({
     activeScope,
     routeStops,
-    routeSegments,
+    routeSegments: focusedRouteSegments,
     markers,
     selectedSegmentId,
+  });
+  const visibleFocusCues = visibleFocusCuesFor({
+    focusCues,
+    visibleMarkers: visibleMapContent.markers,
+    visibleRouteSegments: visibleMapContent.routeSegments,
   });
   const scope = scopePresentationFor({
     activeScope,
@@ -606,6 +890,7 @@ export function buildTripMapSurfaceModel({
     selectedSegmentId: visibleMapContent.selectedSegment?.id ?? null,
     placeMarkers: visibleMapContent.markers,
     roughRouteGeometry: visibleMapContent.routeSegments,
+    focusCues: visibleFocusCues,
     confidence: deriveMapConfidence({ routeState, provider }),
     diagnostics: {
       provider,
@@ -617,11 +902,13 @@ export function buildTripMapSurfaceModel({
   return {
     provider,
     routeStops,
-    routeSegments,
+    routeSegments: focusedRouteSegments,
     markers,
     visibleRouteStops: visibleMapContent.routeStops,
     visibleRouteSegments: visibleMapContent.routeSegments,
     visibleMarkers: visibleMapContent.markers,
+    focusCues,
+    visibleFocusCues,
     destinationAnchors,
     destinationContext,
     scenarioFocusAreas: scenarioFocusAreas?.filter(Boolean) ?? [],

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -56,6 +56,26 @@ export type RouteSegment = {
   warning: string | null;
 };
 
+export type MapViewScope = "global" | "regional" | "local";
+export type MapGeometryConfidence = "high" | "medium" | "low";
+
+export type MapWorkspaceView = {
+  activeScope: MapViewScope;
+  activeRouteOptionId: string;
+  selectedSegmentId: string | null;
+  placeMarkers: MapMarker[];
+  roughRouteGeometry: RouteSegment[];
+  confidence: {
+    level: MapGeometryConfidence;
+    summary: string;
+  };
+  diagnostics: {
+    provider: MapSurfaceProvider;
+    routeState: "ready" | "sparse";
+    routeWarning: string | null;
+  };
+};
+
 export type TripMapSurfaceModel = {
   provider: MapSurfaceProvider;
   routeStops: RouteStop[];
@@ -70,6 +90,7 @@ export type TripMapSurfaceModel = {
   feasibilitySummary: string;
   routeState: "ready" | "sparse";
   routeWarning: string | null;
+  workspaceView: MapWorkspaceView;
 };
 
 export function humanizeStop(stop: string): string {
@@ -316,6 +337,31 @@ function buildScenarioAffordances({
   return affordances;
 }
 
+function deriveMapConfidence({
+  routeState,
+  provider,
+}: {
+  routeState: "ready" | "sparse";
+  provider: MapSurfaceProvider;
+}): MapWorkspaceView["confidence"] {
+  if (routeState === "sparse") {
+    return {
+      level: "low",
+      summary: "Low confidence: route geometry is incomplete and shown as a rough preview.",
+    };
+  }
+  if (provider.kind === "fallback") {
+    return {
+      level: "medium",
+      summary: "Medium confidence: route geometry is approximate while the map provider is unavailable.",
+    };
+  }
+  return {
+    level: "high",
+    summary: "High confidence: route geometry is backed by live provider rendering.",
+  };
+}
+
 export function buildTripMapSurfaceModel({
   activeScenario,
   bundles,
@@ -421,6 +467,19 @@ export function buildTripMapSurfaceModel({
         "Google Maps JavaScript is the active presentation adapter; route, marker, and warning state still comes from workspace runtime data.",
     };
   }
+  const workspaceView: MapWorkspaceView = {
+    activeScope: "regional",
+    activeRouteOptionId: activeScenario.scenario_id,
+    selectedSegmentId: routeSegments[0]?.id ?? null,
+    placeMarkers: markers,
+    roughRouteGeometry: routeSegments,
+    confidence: deriveMapConfidence({ routeState, provider }),
+    diagnostics: {
+      provider,
+      routeState,
+      routeWarning,
+    },
+  };
 
   return {
     provider,
@@ -438,5 +497,6 @@ export function buildTripMapSurfaceModel({
     feasibilitySummary: summarizeFeasibility(feasibilitySummary, destinationAnchors),
     routeState,
     routeWarning,
+    workspaceView,
   };
 }

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -894,7 +894,7 @@ describe("WorkspacePage", () => {
     const routeContextMap = screen.getByLabelText("Route context map");
 
     expect(screen.getAllByRole("heading", { name: "Kyoto base with Uji day trip" }).length).toBeGreaterThan(0);
-    expect(screen.getByRole("heading", { name: "Map preview for Kyoto base with Uji day trip" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Map for Kyoto base with Uji day trip" })).toBeInTheDocument();
     expect(within(routeContextMap).getAllByText("Kyoto").length).toBeGreaterThan(0);
     expect(within(routeContextMap).getAllByText("Uji").length).toBeGreaterThan(0);
     expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
@@ -1285,7 +1285,7 @@ describe("WorkspacePage", () => {
     });
 
     expect(
-      screen.getByRole("heading", { name: "Map preview for Kyoto base with Uji day trip" })
+      screen.getByRole("heading", { name: "Map for Kyoto base with Uji day trip" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("kyoto -> uji -> kyoto").length).toBeGreaterThan(0);
     expect(screen.getByText("93 / 100 planner score")).toBeInTheDocument();
@@ -1293,7 +1293,7 @@ describe("WorkspacePage", () => {
     await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
 
     expect(
-      screen.getByRole("heading", { name: "Map preview for Kyoto plus Osaka fallback" })
+      screen.getByRole("heading", { name: "Map for Kyoto plus Osaka fallback" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("kyoto -> osaka -> kyoto").length).toBeGreaterThan(0);
     expect(screen.getByText("88 / 100 planner score")).toBeInTheDocument();
@@ -1321,12 +1321,17 @@ describe("WorkspacePage", () => {
       ).toBeInTheDocument();
     });
 
-    expect(screen.getAllByText("Google Maps JavaScript adapter").length).toBeGreaterThan(0);
     expect(screen.getByLabelText("Route geometry overlay for Kyoto base with Uji day trip")).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: /stop marker:/ }).length).toBeGreaterThan(0);
     expect(container.querySelector("iframe")).toBeNull();
     expect(screen.queryByTitle(/google maps/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Fallback option markers")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
+    expect(
+      screen.getAllByText("High confidence: the route has enough map detail for close review.")
+        .length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("Google Maps JavaScript adapter")).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /lodging marker: Osaka arrival buffer/ }));
     expect(screen.getAllByRole("heading", { name: "Osaka arrival buffer" }).length).toBeGreaterThan(0);
     await user.click(screen.getByRole("button", { name: /activity marker: Kyoto cultural anchor/ }));
@@ -1334,7 +1339,6 @@ describe("WorkspacePage", () => {
     await user.click(screen.getByRole("button", { name: /policy marker: Route burden warning/ }));
     expect(screen.getByRole("heading", { name: "Route burden warning" })).toBeInTheDocument();
     expect(screen.getAllByText("Approval or feasibility warning active").length).toBeGreaterThan(0);
-    expect(screen.getByText("Live provider path")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
 
@@ -1357,8 +1361,8 @@ describe("WorkspacePage", () => {
       ).toBeInTheDocument();
     });
 
-    expect(screen.getAllByText("Google Maps JavaScript adapter").length).toBeGreaterThan(0);
-    expect(screen.getByText("Live provider path")).toBeInTheDocument();
+    expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
+    expect(screen.queryByText("Google Maps JavaScript adapter")).not.toBeInTheDocument();
   });
 
   it("updates the dedicated comparison surfaces when scenario and trip selections change", async () => {
@@ -1377,7 +1381,7 @@ describe("WorkspacePage", () => {
     expect(screen.getAllByText("Moderate travel friction with a clear cultural center of gravity.").length).toBeGreaterThan(0);
     await user.click(screen.getByRole("button", { name: "Compare 2. Kyoto plus Osaka fallback" }));
     expect(
-      screen.getByRole("heading", { name: "Map preview for Kyoto plus Osaka fallback" })
+      screen.getByRole("heading", { name: "Map for Kyoto plus Osaka fallback" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("Osaka rainy-day fallback").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Higher transfer load to preserve nightlife breadth.").length).toBeGreaterThan(0);
@@ -1502,9 +1506,13 @@ describe("WorkspacePage", () => {
 
     expect(screen.getByText("Compact review keeps route, day plan, and next choices close together.")).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.getByText("Textual fallback route path")).toBeInTheDocument();
+      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
     });
-    expect(screen.getAllByText(/Google Maps JavaScript is not configured in this environment/).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Medium confidence: this is an approximate sketch from the current route stops.")
+        .length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/Google Maps JavaScript is not configured in this environment/)).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Compact day-by-day review" })).toBeInTheDocument();
   });
 
@@ -1519,10 +1527,10 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByText("Provider loading fallback path")).toBeInTheDocument();
+      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
     });
 
-    expect(screen.getAllByText(/Google Maps JavaScript is loading/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Google Maps JavaScript is loading/)).not.toBeInTheDocument();
     expect(within(screen.getByLabelText("Route context map")).getAllByText("Kyoto").length).toBeGreaterThan(0);
   });
 
@@ -1537,10 +1545,10 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByText("Provider error fallback path")).toBeInTheDocument();
+      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
     });
 
-    expect(screen.getAllByText(/failed to load/).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/failed to load/)).not.toBeInTheDocument();
     expect(screen.getByLabelText("Fallback option markers")).toBeInTheDocument();
     expect(within(screen.getByLabelText("Route context map")).getAllByText("Kyoto").length).toBeGreaterThan(0);
   });
@@ -1581,11 +1589,14 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByText("Sparse route fallback path")).toBeInTheDocument();
+      expect(
+        screen.getAllByText("Low confidence: the route needs more stops before the map can show its shape.")
+          .length
+      ).toBeGreaterThan(0);
     });
 
-    expect(screen.getAllByText(/needs at least an origin and destination/).length).toBeGreaterThan(0);
-    expect(screen.getByRole("heading", { name: "Map preview for Kyoto base with Uji day trip" })).toBeInTheDocument();
+    expect(screen.queryByText(/needs at least an origin and destination/)).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Map for Kyoto base with Uji day trip" })).toBeInTheDocument();
     expect(within(screen.getByLabelText("Route context map")).getAllByText("Kyoto").length).toBeGreaterThan(0);
   });
 

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1289,6 +1289,7 @@ function WorkspacePageContent({
           feasibilitySummary={currentWorkspace.feasibility_summary}
           tripPrimaryRegions={trip.trip_frame.primary_regions}
           policyPosture={panelVisibility.showPolicyPosture ? scenarioPolicyPosture : null}
+          planningLedger={currentWorkspace.planning_ledger}
           compactLayout={isCompactLayout}
         />
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -978,6 +978,11 @@ a {
   stroke-dasharray: 7 5;
 }
 
+.map-route-line-focused {
+  stroke-width: 6;
+  filter: drop-shadow(0 0 3px rgba(56, 117, 107, 0.5));
+}
+
 .map-marker {
   position: absolute;
   display: grid;
@@ -1073,6 +1078,12 @@ a {
   outline-offset: 3px;
 }
 
+.map-stop-focused .map-stop-marker {
+  box-shadow:
+    0 0 0 6px rgba(56, 117, 107, 0.16),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
 .map-stop-copy {
   display: grid;
   gap: 0.3rem;
@@ -1132,6 +1143,10 @@ a {
   outline: 2px solid rgba(56, 117, 107, 0.25);
 }
 
+.map-option-marker-focused {
+  box-shadow: 0 0 0 4px rgba(56, 117, 107, 0.12);
+}
+
 .map-warning {
   margin: 0;
   border-radius: 8px;
@@ -1143,6 +1158,24 @@ a {
 
 .map-marker-detail {
   border: 1px solid rgba(56, 117, 107, 0.2);
+}
+
+.map-ledger-focus-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0.85rem 0 0;
+  padding-left: 1rem;
+  color: #365063;
+}
+
+.map-ledger-focus-list li {
+  padding-left: 0.15rem;
+}
+
+.map-ledger-focus-list span {
+  display: block;
+  color: #13212c;
+  font-weight: 800;
 }
 
 .map-metrics {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -846,6 +846,48 @@ a {
   color: #845623;
 }
 
+.map-confidence-pill-high {
+  background: rgba(56, 117, 107, 0.16);
+  color: #234f48;
+}
+
+.map-confidence-pill-medium {
+  background: rgba(132, 86, 35, 0.14);
+  color: #845623;
+}
+
+.map-confidence-pill-low {
+  background: rgba(155, 47, 47, 0.12);
+  color: #8a2f2f;
+}
+
+.map-scope-controls,
+.map-segment-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 1rem 0 0;
+}
+
+.map-scope-button,
+.map-segment-button {
+  border: 1px solid rgba(19, 33, 44, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.78);
+  color: #13212c;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 0.7rem 0.9rem;
+}
+
+.map-scope-button-active,
+.map-segment-button-active {
+  border-color: rgba(56, 117, 107, 0.45);
+  background: #234f48;
+  color: #f7f1e5;
+}
+
 .map-scenario-toggle {
   display: flex;
   flex-wrap: wrap;
@@ -1184,7 +1226,9 @@ a {
     grid-template-columns: 1fr;
   }
 
-  .map-toggle-chip {
+  .map-toggle-chip,
+  .map-scope-button,
+  .map-segment-button {
     width: 100%;
     text-align: left;
   }

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -291,9 +291,10 @@ def test_route_option_actions_create_durable_ledger_history(client: TestClient) 
 
     reloaded = client.get(f"/api/workspace/{trip_id}")
     assert reloaded.status_code == 200
-    assert reloaded.json()["planning_ledger"]["summary"]["rejected_options"][0][
-        "related_option_id"
-    ] == scenario_id
+    assert (
+        reloaded.json()["planning_ledger"]["summary"]["rejected_options"][0]["related_option_id"]
+        == scenario_id
+    )
 
 
 def test_planner_turn_extracts_constraints_into_planning_ledger(
@@ -375,9 +376,16 @@ def test_workspace_scenario_comparison_endpoint_returns_runtime_surface(
     assert payload["scenarios"][0]["delta"]["transfers_delta"] == 0
     assert payload["lead_scenario_id"] == payload["scenarios"][0]["scenario_id"]
     assert payload["scenarios"][0]["map_view"]["active_scope"] == "regional"
-    assert payload["scenarios"][0]["map_view"]["active_route_option_id"] == payload["scenarios"][0][
-        "scenario_id"
-    ]
+    assert (
+        payload["scenarios"][0]["map_view"]["active_route_option_id"]
+        == payload["scenarios"][0]["scenario_id"]
+    )
+    assert payload["scenarios"][0]["map_view"]["place_markers"][0]["label"]
+    assert payload["scenarios"][0]["map_view"]["rough_route_geometry"][0]["from_label"]
+    assert (
+        payload["scenarios"][0]["map_view"]["selected_segment_id"]
+        == payload["scenarios"][0]["map_view"]["rough_route_geometry"][0]["id"]
+    )
     assert "provider" in payload["scenarios"][0]["map_diagnostics"]
     assert "provider" not in payload["scenarios"][0]["map_view"]
     assert "runtime scenario" in payload["summary"].lower()

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -374,6 +374,12 @@ def test_workspace_scenario_comparison_endpoint_returns_runtime_surface(
     assert payload["comparison_axes"][-1]["key"] == "estimated_total"
     assert payload["scenarios"][0]["delta"]["transfers_delta"] == 0
     assert payload["lead_scenario_id"] == payload["scenarios"][0]["scenario_id"]
+    assert payload["scenarios"][0]["map_view"]["active_scope"] == "regional"
+    assert payload["scenarios"][0]["map_view"]["active_route_option_id"] == payload["scenarios"][0][
+        "scenario_id"
+    ]
+    assert "provider" in payload["scenarios"][0]["map_diagnostics"]
+    assert "provider" not in payload["scenarios"][0]["map_view"]
     assert "runtime scenario" in payload["summary"].lower()
 
 

--- a/tests/contracts/test_route_context_map_target.py
+++ b/tests/contracts/test_route_context_map_target.py
@@ -40,8 +40,19 @@ _REQUIRED_SCENARIO_FIELDS = (
     "route_sequence",
     "route_summary",
     "policy_posture",
+    "map_view",
+    "map_diagnostics",
 )
-_REQUIRED_SEGMENT_FIELDS = ("id", "fromLabel", "toLabel", "x1", "y1", "x2", "y2")
+_REQUIRED_MAP_VIEW_FIELDS = (
+    "active_scope",
+    "active_route_option_id",
+    "selected_segment_id",
+    "place_markers",
+    "rough_route_geometry",
+    "confidence",
+)
+_REQUIRED_MARKER_FIELDS = ("id", "label", "x", "y")
+_REQUIRED_GEOMETRY_FIELDS = ("id", "from_label", "to_label", "x1", "y1", "x2", "y2")
 
 
 def _missing(payload: dict, fields: tuple[str, ...], label: str) -> list[str]:
@@ -75,11 +86,19 @@ def test_route_context_map_target_fixture_exposes_required_fields() -> None:
     )
     for index, scenario in enumerate(scenarios):
         missing += _missing(scenario, _REQUIRED_SCENARIO_FIELDS, f"scenarios[{index}]")
-        for seg_index, segment in enumerate(scenario.get("route_segments") or []):
+        map_view = scenario.get("map_view") or {}
+        missing += _missing(map_view, _REQUIRED_MAP_VIEW_FIELDS, f"scenarios[{index}].map_view")
+        for marker_index, marker in enumerate(map_view.get("place_markers") or []):
+            missing += _missing(
+                marker,
+                _REQUIRED_MARKER_FIELDS,
+                f"scenarios[{index}].map_view.place_markers[{marker_index}]",
+            )
+        for seg_index, segment in enumerate(map_view.get("rough_route_geometry") or []):
             missing += _missing(
                 segment,
-                _REQUIRED_SEGMENT_FIELDS,
-                f"scenarios[{index}].route_segments[{seg_index}]",
+                _REQUIRED_GEOMETRY_FIELDS,
+                f"scenarios[{index}].map_view.rough_route_geometry[{seg_index}]",
             )
 
     assert not missing, (
@@ -102,7 +121,8 @@ def test_route_context_map_target_segments_use_normalized_coordinates() -> None:
     out_of_range: list[str] = []
 
     for scenario in fixture["runtime_scenario_comparison"]["scenarios"]:
-        for segment in scenario.get("route_segments") or []:
+        map_view = scenario.get("map_view") or {}
+        for segment in map_view.get("rough_route_geometry") or []:
             for axis in ("x1", "y1", "x2", "y2"):
                 value = segment.get(axis)
                 if value is None or not (0.0 <= float(value) <= 1.0):
@@ -126,7 +146,8 @@ def test_route_context_map_target_segments_emit_optional_warning_field() -> None
     """
     fixture = _load_fixture()
     for scenario in fixture["runtime_scenario_comparison"]["scenarios"]:
-        for segment in scenario.get("route_segments") or []:
+        map_view = scenario.get("map_view") or {}
+        for segment in map_view.get("rough_route_geometry") or []:
             assert "warning" in segment, (
                 f"Segment {segment.get('id')!r} on scenario "
                 f"{scenario.get('scenario_id')!r} is missing the documented "

--- a/tests/fixtures/maps/route_context_map_target.json
+++ b/tests/fixtures/maps/route_context_map_target.json
@@ -33,6 +33,58 @@
         "policy_posture": "approval-ready",
         "route_sequence": ["dest-city-chicago", "dest-city-madison"],
         "route_summary": "ORD → MSN with direct rental and policy-aligned lodging.",
+        "map_view": {
+          "active_scope": "regional",
+          "active_route_option_id": "scenario-best-approval",
+          "selected_segment_id": "seg-1",
+          "place_markers": [
+            {
+              "id": "route-stop:1",
+              "source_id": "dest-city-chicago",
+              "label": "Chicago",
+              "route_index": 0,
+              "x": 0.18,
+              "y": 0.42
+            },
+            {
+              "id": "route-stop:2",
+              "source_id": "dest-city-madison",
+              "label": "Madison",
+              "route_index": 1,
+              "x": 0.62,
+              "y": 0.31
+            }
+          ],
+          "rough_route_geometry": [
+            {
+              "id": "seg-1",
+              "from_marker_id": "route-stop:1",
+              "to_marker_id": "route-stop:2",
+              "from_label": "Chicago",
+              "to_label": "Madison",
+              "x1": 0.18,
+              "y1": 0.42,
+              "x2": 0.62,
+              "y2": 0.31,
+              "warning": null
+            }
+          ],
+          "confidence": {
+            "level": "high",
+            "summary": "This route outline is drawn from ranked scenario data."
+          }
+        },
+        "map_diagnostics": {
+          "provider": {
+            "kind": "fallback",
+            "status": "fallback",
+            "details": "Fixture geometry is normalized for fallback rendering."
+          },
+          "route_state": "ready",
+          "route_warning": null,
+          "source_result_id": "fixture:scenario-best-approval",
+          "objective_refs": ["objective:fixture-map"]
+        },
         "route_segments": [
           {
             "id": "seg-1",
@@ -60,6 +112,58 @@
         "policy_posture": "approval-debt",
         "route_sequence": ["dest-city-chicago", "dest-city-madison"],
         "route_summary": "Premium fare with policy exception path.",
+        "map_view": {
+          "active_scope": "regional",
+          "active_route_option_id": "scenario-faster-with-debt",
+          "selected_segment_id": "seg-1b",
+          "place_markers": [
+            {
+              "id": "route-stop:1",
+              "source_id": "dest-city-chicago",
+              "label": "Chicago",
+              "route_index": 0,
+              "x": 0.18,
+              "y": 0.42
+            },
+            {
+              "id": "route-stop:2",
+              "source_id": "dest-city-madison",
+              "label": "Madison",
+              "route_index": 1,
+              "x": 0.62,
+              "y": 0.31
+            }
+          ],
+          "rough_route_geometry": [
+            {
+              "id": "seg-1b",
+              "from_marker_id": "route-stop:1",
+              "to_marker_id": "route-stop:2",
+              "from_label": "Chicago",
+              "to_label": "Madison",
+              "x1": 0.18,
+              "y1": 0.42,
+              "x2": 0.62,
+              "y2": 0.31,
+              "warning": "Requires exception approval before booking."
+            }
+          ],
+          "confidence": {
+            "level": "medium",
+            "summary": "This route outline is approximate while feasibility is still settling."
+          }
+        },
+        "map_diagnostics": {
+          "provider": {
+            "kind": "fallback",
+            "status": "fallback",
+            "details": "Fixture geometry is normalized for fallback rendering."
+          },
+          "route_state": "ready",
+          "route_warning": "Requires exception approval before booking.",
+          "source_result_id": "fixture:scenario-faster-with-debt",
+          "objective_refs": ["objective:fixture-map"]
+        },
         "route_segments": [
           {
             "id": "seg-1b",

--- a/tests/planner/MIGRATIONS.md
+++ b/tests/planner/MIGRATIONS.md
@@ -61,7 +61,7 @@ note here, or tighten to `strict=True` with a precise `reason=`.
     test against `tests/fixtures/maps/route_context_map_target.json`.
   - `frontend/src/components/maps/mapSurface.ts` — canonical TypeScript types
     (`TripMapSurfaceModel`, `MapSurfaceProvider`, `RouteStop`, `RouteSegment`,
-    `MapMarker`, `MapMarkerKind`, `MapProviderLoadState`).
+    `MapMarker`, `MapMarkerKind`, `MapFocusCue`, `MapProviderLoadState`).
   Asserting a Python `trip_planner.contracts` export contradicts the shipped
   design and would prevent the documented surface from ever passing the test.
 - **Remaining gap:** the dedicated map surface UI (`#699`) and the timeline

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -849,6 +849,62 @@ def _route_option_available_actions(state: str) -> list[dict[str, str]]:
     return actions
 
 
+def _humanize_route_stop(stop: str) -> str:
+    return (
+        stop.replace("dest-city-", "")
+        .replace("dest-", "")
+        .replace("city-", "")
+        .replace("_", " ")
+        .replace("-", " ")
+        .strip()
+        .title()
+    )
+
+
+def _build_runtime_map_view_payload(
+    *,
+    scenario: dict[str, Any],
+    summary: dict[str, Any],
+    route_sequence: list[str],
+) -> dict[str, Any]:
+    confidence_level = "high" if summary.get("feasible", False) else "medium"
+    return {
+        "active_scope": "regional",
+        "active_route_option_id": scenario["scenario_id"],
+        "selected_segment_id": None,
+        "place_markers": [_humanize_route_stop(stop) for stop in route_sequence],
+        "rough_route_geometry": [],
+        "confidence": {
+            "level": confidence_level,
+            "summary": (
+                "Route geometry is aligned with ranked scenario data."
+                if confidence_level == "high"
+                else "Route geometry is approximate while scenario feasibility is still settling."
+            ),
+        },
+    }
+
+
+def _build_runtime_map_diagnostics_payload(
+    *,
+    scenario: dict[str, Any],
+    summary: dict[str, Any],
+    route_sequence: list[str],
+) -> dict[str, Any]:
+    has_route = len(route_sequence) > 1
+    return {
+        "provider": {
+            "kind": "fallback",
+            "status": "sparse-route" if not has_route else "fallback",
+            "details": "Route geometry is synthesized from scenario route_sequence.",
+        },
+        "route_state": "ready" if has_route else "sparse",
+        "route_warning": None if summary.get("feasible", False) else "scenario_not_feasible",
+        "source_result_id": scenario["source_result_id"],
+        "objective_refs": list(scenario.get("objective_refs") or []),
+    }
+
+
 def _build_runtime_scenario_comparison(
     *,
     trip_id: str,
@@ -981,6 +1037,16 @@ def _build_runtime_scenario_comparison(
                 "highlights": _comparison_highlights(scenario=scenario, lead=lead),
                 "source_result_id": scenario["source_result_id"],
                 "objective_refs": list(scenario.get("objective_refs") or []),
+                "map_view": _build_runtime_map_view_payload(
+                    scenario=scenario,
+                    summary=summary,
+                    route_sequence=list(summary.get("route_sequence") or []),
+                ),
+                "map_diagnostics": _build_runtime_map_diagnostics_payload(
+                    scenario=scenario,
+                    summary=summary,
+                    route_sequence=list(summary.get("route_sequence") or []),
+                ),
             }
         )
 

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -861,6 +861,57 @@ def _humanize_route_stop(stop: str) -> str:
     )
 
 
+def _map_coordinate_for_route_index(index: int, route_length: int) -> dict[str, float]:
+    if route_length <= 1:
+        return {"x": 0.5, "y": 0.5}
+
+    progress = index / (route_length - 1)
+    wave = -1 if index % 2 == 0 else 1
+    return {
+        "x": round(0.12 + progress * 0.76, 4),
+        "y": round(0.52 + wave * 0.18, 4),
+    }
+
+
+def _build_runtime_map_place_markers(route_sequence: list[str]) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": f"route-stop:{index + 1}",
+            "source_id": stop,
+            "label": _humanize_route_stop(stop),
+            "route_index": index,
+            **_map_coordinate_for_route_index(index, len(route_sequence)),
+        }
+        for index, stop in enumerate(route_sequence)
+        if stop
+    ]
+
+
+def _build_runtime_map_route_geometry(
+    place_markers: list[dict[str, Any]],
+    *,
+    route_warning: str | None,
+) -> list[dict[str, Any]]:
+    segments: list[dict[str, Any]] = []
+    for index, marker in enumerate(place_markers[:-1]):
+        next_marker = place_markers[index + 1]
+        segments.append(
+            {
+                "id": f"route-segment:{index + 1}",
+                "from_marker_id": marker["id"],
+                "to_marker_id": next_marker["id"],
+                "from_label": marker["label"],
+                "to_label": next_marker["label"],
+                "x1": marker["x"],
+                "y1": marker["y"],
+                "x2": next_marker["x"],
+                "y2": next_marker["y"],
+                "warning": route_warning if index == 0 else None,
+            }
+        )
+    return segments
+
+
 def _build_runtime_map_view_payload(
     *,
     scenario: dict[str, Any],
@@ -868,18 +919,24 @@ def _build_runtime_map_view_payload(
     route_sequence: list[str],
 ) -> dict[str, Any]:
     confidence_level = "high" if summary.get("feasible", False) else "medium"
+    route_warning = None if summary.get("feasible", False) else "Scenario feasibility needs review."
+    place_markers = _build_runtime_map_place_markers(route_sequence)
+    rough_route_geometry = _build_runtime_map_route_geometry(
+        place_markers,
+        route_warning=route_warning,
+    )
     return {
         "active_scope": "regional",
         "active_route_option_id": scenario["scenario_id"],
-        "selected_segment_id": None,
-        "place_markers": [_humanize_route_stop(stop) for stop in route_sequence],
-        "rough_route_geometry": [],
+        "selected_segment_id": rough_route_geometry[0]["id"] if rough_route_geometry else None,
+        "place_markers": place_markers,
+        "rough_route_geometry": rough_route_geometry,
         "confidence": {
             "level": confidence_level,
             "summary": (
-                "Route geometry is aligned with ranked scenario data."
+                "This route outline is drawn from ranked scenario data."
                 if confidence_level == "high"
-                else "Route geometry is approximate while scenario feasibility is still settling."
+                else "This route outline is approximate while feasibility is still settling."
             ),
         },
     }
@@ -1581,24 +1638,12 @@ def _serialize_ledger_entry(record: PersistedPlanningLedgerEntry) -> dict[str, A
 def _planning_ledger_summary(entries: list[dict[str, Any]]) -> dict[str, Any]:
     active = [entry for entry in entries if entry["status"] == "active"]
     return {
-        "active_decisions": [
-            entry for entry in active if entry["item_type"] == "decision"
-        ],
-        "open_questions": [
-            entry for entry in active if entry["item_type"] == "open_question"
-        ],
-        "active_options": [
-            entry for entry in active if entry["item_type"] == "option_considered"
-        ],
-        "rejected_options": [
-            entry for entry in entries if entry["item_type"] == "option_rejected"
-        ],
-        "constraints": [
-            entry for entry in active if entry["item_type"] == "constraint"
-        ],
-        "assumptions": [
-            entry for entry in active if entry["item_type"] == "assumption"
-        ],
+        "active_decisions": [entry for entry in active if entry["item_type"] == "decision"],
+        "open_questions": [entry for entry in active if entry["item_type"] == "open_question"],
+        "active_options": [entry for entry in active if entry["item_type"] == "option_considered"],
+        "rejected_options": [entry for entry in entries if entry["item_type"] == "option_rejected"],
+        "constraints": [entry for entry in active if entry["item_type"] == "constraint"],
+        "assumptions": [entry for entry in active if entry["item_type"] == "assumption"],
         "source_references": [
             entry for entry in active if entry["item_type"] == "source_reference"
         ],
@@ -1637,9 +1682,7 @@ def _add_planning_ledger_entry(
     metadata: dict[str, Any] | None = None,
 ) -> PersistedPlanningLedgerEntry:
     if item_type not in PLANNING_LEDGER_ITEM_TYPES:
-        raise ValueError(
-            f"item_type must be one of {', '.join(PLANNING_LEDGER_ITEM_TYPES)}"
-        )
+        raise ValueError(f"item_type must be one of {', '.join(PLANNING_LEDGER_ITEM_TYPES)}")
     if status not in PLANNING_LEDGER_STATUSES:
         raise ValueError(f"status must be one of {', '.join(PLANNING_LEDGER_STATUSES)}")
     now = datetime.now(UTC)
@@ -3206,9 +3249,7 @@ def update_planning_ledger_entry(
         .where(PersistedPlanningLedgerEntry.ledger_entry_id == ledger_entry_id)
     )
     if entry is None:
-        raise WorkspaceTripNotFoundError(
-            f"Ledger entry '{ledger_entry_id}' was not found."
-        )
+        raise WorkspaceTripNotFoundError(f"Ledger entry '{ledger_entry_id}' was not found.")
     if updates.get("status") is not None:
         status = str(updates["status"])
         if status not in PLANNING_LEDGER_STATUSES:
@@ -3502,11 +3543,11 @@ def submit_workspace_option_feedback(
     ledger_status = (
         "rejected"
         if action_type == "reject"
-        else "completed"
-        if action_type == "accept"
-        else "deferred"
-        if action_type == "save_as_fallback"
-        else "active"
+        else (
+            "completed"
+            if action_type == "accept"
+            else "deferred" if action_type == "save_as_fallback" else "active"
+        )
     )
     _add_planning_ledger_entry(
         db_session,
@@ -3664,11 +3705,11 @@ def submit_workspace_route_option_action(
     ledger_status = (
         "rejected"
         if action_type == "reject"
-        else "completed"
-        if action_type == "make_baseline"
-        else "deferred"
-        if action_type == "keep"
-        else "active"
+        else (
+            "completed"
+            if action_type == "make_baseline"
+            else "deferred" if action_type == "keep" else "active"
+        )
     )
     _add_planning_ledger_entry(
         db_session,


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1129 -->

### Source Issue #1129: [Agent] Add Global, Regional, And Local Map Workspace Modes

Base: main
Head: codex/issue-1129

Source: https://github.com/stranske/trip-planner/issues/1129

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
A useful planning map needs different levels of precision. Early planning benefits from a rough whole-trip outline; route comparison needs regional movement; daily or segment planning needs local detail. The map should communicate what level is being shown and how confident the underlying data is.

#### Tasks
- [x] Define `MapWorkspaceView` with active scope, route option ID, selected segment, place markers, rough route geometry, confidence, and diagnostic details.
- [x] Extend backend workspace map payloads to separate user-facing map state from provider/debug state.
- [x] Update `TripMap` to support global, regional, and local modes with clear scope controls.
- [x] Connect route option selection to the displayed map route.
- [x] Connect notebook or ledger focus to relevant map markers or segments when linked data exists.
- [x] Add visible confidence language for approximate route shapes and missing provider data.
- [x] Add map tests for scope switching, route selection, missing geometry, and hidden provider diagnostics.

#### Acceptance Criteria
- [x] The map can switch between whole-trip, regional route, and local segment views without losing the active route option.
- [x] The UI labels approximate versus precise route data in traveler-friendly language.
- [x] Provider diagnostics and fallback details are not shown in normal map mode.
- [x] Route-option selection updates the map view.
- [x] Tests cover mode switching and empty/low-confidence map states.
<!-- auto-status-summary:end -->

## Summary
- Rebased the PR onto current `main` and resolved the workspace-service conflict.
- Added scoped map state and traveler-facing controls for whole-trip, route, and segment views.
- Expanded backend `map_view` with user-facing markers/rough route geometry while keeping provider details in `map_diagnostics`.
- Hid raw provider/fallback diagnostics from the normal `TripMap` UI and replaced them with confidence/scope language.
- Updated the route-context map contract and fixture/test coverage for the scoped map payload.

## Validation
- `pytest -q tests/app/test_workspace.py::test_workspace_scenario_comparison_endpoint_returns_runtime_surface tests/contracts/test_route_context_map_target.py`
- `npm --prefix frontend test -- src/components/maps/mapSurface.test.ts src/components/maps/TripMap.test.tsx`
- `npm --prefix frontend test -- src/routes/WorkspacePage.test.tsx`
- `npm --prefix frontend run build`
- `python -m black --check --line-length 100 trip_planner/app/services/workspace.py tests/app/test_workspace.py tests/contracts/test_route_context_map_target.py`
- `git diff --check`


Closes #1129
