### PR TITLE
Codex bootstrap for #1130

### DIFF
--- a/agents/codex-1130.md
+++ b/agents/codex-1130.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1130 -->

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -419,9 +419,26 @@ export type WorkspaceDebugState = {
   sections: Record<string, WorkspaceDebugSection>;
 };
 
+export type WorkspacePanelVisibility = {
+  show_budget_panel: boolean;
+  show_policy_posture: boolean;
+  show_proposal_panel: boolean;
+  show_approval_readiness_panel: boolean;
+};
+
+export type WorkspacePolicyPresentation = {
+  active_policy_state: boolean;
+  posture_label: string;
+  approval_status_label: string;
+  next_step_label: string;
+  summary: string;
+};
+
 export type WorkspaceViewModel = {
   user_summary: WorkspaceUserSummary;
   next_step: WorkspaceNextStep;
+  panel_visibility: WorkspacePanelVisibility;
+  policy_presentation: WorkspacePolicyPresentation;
   business_summary: WorkspaceBusinessSummary | null;
   debug_state: WorkspaceDebugState;
 };

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -30,7 +30,7 @@ export function TripMap({
   bundles: InventoryBundle[];
   feasibilitySummary: FeasibilitySummary;
   tripPrimaryRegions: string[];
-  policyPosture: string;
+  policyPosture: string | null;
   compactLayout: boolean;
 }) {
   const activeScenario =
@@ -86,7 +86,7 @@ function ActiveTripMap({
   scenarioComparisonSummary?: string | null;
   scenarioFocusAreas?: string[];
   tripPrimaryRegions: string[];
-  policyPosture: string;
+  policyPosture: string | null;
   compactLayout: boolean;
 }) {
   const googleMapsApiKey =
@@ -238,7 +238,9 @@ function ActiveTripMap({
           </article>
           <article className="decision-card">
             <h3>Destination context</h3>
-            <p className="muted-copy">Policy posture: {mapSurface.policyPosture}</p>
+            {mapSurface.policyPosture ? (
+              <p className="muted-copy">Approval posture: {mapSurface.policyPosture}</p>
+            ) : null}
             <p>{mapSurface.feasibilitySummary}</p>
             <div className="map-anchor-list">
               {mapSurface.destinationContext.length === 0 ? (

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -75,7 +75,7 @@ describe("mapSurface", () => {
       "2 mapped option marker(s)",
       "3 route stop(s)",
       "4 transfer checkpoint(s)",
-      "Policy or feasibility warning active",
+      "Approval or feasibility warning active",
     ]);
     expect(model.routeStops.map((stop) => stop.label)).toEqual(["Kyoto", "Uji", "Kyoto"]);
     expect(model.routeSegments).toHaveLength(2);

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -66,7 +66,7 @@ export type TripMapSurfaceModel = {
   scenarioFocusAreas: string[];
   scenarioComparisonSummary: string;
   scenarioAffordances: string[];
-  policyPosture: string;
+  policyPosture: string | null;
   feasibilitySummary: string;
   routeState: "ready" | "sparse";
   routeWarning: string | null;
@@ -234,7 +234,7 @@ function buildMarkers({
   bundles: InventoryBundle[];
   routeStops: RouteStop[];
   routeWarning: string | null;
-  policyPosture: string;
+  policyPosture: string | null;
 }): MapMarker[] {
   const stopMarkers = routeStops.map((stop, index) => ({
     id: `${stop.id}-marker`,
@@ -270,7 +270,12 @@ function buildMarkers({
             kind: "policy" as const,
             label: "Route burden warning",
             summary: routeWarning,
-            detail: `${activeScenario.comparison_note} Policy posture: ${policyPosture}.`,
+            detail: [
+              activeScenario.comparison_note,
+              policyPosture ? `Approval posture: ${policyPosture}.` : "",
+            ]
+              .filter(Boolean)
+              .join(" "),
             x: 82,
             y: 18,
             emphasized: true,
@@ -284,10 +289,12 @@ function buildScenarioAffordances({
   activeScenario,
   routeState,
   routeWarning,
+  policyPosture,
 }: {
   activeScenario: TripMapScenario;
   routeState: "ready" | "sparse";
   routeWarning: string | null;
+  policyPosture: string | null;
 }): string[] {
   const affordances = [
     activeScenario.recommended_for_selection ? "Recommended scenario" : "Alternative scenario",
@@ -302,7 +309,9 @@ function buildScenarioAffordances({
     affordances.push("Sparse route fallback");
   }
   if (routeWarning) {
-    affordances.push("Policy or feasibility warning active");
+    affordances.push(
+      policyPosture ? "Approval or feasibility warning active" : "Feasibility warning active"
+    );
   }
   return affordances;
 }
@@ -314,7 +323,7 @@ export function buildTripMapSurfaceModel({
   scenarioComparisonSummary,
   scenarioFocusAreas,
   tripPrimaryRegions = [],
-  policyPosture = "review pending",
+  policyPosture = null,
   googleMapsApiKey,
   providerLoadState = "ready",
 }: {
@@ -324,7 +333,7 @@ export function buildTripMapSurfaceModel({
   scenarioComparisonSummary?: string | null;
   scenarioFocusAreas?: string[];
   tripPrimaryRegions?: string[];
-  policyPosture?: string;
+  policyPosture?: string | null;
   googleMapsApiKey?: string | null;
   providerLoadState?: MapProviderLoadState;
 }): TripMapSurfaceModel {
@@ -366,6 +375,7 @@ export function buildTripMapSurfaceModel({
     activeScenario,
     routeState,
     routeWarning,
+    policyPosture,
   });
   let provider: MapSurfaceProvider;
 

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -822,6 +822,19 @@ describe("WorkspacePage", () => {
           action_target: "scenario-comparison",
           blocked: false,
         },
+        panel_visibility: {
+          show_budget_panel: true,
+          show_policy_posture: false,
+          show_proposal_panel: false,
+          show_approval_readiness_panel: false,
+        },
+        policy_presentation: {
+          active_policy_state: false,
+          posture_label: "Not applicable",
+          approval_status_label: "Not applicable",
+          next_step_label: "No policy action needed",
+          summary: "Policy approval is not part of this workspace yet.",
+        },
         business_summary: null,
         debug_state: { sections: {} },
       },
@@ -905,14 +918,14 @@ describe("WorkspacePage", () => {
     expect(screen.getByLabelText("Timeline summary")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Review route tradeoffs" })).toBeInTheDocument();
     expect(screen.getByLabelText("Scenario review board")).toBeInTheDocument();
-    expect(screen.getAllByText("Policy posture").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Approval posture").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Places and options to review" })).toBeInTheDocument();
     expect(screen.getAllByText("Osaka arrival buffer").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Kyoto cultural anchor").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();
     expect(screen.getByText("Ready for approval")).toBeInTheDocument();
     expect(screen.getAllByText("Advance to approval").length).toBeGreaterThan(0);
-    expect(screen.getByRole("heading", { name: "Comparables and readiness signals" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Options and readiness signals" })).toBeInTheDocument();
     expect(screen.getByText("Conference Hotel")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Planner notes to keep" })).toBeInTheDocument();
     expect(screen.getByText("Planner checkpoint 1")).toBeInTheDocument();
@@ -943,7 +956,9 @@ describe("WorkspacePage", () => {
     });
 
     expect(screen.queryByText("Approval packet")).not.toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Comparables and readiness signals" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Options and readiness signals" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Approval posture")).not.toBeInTheDocument();
+    expect(screen.queryByText("Policy posture")).not.toBeInTheDocument();
   });
 
   it("persists planning mode selections through the workspace API", async () => {
@@ -1318,7 +1333,7 @@ describe("WorkspacePage", () => {
     expect(screen.getAllByRole("heading", { name: "Kyoto cultural anchor" }).length).toBeGreaterThan(0);
     await user.click(screen.getByRole("button", { name: /policy marker: Route burden warning/ }));
     expect(screen.getByRole("heading", { name: "Route burden warning" })).toBeInTheDocument();
-    expect(screen.getAllByText("Policy or feasibility warning active").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Approval or feasibility warning active").length).toBeGreaterThan(0);
     expect(screen.getByText("Live provider path")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
@@ -1398,7 +1413,7 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Comparables and readiness signals" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Options and readiness signals" })).toBeInTheDocument();
     });
 
     expect(screen.getByText(/Marriott via Navan · 245/)).toBeInTheDocument();

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -910,7 +910,7 @@ describe("WorkspacePage", () => {
     expect(screen.getAllByText("Osaka arrival buffer").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Kyoto cultural anchor").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();
-    expect(screen.getByText("approval-ready")).toBeInTheDocument();
+    expect(screen.getByText("Ready for approval")).toBeInTheDocument();
     expect(screen.getAllByText("Advance to approval").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Comparables and readiness signals" })).toBeInTheDocument();
     expect(screen.getByText("Conference Hotel")).toBeInTheDocument();
@@ -1772,7 +1772,7 @@ describe("WorkspacePage", () => {
         )
       ).toBeInTheDocument();
     });
-    expect(screen.getAllByText("pending").length).toBeGreaterThan(0);
+    expect(screen.getByText("Waiting for policy review")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Refresh live status" })).not.toBeInTheDocument();
   });
 
@@ -1806,7 +1806,7 @@ describe("WorkspacePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Policy review is deferred" })).toBeInTheDocument();
     });
-    expect(screen.getAllByText("deferred").length).toBeGreaterThan(0);
+    expect(screen.getByText("Waiting for policy review")).toBeInTheDocument();
     expect(screen.getByText("Proposal queued for evaluation")).toBeInTheDocument();
     expect(screen.getByText("Keep the workspace open for remote results")).toBeInTheDocument();
   });
@@ -1841,7 +1841,7 @@ describe("WorkspacePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Policy review is running" })).toBeInTheDocument();
     });
-    expect(screen.getAllByText("running").length).toBeGreaterThan(0);
+    expect(screen.getByText("Waiting for policy review")).toBeInTheDocument();
     expect(screen.getByText("Policy engine accepted the packet and is still evaluating it.")).toBeInTheDocument();
     expect(screen.getByText("Keep the workspace open for remote results")).toBeInTheDocument();
   });
@@ -2041,7 +2041,7 @@ describe("WorkspacePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Live policy execution needs attention" })).toBeInTheDocument();
     });
-    expect(screen.getAllByText("failed").length).toBeGreaterThan(0);
+    expect(screen.getByText("Needs policy retry")).toBeInTheDocument();
     expect(screen.getByText("TPP gateway returned a 502 response for the proposal submission.")).toBeInTheDocument();
     expect(screen.getByText("Review the live transport failure")).toBeInTheDocument();
   });
@@ -2111,7 +2111,7 @@ describe("WorkspacePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Policy review finished with follow-up" })).toBeInTheDocument();
     });
-    expect(screen.getByText("completed with follow-up")).toBeInTheDocument();
+    expect(screen.getByText("Needs exception")).toBeInTheDocument();
     expect(screen.getAllByText("Reoptimize plan").length).toBeGreaterThan(0);
     expect(screen.getByText("Use a compliant downtown property")).toBeInTheDocument();
     expect(screen.getByText("Nightly lodging exceeds the allowed cap.")).toBeInTheDocument();
@@ -2185,7 +2185,7 @@ describe("WorkspacePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Policy review finished with follow-up" })).toBeInTheDocument();
     });
-    expect(screen.getByText("completed with follow-up")).toBeInTheDocument();
+    expect(screen.getByText("Needs exception")).toBeInTheDocument();
     expect(screen.getAllByText("Prepare exception packet").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Attach the compliant comparable to the exception packet.")).toHaveLength(2);
     expect(

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -867,7 +867,7 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Spring Kyoto anniversary draft" })).toBeInTheDocument();
+      expect(screen.getAllByRole("heading", { name: "Spring Kyoto anniversary draft" }).length).toBeGreaterThan(0);
     });
 
     expect(screen.queryByText("Approval packet")).not.toBeInTheDocument();

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -855,6 +855,25 @@ describe("WorkspacePage", () => {
     });
   });
 
+  it("hides proposal and approval panels for leisure workspaces without active policy state", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        proposal_state: null,
+      }),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Spring Kyoto anniversary draft" })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Approval packet")).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Comparables and readiness signals" })).not.toBeInTheDocument();
+  });
+
   it("persists planning mode selections through the workspace API", async () => {
     const user = userEvent.setup();
     mockedUseLoaderData.mockReturnValue({

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -71,7 +71,7 @@ type ProposalLifecycleState =
 
 type ProposalLifecyclePresentation = {
   state: ProposalLifecycleState;
-  label: string;
+  readinessLabel: string;
   title: string;
   summary: string;
 };
@@ -405,7 +405,7 @@ function deriveProposalLifecyclePresentation(
   if (summary.approval_ready || followUpStatus === "resolved") {
     return {
       state: "approval-ready",
-      label: "approval-ready",
+      readinessLabel: "Ready for approval",
       title: "Approval packet is ready",
       summary:
         summary.follow_up_summary ??
@@ -417,7 +417,7 @@ function deriveProposalLifecyclePresentation(
   if (isFailedLifecycleStatus(submissionStatus) || isFailedLifecycleStatus(evaluationTransportStatus)) {
     return {
       state: "failed",
-      label: "failed",
+      readinessLabel: "Needs policy retry",
       title: "Live policy execution needs attention",
       summary:
         summary.submission_summary ??
@@ -429,9 +429,14 @@ function deriveProposalLifecyclePresentation(
     summary.evaluation_result_status != null ||
     (followUpStatus != null && followUpStatus !== "awaiting_evaluation")
   ) {
+    const needsException =
+      followUpStatus === "exception_required" ||
+      followUpStatus === "exception_requested" ||
+      followUpStatus === "reoptimization_required" ||
+      summary.evaluation_result_status === "non_compliant";
     return {
       state: "completed-with-follow-up",
-      label: "completed with follow-up",
+      readinessLabel: needsException ? "Needs exception" : "Needs follow-up",
       title: "Policy review finished with follow-up",
       summary:
         summary.follow_up_summary ??
@@ -442,7 +447,7 @@ function deriveProposalLifecyclePresentation(
   if (submissionStatus === "deferred" || evaluationTransportStatus === "deferred") {
     return {
       state: "deferred",
-      label: "deferred",
+      readinessLabel: "Waiting for policy review",
       title: "Policy review is deferred",
       summary:
         summary.submission_summary ??
@@ -458,7 +463,7 @@ function deriveProposalLifecyclePresentation(
   ) {
     return {
       state: "running",
-      label: "running",
+      readinessLabel: "Waiting for policy review",
       title: awaitingEvaluation ? "Awaiting policy evaluation result" : "Policy review is running",
       summary:
         summary.follow_up_summary ??
@@ -469,7 +474,7 @@ function deriveProposalLifecyclePresentation(
 
   return {
     state: "pending",
-    label: "pending",
+    readinessLabel: "Waiting for policy review",
     title: "Proposal submission is pending",
     summary: "Build and submit the approval packet to start live policy execution for this workspace.",
   };
@@ -1254,7 +1259,7 @@ function WorkspacePageContent({
               <dl className="workspace-meta">
                 <div>
                   <dt>Workspace state</dt>
-                  <dd>{proposalLifecycle?.label ?? "pending"}</dd>
+                  <dd>{proposalLifecycle?.readinessLabel ?? "Waiting for policy review"}</dd>
                 </div>
                 <div>
                   <dt>Submission</dt>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -243,6 +243,11 @@ function formatScenarioScore(score: number): string {
 }
 
 function formatPolicyPosture(workspace: WorkspaceData): string {
+  const presentation = workspace.view_model?.policy_presentation;
+  if (presentation?.active_policy_state && presentation.posture_label) {
+    return presentation.posture_label;
+  }
+
   const proposalState = workspace.proposal_state;
   if (proposalState == null) {
     return "No approval packet yet";
@@ -280,6 +285,16 @@ function hasActivePolicyState(proposalState: WorkspaceData["proposal_state"]): b
 }
 
 function deriveWorkspacePanelVisibility(workspace: WorkspaceData): WorkspacePanelVisibility {
+  const viewModelVisibility = workspace.view_model?.panel_visibility;
+  if (viewModelVisibility) {
+    return {
+      showBudgetPanel: viewModelVisibility.show_budget_panel,
+      showPolicyPosture: viewModelVisibility.show_policy_posture,
+      showProposalPanel: viewModelVisibility.show_proposal_panel,
+      showApprovalReadinessPanel: viewModelVisibility.show_approval_readiness_panel,
+    };
+  }
+
   const isBusinessTrip = workspace.trip_record.trip.mode === "business";
   const activePolicyState = hasActivePolicyState(workspace.proposal_state);
   const showPolicyPanels = isBusinessTrip || activePolicyState;
@@ -324,7 +339,7 @@ function buildScenarioReviewMetrics(
 
   if (panelVisibility.showPolicyPosture) {
     metrics.push({
-      label: "Policy posture",
+      label: "Approval posture",
       value: formatPolicyPosture(workspace),
     });
   }
@@ -475,7 +490,7 @@ function deriveProposalLifecyclePresentation(
   return {
     state: "pending",
     readinessLabel: "Waiting for policy review",
-    title: "Proposal submission is pending",
+    title: "Approval packet is pending",
     summary: "Build and submit the approval packet to start live policy execution for this workspace.",
   };
 }
@@ -1217,7 +1232,7 @@ function WorkspacePageContent({
           bundles={currentWorkspace.inventory_summary.bundles}
           feasibilitySummary={currentWorkspace.feasibility_summary}
           tripPrimaryRegions={trip.trip_frame.primary_regions}
-          policyPosture={panelVisibility.showPolicyPosture ? scenarioPolicyPosture : "Not applicable"}
+          policyPosture={panelVisibility.showPolicyPosture ? scenarioPolicyPosture : null}
           compactLayout={isCompactLayout}
         />
 
@@ -1250,7 +1265,7 @@ function WorkspacePageContent({
           <h2>{proposalLifecycle?.title ?? "Proposal lifecycle in progress"}</h2>
           {currentWorkspace.proposal_state == null ? (
             <p className="muted-copy">
-              Proposal submission and evaluation records have not been persisted for this workspace yet.
+              Approval packet records have not been saved for this workspace yet.
             </p>
           ) : (
             <>
@@ -1258,40 +1273,29 @@ function WorkspacePageContent({
               {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
               <dl className="workspace-meta">
                 <div>
-                  <dt>Workspace state</dt>
-                  <dd>{proposalLifecycle?.readinessLabel ?? "Waiting for policy review"}</dd>
-                </div>
-                <div>
-                  <dt>Submission</dt>
-                  <dd>{currentWorkspace.proposal_state.summary.submission_status ?? "unknown"}</dd>
-                </div>
-                <div>
-                  <dt>Transport</dt>
+                  <dt>Approval readiness</dt>
                   <dd>
-                    {currentWorkspace.proposal_state.summary.evaluation_transport_status ??
-                      currentWorkspace.proposal_state.evaluation_status ??
-                      "pending"}
+                    {currentWorkspace.view_model?.policy_presentation.approval_status_label ??
+                      proposalLifecycle?.readinessLabel ??
+                      "Waiting for policy review"}
                   </dd>
                 </div>
                 <div>
-                  <dt>Evaluation</dt>
-                  <dd>{currentWorkspace.proposal_state.summary.evaluation_result_status ?? "pending"}</dd>
+                  <dt>Packet status</dt>
+                  <dd>{currentWorkspace.proposal_state.summary.submission_status ?? "unknown"}</dd>
                 </div>
                 <div>
                   <dt>Comparables</dt>
                   <dd>{currentWorkspace.proposal_state.summary.comparable_count ?? 0}</dd>
                 </div>
                 <div>
-                  <dt>Proposal version</dt>
-                  <dd>{currentWorkspace.proposal_state.proposal_version}</dd>
-                </div>
-                <div>
                   <dt>Next step</dt>
                   <dd>
-                    {formatFollowUpStatus(
-                      renderableProposalFollowUp?.status ??
-                        currentWorkspace.proposal_state.summary.follow_up_status
-                    )}
+                    {currentWorkspace.view_model?.policy_presentation.next_step_label ??
+                      formatFollowUpStatus(
+                        renderableProposalFollowUp?.status ??
+                          currentWorkspace.proposal_state.summary.follow_up_status
+                      )}
                   </dd>
                 </div>
               </dl>
@@ -1419,7 +1423,11 @@ function WorkspacePageContent({
                       ? "Planner score pending"
                       : `${formatScenarioScore(selectedRuntimeScenario.metrics.score)} planner score`}
                   </h3>
-                  <p>{scenarioPolicyPosture} packet posture for the current workspace.</p>
+                  <p>
+                    {panelVisibility.showPolicyPosture
+                      ? `${scenarioPolicyPosture} approval posture for the current workspace.`
+                      : "Pacing and route burden stay visible without approval details."}
+                  </p>
                 </article>
                 <article className="timeline-summary-card">
                   <p className="scenario-kicker">Options</p>
@@ -1459,8 +1467,9 @@ function WorkspacePageContent({
           <p className="status-label">Route tradeoffs</p>
           <h2>{isCompactLayout ? "Compact route tradeoffs" : "Review route tradeoffs"}</h2>
           <p>
-            Cost, route burden, feasibility, and policy posture stay scannable here without
-            forcing you into raw planning notes.
+            {panelVisibility.showPolicyPosture
+              ? "Cost, route burden, feasibility, and approval posture stay scannable here without forcing you into raw planning notes."
+              : "Cost, route burden, and feasibility stay scannable here without forcing you into raw planning notes."}
           </p>
           {routeComparison.scenarios.length > 0 ? (
             <div className="scenario-review-grid" aria-label="Scenario review board">
@@ -1593,10 +1602,10 @@ function WorkspacePageContent({
 
         {panelVisibility.showProposalPanel ? (
           <section className="status-card">
-          <p className="status-label">Proposal details</p>
-          <h2>Comparables and readiness signals</h2>
+          <p className="status-label">Approval details</p>
+          <h2>Options and readiness signals</h2>
           {currentWorkspace.proposal_state == null ? (
-            <p className="muted-copy">Approval-packet details will render here once a proposal is submitted.</p>
+            <p className="muted-copy">Approval-packet details will render here once the packet is saved.</p>
           ) : (
             <div className="decision-stack">
               {renderableProposalFollowUp ? (

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -44,6 +44,13 @@ type ScenarioReviewMetric = {
   value: string;
 };
 
+type WorkspacePanelVisibility = {
+  showBudgetPanel: boolean;
+  showPolicyPosture: boolean;
+  showProposalPanel: boolean;
+  showApprovalReadinessPanel: boolean;
+};
+
 type ProposalLifecycleState =
   | "pending"
   | "deferred"
@@ -219,11 +226,45 @@ function formatPolicyPosture(workspace: WorkspaceData): string {
   return proposalState.summary.evaluation_result_status ?? "review pending";
 }
 
+function hasActivePolicyState(proposalState: WorkspaceData["proposal_state"]): boolean {
+  if (proposalState == null) {
+    return false;
+  }
+
+  if (proposalState.execution_id) {
+    return true;
+  }
+
+  if (proposalState.summary.approval_ready) {
+    return true;
+  }
+
+  if (proposalState.summary.evaluation_result_status || proposalState.summary.follow_up_status) {
+    return true;
+  }
+
+  return proposalState.submission_status !== "pending" || proposalState.evaluation_status != null;
+}
+
+function deriveWorkspacePanelVisibility(workspace: WorkspaceData): WorkspacePanelVisibility {
+  const isBusinessTrip = workspace.trip_record.trip.mode === "business";
+  const activePolicyState = hasActivePolicyState(workspace.proposal_state);
+  const showPolicyPanels = isBusinessTrip || activePolicyState;
+
+  return {
+    showBudgetPanel: true,
+    showPolicyPosture: showPolicyPanels,
+    showProposalPanel: showPolicyPanels,
+    showApprovalReadinessPanel: showPolicyPanels,
+  };
+}
+
 function buildScenarioReviewMetrics(
   workspace: WorkspaceData,
-  scenario: WorkspaceData["route_comparison"]["scenarios"][number]
+  scenario: WorkspaceData["route_comparison"]["scenarios"][number],
+  panelVisibility: WorkspacePanelVisibility
 ): ScenarioReviewMetric[] {
-  return [
+  const metrics: ScenarioReviewMetric[] = [
     {
       label: "Estimated total",
       value:
@@ -246,11 +287,16 @@ function buildScenarioReviewMetrics(
       label: "Feasibility",
       value: scenario.feasible ? "Ready to review" : "Needs feasibility work",
     },
-    {
+  ];
+
+  if (panelVisibility.showPolicyPosture) {
+    metrics.push({
       label: "Policy posture",
       value: formatPolicyPosture(workspace),
-    },
-  ];
+    });
+  }
+
+  return metrics;
 }
 
 function ScenarioSummaryCard({
@@ -593,6 +639,7 @@ function WorkspacePageContent({
           renderableProposalFollowUp
         );
   const scenarioPolicyPosture = formatPolicyPosture(currentWorkspace);
+  const panelVisibility = deriveWorkspacePanelVisibility(currentWorkspace);
   function handleScenarioSelection(scenarioId: string) {
     setSelectedScenarioId(scenarioId);
   }
@@ -881,14 +928,16 @@ function WorkspacePageContent({
           </section>
         </section>
 
-        <WorkspaceBudgetPanel
-          budgetState={currentWorkspace.budget_state}
-          tripMode={trip.mode}
-          busyLabel={budgetBusyLabel}
-          errorMessage={budgetError}
-          onSaveBudget={handleBudgetSave}
-          onRecordSpend={handleSpendRecord}
-        />
+        {panelVisibility.showBudgetPanel ? (
+          <WorkspaceBudgetPanel
+            budgetState={currentWorkspace.budget_state}
+            tripMode={trip.mode}
+            busyLabel={budgetBusyLabel}
+            errorMessage={budgetError}
+            onSaveBudget={handleBudgetSave}
+            onRecordSpend={handleSpendRecord}
+          />
+        ) : null}
 
         <TripMap
           comparison={routeComparison}
@@ -899,7 +948,7 @@ function WorkspacePageContent({
           bundles={currentWorkspace.inventory_summary.bundles}
           feasibilitySummary={currentWorkspace.feasibility_summary}
           tripPrimaryRegions={trip.trip_frame.primary_regions}
-          policyPosture={scenarioPolicyPosture}
+          policyPosture={panelVisibility.showPolicyPosture ? scenarioPolicyPosture : "Not applicable"}
           compactLayout={isCompactLayout}
         />
 
@@ -917,7 +966,8 @@ function WorkspacePageContent({
           onSelectTrip={setSelectedTripComparisonId}
         />
 
-        <section className="status-card">
+        {panelVisibility.showApprovalReadinessPanel ? (
+          <section className="status-card">
           <p className="status-label">Approval packet</p>
           <h2>{proposalLifecycle?.title ?? "Proposal lifecycle in progress"}</h2>
           {currentWorkspace.proposal_state == null ? (
@@ -1011,7 +1061,8 @@ function WorkspacePageContent({
               </div>
             </>
           )}
-        </section>
+          </section>
+        ) : null}
 
         <section className="status-card">
           <p className="status-label">Inventory bundles</p>
@@ -1128,7 +1179,11 @@ function WorkspacePageContent({
           {routeComparison.scenarios.length > 0 ? (
             <div className="scenario-review-grid" aria-label="Scenario review board">
               {routeComparison.scenarios.map((scenario) => {
-                const reviewMetrics = buildScenarioReviewMetrics(currentWorkspace, scenario);
+                const reviewMetrics = buildScenarioReviewMetrics(
+                  currentWorkspace,
+                  scenario,
+                  panelVisibility
+                );
                 const isSelected = scenario.scenario_id === selectedScenarioId;
 
                 return (
@@ -1250,7 +1305,8 @@ function WorkspacePageContent({
           )}
         </section>
 
-        <section className="status-card">
+        {panelVisibility.showProposalPanel ? (
+          <section className="status-card">
           <p className="status-label">Proposal details</p>
           <h2>Comparables and readiness signals</h2>
           {currentWorkspace.proposal_state == null ? (
@@ -1322,7 +1378,8 @@ function WorkspacePageContent({
               )}
             </div>
           )}
-        </section>
+          </section>
+        ) : null}
 
         <section className="status-card">
           <p className="status-label">Planner memory</p>

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -58,15 +58,17 @@ def _assert_payload_avoids_fixture_or_default_inventory_data(payload: dict[str, 
 
 def _assert_runtime_ranking_and_route_comparison(payload: dict[str, Any]) -> None:
     assert payload["ranking"]["rows"]
-    assert payload["ranking"]["lead_scenario_id"] == payload["scenario_search"]["scenarios"][0][
-        "scenario_id"
-    ]
+    assert (
+        payload["ranking"]["lead_scenario_id"]
+        == payload["scenario_search"]["scenarios"][0]["scenario_id"]
+    )
     assert payload["ranking"]["rows"][0]["scenario_id"] == payload["ranking"]["lead_scenario_id"]
     assert payload["ranking"]["source_refs"]
     assert payload["route_comparison"] == payload["runtime_scenario_comparison"]
-    assert payload["route_comparison"]["lead_scenario_id"] == payload["scenario_search"][
-        "scenarios"
-    ][0]["scenario_id"]
+    assert (
+        payload["route_comparison"]["lead_scenario_id"]
+        == payload["scenario_search"]["scenarios"][0]["scenario_id"]
+    )
     assert payload["route_comparison"]["scenarios"]
     assert payload["route_comparison"]["source_refs"]
 
@@ -1002,7 +1004,7 @@ def test_workspace_endpoint_surfaces_persisted_policy_readiness_for_business_tri
     assert (
         payload["planner_panel_state"]["proposal"]["constraint_set_id"] == "policy-standard-2026-02"
     )
-    assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Policy posture loaded"
+    assert payload["planner_panel_state"]["outputs"][-1]["title"] == "Approval readiness loaded"
     assert payload["planner_panel_state"]["next_step_actions"][0]["target_section"] == "approval"
     assert "Navan" in payload["planner_panel_state"]["policy_evaluation"]["notes"][-2]
 
@@ -1245,7 +1247,7 @@ def test_workspace_endpoint_prefers_persisted_proposal_lifecycle_for_business_tr
         payload["planner_panel_state"]["policy_evaluation"]["evaluation_id"] == "eval-approved-001"
     )
     titles = [item["title"] for item in payload["planner_panel_state"]["outputs"]]
-    assert "Proposal lifecycle loaded" in titles
+    assert "Approval packet loaded" in titles
     assert "Approval-ready proposal" in titles
     assert payload["proposal_state"]["follow_up"]["status"] == "resolved"
 
@@ -1357,7 +1359,7 @@ def test_workspace_endpoint_does_not_mix_policy_preview_with_pending_proposal_st
     payload = response.json()
     assert payload["planner_panel_state"]["proposal"]["proposal_id"] == f"proposal:{trip_id}"
     assert payload["planner_panel_state"]["policy_evaluation"] is None
-    assert "Policy posture loaded" not in [
+    assert "Approval readiness loaded" not in [
         item["title"] for item in payload["planner_panel_state"]["outputs"]
     ]
 
@@ -1688,8 +1690,8 @@ def test_workspace_endpoint_surfaces_exception_follow_up_for_live_policy_results
 @pytest.mark.parametrize(
     ("error_code", "expected_title"),
     [
-        ("timeout", "Live TPP request timed out"),
-        ("breaker_open", "Live TPP breaker is open"),
+        ("timeout", "Approval service request timed out"),
+        ("breaker_open", "Approval service is temporarily unavailable"),
     ],
 )
 def test_workspace_endpoint_persists_transport_fallback_notice_for_live_submission_errors(
@@ -1817,8 +1819,8 @@ def test_workspace_endpoint_persists_transport_fallback_notice_for_live_submissi
     )
     assert fallback_output is not None
     assert fallback_output["title"] == expected_title
-    assert "stored-policy posture" in fallback_output["body"]
-    assert fallback_output["highlights"][0] == f"error_code={error_code}"
+    assert "latest saved approval information" in fallback_output["body"]
+    assert fallback_output["highlights"][0] == "Saved approval information is still available."
 
 
 def test_workspace_planner_decision_answer_persists_across_reload(client: TestClient) -> None:
@@ -1995,9 +1997,7 @@ def test_runtime_route_options_hold_blocked_scenarios_for_research() -> None:
                 _route_option_scenario(
                     "scenario:blocked", feasible=False, recommended=True, rank=1
                 ),
-                _route_option_scenario(
-                    "scenario:open", feasible=True, recommended=False, rank=2
-                ),
+                _route_option_scenario("scenario:open", feasible=True, recommended=False, rank=2),
             ],
         },
         session=None,
@@ -2006,9 +2006,7 @@ def test_runtime_route_options_hold_blocked_scenarios_for_research() -> None:
     blocked = comparison["scenarios"][0]
     assert blocked["status"] == "blocked"
     assert blocked["state"] == "needs_research"
-    assert "make_baseline" not in [
-        action["action_type"] for action in blocked["available_actions"]
-    ]
+    assert "make_baseline" not in [action["action_type"] for action in blocked["available_actions"]]
 
 
 def test_workspace_route_option_actions_update_comparison_and_ledger(
@@ -2101,8 +2099,7 @@ def test_workspace_route_option_actions_update_comparison_and_ledger(
     )
     assert reopened_row["state"] in {"active", "fallback"}
     assert any(
-        action["action_type"] == "make_baseline"
-        for action in reopened_row["available_actions"]
+        action["action_type"] == "make_baseline" for action in reopened_row["available_actions"]
     )
     assert f"reopened:{rejected_id}" not in json.dumps(reopened_payload)
 
@@ -2240,10 +2237,10 @@ def test_planner_panel_state_surfaces_stored_policy_fallback_notice_for_breaker_
         None,
     )
     assert fallback_output is not None
-    assert fallback_output["title"] == "Live TPP breaker is open"
-    assert "stored-policy posture" in fallback_output["body"]
+    assert fallback_output["title"] == "Approval service is temporarily unavailable"
+    assert "latest saved approval information" in fallback_output["body"]
     assert fallback_output["status"] == "caution"
-    assert fallback_output["highlights"][0] == "error_code=breaker_open"
+    assert fallback_output["highlights"][0] == "Saved approval information is still available."
 
 
 def test_planner_panel_state_surfaces_policy_sync_fallback_notice_for_breaker_open() -> None:
@@ -2282,10 +2279,10 @@ def test_planner_panel_state_surfaces_policy_sync_fallback_notice_for_breaker_op
         None,
     )
     assert fallback_output is not None
-    assert fallback_output["title"] == "Live TPP breaker is open"
-    assert "stored-policy posture" in fallback_output["body"]
+    assert fallback_output["title"] == "Approval service is temporarily unavailable"
+    assert "latest saved approval information" in fallback_output["body"]
     assert fallback_output["status"] == "caution"
-    assert fallback_output["highlights"][0] == "error_code=breaker_open"
+    assert fallback_output["highlights"][0] == "Saved approval information is still available."
 
 
 def test_planner_panel_state_surfaces_stored_policy_fallback_notice_for_timeout() -> None:
@@ -2324,10 +2321,10 @@ def test_planner_panel_state_surfaces_stored_policy_fallback_notice_for_timeout(
         None,
     )
     assert fallback_output is not None
-    assert fallback_output["title"] == "Live TPP request timed out"
-    assert "stored-policy posture" in fallback_output["body"]
+    assert fallback_output["title"] == "Approval service request timed out"
+    assert "latest saved approval information" in fallback_output["body"]
     assert fallback_output["status"] == "caution"
-    assert fallback_output["highlights"][0] == "error_code=timeout"
+    assert fallback_output["highlights"][0] == "Saved approval information is still available."
 
 
 def test_planner_panel_state_uses_submission_error_details_code_for_timeout_fallback() -> None:
@@ -2366,10 +2363,10 @@ def test_planner_panel_state_uses_submission_error_details_code_for_timeout_fall
         None,
     )
     assert fallback_output is not None
-    assert fallback_output["title"] == "Live TPP request timed out"
-    assert "stored-policy posture" in fallback_output["body"]
+    assert fallback_output["title"] == "Approval service request timed out"
+    assert "latest saved approval information" in fallback_output["body"]
     assert fallback_output["status"] == "caution"
-    assert fallback_output["highlights"][0] == "error_code=timeout"
+    assert fallback_output["highlights"][0] == "Saved approval information is still available."
 
 
 def test_planner_panel_state_surfaces_stored_policy_fallback_notice_for_evaluation_timeout() -> (
@@ -2410,10 +2407,10 @@ def test_planner_panel_state_surfaces_stored_policy_fallback_notice_for_evaluati
         None,
     )
     assert fallback_output is not None
-    assert fallback_output["title"] == "Live TPP request timed out"
-    assert "stored-policy posture" in fallback_output["body"]
+    assert fallback_output["title"] == "Approval service request timed out"
+    assert "latest saved approval information" in fallback_output["body"]
     assert fallback_output["status"] == "caution"
-    assert fallback_output["highlights"][0] == "error_code=timeout"
+    assert fallback_output["highlights"][0] == "Saved approval information is still available."
 
 
 def test_planner_panel_state_surfaces_policy_sync_fallback_notice_for_timeout() -> None:
@@ -2452,10 +2449,10 @@ def test_planner_panel_state_surfaces_policy_sync_fallback_notice_for_timeout() 
         None,
     )
     assert fallback_output is not None
-    assert fallback_output["title"] == "Live TPP request timed out"
-    assert "stored-policy posture" in fallback_output["body"]
+    assert fallback_output["title"] == "Approval service request timed out"
+    assert "latest saved approval information" in fallback_output["body"]
     assert fallback_output["status"] == "caution"
-    assert fallback_output["highlights"][0] == "error_code=timeout"
+    assert fallback_output["highlights"][0] == "Saved approval information is still available."
 
 
 def _load_feasibility_fixture(name: str) -> InventoryBundle:
@@ -2526,9 +2523,9 @@ def _assert_user_summary_avoids_raw_runtime_language(view_model: dict[str, Any])
     for value in user_facing_strings:
         lowered = value.lower()
         for token in _RAW_DEBUG_TOKENS_FORBIDDEN_IN_USER_COPY:
-            assert token not in lowered, (
-                f"User-facing view-model copy must not leak '{token}': {value!r}"
-            )
+            assert (
+                token not in lowered
+            ), f"User-facing view-model copy must not leak '{token}': {value!r}"
 
 
 def test_workspace_endpoint_includes_typed_view_model_for_leisure_trip(
@@ -2552,6 +2549,14 @@ def test_workspace_endpoint_includes_typed_view_model_for_leisure_trip(
     assert next_step["summary"]
 
     assert view_model["business_summary"] is None
+    assert view_model["panel_visibility"] == {
+        "show_budget_panel": True,
+        "show_policy_posture": False,
+        "show_proposal_panel": False,
+        "show_approval_readiness_panel": False,
+    }
+    assert view_model["policy_presentation"]["active_policy_state"] is False
+    assert view_model["policy_presentation"]["posture_label"] == "Not applicable"
 
     debug_state = view_model["debug_state"]
     assert "runtime_state" in debug_state["sections"]
@@ -2588,6 +2593,18 @@ def test_workspace_endpoint_includes_typed_view_model_for_business_trip(
         "needs_attention",
     }
     assert business_summary["headline"]
+    assert view_model["panel_visibility"]["show_policy_posture"] is True
+    assert view_model["panel_visibility"]["show_proposal_panel"] is True
+    assert view_model["panel_visibility"]["show_approval_readiness_panel"] is True
+    assert view_model["policy_presentation"]["posture_label"] in {
+        "Approval not started",
+        "Ready for approval",
+        "Waiting for policy review",
+        "Needs exception",
+        "Needs follow-up",
+        "Not ready for approval",
+        "Policy state available",
+    }
 
     debug_state = view_model["debug_state"]
     assert "runtime_state" in debug_state["sections"]
@@ -2612,6 +2629,38 @@ def test_workspace_view_model_builder_handles_empty_runtime_state() -> None:
     assert view_model["next_step"]["blocked"] is True
     assert view_model["business_summary"] is None
     assert view_model["debug_state"]["sections"]["runtime_state"]["payload"]["status"] == "empty"
+
+
+def test_workspace_view_model_keeps_active_leisure_policy_state_visible() -> None:
+    payload = {
+        "trip_record": {
+            "trip": {"title": "Leisure exception workspace", "mode": "leisure"},
+        },
+        "runtime_state": {"status": "ready", "title": "Ready", "summary": "Ready"},
+        "saved_scenarios": [{"saved_scenario_id": "scenario-1"}],
+        "inventory_summary": {"bundle_count": 1},
+        "feasibility_summary": {"attention_bundle_count": 0},
+        "proposal_state": {
+            "execution_id": "exec-active-leisure",
+            "submission_status": "submitted",
+            "evaluation_status": "completed",
+            "summary": {
+                "submission_status": "submitted",
+                "evaluation_result_status": "failed",
+                "follow_up_status": "exception_required",
+                "approval_ready": False,
+                "highlights": ["A lodging exception needs review."],
+            },
+        },
+    }
+
+    view_model = workspace_service._build_workspace_view_model(payload)
+
+    assert view_model["business_summary"] is None
+    assert view_model["panel_visibility"]["show_policy_posture"] is True
+    assert view_model["panel_visibility"]["show_proposal_panel"] is True
+    assert view_model["policy_presentation"]["posture_label"] == "Needs exception"
+    assert "proposal_state" in view_model["debug_state"]["sections"]
 
 
 def test_workspace_view_model_debug_sections_preserve_raw_payload_shapes() -> None:

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -55,9 +55,7 @@ class WorkspaceUserSummary(BaseModel):
     trip_mode: Literal["leisure", "business"] = Field(
         description="Workspace product mode used to gate user-facing copy."
     )
-    mode_label: str = Field(
-        description="User-friendly mode label (e.g. 'Leisure trip')."
-    )
+    mode_label: str = Field(description="User-friendly mode label (e.g. 'Leisure trip').")
     status: Literal["ready", "partial", "empty"] = Field(
         description="High-level workspace status used for top-level framing."
     )
@@ -108,6 +106,25 @@ class WorkspaceBusinessSummary(BaseModel):
     )
 
 
+class WorkspacePanelVisibility(BaseModel):
+    """Mode-aware rules for normal workspace panels."""
+
+    show_budget_panel: bool = True
+    show_policy_posture: bool = False
+    show_proposal_panel: bool = False
+    show_approval_readiness_panel: bool = False
+
+
+class WorkspacePolicyPresentation(BaseModel):
+    """User-facing policy/proposal state labels for the normal workspace."""
+
+    active_policy_state: bool = False
+    posture_label: str = "Not applicable"
+    approval_status_label: str = "Not applicable"
+    next_step_label: str = "No policy action needed"
+    summary: str = "Policy approval is not part of this workspace yet."
+
+
 class WorkspaceDebugSection(BaseModel):
     """A named debug-only payload section that mirrors raw runtime state."""
 
@@ -141,6 +158,10 @@ class WorkspaceViewModel(BaseModel):
 
     user_summary: WorkspaceUserSummary
     next_step: WorkspaceNextStep
+    panel_visibility: WorkspacePanelVisibility = Field(default_factory=WorkspacePanelVisibility)
+    policy_presentation: WorkspacePolicyPresentation = Field(
+        default_factory=WorkspacePolicyPresentation
+    )
     business_summary: WorkspaceBusinessSummary | None = None
     debug_state: WorkspaceDebugState
 

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -140,9 +140,7 @@ def _load_saved_scenarios(
     payload = _load_json(_state_fixture_dir("scenarios") / name)
     records = [SavedScenarioRecord.from_dict(item) for item in payload["records"]]
     comparison = payload.get("comparison")
-    return records, (
-        ScenarioComparison.from_dict(comparison) if comparison is not None else None
-    )
+    return records, (ScenarioComparison.from_dict(comparison) if comparison is not None else None)
 
 
 def _load_session(name: str) -> PlanningSessionState:
@@ -164,8 +162,7 @@ def _canonicalize_saved_scenario_ids(
         matches = [
             record.saved_scenario_id
             for record in saved_scenarios
-            if set(record.saved_scenario_id.split(":")[-1].split("-"))
-            == candidate_tokens
+            if set(record.saved_scenario_id.split(":")[-1].split("-")) == candidate_tokens
         ]
         if len(matches) == 1:
             return matches[0]
@@ -173,9 +170,7 @@ def _canonicalize_saved_scenario_ids(
 
     session.current_saved_scenario_id = normalize(session.current_saved_scenario_id)
     for decision in session.pending_decisions:
-        decision.related_saved_scenario_id = normalize(
-            decision.related_saved_scenario_id
-        )
+        decision.related_saved_scenario_id = normalize(decision.related_saved_scenario_id)
 
 
 def _leisure_search_result(trip_id: str) -> ScenarioSearchResult:
@@ -261,9 +256,7 @@ def _leisure_search_result(trip_id: str) -> ScenarioSearchResult:
                         summary="The fallback opens more nightlife at the cost of extra transfers.",
                         factor_keys=["breadth", "transfer_cost"],
                         machine_context={"planner_mode": "leisure"},
-                        human_summary=[
-                            "Broader exploration, slightly more travel fatigue."
-                        ],
+                        human_summary=["Broader exploration, slightly more travel fatigue."],
                         source_refs=["ranked-results:kyoto-spring"],
                     )
                 ],
@@ -368,7 +361,7 @@ def _business_search_result(trip_id: str) -> ScenarioSearchResult:
             ),
         ],
         explanation=[
-            "Business timeline still derives from route order; policy posture is communicated via scenario tradeoffs."
+            "Business timeline still derives from route order; approval posture is communicated via scenario tradeoffs."
         ],
         source_refs=["ranked-results:client-summit", "objective:client-summit"],
     )
@@ -488,9 +481,7 @@ def _route_option_variant(
             "severity": "warning",
             "blocking": False,
             "related_ids": [str(base_scenario.get("scenario_id") or "")],
-            "notes": [
-                "Generated as a rough comparison route until deeper planner research runs."
-            ],
+            "notes": ["Generated as a rough comparison route until deeper planner research runs."],
         },
     ]
     generated["notes"] = [
@@ -643,9 +634,7 @@ def _comparison_highlights(
     lead: dict[str, Any],
 ) -> list[str]:
     summary = scenario["scenario_summary"]
-    route_sequence = (
-        " -> ".join(summary.get("route_sequence") or []) or "route sequence pending"
-    )
+    route_sequence = " -> ".join(summary.get("route_sequence") or []) or "route sequence pending"
     highlights = [
         f"Route: {route_sequence}.",
         f"Travel {summary['total_travel_minutes']} minutes with {summary['total_transfer_count']} transfer(s).",
@@ -655,12 +644,10 @@ def _comparison_highlights(
     else:
         score_delta = round(float(scenario["score"]) - float(lead["score"]), 2)
         travel_delta = (
-            summary["total_travel_minutes"]
-            - lead["scenario_summary"]["total_travel_minutes"]
+            summary["total_travel_minutes"] - lead["scenario_summary"]["total_travel_minutes"]
         )
         transfers_delta = (
-            summary["total_transfer_count"]
-            - lead["scenario_summary"]["total_transfer_count"]
+            summary["total_transfer_count"] - lead["scenario_summary"]["total_transfer_count"]
         )
         delta_parts = [f"Score {score_delta:+.2f} versus the lead scenario."]
         if travel_delta:
@@ -669,9 +656,7 @@ def _comparison_highlights(
             delta_parts.append(f"Transfers {transfers_delta:+d} versus lead.")
         estimated_total_delta = _estimated_total_delta(scenario, lead)
         if estimated_total_delta is not None:
-            delta_parts.append(
-                f"Estimated total {estimated_total_delta:+.2f} versus lead."
-            )
+            delta_parts.append(f"Estimated total {estimated_total_delta:+.2f} versus lead.")
         highlights.append(" ".join(delta_parts))
     highlights.extend(
         tradeoff["summary"] for tradeoff in scenario.get("unresolved_tradeoffs", [])[:2]
@@ -689,10 +674,7 @@ def _latest_presentation_for_option_set(
     if not isinstance(presentations, list):
         return None
     for presentation in reversed(presentations):
-        if (
-            isinstance(presentation, dict)
-            and presentation.get("option_set_id") == option_set_id
-        ):
+        if isinstance(presentation, dict) and presentation.get("option_set_id") == option_set_id:
             return presentation
     return None
 
@@ -715,9 +697,7 @@ def _session_route_option_state(
         return set(), None, set(), set()
 
     rejected_option_ids = {
-        item
-        for item in presentation.get("rejected_option_ids", [])
-        if isinstance(item, str)
+        item for item in presentation.get("rejected_option_ids", []) if isinstance(item, str)
     }
     selected_option_id = presentation.get("selected_option_id")
     if not isinstance(selected_option_id, str) or selected_option_id == "":
@@ -765,9 +745,7 @@ def _route_option_purpose(*, state: str, status: str, scenario: dict[str, Any]) 
     if state == "rejected":
         return f"Keep {title} in history so the reason for rejecting it is not lost."
     if state == "needs_research":
-        return (
-            f"Send {title} back for a focused revision before treating it as settled."
-        )
+        return f"Send {title} back for a focused revision before treating it as settled."
     if status == "recommended":
         return f"Compare {title} as a strong candidate before making it the baseline."
     return f"Compare {title} as an active alternative while the route is still taking shape."
@@ -791,9 +769,7 @@ def _route_option_confidence(*, scenario: dict[str, Any], state: str) -> float:
     return round(max(0.05, min(confidence, 0.98)), 2)
 
 
-def _route_option_unresolved_questions(
-    *, scenario: dict[str, Any], state: str
-) -> list[str]:
+def _route_option_unresolved_questions(*, scenario: dict[str, Any], state: str) -> list[str]:
     summary = scenario.get("scenario_summary") or {}
     questions: list[str] = []
     if not summary.get("route_sequence"):
@@ -805,9 +781,7 @@ def _route_option_unresolved_questions(
         if isinstance(tradeoff_summary, str) and tradeoff_summary:
             questions.append(f"Can this tradeoff work for the trip: {tradeoff_summary}")
     if state == "needs_research":
-        questions.append(
-            "What should the planner change before comparing this route again?"
-        )
+        questions.append("What should the planner change before comparing this route again?")
     return questions[:3]
 
 
@@ -901,18 +875,14 @@ def _build_runtime_scenario_comparison(
         }
 
     scenario_ids = {scenario["scenario_id"] for scenario in scenarios}
-    if (
-        selected_option_id not in scenario_ids
-        or selected_option_id in rejected_option_ids
-    ):
+    if selected_option_id not in scenario_ids or selected_option_id in rejected_option_ids:
         selected_option_id = None
     lead = (
         next(
             (
                 scenario
                 for scenario in scenarios
-                if selected_option_id is not None
-                and scenario["scenario_id"] == selected_option_id
+                if selected_option_id is not None and scenario["scenario_id"] == selected_option_id
             ),
             None,
         )
@@ -979,9 +949,7 @@ def _build_runtime_scenario_comparison(
                     "estimated_total": estimated_total,
                 },
                 "delta": {
-                    "score_delta": round(
-                        float(scenario["score"]) - float(lead["score"]), 2
-                    ),
+                    "score_delta": round(float(scenario["score"]) - float(lead["score"]), 2),
                     "travel_minutes_delta": (
                         summary["total_travel_minutes"]
                         - lead["scenario_summary"]["total_travel_minutes"]
@@ -1104,16 +1072,12 @@ def _default_workspace_decisions(trip_id: str) -> list[PendingDecision]:
             ],
             blocking=True,
             related_option_set_id=f"option-set:{trip_id}:workspace-bootstrap",
-            notes=[
-                "Workspace bootstrap decision seeded for persisted planner interaction."
-            ],
+            notes=["Workspace bootstrap decision seeded for persisted planner interaction."],
         )
     ]
 
 
-def _default_workspace_presentation(
-    trip_id: str, shown_at: str
-) -> OptionPresentationRecord:
+def _default_workspace_presentation(trip_id: str, shown_at: str) -> OptionPresentationRecord:
     return OptionPresentationRecord(
         presentation_id=f"presentation:{trip_id}:workspace-bootstrap",
         option_set_id=f"option-set:{trip_id}:workspace-bootstrap",
@@ -1139,9 +1103,7 @@ def _default_workspace_session(record: PersistedTrip) -> PlanningSessionState:
         mode=record.mode,
         started_at=_isoformat(record.created_at),
         updated_at=timestamp,
-        recent_option_presentations=[
-            _default_workspace_presentation(record.trip_id, timestamp)
-        ],
+        recent_option_presentations=[_default_workspace_presentation(record.trip_id, timestamp)],
         pending_decisions=_default_workspace_decisions(record.trip_id),
         activity_log_id=f"activity-log:{record.trip_id}",
         active_budget_plan_id=record.budget_state_id,
@@ -1282,15 +1244,11 @@ def _bootstrap_saved_scenario_records(
                         "keeps a broader comparison lane available."
                     ),
                     "focus_areas": ["scope", "comparison-readiness"],
-                    "notes": [
-                        "Bootstrap comparison scaffold for persisted workspace rendering."
-                    ],
+                    "notes": ["Bootstrap comparison scaffold for persisted workspace rendering."],
                 }
             ],
             "tags": ["workspace-bootstrap", "preferred"],
-            "notes": [
-                "Created automatically during the first persisted workspace bootstrap."
-            ],
+            "notes": ["Created automatically during the first persisted workspace bootstrap."],
         }
     )
     fallback = SavedScenarioRecord.from_dict(
@@ -1316,9 +1274,7 @@ def _bootstrap_saved_scenario_records(
             ],
             "comparisons": [],
             "tags": ["workspace-bootstrap", "fallback"],
-            "notes": [
-                "Created automatically during the first persisted workspace bootstrap."
-            ],
+            "notes": ["Created automatically during the first persisted workspace bootstrap."],
         }
     )
     return baseline, fallback
@@ -1421,13 +1377,9 @@ def _build_saved_scenario_runtime_search(
                     "route_sequence": route_sequence,
                     "notes": list(version.get("notes") or []),
                 },
-                "supporting_option_ids": list(
-                    version["snapshot_refs"].get("option_set_ids") or []
-                ),
+                "supporting_option_ids": list(version["snapshot_refs"].get("option_set_ids") or []),
                 "objective_refs": [
-                    ref
-                    for ref in [version["snapshot_refs"].get("objective_id")]
-                    if ref is not None
+                    ref for ref in [version["snapshot_refs"].get("objective_id")] if ref is not None
                 ],
                 "unresolved_tradeoffs": (
                     [
@@ -1595,9 +1547,8 @@ def _build_persisted_trip_workspace(
             inventory_status=inventory_status,
         )
     )
-    resolved_feasibility_summary = (
-        feasibility_summary
-        or build_feasibility_summary_payload(resolved_inventory_bundles)
+    resolved_feasibility_summary = feasibility_summary or build_feasibility_summary_payload(
+        resolved_inventory_bundles
     )
     runtime_scenario_comparison = _build_runtime_scenario_comparison(
         trip_id=record.trip_id,
@@ -1694,6 +1645,126 @@ _DEBUG_PAYLOAD_KEYS: tuple[str, ...] = (
 )
 
 
+def _workspace_policy_state_is_active(
+    *,
+    policy_state: Any,
+    proposal_state: Any,
+) -> bool:
+    if isinstance(policy_state, dict) and policy_state:
+        return True
+    if not isinstance(proposal_state, dict) or not proposal_state:
+        return False
+
+    summary = proposal_state.get("summary") or {}
+    summary = summary if isinstance(summary, dict) else {}
+    if proposal_state.get("execution_id"):
+        return True
+    if summary.get("approval_ready"):
+        return True
+    if summary.get("evaluation_result_status") or summary.get("follow_up_status"):
+        return True
+    submission_status = str(
+        summary.get("submission_status") or proposal_state.get("submission_status") or ""
+    ).lower()
+    evaluation_status = str(
+        summary.get("evaluation_transport_status") or proposal_state.get("evaluation_status") or ""
+    ).lower()
+    return submission_status not in {"", "pending"} or evaluation_status not in {
+        "",
+        "pending",
+    }
+
+
+def _workspace_approval_status(
+    proposal_state: dict[str, Any],
+) -> tuple[str, str, list[str]]:
+    proposal_summary = proposal_state.get("summary") or {}
+    proposal_summary = proposal_summary if isinstance(proposal_summary, dict) else {}
+    approval_ready = bool(proposal_summary.get("approval_ready"))
+    follow_up_status = str(proposal_summary.get("follow_up_status") or "").lower()
+    evaluation_status = str(
+        proposal_summary.get("evaluation_result_status")
+        or proposal_summary.get("submission_status")
+        or ""
+    ).lower()
+
+    if approval_ready:
+        return "approved", "Your trip is ready for approval.", []
+    if evaluation_status in {"in_review", "pending", "submitted"}:
+        return "in_review", "Your trip approval is in review.", []
+    if evaluation_status in {"failed", "rejected", "needs_attention"} or follow_up_status in {
+        "exception_required",
+        "reoptimization_required",
+        "remediation_required",
+    }:
+        blockers = [
+            str(item)
+            for item in (proposal_summary.get("highlights") or [])
+            if isinstance(item, str)
+        ]
+        return "needs_attention", "Approval needs your attention.", blockers
+    if proposal_state:
+        return "not_ready", "Approval is not ready yet.", []
+    return "not_applicable", "Approval is not required yet.", []
+
+
+def _policy_presentation_for_workspace(
+    *,
+    active_policy_state: bool,
+    proposal_state: Any,
+) -> dict[str, Any]:
+    if not active_policy_state:
+        return {
+            "active_policy_state": False,
+            "posture_label": "Not applicable",
+            "approval_status_label": "Not applicable",
+            "next_step_label": "No policy action needed",
+            "summary": "Policy approval is not part of this workspace yet.",
+        }
+
+    proposal_state = proposal_state if isinstance(proposal_state, dict) else {}
+    if not proposal_state:
+        return {
+            "active_policy_state": True,
+            "posture_label": "Approval not started",
+            "approval_status_label": "Approval not started",
+            "next_step_label": "Build approval packet",
+            "summary": "No approval packet has been submitted yet.",
+        }
+
+    approval_status, headline, blockers = _workspace_approval_status(proposal_state)
+    summary = proposal_state.get("summary") or {}
+    summary = summary if isinstance(summary, dict) else {}
+    follow_up_status = str(summary.get("follow_up_status") or "").lower()
+
+    if approval_status == "approved":
+        posture_label = "Ready for approval"
+        next_step_label = "Prepare approval packet"
+    elif follow_up_status == "exception_required":
+        posture_label = "Needs exception"
+        next_step_label = "Review exception request"
+    elif approval_status == "needs_attention":
+        posture_label = "Needs follow-up"
+        next_step_label = "Resolve policy follow-up"
+    elif approval_status == "in_review":
+        posture_label = "Waiting for policy review"
+        next_step_label = "Wait for policy review"
+    elif approval_status == "not_ready":
+        posture_label = "Not ready for approval"
+        next_step_label = "Complete approval packet"
+    else:
+        posture_label = "Policy state available"
+        next_step_label = "Review policy details"
+
+    return {
+        "active_policy_state": True,
+        "posture_label": posture_label,
+        "approval_status_label": posture_label,
+        "next_step_label": next_step_label,
+        "summary": " ".join([headline, *blockers[:1]]).strip(),
+    }
+
+
 def _build_workspace_view_model(
     payload: dict[str, Any],
     *,
@@ -1727,9 +1798,7 @@ def _build_workspace_view_model(
     saved_scenarios = payload.get("saved_scenarios") or []
     saved_scenarios = saved_scenarios if isinstance(saved_scenarios, list) else []
     feasibility_summary = payload.get("feasibility_summary") or {}
-    feasibility_summary = (
-        feasibility_summary if isinstance(feasibility_summary, dict) else {}
-    )
+    feasibility_summary = feasibility_summary if isinstance(feasibility_summary, dict) else {}
 
     decided: list[str] = []
     if saved_scenarios:
@@ -1752,9 +1821,7 @@ def _build_workspace_view_model(
     if status == "ready":
         headline = "Your trip plan is ready to review."
         next_step_title = "Review and pick a scenario"
-        next_step_summary = (
-            "Compare the saved scenarios and choose one to keep planning around."
-        )
+        next_step_summary = "Compare the saved scenarios and choose one to keep planning around."
         next_step_action = "Open scenario comparison"
         next_step_target = "scenario-comparison"
         blocked = False
@@ -1771,9 +1838,7 @@ def _build_workspace_view_model(
     else:
         headline = "Trip planning hasn't started yet."
         next_step_title = "Start planning"
-        next_step_summary = (
-            "Add the missing trip context to start assembling scenarios."
-        )
+        next_step_summary = "Add the missing trip context to start assembling scenarios."
         next_step_action = "Open trip setup"
         next_step_target = "trip-setup"
         blocked = True
@@ -1796,45 +1861,29 @@ def _build_workspace_view_model(
         "blocked": blocked,
     }
 
+    policy_state = payload.get("policy_state")
+    proposal_state_value = payload.get("proposal_state")
+    active_policy_state = _workspace_policy_state_is_active(
+        policy_state=policy_state,
+        proposal_state=proposal_state_value,
+    )
+    show_policy_panels = resolved_mode == "business" or active_policy_state
+    panel_visibility = {
+        "show_budget_panel": True,
+        "show_policy_posture": show_policy_panels,
+        "show_proposal_panel": show_policy_panels,
+        "show_approval_readiness_panel": show_policy_panels,
+    }
+    policy_presentation = _policy_presentation_for_workspace(
+        active_policy_state=show_policy_panels,
+        proposal_state=proposal_state_value,
+    )
+
     business_summary: dict[str, Any] | None = None
     if resolved_mode == "business":
         proposal_state = payload.get("proposal_state") or {}
         proposal_state = proposal_state if isinstance(proposal_state, dict) else {}
-        proposal_summary = proposal_state.get("summary") or {}
-        proposal_summary = (
-            proposal_summary if isinstance(proposal_summary, dict) else {}
-        )
-        approval_ready = bool(proposal_summary.get("approval_ready"))
-        evaluation_status = str(
-            proposal_summary.get("evaluation_result_status")
-            or proposal_summary.get("submission_status")
-            or ""
-        ).lower()
-
-        if approval_ready:
-            approval_status = "approved"
-            approval_headline = "Your trip is ready for approval."
-            blockers: list[str] = []
-        elif evaluation_status in {"in_review", "pending", "submitted"}:
-            approval_status = "in_review"
-            approval_headline = "Your trip approval is in review."
-            blockers = []
-        elif evaluation_status in {"failed", "rejected", "needs_attention"}:
-            approval_status = "needs_attention"
-            approval_headline = "Approval needs your attention."
-            blockers = [
-                str(item)
-                for item in (proposal_summary.get("highlights") or [])
-                if isinstance(item, str)
-            ]
-        elif proposal_state:
-            approval_status = "not_ready"
-            approval_headline = "Approval is not ready yet."
-            blockers = []
-        else:
-            approval_status = "not_applicable"
-            approval_headline = "Approval is not required yet."
-            blockers = []
+        approval_status, approval_headline, blockers = _workspace_approval_status(proposal_state)
 
         business_summary = {
             "approval_status": approval_status,
@@ -1855,6 +1904,8 @@ def _build_workspace_view_model(
     return {
         "user_summary": user_summary,
         "next_step": next_step,
+        "panel_visibility": panel_visibility,
+        "policy_presentation": policy_presentation,
         "business_summary": business_summary,
         "debug_state": {"sections": debug_sections},
     }
@@ -1903,9 +1954,7 @@ def _build_workspace_runtime_state(
         }
     return {
         "status": str(inventory_runtime_state.get("status") or "empty"),
-        "title": str(
-            inventory_runtime_state.get("title") or "Workspace runtime is still empty"
-        ),
+        "title": str(inventory_runtime_state.get("title") or "Workspace runtime is still empty"),
         "summary": str(
             inventory_runtime_state.get("summary")
             or "Trip context is not complete enough for runtime workspace assembly yet."
@@ -1983,12 +2032,8 @@ def _build_runtime_scenario_comparison_payload(
         }
         for scenario in persisted_saved_scenarios_records
     ]
-    persisted_inventory_bundles, inventory_summary = _build_workspace_inventory_inputs(
-        record
-    )
-    inventory_status = str(
-        (inventory_summary.get("runtime_state") or {}).get("status") or "empty"
-    )
+    persisted_inventory_bundles, inventory_summary = _build_workspace_inventory_inputs(record)
+    inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
     return _build_runtime_scenario_comparison(
         trip_id=trip_id,
         trip_title=record.title,
@@ -2155,9 +2200,7 @@ def _build_planner_panel_state(
 ) -> dict[str, Any]:
     scenarios = list(scenario_search.get("scenarios", []))
     primary_regions = list(trip["trip_frame"].get("primary_regions") or [])
-    region_summary = (
-        ", ".join(primary_regions[:2]) if primary_regions else "the current trip frame"
-    )
+    region_summary = ", ".join(primary_regions[:2]) if primary_regions else "the current trip frame"
 
     if scenarios:
         option_set = {
@@ -2190,12 +2233,9 @@ def _build_planner_panel_state(
                     "label": scenario["title"],
                     "summary": scenario["scenario_summary"]["headline"],
                     "drawbacks": [
-                        tradeoff["summary"]
-                        for tradeoff in scenario.get("unresolved_tradeoffs", [])
+                        tradeoff["summary"] for tradeoff in scenario.get("unresolved_tradeoffs", [])
                     ]
-                    or [
-                        "No explicit unresolved tradeoffs were recorded for this scenario yet."
-                    ],
+                    or ["No explicit unresolved tradeoffs were recorded for this scenario yet."],
                     "explanation": [
                         f"Rank #{scenario['rank']} with score {scenario['score']:.2f}.",
                         f"Route sequence: {' -> '.join(scenario['scenario_summary'].get('route_sequence', [])) or 'not surfaced yet'}.",
@@ -2259,9 +2299,7 @@ def _build_planner_panel_state(
                     "kind": "trip_setup",
                     "label": "Broaden the first planner pass",
                     "summary": "Expand regions, dates, or traveler notes before the first ranked scenario run.",
-                    "drawbacks": [
-                        "A broader scope can delay the first saved scenario comparison."
-                    ],
+                    "drawbacks": ["A broader scope can delay the first saved scenario comparison."],
                     "explanation": [
                         "Best when the trip shell is real but still intentionally under-specified.",
                     ],
@@ -2294,11 +2332,9 @@ def _build_planner_panel_state(
             },
         ]
 
-    rejected_option_ids, selected_option_id, fallback_option_ids = (
-        _session_feedback_state(
-            session,
-            option_set["option_set_id"],
-        )
+    rejected_option_ids, selected_option_id, fallback_option_ids = _session_feedback_state(
+        session,
+        option_set["option_set_id"],
     )
     option_set["options"] = [
         {
@@ -2313,13 +2349,10 @@ def _build_planner_panel_state(
                 )
             ),
             "explanation": (
-                ["You already chose this direction in the workspace."]
-                + option["explanation"]
+                ["You already chose this direction in the workspace."] + option["explanation"]
                 if option["option_id"] == selected_option_id
                 else (
-                    [
-                        "This option was kept as an explicit fallback for later comparison."
-                    ]
+                    ["This option was kept as an explicit fallback for later comparison."]
                     + option["explanation"]
                     if option["option_id"] in fallback_option_ids
                     else option["explanation"]
@@ -2337,8 +2370,7 @@ def _build_planner_panel_state(
             "prompt": decision["prompt"],
             "choices": (
                 list(decision["choices"])
-                if isinstance(decision.get("choices"), (list, tuple))
-                and decision["choices"]
+                if isinstance(decision.get("choices"), (list, tuple)) and decision["choices"]
                 else [
                     "Keep the current direction.",
                     "Compare another planner-backed option first.",
@@ -2394,8 +2426,7 @@ def _build_planner_panel_state(
 
     proposal_state = (
         dict(proposal_context["proposal_state"])
-        if proposal_context is not None
-        and proposal_context.get("proposal_state") is not None
+        if proposal_context is not None and proposal_context.get("proposal_state") is not None
         else None
     )
     if proposal_state is not None:
@@ -2406,15 +2437,12 @@ def _build_planner_panel_state(
             else None
         )
         proposal = (
-            dict(proposal_state["proposal"])
-            if proposal_state.get("proposal") is not None
-            else None
+            dict(proposal_state["proposal"]) if proposal_state.get("proposal") is not None else None
         )
     else:
         policy_evaluation = (
             dict(policy_context["policy_evaluation"])
-            if policy_context is not None
-            and policy_context.get("policy_evaluation") is not None
+            if policy_context is not None and policy_context.get("policy_evaluation") is not None
             else None
         )
         proposal = (
@@ -2426,16 +2454,14 @@ def _build_planner_panel_state(
         outputs.append(
             {
                 "output_id": f"output:{trip['trip_id']}:policy-ready",
-                "title": "Policy posture loaded",
-                "body": "The workspace is using persisted policy inputs instead of mock approval-readiness state.",
+                "title": "Approval readiness loaded",
+                "body": "The workspace is using saved approval inputs instead of placeholder readiness state.",
                 "tags": ["policy", "workspace", trip["mode"]],
                 "status": (
                     "positive"
                     if policy_evaluation["status"] == "compliant"
                     else (
-                        "critical"
-                        if policy_evaluation["status"] == "non_compliant"
-                        else "caution"
+                        "critical" if policy_evaluation["status"] == "non_compliant" else "caution"
                     )
                 ),
                 "highlights": list(policy_evaluation.get("notes") or [])[:3],
@@ -2446,16 +2472,14 @@ def _build_planner_panel_state(
             {
                 "action_id": f"action:{trip['trip_id']}:review-policy",
                 "action_kind": "prepare_approval",
-                "label": "Review policy posture",
-                "description": "Inspect imported policy constraints and approval-readiness before moving to submission work.",
+                "label": "Review approval readiness",
+                "description": "Inspect saved approval constraints and readiness before moving to submission work.",
                 "emphasis": "primary",
                 "target_section": "approval",
             },
         )
     policy_summary = (
-        dict(policy_context.get("summary") or {})
-        if isinstance(policy_context, dict)
-        else {}
+        dict(policy_context.get("summary") or {}) if isinstance(policy_context, dict) else {}
     )
     policy_transport_error = (
         dict(policy_summary.get("transport_error") or {})
@@ -2463,23 +2487,21 @@ def _build_planner_panel_state(
         else {}
     )
     policy_error_code = policy_transport_error.get("error_code")
-    if policy_summary.get(
-        "status"
-    ) == "stored_policy_fallback" and policy_error_code in {
+    if policy_summary.get("status") == "stored_policy_fallback" and policy_error_code in {
         "breaker_open",
         "timeout",
     }:
         if policy_error_code == "breaker_open":
-            notice_title = "Live TPP breaker is open"
+            notice_title = "Approval service is temporarily unavailable"
             notice_body = (
-                "Live policy sync transport is temporarily unavailable. The workspace is using "
-                "stored-policy posture until the breaker reset window elapses."
+                "The workspace is using the latest saved approval information while the live "
+                "service recovers."
             )
         else:
-            notice_title = "Live TPP request timed out"
+            notice_title = "Approval service request timed out"
             notice_body = (
-                "Live policy sync transport timed out. The workspace is using stored-policy "
-                "posture while live transport recovers."
+                "The workspace is using the latest saved approval information while the live "
+                "service recovers."
             )
         outputs.append(
             {
@@ -2489,8 +2511,8 @@ def _build_planner_panel_state(
                 "tags": ["policy", "transport", "stored-policy", trip["mode"]],
                 "status": "caution",
                 "highlights": [
-                    f"error_code={policy_error_code}",
-                    str(policy_transport_error.get("message") or ""),
+                    "Saved approval information is still available.",
+                    "Retry the live approval refresh later.",
                 ],
             }
         )
@@ -2500,17 +2522,13 @@ def _build_planner_panel_state(
         outputs.append(
             {
                 "output_id": f"output:{trip['trip_id']}:proposal-lifecycle",
-                "title": "Proposal lifecycle loaded",
-                "body": "The workspace now carries persisted proposal submission and evaluation state.",
+                "title": "Approval packet loaded",
+                "body": "The workspace now carries saved approval packet and review state.",
                 "tags": ["proposal", "approval", trip["mode"]],
                 "status": (
                     "positive"
                     if summary.get("approval_ready")
-                    else (
-                        "caution"
-                        if summary.get("evaluation_transport_status")
-                        else "neutral"
-                    )
+                    else ("caution" if summary.get("evaluation_transport_status") else "neutral")
                 ),
                 "highlights": list(summary.get("highlights") or [])[:3],
             }
@@ -2526,16 +2544,16 @@ def _build_planner_panel_state(
             error_code = _transport_error_code(transport_error)
             if error_code in {"breaker_open", "timeout"}:
                 if error_code == "breaker_open":
-                    notice_title = "Live TPP breaker is open"
+                    notice_title = "Approval service is temporarily unavailable"
                     notice_body = (
-                        "Live policy transport is temporarily unavailable. The workspace is using "
-                        "stored-policy posture until the breaker reset window elapses."
+                        "The workspace is using the latest saved approval information while the "
+                        "live service recovers."
                     )
                 else:
-                    notice_title = "Live TPP request timed out"
+                    notice_title = "Approval service request timed out"
                     notice_body = (
-                        "Live policy transport timed out. The workspace is using stored-policy "
-                        "posture while live transport recovers."
+                        "The workspace is using the latest saved approval information while the "
+                        "live service recovers."
                     )
                 outputs.append(
                     {
@@ -2550,8 +2568,8 @@ def _build_planner_panel_state(
                         ],
                         "status": "caution",
                         "highlights": [
-                            f"error_code={error_code}",
-                            str(transport_error.get("message") or ""),
+                            "Saved approval information is still available.",
+                            "Retry the live approval refresh later.",
                         ],
                     }
                 )
@@ -2579,10 +2597,8 @@ def _build_planner_panel_state(
                 0,
                 {
                     "action_id": f"action:{trip['trip_id']}:proposal-follow-up",
-                    "action_kind": follow_up.get("recommended_action")
-                    or "review_follow_up",
-                    "label": follow_up.get("recommended_label")
-                    or "Review proposal follow-up",
+                    "action_kind": follow_up.get("recommended_action") or "review_follow_up",
+                    "label": follow_up.get("recommended_label") or "Review proposal follow-up",
                     "description": follow_up.get("summary")
                     or "Inspect the persisted follow-up lane for the latest policy result.",
                     "emphasis": "primary",
@@ -2612,9 +2628,7 @@ def _build_planner_panel_state(
                 1,
                 session["interaction_state"].get("auto_advance_research_passes", 1) + 1,
             ),
-            "target_options_before_checkpoint": max(
-                2, min(3, len(option_set["options"]))
-            ),
+            "target_options_before_checkpoint": max(2, min(3, len(option_set["options"]))),
             "surface_options_early": session["interaction_state"].get(
                 "option_preview_timing",
                 "balanced",
@@ -2643,9 +2657,7 @@ def get_workspace_payload(
             fixture = None
     if fixture is not None:
         trip_record = _load_trip_record(fixture.trip_fixture)
-        saved_scenarios, scenario_comparison = _load_saved_scenarios(
-            fixture.scenarios_fixture
-        )
+        saved_scenarios, scenario_comparison = _load_saved_scenarios(fixture.scenarios_fixture)
         session = _load_session(fixture.session_fixture)
         _canonicalize_saved_scenario_ids(session, saved_scenarios)
         inventory_assembly_input = _build_inventory_assembly_input(
@@ -2686,9 +2698,7 @@ def get_workspace_payload(
             "trip_record": trip_record.to_dict(),
             "session": session.to_dict(),
             "saved_scenarios": [record.to_dict() for record in saved_scenarios],
-            "scenario_comparison": (
-                scenario_comparison.to_dict() if scenario_comparison else None
-            ),
+            "scenario_comparison": (scenario_comparison.to_dict() if scenario_comparison else None),
             "scenario_search": scenario_search.to_dict(),
             "ranking": ranking,
             "route_comparison": runtime_scenario_comparison,
@@ -2750,12 +2760,8 @@ def get_workspace_payload(
             session_record=session_record,
         )
         bootstrap_updated = True
-    persisted_inventory_bundles, inventory_summary = _build_workspace_inventory_inputs(
-        record
-    )
-    inventory_status = str(
-        (inventory_summary.get("runtime_state") or {}).get("status") or "empty"
-    )
+    persisted_inventory_bundles, inventory_summary = _build_workspace_inventory_inputs(record)
+    inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
     runtime_search = _build_runtime_scenario_search_for_trip(
         record=record,
         inventory_bundles=persisted_inventory_bundles,
@@ -2807,11 +2813,7 @@ def get_workspace_payload(
     feasibility_summary = build_feasibility_summary_payload(persisted_inventory_bundles)
     return _build_persisted_trip_workspace(
         record,
-        session=(
-            _serialize_session_record(session_record)
-            if session_record is not None
-            else None
-        ),
+        session=(_serialize_session_record(session_record) if session_record is not None else None),
         saved_scenarios=[
             {
                 "saved_scenario_id": scenario.saved_scenario_id,
@@ -2903,9 +2905,7 @@ def _get_or_create_workspace_session_record(
         recent_option_presentations=[
             item.to_dict() for item in default_session.recent_option_presentations
         ],
-        pending_decisions=[
-            item.to_dict() for item in default_session.pending_decisions
-        ],
+        pending_decisions=[item.to_dict() for item in default_session.pending_decisions],
         status=default_session.status,
         selected_planning_mode=default_session.selected_planning_mode,
         current_checkpoint_id=default_session.current_checkpoint_id,
@@ -2959,12 +2959,8 @@ def _current_workspace_option_set(
         if session.recent_option_presentations
         else _default_workspace_presentation(trip_id, session.updated_at)
     )
-    option_set_id = (
-        presentation.option_set_id or f"option-set:{trip_id}:workspace-bootstrap"
-    )
-    option_ids = [
-        option_id for option_id in presentation.surfaced_option_ids if option_id
-    ]
+    option_set_id = presentation.option_set_id or f"option-set:{trip_id}:workspace-bootstrap"
+    option_ids = [option_id for option_id in presentation.surfaced_option_ids if option_id]
     return option_set_id, option_ids
 
 
@@ -3043,32 +3039,20 @@ def answer_workspace_planner_decision(
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
     matching = next(
-        (
-            decision
-            for decision in session.pending_decisions
-            if decision.decision_id == decision_id
-        ),
+        (decision for decision in session.pending_decisions if decision.decision_id == decision_id),
         None,
     )
     if matching is None:
-        raise ValueError(
-            f"Decision '{decision_id}' was not found in the workspace session."
-        )
+        raise ValueError(f"Decision '{decision_id}' was not found in the workspace session.")
     if choice not in matching.choices:
-        raise ValueError(
-            f"Choice '{choice}' is not valid for decision '{decision_id}'."
-        )
+        raise ValueError(f"Choice '{choice}' is not valid for decision '{decision_id}'.")
 
     session.pending_decisions = [
-        decision
-        for decision in session.pending_decisions
-        if decision.decision_id != decision_id
+        decision for decision in session.pending_decisions if decision.decision_id != decision_id
     ]
     session.updated_at = _isoformat(datetime.now(UTC))
     session.notes.append(f"decision:{decision_id}:{choice}")
-    session_record.pending_decisions = [
-        item.to_dict() for item in session.pending_decisions
-    ]
+    session_record.pending_decisions = [item.to_dict() for item in session.pending_decisions]
     session_record.notes = list(session.notes)
     session_record.last_updated_at = session.updated_at
     record.updated_at = datetime.now(UTC)
@@ -3114,9 +3098,7 @@ def submit_workspace_option_feedback(
     record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
-    option_set_id, valid_option_ids = _current_workspace_option_set(
-        session, trip_id=trip_id
-    )
+    option_set_id, valid_option_ids = _current_workspace_option_set(session, trip_id=trip_id)
     if option_id not in valid_option_ids:
         raise ValueError(
             f"Option '{option_id}' is not available in the current workspace option set."
@@ -3142,25 +3124,23 @@ def submit_workspace_option_feedback(
             item for item in presentation.rejected_option_ids if item != option_id
         ]
         event_kind = "decision_recorded"
-        summary = (
-            f"Traveler accepted option '{option_id}' from the workspace planner panel."
-        )
+        summary = f"Traveler accepted option '{option_id}' from the workspace planner panel."
     elif action_type == "reject":
         if option_id not in presentation.rejected_option_ids:
             presentation.rejected_option_ids.append(option_id)
         if presentation.selected_option_id == option_id:
             presentation.selected_option_id = None
         event_kind = "option_rejected"
-        summary = (
-            f"Traveler rejected option '{option_id}' from the workspace planner panel."
-        )
+        summary = f"Traveler rejected option '{option_id}' from the workspace planner panel."
     elif action_type == "save_as_fallback":
         presentation.notes = [
             note for note in presentation.notes if not note.startswith("fallback:")
         ]
         presentation.notes.append(f"fallback:{option_id}")
         event_kind = "decision_recorded"
-        summary = f"Traveler saved option '{option_id}' as a fallback in the workspace planner panel."
+        summary = (
+            f"Traveler saved option '{option_id}' as a fallback in the workspace planner panel."
+        )
     else:
         session.interaction_state.auto_advance_research_passes += 1
         event_kind = "rerank_requested"
@@ -3170,10 +3150,7 @@ def submit_workspace_option_feedback(
     session.recent_option_presentations = [presentation]
     session.updated_at = _isoformat(datetime.now(UTC))
     session.notes.append(f"feedback:{action_type}:{option_id}")
-    if (
-        action_type in {"revise", "do_more_before_asking_again"}
-        and not session.pending_decisions
-    ):
+    if action_type in {"revise", "do_more_before_asking_again"} and not session.pending_decisions:
         session.pending_decisions = [
             PendingDecision(
                 decision_id=f"decision:{trip_id}:follow-up",
@@ -3192,9 +3169,7 @@ def submit_workspace_option_feedback(
     session_record.recent_option_presentations = [
         item.to_dict() for item in session.recent_option_presentations
     ]
-    session_record.pending_decisions = [
-        item.to_dict() for item in session.pending_decisions
-    ]
+    session_record.pending_decisions = [item.to_dict() for item in session.pending_decisions]
     session_record.interaction_state = session.interaction_state.to_dict()
     session_record.notes = list(session.notes)
     session_record.last_updated_at = session.updated_at
@@ -3244,16 +3219,12 @@ def submit_workspace_route_option_action(
     action_type: str,
 ) -> dict[str, Any]:
     if action_type not in ROUTE_OPTION_ACTIONS:
-        raise ValueError(
-            f"action_type must be one of {', '.join(ROUTE_OPTION_ACTIONS)}"
-        )
+        raise ValueError(f"action_type must be one of {', '.join(ROUTE_OPTION_ACTIONS)}")
 
     record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
-    option_set_id, valid_option_ids = _current_workspace_option_set(
-        session, trip_id=trip_id
-    )
+    option_set_id, valid_option_ids = _current_workspace_option_set(session, trip_id=trip_id)
     if option_id not in valid_option_ids:
         raise ValueError(
             f"Route option '{option_id}' is not available in the current workspace comparison."
@@ -3273,9 +3244,7 @@ def submit_workspace_route_option_action(
     presentation.rejected_option_ids = [
         item for item in presentation.rejected_option_ids if item in valid_option_ids
     ]
-    presentation.notes = _without_route_option_notes(
-        list(presentation.notes), option_id
-    )
+    presentation.notes = _without_route_option_notes(list(presentation.notes), option_id)
 
     if action_type == "make_baseline":
         presentation.selected_option_id = option_id
@@ -3338,9 +3307,7 @@ def submit_workspace_route_option_action(
     session_record.recent_option_presentations = [
         item.to_dict() for item in session.recent_option_presentations
     ]
-    session_record.pending_decisions = [
-        item.to_dict() for item in session.pending_decisions
-    ]
+    session_record.pending_decisions = [item.to_dict() for item in session.pending_decisions]
     session_record.interaction_state = session.interaction_state.to_dict()
     session_record.notes = list(session.notes)
     session_record.last_updated_at = session.updated_at


### PR DESCRIPTION
### Keepalive: ON
<!-- meta:issue:1130 -->

Closes #1130

## Summary
- add backend workspace view-model visibility rules for budget, policy posture, proposal, and approval-readiness surfaces
- translate policy/proposal state into plain-language approval labels and keep raw policy/proposal payloads in debug sections
- hide approval/policy posture from normal leisure map and route-review surfaces unless active policy state exists
- update visible fallback copy so normal UI does not expose raw TPP transport/error-code language

## Tasks
- [x] Define mode-aware rules for when policy, budget, proposal, and approval-readiness panels appear.
- [x] Translate policy/proposal states into traveler or business-user labels such as "ready for approval", "needs exception", or "waiting for policy review".
- [x] Remove policy posture from leisure route-comparison metrics unless a leisure trip explicitly has active policy state.
- [x] Move raw TPP identifiers, transport statuses, polling details, and result payloads behind debug/advanced affordances.
- [x] Add backend tests for leisure, business, and mixed edge cases.
- [x] Add frontend tests that leisure workspaces do not render approval widgets and business workspaces still render readiness state.

## Acceptance Criteria
- [x] Leisure workspaces without active policy state do not show policy posture, proposal lifecycle, approval packet, or TPP labels in normal UI.
- [x] Business workspaces show approval readiness and required follow-up in plain language.
- [x] Raw policy/proposal diagnostics remain available for debug inspection.
- [x] Route comparison metrics do not include policy posture for normal leisure trips.
- [x] Tests cover the visibility rules for leisure and business trips.

## Validation
- `python -m black --check --line-length 100 --exclude '(\\.workflows-lib|node_modules)' trip_planner/app/schemas/workspace.py trip_planner/app/services/workspace.py tests/app/test_workspace.py`
- `python -m ruff check trip_planner/app/schemas/workspace.py trip_planner/app/services/workspace.py tests/app/test_workspace.py`
- `python -m mypy trip_planner/app/schemas/workspace.py trip_planner/app/services/workspace.py`
- `python -m pytest -q tests/app/test_workspace.py --no-cov`
- `npm test -- --run src/routes/WorkspacePage.test.tsx src/components/maps/mapSurface.test.ts`
- `npm run build`
- `git diff --check`
