### PR TITLE
Issue #1122: add product workspace view model

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -374,7 +374,7 @@ export type WorkspaceBusinessSummary = {
 
 export type WorkspaceDebugSection = {
   title: string;
-  payload: Record<string, unknown>;
+  payload: unknown;
 };
 
 export type WorkspaceDebugState = {

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -343,6 +343,51 @@ export type PlannerSessionResponse = {
   messages: PlannerMessage[];
 };
 
+export type WorkspaceUserSummary = {
+  trip_title: string;
+  trip_mode: "leisure" | "business";
+  mode_label: string;
+  status: "ready" | "partial" | "empty";
+  headline: string;
+  decided: string[];
+  uncertain: string[];
+};
+
+export type WorkspaceNextStep = {
+  title: string;
+  summary: string;
+  action_label: string | null;
+  action_target: string | null;
+  blocked: boolean;
+};
+
+export type WorkspaceBusinessSummary = {
+  approval_status:
+    | "not_applicable"
+    | "not_ready"
+    | "in_review"
+    | "approved"
+    | "needs_attention";
+  headline: string;
+  blockers: string[];
+};
+
+export type WorkspaceDebugSection = {
+  title: string;
+  payload: Record<string, unknown>;
+};
+
+export type WorkspaceDebugState = {
+  sections: Record<string, WorkspaceDebugSection>;
+};
+
+export type WorkspaceViewModel = {
+  user_summary: WorkspaceUserSummary;
+  next_step: WorkspaceNextStep;
+  business_summary: WorkspaceBusinessSummary | null;
+  debug_state: WorkspaceDebugState;
+};
+
 export type WorkspaceData = {
   trip_record: TripRecord;
   session: SessionState;
@@ -470,6 +515,7 @@ export type WorkspaceData = {
       follow_up_summary?: string;
     };
   } | null;
+  view_model: WorkspaceViewModel | null;
 };
 
 export type BudgetPlanUpsertPayload = {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -692,6 +692,7 @@ const workspacePayload = {
       },
     ],
   },
+  view_model: null,
 } satisfies WorkspaceData;
 
 const plannerSessionPayload = {
@@ -791,6 +792,65 @@ describe("WorkspacePage", () => {
     mockedSaveWorkspaceBudget.mockReset();
     mockedRecordWorkspaceSpendEvent.mockReset();
     mockedRefreshWorkspaceProposalStatus.mockReset();
+  });
+
+  it("does not render raw runtime/provider/debug labels for default leisure workspaces", async () => {
+    const leisureWorkspaceWithViewModel: WorkspaceData = {
+      ...workspacePayload,
+      view_model: {
+        user_summary: {
+          trip_title: workspacePayload.trip_record.trip.title,
+          trip_mode: "leisure",
+          mode_label: "Leisure trip",
+          status: "ready",
+          headline: "Your trip plan is ready to review.",
+          decided: ["2 saved scenario draft(s)"],
+          uncertain: [],
+        },
+        next_step: {
+          title: "Review and pick a scenario",
+          summary:
+            "Compare the saved scenarios and choose one to keep planning around.",
+          action_label: "Open scenario comparison",
+          action_target: "scenario-comparison",
+          blocked: false,
+        },
+        business_summary: null,
+        debug_state: { sections: {} },
+      },
+    };
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(leisureWorkspaceWithViewModel),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("heading", { name: "Spring Kyoto anniversary draft" }).length
+      ).toBeGreaterThan(0);
+    });
+    expect(screen.getByText("Leisure trip")).toBeInTheDocument();
+    expect(screen.getByText("Your trip plan is ready to review.")).toBeInTheDocument();
+    expect(screen.getByText("2 saved scenario draft(s)")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Review and pick a scenario" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Compare the saved scenarios and choose one to keep planning around.")
+    ).toBeInTheDocument();
+
+    const renderedText = document.body.textContent ?? "";
+    const forbiddenRawLabels = [
+      "runtime provider",
+      "fallback mode",
+      "policy_state_id",
+      "proposal_state_id",
+      "session_state_id",
+      "scenario_search_id",
+    ];
+    for (const label of forbiddenRawLabels) {
+      expect(renderedText.toLowerCase()).not.toContain(label.toLowerCase());
+    }
   });
 
   it("renders timeline structure from persisted trip and scenario state", async () => {

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -749,8 +749,8 @@ function WorkspacePageContent({
               <article className="decision-card">
                 <p className="scenario-kicker">Decided</p>
                 <ul>
-                  {productView.user_summary.decided.map((item) => (
-                    <li key={item}>{item}</li>
+                  {productView.user_summary.decided.map((item, index) => (
+                    <li key={`${index}-${item}`}>{item}</li>
                   ))}
                 </ul>
               </article>
@@ -759,8 +759,8 @@ function WorkspacePageContent({
               <article className="decision-card">
                 <p className="scenario-kicker">Still open</p>
                 <ul>
-                  {productView.user_summary.uncertain.map((item) => (
-                    <li key={item}>{item}</li>
+                  {productView.user_summary.uncertain.map((item, index) => (
+                    <li key={`${index}-${item}`}>{item}</li>
                   ))}
                 </ul>
               </article>
@@ -779,8 +779,8 @@ function WorkspacePageContent({
                 <h3>{productView.business_summary.headline}</h3>
                 {productView.business_summary.blockers.length > 0 ? (
                   <ul>
-                    {productView.business_summary.blockers.map((blocker) => (
-                      <li key={blocker}>{blocker}</li>
+                    {productView.business_summary.blockers.map((blocker, index) => (
+                      <li key={`${index}-${blocker}`}>{blocker}</li>
                     ))}
                   </ul>
                 ) : null}

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -568,6 +568,7 @@ function WorkspacePageContent({
   }, [workspace.trip_record.trip.trip_id]);
 
   const { trip } = currentWorkspace.trip_record;
+  const productView = currentWorkspace.view_model;
   const activeScenario = resolveActiveScenario(currentWorkspace);
   const routeComparison = resolveRouteComparison(currentWorkspace);
   const selectedRuntimeScenario =
@@ -737,9 +738,56 @@ function WorkspacePageContent({
       data-layout={isCompactLayout ? "compact" : "full"}
     >
       <div className="workspace-hero status-card">
-        <p className="status-label">Workspace timeline</p>
-        <h2>{trip.title}</h2>
-        <p>{trip.summary}</p>
+        <p className="status-label">
+          {productView?.user_summary.mode_label ?? "Workspace timeline"}
+        </p>
+        <h2>{productView?.user_summary.trip_title ?? trip.title}</h2>
+        <p>{productView?.user_summary.headline ?? trip.summary}</p>
+        {productView ? (
+          <div className="decision-stack" aria-label="Product workspace summary">
+            {productView.user_summary.decided.length > 0 ? (
+              <article className="decision-card">
+                <p className="scenario-kicker">Decided</p>
+                <ul>
+                  {productView.user_summary.decided.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </article>
+            ) : null}
+            {productView.user_summary.uncertain.length > 0 ? (
+              <article className="decision-card">
+                <p className="scenario-kicker">Still open</p>
+                <ul>
+                  {productView.user_summary.uncertain.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </article>
+            ) : null}
+            <article className="decision-card">
+              <p className="scenario-kicker">Next action</p>
+              <h3>{productView.next_step.title}</h3>
+              <p>{productView.next_step.summary}</p>
+              {productView.next_step.action_label ? (
+                <p className="muted-copy">{productView.next_step.action_label}</p>
+              ) : null}
+            </article>
+            {productView.business_summary ? (
+              <article className="decision-card">
+                <p className="scenario-kicker">Approval readiness</p>
+                <h3>{productView.business_summary.headline}</h3>
+                {productView.business_summary.blockers.length > 0 ? (
+                  <ul>
+                    {productView.business_summary.blockers.map((blocker) => (
+                      <li key={blocker}>{blocker}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </article>
+            ) : null}
+          </div>
+        ) : null}
         <dl className="workspace-meta">
           <div>
             <dt>Dates</dt>
@@ -767,6 +815,16 @@ function WorkspacePageContent({
             ? "Compact review stack keeps map, timeline, and tradeoff calls visible on smaller screens."
             : "Review-ready workspace keeps route context, daily pacing, and tradeoffs visible at once."}
         </p>
+        {productView && Object.keys(productView.debug_state.sections).length > 0 ? (
+          <details className="workspace-debug-disclosure">
+            <summary>Advanced diagnostics</summary>
+            <p className="muted-copy">
+              {Object.keys(productView.debug_state.sections).length} debug section
+              {Object.keys(productView.debug_state.sections).length === 1 ? "" : "s"} available in the
+              workspace payload.
+            </p>
+          </details>
+        ) : null}
       </div>
 
       <div className="workspace-grid">

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -2331,3 +2331,115 @@ def test_feasibility_planner_outputs_surface_blocking_transition_details() -> No
         or "cannot be reached inside its advertised start window" in highlight.lower()
         for highlight in outputs[1]["highlights"]
     )
+
+
+_RAW_DEBUG_TOKENS_FORBIDDEN_IN_USER_COPY = (
+    "runtime provider",
+    "runtime_state_id",
+    "fallback mode",
+    "policy_state_id",
+    "proposal_state_id",
+    "session_state_id",
+    "scenario_search_id",
+)
+
+
+def _assert_user_summary_avoids_raw_runtime_language(view_model: dict[str, Any]) -> None:
+    user_summary = view_model["user_summary"]
+    next_step = view_model["next_step"]
+    user_facing_strings = [user_summary["headline"], next_step["title"], next_step["summary"]]
+    user_facing_strings.extend(user_summary.get("decided", []))
+    user_facing_strings.extend(user_summary.get("uncertain", []))
+    business_summary = view_model.get("business_summary")
+    if business_summary is not None:
+        user_facing_strings.append(business_summary["headline"])
+        user_facing_strings.extend(business_summary.get("blockers", []))
+    for value in user_facing_strings:
+        lowered = value.lower()
+        for token in _RAW_DEBUG_TOKENS_FORBIDDEN_IN_USER_COPY:
+            assert token not in lowered, (
+                f"User-facing view-model copy must not leak '{token}': {value!r}"
+            )
+
+
+def test_workspace_endpoint_includes_typed_view_model_for_leisure_trip(
+    client: TestClient,
+) -> None:
+    response = client.get("/api/workspace/trip-leisure-kyoto-draft")
+
+    assert response.status_code == 200
+    payload = response.json()
+    view_model = payload["view_model"]
+    assert view_model is not None
+    user_summary = view_model["user_summary"]
+    assert user_summary["trip_mode"] == "leisure"
+    assert user_summary["mode_label"] == "Leisure trip"
+    assert user_summary["status"] in {"ready", "partial", "empty"}
+    assert user_summary["trip_title"]
+    assert user_summary["headline"]
+
+    next_step = view_model["next_step"]
+    assert next_step["title"]
+    assert next_step["summary"]
+
+    assert view_model["business_summary"] is None
+
+    debug_state = view_model["debug_state"]
+    assert "runtime_state" in debug_state["sections"]
+    assert "policy_state" not in debug_state["sections"]
+    assert "proposal_state" not in debug_state["sections"]
+    assert (
+        debug_state["sections"]["runtime_state"]["payload"]["status"]
+        == payload["runtime_state"]["status"]
+    )
+
+    _assert_user_summary_avoids_raw_runtime_language(view_model)
+
+
+def test_workspace_endpoint_includes_typed_view_model_for_business_trip(
+    client: TestClient,
+) -> None:
+    response = client.get("/api/workspace/trip-business-client-summit")
+
+    assert response.status_code == 200
+    payload = response.json()
+    view_model = payload["view_model"]
+    assert view_model is not None
+    user_summary = view_model["user_summary"]
+    assert user_summary["trip_mode"] == "business"
+    assert user_summary["mode_label"] == "Business trip"
+
+    business_summary = view_model["business_summary"]
+    assert business_summary is not None
+    assert business_summary["approval_status"] in {
+        "not_applicable",
+        "not_ready",
+        "in_review",
+        "approved",
+        "needs_attention",
+    }
+    assert business_summary["headline"]
+
+    debug_state = view_model["debug_state"]
+    assert "runtime_state" in debug_state["sections"]
+
+    _assert_user_summary_avoids_raw_runtime_language(view_model)
+
+
+def test_workspace_view_model_builder_handles_empty_runtime_state() -> None:
+    payload = {
+        "trip_record": {
+            "trip": {"title": "Bare workspace", "mode": "leisure"},
+        },
+        "runtime_state": {"status": "empty", "title": "", "summary": ""},
+        "saved_scenarios": [],
+        "inventory_summary": {"bundle_count": 0},
+        "feasibility_summary": {"attention_bundle_count": 0},
+    }
+
+    view_model = workspace_service._build_workspace_view_model(payload)
+
+    assert view_model["user_summary"]["status"] == "empty"
+    assert view_model["next_step"]["blocked"] is True
+    assert view_model["business_summary"] is None
+    assert view_model["debug_state"]["sections"]["runtime_state"]["payload"]["status"] == "empty"

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -2443,3 +2443,24 @@ def test_workspace_view_model_builder_handles_empty_runtime_state() -> None:
     assert view_model["next_step"]["blocked"] is True
     assert view_model["business_summary"] is None
     assert view_model["debug_state"]["sections"]["runtime_state"]["payload"]["status"] == "empty"
+
+
+def test_workspace_view_model_debug_sections_preserve_raw_payload_shapes() -> None:
+    saved_scenarios = [{"saved_scenario_id": "scenario-1"}]
+    activity_log = [{"activity_event_id": "activity-1"}]
+    payload = {
+        "trip_record": {
+            "trip": {"title": "Raw debug workspace", "mode": "leisure"},
+        },
+        "runtime_state": {"status": "ready", "title": "Ready", "summary": "Ready"},
+        "saved_scenarios": saved_scenarios,
+        "inventory_summary": {"bundle_count": 1},
+        "feasibility_summary": {"attention_bundle_count": 0},
+        "activity_log": activity_log,
+    }
+
+    view_model = workspace_service._build_workspace_view_model(payload)
+    debug_sections = view_model["debug_state"]["sections"]
+
+    assert debug_sections["saved_scenarios"]["payload"] == saved_scenarios
+    assert debug_sections["activity_log"]["payload"] == activity_log

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -110,7 +110,7 @@ class WorkspaceDebugSection(BaseModel):
     """A named debug-only payload section that mirrors raw runtime state."""
 
     title: str = Field(description="Debug section title shown in the advanced surface.")
-    payload: dict[str, Any] = Field(
+    payload: Any = Field(
         default_factory=dict,
         description="Raw payload attached to this debug section.",
     )

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -43,6 +43,106 @@ class InventorySummary(BaseModel):
     )
 
 
+class WorkspaceUserSummary(BaseModel):
+    """User-facing trip summary for the product workspace surface.
+
+    Field values must avoid raw runtime/provider/object-id language; that
+    detail belongs in :class:`WorkspaceDebugState` and is rendered behind an
+    explicit debug affordance.
+    """
+
+    trip_title: str = Field(description="Human-readable trip title.")
+    trip_mode: Literal["leisure", "business"] = Field(
+        description="Workspace product mode used to gate user-facing copy."
+    )
+    mode_label: str = Field(description="User-friendly mode label (e.g. 'Leisure trip').")
+    status: Literal["ready", "partial", "empty"] = Field(
+        description="High-level workspace status used for top-level framing."
+    )
+    headline: str = Field(description="Short user-facing headline for the trip.")
+    decided: list[str] = Field(
+        default_factory=list,
+        description="User-facing 'what has been decided' bullet list.",
+    )
+    uncertain: list[str] = Field(
+        default_factory=list,
+        description="User-facing 'what is still uncertain' bullet list.",
+    )
+
+
+class WorkspaceNextStep(BaseModel):
+    """Recommended next user action for the trip workspace."""
+
+    title: str = Field(description="Short next-step title in user language.")
+    summary: str = Field(description="Longer next-step summary in user language.")
+    action_label: str | None = Field(
+        default=None,
+        description="Optional CTA label rendered alongside the next-step copy.",
+    )
+    action_target: str | None = Field(
+        default=None,
+        description="Optional anchor or route hint for the recommended action.",
+    )
+    blocked: bool = Field(
+        default=False,
+        description="True when the recommended action is blocked on a missing input.",
+    )
+
+
+class WorkspaceBusinessSummary(BaseModel):
+    """Optional business-mode approval readiness expressed in user language."""
+
+    approval_status: Literal[
+        "not_applicable",
+        "not_ready",
+        "in_review",
+        "approved",
+        "needs_attention",
+    ] = Field(description="Approval readiness in user-facing terms.")
+    headline: str = Field(description="Short user-facing approval headline.")
+    blockers: list[str] = Field(
+        default_factory=list,
+        description="User-facing list of open approval blockers.",
+    )
+
+
+class WorkspaceDebugSection(BaseModel):
+    """A named debug-only payload section that mirrors raw runtime state."""
+
+    title: str = Field(description="Debug section title shown in the advanced surface.")
+    payload: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Raw payload attached to this debug section.",
+    )
+
+
+class WorkspaceDebugState(BaseModel):
+    """Hidden debug surface containing raw runtime/provider/object-id payloads.
+
+    The product workspace view should only render this state behind an
+    explicit debug/advanced affordance.
+    """
+
+    sections: dict[str, WorkspaceDebugSection] = Field(
+        default_factory=dict,
+        description="Named raw debug sections keyed by stable section id.",
+    )
+
+
+class WorkspaceViewModel(BaseModel):
+    """Typed product view model that translates :class:`WorkspaceResponse`.
+
+    The view model splits the workspace payload into traveler-facing,
+    business-facing, and debug-facing sections so the frontend can render a
+    stable user surface without leaking raw runtime detail.
+    """
+
+    user_summary: WorkspaceUserSummary
+    next_step: WorkspaceNextStep
+    business_summary: WorkspaceBusinessSummary | None = None
+    debug_state: WorkspaceDebugState
+
+
 class WorkspaceResponse(BaseModel):
     trip_record: dict[str, Any] = Field(
         description="Persisted trip record payload for the workspace."
@@ -104,6 +204,13 @@ class WorkspaceResponse(BaseModel):
     proposal_state: dict[str, Any] | None = Field(
         default=None,
         description="Persisted proposal submission and evaluation lifecycle state for business-workspace flows.",
+    )
+    view_model: WorkspaceViewModel | None = Field(
+        default=None,
+        description=(
+            "Typed product workspace view model with user-facing summary, next-step,"
+            " optional business-summary, and hidden debug sections."
+        ),
     )
 
 

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -80,7 +80,7 @@ WORKSPACE_ACTIVITY_LOG_LIMIT = 50
 _BOOTSTRAP_SCENARIO_SCORE_BY_LABEL = {
     "baseline": 0.82,
     "fallback": 0.68,
-    }
+}
 
 
 class WorkspaceTripNotFoundError(ValueError):
@@ -1386,7 +1386,7 @@ def _build_workspace_view_model(
         "next_step": next_step,
         "business_summary": business_summary,
         "debug_state": {"sections": debug_sections},
-}
+    }
 
 
 def _build_workspace_runtime_state(

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -80,7 +80,7 @@ WORKSPACE_ACTIVITY_LOG_LIMIT = 50
 _BOOTSTRAP_SCENARIO_SCORE_BY_LABEL = {
     "baseline": 0.82,
     "fallback": 0.68,
-}
+    }
 
 
 class WorkspaceTripNotFoundError(ValueError):
@@ -1378,7 +1378,7 @@ def _build_workspace_view_model(
             continue
         debug_sections[key] = {
             "title": key.replace("_", " ").title(),
-            "payload": _coerce_debug_payload(raw_value),
+            "payload": raw_value,
         }
 
     return {
@@ -1386,17 +1386,7 @@ def _build_workspace_view_model(
         "next_step": next_step,
         "business_summary": business_summary,
         "debug_state": {"sections": debug_sections},
-    }
-
-
-def _coerce_debug_payload(value: Any) -> dict[str, Any]:
-    """Wrap a raw debug payload into a dict shape suitable for the schema."""
-
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, list):
-        return {"items": value}
-    return {"value": value}
+}
 
 
 def _build_workspace_runtime_state(

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1143,7 +1143,7 @@ def _build_persisted_trip_workspace(
         runtime_scenario_comparison=runtime_scenario_comparison,
     )
 
-    return {
+    payload: dict[str, Any] = {
         "trip_record": trip_record,
         "session": resolved_session,
         "saved_scenarios": ordered_saved_scenarios,
@@ -1180,6 +1180,8 @@ def _build_persisted_trip_workspace(
         "policy_state": (policy_context or {}).get("policy_state"),
         "proposal_state": (proposal_context or {}).get("proposal_state"),
     }
+    payload["view_model"] = _build_workspace_view_model(payload, trip_mode=record.mode)
+    return payload
 
 
 def _empty_workspace_scenario_search() -> dict[str, Any]:
@@ -1192,6 +1194,209 @@ def _empty_workspace_scenario_search() -> dict[str, Any]:
         ],
         "source_refs": [],
     }
+
+
+_TRIP_MODE_LABELS: dict[str, str] = {
+    "leisure": "Leisure trip",
+    "business": "Business trip",
+}
+
+# Raw workspace payload keys that must NEVER appear in user-facing view-model
+# copy. They are mirrored under WorkspaceDebugState.sections so an explicit
+# debug/advanced affordance can still surface them.
+_DEBUG_PAYLOAD_KEYS: tuple[str, ...] = (
+    "runtime_state",
+    "inventory_summary",
+    "scenario_search",
+    "ranking",
+    "route_comparison",
+    "runtime_scenario_comparison",
+    "feasibility_summary",
+    "planner_panel_state",
+    "policy_state",
+    "proposal_state",
+    "trip_record",
+    "session",
+    "saved_scenarios",
+    "activity_log",
+    "planner_memory",
+)
+
+
+def _build_workspace_view_model(
+    payload: dict[str, Any],
+    *,
+    trip_mode: str | None = None,
+) -> dict[str, Any]:
+    """Map a workspace payload dict into the typed product view model.
+
+    The mapper deliberately keeps user-facing strings free of raw runtime,
+    provider, fallback, policy/proposal id, and trip-scoped object id
+    language. Raw payloads are mirrored under ``debug_state.sections`` so the
+    frontend can render them only behind an explicit debug affordance.
+    """
+
+    trip_record = payload.get("trip_record") or {}
+    trip_block = trip_record.get("trip") if isinstance(trip_record, dict) else {}
+    trip_block = trip_block if isinstance(trip_block, dict) else {}
+
+    resolved_mode = str(trip_mode or trip_block.get("mode") or "leisure")
+    if resolved_mode not in _TRIP_MODE_LABELS:
+        resolved_mode = "leisure"
+    mode_label = _TRIP_MODE_LABELS[resolved_mode]
+
+    runtime_state = payload.get("runtime_state") or {}
+    runtime_state = runtime_state if isinstance(runtime_state, dict) else {}
+    status = str(runtime_state.get("status") or "empty")
+    if status not in {"ready", "partial", "empty"}:
+        status = "empty"
+
+    trip_title = str(trip_block.get("title") or "Trip workspace")
+
+    saved_scenarios = payload.get("saved_scenarios") or []
+    saved_scenarios = saved_scenarios if isinstance(saved_scenarios, list) else []
+    feasibility_summary = payload.get("feasibility_summary") or {}
+    feasibility_summary = (
+        feasibility_summary if isinstance(feasibility_summary, dict) else {}
+    )
+
+    decided: list[str] = []
+    if saved_scenarios:
+        decided.append(f"{len(saved_scenarios)} saved scenario draft(s)")
+    inventory_summary = payload.get("inventory_summary") or {}
+    inventory_summary = inventory_summary if isinstance(inventory_summary, dict) else {}
+    bundle_count = int(inventory_summary.get("bundle_count") or 0)
+    if bundle_count:
+        decided.append(f"{bundle_count} inventory bundle(s) assembled")
+
+    uncertain: list[str] = []
+    attention_count = int(feasibility_summary.get("attention_bundle_count") or 0)
+    if attention_count:
+        uncertain.append(f"{attention_count} bundle(s) need attention")
+    if status == "empty":
+        uncertain.append("Trip context is not complete yet.")
+    elif status == "partial":
+        uncertain.append("Scenario comparison is not yet ready.")
+
+    if status == "ready":
+        headline = "Your trip plan is ready to review."
+        next_step_title = "Review and pick a scenario"
+        next_step_summary = (
+            "Compare the saved scenarios and choose one to keep planning around."
+        )
+        next_step_action = "Open scenario comparison"
+        next_step_target = "scenario-comparison"
+        blocked = False
+    elif status == "partial":
+        headline = "Your trip plan is partially assembled."
+        next_step_title = "Continue planning"
+        next_step_summary = (
+            "Inventory is in place; resolve the open uncertainties to unlock"
+            " scenario comparison."
+        )
+        next_step_action = "Continue planning"
+        next_step_target = "planner"
+        blocked = False
+    else:
+        headline = "Trip planning hasn't started yet."
+        next_step_title = "Start planning"
+        next_step_summary = (
+            "Add the missing trip context to start assembling scenarios."
+        )
+        next_step_action = "Open trip setup"
+        next_step_target = "trip-setup"
+        blocked = True
+
+    user_summary = {
+        "trip_title": trip_title,
+        "trip_mode": resolved_mode,
+        "mode_label": mode_label,
+        "status": status,
+        "headline": headline,
+        "decided": decided,
+        "uncertain": uncertain,
+    }
+
+    next_step = {
+        "title": next_step_title,
+        "summary": next_step_summary,
+        "action_label": next_step_action,
+        "action_target": next_step_target,
+        "blocked": blocked,
+    }
+
+    business_summary: dict[str, Any] | None = None
+    if resolved_mode == "business":
+        proposal_state = payload.get("proposal_state") or {}
+        proposal_state = (
+            proposal_state if isinstance(proposal_state, dict) else {}
+        )
+        proposal_summary = proposal_state.get("summary") or {}
+        proposal_summary = proposal_summary if isinstance(proposal_summary, dict) else {}
+        approval_ready = bool(proposal_summary.get("approval_ready"))
+        evaluation_status = str(
+            proposal_summary.get("evaluation_result_status")
+            or proposal_summary.get("submission_status")
+            or ""
+        ).lower()
+
+        if approval_ready:
+            approval_status = "approved"
+            approval_headline = "Your trip is ready for approval."
+            blockers: list[str] = []
+        elif evaluation_status in {"in_review", "pending", "submitted"}:
+            approval_status = "in_review"
+            approval_headline = "Your trip approval is in review."
+            blockers = []
+        elif evaluation_status in {"failed", "rejected", "needs_attention"}:
+            approval_status = "needs_attention"
+            approval_headline = "Approval needs your attention."
+            blockers = [
+                str(item)
+                for item in (proposal_summary.get("highlights") or [])
+                if isinstance(item, str)
+            ]
+        elif proposal_state:
+            approval_status = "not_ready"
+            approval_headline = "Approval is not ready yet."
+            blockers = []
+        else:
+            approval_status = "not_applicable"
+            approval_headline = "Approval is not required yet."
+            blockers = []
+
+        business_summary = {
+            "approval_status": approval_status,
+            "headline": approval_headline,
+            "blockers": blockers,
+        }
+
+    debug_sections: dict[str, dict[str, Any]] = {}
+    for key in _DEBUG_PAYLOAD_KEYS:
+        raw_value = payload.get(key)
+        if raw_value is None:
+            continue
+        debug_sections[key] = {
+            "title": key.replace("_", " ").title(),
+            "payload": _coerce_debug_payload(raw_value),
+        }
+
+    return {
+        "user_summary": user_summary,
+        "next_step": next_step,
+        "business_summary": business_summary,
+        "debug_state": {"sections": debug_sections},
+    }
+
+
+def _coerce_debug_payload(value: Any) -> dict[str, Any]:
+    """Wrap a raw debug payload into a dict shape suitable for the schema."""
+
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, list):
+        return {"items": value}
+    return {"value": value}
 
 
 def _build_workspace_runtime_state(
@@ -1949,7 +2154,7 @@ def get_workspace_payload(
             assembly_input=inventory_assembly_input,
         )
 
-        return {
+        fixture_payload: dict[str, Any] = {
             "trip_record": trip_record.to_dict(),
             "session": session.to_dict(),
             "saved_scenarios": [record.to_dict() for record in saved_scenarios],
@@ -1987,6 +2192,10 @@ def get_workspace_payload(
             "policy_state": None,
             "proposal_state": None,
         }
+        fixture_payload["view_model"] = _build_workspace_view_model(
+            fixture_payload, trip_mode=trip_record.trip.mode
+        )
+        return fixture_payload
 
     record = db_session.scalar(
         select(PersistedTrip)


### PR DESCRIPTION
Closes #1122

## Summary
- Add typed product workspace view-model schemas and backend mapping for user summary, next action, business approval readiness, and hidden debug state.
- Include the view model in workspace payloads while preserving raw runtime/provider/policy/proposal data under debug sections.
- Render the product summary and next action in WorkspacePage and add backend/frontend coverage for leisure and business workspaces.

## Tasks
- [x] Add backend schema types for WorkspaceViewModel, WorkspaceUserSummary, WorkspaceNextStep, and WorkspaceDebugState.
- [x] Add a service that maps the existing workspace payload into traveler-facing, business-facing, and debug-facing sections.
- [x] Keep raw runtime state, provider status, object IDs, policy payloads, and fallback details under the debug section.
- [x] Add frontend TypeScript types for the view model and update the workspace API client.
- [x] Update WorkspacePage to render top-level trip summary, current plan state, missing decisions, and next action from the new view model.
- [x] Add frontend tests that assert normal leisure workspaces do not show raw runtime/provider/debug language by default.
- [x] Add backend tests for leisure and business trips that verify the debug section is still present in the API payload.

## Validation
- python -m pytest tests/app/test_workspace.py -q --no-cov
- npm test -- --run WorkspacePage.test.tsx
- npm run build
- git diff --check