### PR TITLE
Issue #1123: add planner turn triage metadata

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -316,6 +316,17 @@ export type PlannerToolCallResponse = {
   output: Record<string, unknown>;
 };
 
+export type PlannerTurnMetadata = {
+  plan_maturity: string;
+  task_class: string;
+  visible_response_blocks: Array<{
+    kind: string;
+    title: string;
+    items: string[];
+  }>;
+  debug_routing_details: Record<string, unknown>;
+};
+
 export type PlannerMessage = {
   message_id: string;
   role: "user" | "planner" | string;
@@ -323,6 +334,7 @@ export type PlannerMessage = {
   created_at: string;
   refs: string[];
   tool_calls: PlannerToolCallResponse[];
+  turn_metadata?: PlannerTurnMetadata | null;
 };
 
 export type PlannerSessionResponse = {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -965,6 +965,21 @@ describe("WorkspacePage", () => {
           content: "Keep the Uji day trip and compare fewer evening moves before the next checkpoint.",
           created_at: "2026-04-12T06:16:00+00:00",
           refs: ["session:trip-leisure-kyoto-draft", "scenario:trip-leisure-kyoto-draft:1"],
+          turn_metadata: {
+            plan_maturity: "coherent_plan",
+            task_class: "route_comparison",
+            visible_response_blocks: [
+              {
+                kind: "next_steps",
+                title: "Next planning moves",
+                items: ["Compare fewer evening moves.", "Preserve Uji as the baseline day trip."],
+              },
+            ],
+            debug_routing_details: {
+              runtime_mode: "fallback",
+              runtime_provider: null,
+            },
+          },
           tool_calls: [
             {
               tool_name: "read_workspace_state",
@@ -1003,6 +1018,9 @@ describe("WorkspacePage", () => {
     expect(
       screen.getByText("Keep the Uji day trip and compare fewer evening moves before the next checkpoint.")
     ).toBeInTheDocument();
+    expect(screen.getByText("coherent plan")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Next planning moves" })).toBeInTheDocument();
+    expect(screen.getByText("Compare fewer evening moves.")).toBeInTheDocument();
     expect(screen.getByText("read_workspace_state: Read the current workspace state.")).toBeInTheDocument();
     expect(screen.getByLabelText("Message")).toHaveValue("");
   });

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -914,8 +914,10 @@ function WorkspacePageContent({
                           >
                             <h4>{block.title}</h4>
                             <ul>
-                              {block.items.map((item) => (
-                                <li key={item}>{item}</li>
+                              {block.items.map((item, itemIndex) => (
+                                <li key={`${message.message_id}-${block.kind}-${block.title}-${itemIndex}`}>
+                                  {item}
+                                </li>
                               ))}
                             </ul>
                           </section>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -902,6 +902,26 @@ function WorkspacePageContent({
                       {message.role === "user" ? "Traveler" : "Planner"}
                     </p>
                     <p>{message.content}</p>
+                    {message.turn_metadata?.visible_response_blocks.length ? (
+                      <div className="planner-response-blocks">
+                        <span className="planner-routing-pill">
+                          {message.turn_metadata.plan_maturity.replace(/_/g, " ")}
+                        </span>
+                        {message.turn_metadata.visible_response_blocks.map((block) => (
+                          <section
+                            key={`${message.message_id}-${block.kind}-${block.title}`}
+                            className="planner-response-block"
+                          >
+                            <h4>{block.title}</h4>
+                            <ul>
+                              {block.items.map((item) => (
+                                <li key={item}>{item}</li>
+                              ))}
+                            </ul>
+                          </section>
+                        ))}
+                      </div>
+                    ) : null}
                     {message.tool_calls.length > 0 ? (
                       <ul className="planner-tool-call-list">
                         {message.tool_calls.map((toolCall) => (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -428,6 +428,40 @@ a {
   margin: 0;
 }
 
+.planner-response-blocks {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.75rem;
+}
+
+.planner-routing-pill {
+  width: fit-content;
+  border-radius: 999px;
+  padding: 0.3rem 0.55rem;
+  background: rgba(19, 33, 44, 0.1);
+  color: #24394a;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.planner-response-block {
+  border-left: 3px solid rgba(56, 117, 107, 0.55);
+  padding-left: 0.75rem;
+}
+
+.planner-response-block h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.92rem;
+}
+
+.planner-response-block ul {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0;
+  padding-left: 1.05rem;
+}
+
 .planner-message-planner {
   background: rgba(56, 117, 107, 0.12);
 }

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -232,6 +232,11 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
             "planning_synthesis",
         ),
         (
+            "We have June dates and a hotel budget but no destination yet.",
+            "partial_plan",
+            "first_turn_triage",
+        ),
+        (
             "Maybe Japan with good food",
             "partial_plan",
             "first_turn_triage",
@@ -271,6 +276,23 @@ def test_planner_turn_records_adaptive_triage_metadata(
     visible_content = planner_reply["content"].lower()
     assert "model routing" not in visible_content
     assert "provider" not in visible_content
+    assert "fallback" not in visible_content
+
+
+def test_planner_turn_partial_reply_does_not_echo_internal_user_terms(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Could the provider model fallback explain a trip idea?"},
+    )
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    visible_content = planner_reply["content"].lower()
+    assert planner_reply["turn_metadata"]["plan_maturity"] == "partial_plan"
+    assert "provider" not in visible_content
+    assert "model" not in visible_content
     assert "fallback" not in visible_content
 
 

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -182,7 +182,8 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
     payload = response.json()
     assert [message["role"] for message in payload["messages"]] == ["user", "planner"]
     assert "Help me decide" in payload["messages"][0]["content"]
-    assert "Deterministic planner fallback is active" in payload["messages"][1]["content"]
+    assert "fallback" not in payload["messages"][1]["content"].lower()
+    assert payload["messages"][1]["turn_metadata"]["plan_maturity"] == "partial_plan"
     assert payload["messages"][1]["refs"]
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
     assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
@@ -198,6 +199,7 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
             "planner_user_turn",
             "planner_response",
         ]
+        assert stored[-1].payload["turn_metadata"]["task_class"] == "first_turn_triage"
         activity_events = db_session.scalars(
             select(PersistedActivityLogEvent)
             .where(PersistedActivityLogEvent.trip_id == trip_id)
@@ -219,6 +221,57 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
         assert artifact is not None
         assert artifact.memory_artifact_id.startswith("planner-mem:")
         assert artifact.checkpoint_id == checkpoint.checkpoint_id
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_maturity", "expected_task"),
+    [
+        (
+            "We want five days in Kyoto in May with a moderate budget and low-transfer hotels.",
+            "coherent_plan",
+            "planning_synthesis",
+        ),
+        (
+            "Maybe Japan with good food",
+            "partial_plan",
+            "first_turn_triage",
+        ),
+        (
+            "Plan a trip",
+            "open_ended",
+            "first_turn_triage",
+        ),
+        (
+            (
+                "Compare options for a business trip with approval, budget, hotel, train, "
+                "walking, family, food, transfer, and accessibility constraints?"
+            ),
+            "overloaded_constraints",
+            "planning_synthesis",
+        ),
+    ],
+)
+def test_planner_turn_records_adaptive_triage_metadata(
+    client: TestClient,
+    message: str,
+    expected_maturity: str,
+    expected_task: str,
+) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(f"/api/planner/{trip_id}/turns", json={"message": message})
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    metadata = planner_reply["turn_metadata"]
+    assert metadata["plan_maturity"] == expected_maturity
+    assert metadata["task_class"] == expected_task
+    assert metadata["visible_response_blocks"]
+    assert metadata["debug_routing_details"]["runtime_mode"] == "fallback"
+    visible_content = planner_reply["content"].lower()
+    assert "model routing" not in visible_content
+    assert "provider" not in visible_content
+    assert "fallback" not in visible_content
 
 
 def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
@@ -577,7 +630,8 @@ def test_planner_resume_returns_prior_conversation_history(client: TestClient) -
     payload = resumed.json()
     assert payload["resumed_at"] is not None
     assert [message["role"] for message in payload["messages"]] == ["user", "planner"]
-    assert payload["messages"][1]["content"].startswith("Planner API kickoff is using")
+    assert payload["messages"][1]["content"].startswith("Planner API kickoff has a useful starting point")
+    assert payload["messages"][1]["turn_metadata"]["task_class"] == "first_turn_triage"
     assert payload["planner_memory"]["artifacts"][0]["title"] == "Planner checkpoint 1"
 
 

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -22,10 +22,16 @@ class PlannerToolCallResponse(BaseModel):
     output: dict[str, Any] = Field(default_factory=dict)
 
 
+class PlannerVisibleResponseBlock(BaseModel):
+    kind: str = Field(min_length=1, max_length=80)
+    title: str = Field(min_length=1, max_length=160)
+    items: list[str] = Field(default_factory=list)
+
+
 class PlannerTurnMetadata(BaseModel):
     plan_maturity: str
     task_class: str
-    visible_response_blocks: list[dict[str, Any]] = Field(default_factory=list)
+    visible_response_blocks: list[PlannerVisibleResponseBlock] = Field(default_factory=list)
     debug_routing_details: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -22,6 +22,13 @@ class PlannerToolCallResponse(BaseModel):
     output: dict[str, Any] = Field(default_factory=dict)
 
 
+class PlannerTurnMetadata(BaseModel):
+    plan_maturity: str
+    task_class: str
+    visible_response_blocks: list[dict[str, Any]] = Field(default_factory=list)
+    debug_routing_details: dict[str, Any] = Field(default_factory=dict)
+
+
 class PlannerMessageResponse(BaseModel):
     message_id: str
     role: str
@@ -29,6 +36,7 @@ class PlannerMessageResponse(BaseModel):
     created_at: str
     refs: list[str] = Field(default_factory=list)
     tool_calls: list[PlannerToolCallResponse] = Field(default_factory=list)
+    turn_metadata: PlannerTurnMetadata | None = None
 
 
 class PlannerCheckpointResponse(BaseModel):

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -117,6 +117,29 @@ _CONSTRAINT_MARKERS = (
     "transfer",
 )
 _SYNTHESIS_MARKERS = ("compare", "option", "route", "itinerary", "plan", "summary", "decide")
+_NON_DESTINATION_CAPITALIZED_TOKENS = {
+    "i",
+    "i'd",
+    "i'll",
+    "i'm",
+    "we",
+    "we'd",
+    "we'll",
+    "we're",
+    "can",
+    "could",
+    "help",
+    "please",
+}
+
+
+def _looks_like_destination_token(token: str, index: int) -> bool:
+    if not token[:1].isupper():
+        return False
+    lowered = token.lower()
+    if lowered in _DATE_MARKERS:
+        return False
+    return index > 0 or lowered not in _NON_DESTINATION_CAPITALIZED_TOKENS
 
 
 def _planner_turn_metadata(
@@ -128,7 +151,9 @@ def _planner_turn_metadata(
     lowered = message.lower()
     raw_tokens = [token.strip(".,!?;:()[]{}\"'") for token in message.split()]
     tokens = [token.lower() for token in raw_tokens]
-    destination_hits = sum(1 for token in raw_tokens if token[:1].isupper())
+    destination_hits = sum(
+        1 for index, token in enumerate(raw_tokens) if _looks_like_destination_token(token, index)
+    )
     date_hits = sum(1 for marker in _DATE_MARKERS if marker in tokens)
     constraint_hits = sum(1 for marker in _CONSTRAINT_MARKERS if marker in lowered)
     synthesis_hits = sum(1 for marker in _SYNTHESIS_MARKERS if marker in lowered)
@@ -269,7 +294,7 @@ def _fallback_content_from_metadata(
         )
     return (
         f"{trip_title} has a useful starting point. I would close the biggest missing decision "
-        f"from your note, then move into targeted planning. You said: {message.strip()}"
+        "from your note, then move into targeted planning."
     )
 
 

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -63,6 +63,7 @@ class PlannerConversationReply:
     refs: list[str]
     tool_calls: list[dict[str, Any]]
     requested_tool_calls: list[dict[str, Any]] | None = None
+    turn_metadata: dict[str, Any] | None = None
 
 
 class PlannerChatModel(Protocol):
@@ -81,6 +82,195 @@ _GROUNDING_TOOL_NAMES: tuple[str, ...] = (
     "read_policy_state",
     "read_proposal_state",
 )
+
+_DATE_MARKERS = (
+    "january",
+    "february",
+    "march",
+    "april",
+    "may",
+    "june",
+    "july",
+    "august",
+    "september",
+    "october",
+    "november",
+    "december",
+    "weekend",
+    "week",
+    "days",
+    "nights",
+)
+_CONSTRAINT_MARKERS = (
+    "budget",
+    "hotel",
+    "flight",
+    "train",
+    "museum",
+    "food",
+    "kids",
+    "family",
+    "business",
+    "approval",
+    "accessible",
+    "walking",
+    "transfer",
+)
+_SYNTHESIS_MARKERS = ("compare", "option", "route", "itinerary", "plan", "summary", "decide")
+
+
+def _planner_turn_metadata(
+    *,
+    message: str,
+    runtime_config: PlannerRuntimeConfig,
+    turn_index: int,
+) -> dict[str, Any]:
+    lowered = message.lower()
+    raw_tokens = [token.strip(".,!?;:()[]{}\"'") for token in message.split()]
+    tokens = [token.lower() for token in raw_tokens]
+    destination_hits = sum(1 for token in raw_tokens if token[:1].isupper())
+    date_hits = sum(1 for marker in _DATE_MARKERS if marker in tokens)
+    constraint_hits = sum(1 for marker in _CONSTRAINT_MARKERS if marker in lowered)
+    synthesis_hits = sum(1 for marker in _SYNTHESIS_MARKERS if marker in lowered)
+    question_hits = lowered.count("?")
+
+    if lowered in {"help", "plan a trip", "vacation ideas"}:
+        plan_maturity = "open_ended"
+        task_class = "first_turn_triage"
+        blocks = [
+            {
+                "kind": "guidance",
+                "title": "Start with a direction",
+                "items": [
+                    "Choose a destination or region.",
+                    "Add timing, trip length, and traveler constraints.",
+                    "Name one priority such as food, pace, budget, or business approval.",
+                ],
+            },
+            {
+                "kind": "clarifying_questions",
+                "title": "Quick questions",
+                "items": [
+                    "Where are you considering going?",
+                    "When would you like to travel?",
+                    "What would make this trip feel successful?",
+                ],
+            },
+        ]
+    elif constraint_hits >= 5 or question_hits >= 3 or len(tokens) >= 45:
+        plan_maturity = "overloaded_constraints"
+        task_class = "planning_synthesis"
+        blocks = [
+            {
+                "kind": "summary",
+                "title": "Organize the constraints",
+                "items": [
+                    "Group timing, budget, traveler needs, and approval constraints before generating routes.",
+                    "Separate firm requirements from preferences so tradeoffs are visible.",
+                ],
+            },
+            {
+                "kind": "next_steps",
+                "title": "Next planning moves",
+                "items": [
+                    "Confirm must-haves.",
+                    "Rank the top tradeoff areas.",
+                    "Generate fewer, clearer options after the constraints are sorted.",
+                ],
+            },
+        ]
+    elif destination_hits >= 1 and date_hits >= 1 and constraint_hits >= 1:
+        plan_maturity = "coherent_plan"
+        task_class = "route_comparison" if synthesis_hits else "planning_synthesis"
+        blocks = [
+            {
+                "kind": "summary",
+                "title": "Understood plan",
+                "items": [
+                    "You have enough destination, timing, and constraint detail to start shaping options.",
+                    "The next turn can compare routes, pace, stays, or approval needs instead of restarting intake.",
+                ],
+            },
+            {
+                "kind": "next_steps",
+                "title": "Next planning moves",
+                "items": [
+                    "Confirm the most important tradeoff.",
+                    "Compare a small set of route or stay options.",
+                    "Preserve open decisions for the workspace checklist.",
+                ],
+            },
+        ]
+    else:
+        plan_maturity = "partial_plan"
+        task_class = "first_turn_triage"
+        blocks = [
+            {
+                "kind": "summary",
+                "title": "Partial plan",
+                "items": [
+                    "There is enough context to continue, but a few planning decisions are still missing.",
+                    "Targeted questions should close the largest gaps before deeper synthesis.",
+                ],
+            },
+            {
+                "kind": "clarifying_questions",
+                "title": "Targeted questions",
+                "items": [
+                    "What dates or trip length should the planner assume?",
+                    "Which tradeoff matters most: budget, pace, lodging, route, or approvals?",
+                ],
+            },
+        ]
+
+    return {
+        "plan_maturity": plan_maturity,
+        "task_class": task_class,
+        "visible_response_blocks": blocks,
+        "debug_routing_details": {
+            "runtime_mode": runtime_config.mode,
+            "runtime_provider": runtime_config.provider,
+            "runtime_model": runtime_config.model,
+            "turn_index": turn_index,
+            "signals": {
+                "token_count": len(tokens),
+                "date_hits": date_hits,
+                "constraint_hits": constraint_hits,
+                "synthesis_hits": synthesis_hits,
+                "question_hits": question_hits,
+            },
+        },
+    }
+
+
+def _fallback_content_from_metadata(
+    *,
+    trip_title: str,
+    message: str,
+    metadata: dict[str, Any],
+) -> str:
+    maturity = metadata["plan_maturity"]
+    if maturity == "coherent_plan":
+        return (
+            f"I can use the details you gave for {trip_title} to move into option shaping. "
+            "The next useful step is to compare a small set of routes, stays, or pacing tradeoffs "
+            "instead of asking broad intake questions again."
+        )
+    if maturity == "open_ended":
+        return (
+            f"Let's narrow {trip_title} before building options. Share a destination or region, "
+            "rough timing, and one priority, and I will turn it into a focused planning path."
+        )
+    if maturity == "overloaded_constraints":
+        return (
+            f"I will organize the constraints for {trip_title} before generating options. "
+            "First I would separate firm requirements from preferences, then compare only the "
+            "routes or stays that satisfy the must-haves."
+        )
+    return (
+        f"{trip_title} has a useful starting point. I would close the biggest missing decision "
+        f"from your note, then move into targeted planning. You said: {message.strip()}"
+    )
 
 
 def set_planner_chat_model_factory_for_tests(factory: PlannerChatModelFactory | None) -> None:
@@ -101,13 +291,21 @@ class DeterministicPlannerConversationRunnable:
     def invoke(self, request: PlannerConversationRequest) -> PlannerConversationReply:
         panel = request.planner_panel_state
         trip = panel["trip"]
+        metadata = _planner_turn_metadata(
+            message=request.message,
+            runtime_config=get_planner_runtime_config(),
+            turn_index=len(request.runtime_context.get("recent_activity") or []),
+        )
         outputs = list(panel.get("outputs") or [])
         decisions = list(panel.get("pending_decisions") or [])
         options = list((panel.get("option_set") or {}).get("options") or [])
 
         lines = [
-            f"{trip['title']} is using a trip-scoped planner session for this request.",
-            f"You said: {request.message.strip()}",
+            _fallback_content_from_metadata(
+                trip_title=trip["title"],
+                message=request.message,
+                metadata=metadata,
+            )
         ]
         refs = [request.session.session_state_id]
 
@@ -132,11 +330,13 @@ class DeterministicPlannerConversationRunnable:
             lines.append(f"Latest workspace signals: {latest_titles}.")
             refs.extend(output["output_id"] for output in outputs[:2])
 
-        lines.append(
-            "Deterministic planner fallback is active; configure a planner model for tool-grounded orchestration."
-        )
         deduped_refs = list(dict.fromkeys(refs))
-        return PlannerConversationReply(content=" ".join(lines), refs=deduped_refs, tool_calls=[])
+        return PlannerConversationReply(
+            content=" ".join(lines),
+            refs=deduped_refs,
+            tool_calls=[],
+            turn_metadata=metadata,
+        )
 
 
 class _OpenAIPlannerChatModel:
@@ -228,6 +428,11 @@ class ModelBackedPlannerConversationRunnable:
             refs=[request.session.session_state_id],
             tool_calls=[],
             requested_tool_calls=requested_tool_calls,
+            turn_metadata=_planner_turn_metadata(
+                message=request.message,
+                runtime_config=self._config,
+                turn_index=len(request.runtime_context.get("recent_activity") or []),
+            ),
         )
 
 
@@ -252,6 +457,7 @@ def _message_payload(
     created_at: str,
     refs: list[str] | None = None,
     tool_calls: list[dict[str, Any]] | None = None,
+    turn_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "message_id": message_id,
@@ -260,6 +466,7 @@ def _message_payload(
         "created_at": created_at,
         "refs": list(refs or []),
         "tool_calls": list(tool_calls or []),
+        "turn_metadata": turn_metadata,
     }
 
 
@@ -285,6 +492,9 @@ def _conversation_messages(
         raw_refs = record.payload.get("refs", "")
         refs = [item for item in raw_refs.split(",") if item]
         tool_calls = list(record.payload.get("tool_calls") or [])
+        turn_metadata = record.payload.get("turn_metadata")
+        if not isinstance(turn_metadata, dict):
+            turn_metadata = None
         messages.append(
             _message_payload(
                 message_id=record.planner_action_id,
@@ -293,6 +503,7 @@ def _conversation_messages(
                 created_at=record.occurred_at,
                 refs=refs,
                 tool_calls=tool_calls,
+                turn_metadata=turn_metadata,
             )
         )
     return messages
@@ -592,6 +803,18 @@ def submit_planner_turn(
             session_state_id=session.session_state_id,
             error=error,
         )
+    if reply.turn_metadata is None:
+        reply = PlannerConversationReply(
+            content=reply.content,
+            refs=reply.refs,
+            tool_calls=reply.tool_calls,
+            requested_tool_calls=reply.requested_tool_calls,
+            turn_metadata=_planner_turn_metadata(
+                message=normalized_message,
+                runtime_config=runtime_config,
+                turn_index=len(activity_log),
+            ),
+        )
     model_tool_calls = _execute_model_tool_calls(
         db_session,
         user=user,
@@ -624,6 +847,7 @@ def submit_planner_turn(
                 )
             ),
             tool_calls=executed_tool_calls,
+            turn_metadata=reply.turn_metadata,
         )
 
     planner_activity_event_id = f"activity:{trip_id}:{secrets.token_hex(4)}"
@@ -650,6 +874,7 @@ def submit_planner_turn(
             "content": reply.content,
             "refs": ",".join(reply.refs),
             "tool_calls": reply.tool_calls,
+            "turn_metadata": reply.turn_metadata,
             "selected_planning_mode": session.selected_planning_mode,
             "planning_stage": (
                 workspace_payload["planner_panel_state"]


### PR DESCRIPTION
Closes #1123\n\n## Summary\n- add planner turn triage metadata for plan maturity, task class, visible response blocks, and debug routing details\n- adapt deterministic planner replies for coherent, partial, open-ended, and overloaded first turns without exposing model/provider/fallback details in traveler text\n- render structured planner response blocks in the workspace conversation UI\n\n## Validation\n- python -m pytest tests/app/test_planner_routes.py tests/app/test_planner_turn_e2e.py -q --no-cov\n- python -m ruff check trip_planner/app/schemas/planner.py trip_planner/app/services/planner.py tests/app/test_planner_routes.py\n- npm test -- --run WorkspacePage.test.tsx\n- npm run build