### PR TITLE
Issue #1126: Render structured planner conversation blocks

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -327,6 +327,15 @@ export type PlannerTurnMetadata = {
   debug_routing_details: Record<string, unknown>;
 };
 
+export type PlannerStructuredBlock = {
+  kind: string;
+  title: string;
+  body: string;
+  items: string[];
+  metadata: Record<string, unknown>;
+  hidden: boolean;
+};
+
 export type PlannerMessage = {
   message_id: string;
   role: "user" | "planner" | string;
@@ -334,6 +343,7 @@ export type PlannerMessage = {
   created_at: string;
   refs: string[];
   tool_calls: PlannerToolCallResponse[];
+  structured_blocks: PlannerStructuredBlock[];
   turn_metadata?: PlannerTurnMetadata | null;
 };
 

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -724,6 +724,7 @@ const plannerSessionPayload = {
       created_at: "2026-04-12T06:09:00+00:00",
       refs: ["session:trip-leisure-kyoto-draft"],
       tool_calls: [],
+      structured_blocks: [],
     },
     {
       message_id: "planner-action:trip-leisure-kyoto-draft:planner-1",
@@ -732,6 +733,7 @@ const plannerSessionPayload = {
       created_at: "2026-04-12T06:10:00+00:00",
       refs: ["session:trip-leisure-kyoto-draft", "scenario:trip-leisure-kyoto-draft:1"],
       tool_calls: [],
+      structured_blocks: [],
     },
   ],
 } satisfies PlannerSessionResponse;
@@ -958,6 +960,18 @@ describe("WorkspacePage", () => {
           created_at: "2026-04-12T06:15:00+00:00",
           refs: ["session:trip-leisure-kyoto-draft"],
           tool_calls: [],
+          structured_blocks: [
+            {
+              kind: "traveler_input_summary",
+              title: "Traveler input summary",
+              body: "Key details pulled out of the traveler message.",
+              items: ["Preferences: Keep Uji, reduce transfer pressure"],
+              metadata: {
+                preferences: ["Keep Uji, but reduce transfer pressure"],
+              },
+              hidden: false,
+            },
+          ],
         },
         {
           message_id: "planner-action:trip-leisure-kyoto-draft:planner-2",
@@ -980,6 +994,74 @@ describe("WorkspacePage", () => {
               runtime_provider: null,
             },
           },
+          structured_blocks: [
+            {
+              kind: "summary",
+              title: "Planner summary",
+              body: "Keep the Uji day trip and reduce evening movement.",
+              items: ["Preserve the preferred Kyoto baseline."],
+              metadata: {},
+              hidden: false,
+            },
+            {
+              kind: "question",
+              title: "Questions to settle",
+              body: "",
+              items: ["How much evening variety should the route preserve?"],
+              metadata: {},
+              hidden: false,
+            },
+            {
+              kind: "decision",
+              title: "Open decisions",
+              body: "",
+              items: ["Should the current Kyoto route become the saved baseline?"],
+              metadata: {
+                decision_ids: ["decision:save-baseline"],
+              },
+              hidden: false,
+            },
+            {
+              kind: "route_option",
+              title: "Route options in view",
+              body: "",
+              items: ["Kyoto base with Uji day trip: Balanced Kyoto culture baseline"],
+              metadata: {
+                option_ids: ["scenario:trip-leisure-kyoto-draft:1"],
+              },
+              hidden: false,
+            },
+            {
+              kind: "comparison",
+              title: "Comparison frame",
+              body: "",
+              items: [
+                "Kyoto baseline has fewer transfers; Osaka fallback has more evening variety.",
+              ],
+              metadata: {},
+              hidden: false,
+            },
+            {
+              kind: "next_action",
+              title: "Next actions",
+              body: "",
+              items: ["Compare fewer evening moves.", "Preserve Uji as the baseline day trip."],
+              metadata: {},
+              hidden: false,
+            },
+            {
+              kind: "debug",
+              title: "Planner diagnostics",
+              body: "Routing details and tool traces are hidden from the normal traveler view.",
+              items: [],
+              metadata: {
+                routing: {
+                  runtime_mode: "fallback",
+                },
+              },
+              hidden: true,
+            },
+          ],
           tool_calls: [
             {
               tool_name: "read_workspace_state",
@@ -1019,8 +1101,18 @@ describe("WorkspacePage", () => {
       screen.getByText("Keep the Uji day trip and compare fewer evening moves before the next checkpoint.")
     ).toBeInTheDocument();
     expect(screen.getByText("coherent plan")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Next planning moves" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Planner summary" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Questions to settle" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Open decisions" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Route options in view" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Comparison frame" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Next actions" })).toBeInTheDocument();
+    expect(screen.getByText("Traveler input summary")).toBeInTheDocument();
     expect(screen.getByText("Compare fewer evening moves.")).toBeInTheDocument();
+    expect(screen.queryByText("Planner diagnostics")).not.toBeInTheDocument();
+    expect(screen.queryByText("read_workspace_state: Read the current workspace state.")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Diagnostics" }));
+    expect(screen.getByText("Planner diagnostics")).toBeInTheDocument();
     expect(screen.getByText("read_workspace_state: Read the current workspace state.")).toBeInTheDocument();
     expect(screen.getByLabelText("Message")).toHaveValue("");
   });
@@ -1330,6 +1422,8 @@ describe("WorkspacePage", () => {
 
   it("renders the fallback map state and compact review copy on small screens", async () => {
     stubMatchMedia(true);
+    vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "");
+    vi.stubEnv("VITE_GOOGLE_MAPS_PROVIDER_STATE", "missing");
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve(workspacePayload),
       trips: Promise.resolve(tripComparisonPayload),
@@ -1342,7 +1436,9 @@ describe("WorkspacePage", () => {
     });
 
     expect(screen.getByText("Compact review stack keeps map, timeline, and tradeoff calls visible on smaller screens.")).toBeInTheDocument();
-    expect(screen.getByText("Textual fallback route path")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Textual fallback route path")).toBeInTheDocument();
+    });
     expect(screen.getAllByText(/Google Maps JavaScript is not configured in this environment/).length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Compact day-by-day review" })).toBeInTheDocument();
   });

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -543,8 +543,8 @@ function PlannerMessageDiagnostics({
         <details>
           <summary>Tool calls</summary>
           <ul className="planner-tool-call-list">
-            {message.tool_calls.map((toolCall) => (
-              <li key={`${message.message_id}-${toolCall.tool_name}`}>
+            {message.tool_calls.map((toolCall, toolCallIndex) => (
+              <li key={`${message.message_id}-${toolCall.tool_name}-${toolCallIndex}`}>
                 {toolCall.tool_name}: {toolCall.summary}
               </li>
             ))}

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -13,7 +13,9 @@ import {
   type ActualSpendEventUpsertPayload,
   type BudgetPlanUpsertPayload,
   type BudgetWorkspaceState,
+  type PlannerMessage,
   type PlannerSessionResponse,
+  type PlannerStructuredBlock,
   type PlanningMode,
   submitPlannerOptionFeedback,
   type SavedScenarioRecord,
@@ -451,6 +453,136 @@ function mergePlannerSessionState(
   };
 }
 
+const hiddenPlannerBlockKinds = new Set(["debug", "tool_call", "tool_trace", "diagnostic"]);
+
+function legacyStructuredBlocks(message: PlannerMessage): PlannerStructuredBlock[] {
+  return (
+    message.turn_metadata?.visible_response_blocks.map((block) => ({
+      kind: block.kind,
+      title: block.title,
+      body: "",
+      items: block.items,
+      metadata: {},
+      hidden: false,
+    })) ?? []
+  );
+}
+
+function messageStructuredBlocks(message: PlannerMessage): PlannerStructuredBlock[] {
+  return (message.structured_blocks ?? []).length > 0
+    ? message.structured_blocks
+    : legacyStructuredBlocks(message);
+}
+
+function isPlannerDiagnosticBlock(block: PlannerStructuredBlock): boolean {
+  return block.hidden || hiddenPlannerBlockKinds.has(block.kind);
+}
+
+function plannerBlockKindLabel(kind: string): string {
+  return kind.replace(/_/g, " ");
+}
+
+function PlannerStructuredBlockList({ blocks }: { blocks: PlannerStructuredBlock[] }) {
+  if (blocks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="planner-response-blocks">
+      {blocks.map((block, blockIndex) => (
+        <section
+          key={`${block.kind}-${block.title}-${blockIndex}`}
+          className={`planner-response-block planner-response-block-${block.kind}`}
+        >
+          <span className="planner-block-kind">{plannerBlockKindLabel(block.kind)}</span>
+          <h4>{block.title}</h4>
+          {block.body ? <p>{block.body}</p> : null}
+          {block.items.length > 0 ? (
+            <ul>
+              {block.items.map((item, itemIndex) => (
+                <li key={`${block.kind}-${block.title}-${itemIndex}`}>{item}</li>
+              ))}
+            </ul>
+          ) : null}
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function PlannerMessageDiagnostics({
+  message,
+  blocks,
+}: {
+  message: PlannerMessage;
+  blocks: PlannerStructuredBlock[];
+}) {
+  if (blocks.length === 0 && message.tool_calls.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="planner-diagnostics">
+      {blocks.map((block, blockIndex) => (
+        <details key={`${message.message_id}-${block.kind}-${blockIndex}`}>
+          <summary>{block.title}</summary>
+          {block.body ? <p>{block.body}</p> : null}
+          {block.items.length > 0 ? (
+            <ul>
+              {block.items.map((item, itemIndex) => (
+                <li key={`${message.message_id}-${block.kind}-${itemIndex}`}>{item}</li>
+              ))}
+            </ul>
+          ) : null}
+          {Object.keys(block.metadata).length > 0 ? (
+            <pre>{JSON.stringify(block.metadata, null, 2)}</pre>
+          ) : null}
+        </details>
+      ))}
+      {message.tool_calls.length > 0 ? (
+        <details>
+          <summary>Tool calls</summary>
+          <ul className="planner-tool-call-list">
+            {message.tool_calls.map((toolCall) => (
+              <li key={`${message.message_id}-${toolCall.tool_name}`}>
+                {toolCall.tool_name}: {toolCall.summary}
+              </li>
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+function PlannerConversationMessage({
+  message,
+  showDiagnostics,
+}: {
+  message: PlannerMessage;
+  showDiagnostics: boolean;
+}) {
+  const blocks = messageStructuredBlocks(message);
+  const visibleBlocks = blocks.filter((block) => !isPlannerDiagnosticBlock(block));
+  const diagnosticBlocks = blocks.filter(isPlannerDiagnosticBlock);
+
+  return (
+    <article className={`planner-message planner-message-${message.role}`}>
+      <p className="scenario-kicker">{message.role === "user" ? "Traveler" : "Planner"}</p>
+      <p>{message.content}</p>
+      {message.turn_metadata?.plan_maturity ? (
+        <span className="planner-routing-pill">
+          {message.turn_metadata.plan_maturity.replace(/_/g, " ")}
+        </span>
+      ) : null}
+      <PlannerStructuredBlockList blocks={visibleBlocks} />
+      {showDiagnostics ? (
+        <PlannerMessageDiagnostics message={message} blocks={diagnosticBlocks} />
+      ) : null}
+    </article>
+  );
+}
+
 export function WorkspacePage() {
   const { workspace, trips } = useLoaderData() as LoaderData;
   const resolve = useMemo(
@@ -499,6 +631,7 @@ function WorkspacePageContent({
   const [plannerConversationBusyLabel, setPlannerConversationBusyLabel] = useState<string | null>(
     null
   );
+  const [showPlannerDiagnostics, setShowPlannerDiagnostics] = useState(false);
   const [plannerError, setPlannerError] = useState<string | null>(null);
   const [plannerBusyLabel, setPlannerBusyLabel] = useState<string | null>(null);
   const [planningModeBusy, setPlanningModeBusy] = useState(false);
@@ -873,10 +1006,20 @@ function WorkspacePageContent({
                   panel state, memory, and activity trail used by the workspace.
                 </p>
               </div>
-              <span className="planner-conversation-pill">
-                {plannerSession?.messages.length ?? 0} message
-                {(plannerSession?.messages.length ?? 0) === 1 ? "" : "s"}
-              </span>
+              <div className="planner-conversation-actions">
+                <span className="planner-conversation-pill">
+                  {plannerSession?.messages.length ?? 0} message
+                  {(plannerSession?.messages.length ?? 0) === 1 ? "" : "s"}
+                </span>
+                <button
+                  type="button"
+                  className="planner-diagnostics-toggle"
+                  aria-pressed={showPlannerDiagnostics}
+                  onClick={() => setShowPlannerDiagnostics((current) => !current)}
+                >
+                  Diagnostics
+                </button>
+              </div>
             </div>
             {plannerConversationBusyLabel ? (
               <p className="muted-copy">{plannerConversationBusyLabel}</p>
@@ -894,46 +1037,11 @@ function WorkspacePageContent({
                 </article>
               ) : (
                 plannerSession.messages.map((message) => (
-                  <article
+                  <PlannerConversationMessage
                     key={message.message_id}
-                    className={`planner-message planner-message-${message.role}`}
-                  >
-                    <p className="scenario-kicker">
-                      {message.role === "user" ? "Traveler" : "Planner"}
-                    </p>
-                    <p>{message.content}</p>
-                    {message.turn_metadata?.visible_response_blocks.length ? (
-                      <div className="planner-response-blocks">
-                        <span className="planner-routing-pill">
-                          {message.turn_metadata.plan_maturity.replace(/_/g, " ")}
-                        </span>
-                        {message.turn_metadata.visible_response_blocks.map((block) => (
-                          <section
-                            key={`${message.message_id}-${block.kind}-${block.title}`}
-                            className="planner-response-block"
-                          >
-                            <h4>{block.title}</h4>
-                            <ul>
-                              {block.items.map((item, itemIndex) => (
-                                <li key={`${message.message_id}-${block.kind}-${block.title}-${itemIndex}`}>
-                                  {item}
-                                </li>
-                              ))}
-                            </ul>
-                          </section>
-                        ))}
-                      </div>
-                    ) : null}
-                    {message.tool_calls.length > 0 ? (
-                      <ul className="planner-tool-call-list">
-                        {message.tool_calls.map((toolCall) => (
-                          <li key={`${message.message_id}-${toolCall.tool_name}`}>
-                            {toolCall.tool_name}: {toolCall.summary}
-                          </li>
-                        ))}
-                      </ul>
-                    ) : null}
-                  </article>
+                    message={message}
+                    showDiagnostics={showPlannerDiagnostics}
+                  />
                 ))
               )}
             </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -413,6 +413,31 @@ a {
   font-weight: 700;
 }
 
+.planner-conversation-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.planner-diagnostics-toggle {
+  border: 1px solid rgba(19, 33, 44, 0.18);
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+  background: rgba(255, 255, 255, 0.72);
+  color: #24394a;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.planner-diagnostics-toggle[aria-pressed="true"] {
+  background: #24394a;
+  color: #f7f1e5;
+}
+
 .planner-message-list {
   display: grid;
   gap: 0.75rem;
@@ -450,6 +475,15 @@ a {
   padding-left: 0.75rem;
 }
 
+.planner-block-kind {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: #577186;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
 .planner-response-block h4 {
   margin: 0 0 0.35rem;
   font-size: 0.92rem;
@@ -480,6 +514,35 @@ a {
   margin: 0.75rem 0 0;
   padding-left: 1.1rem;
   color: #365063;
+}
+
+.planner-diagnostics {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 0.75rem;
+}
+
+.planner-diagnostics details {
+  border: 1px solid rgba(19, 33, 44, 0.12);
+  border-radius: 12px;
+  padding: 0.65rem 0.75rem;
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.planner-diagnostics summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.planner-diagnostics pre {
+  overflow: auto;
+  margin: 0.6rem 0 0;
+  border-radius: 10px;
+  padding: 0.7rem;
+  background: rgba(19, 33, 44, 0.08);
+  color: #24394a;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
 }
 
 .planner-tool-strip {

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -261,6 +261,9 @@ def test_planner_turn_summarizes_scattered_traveler_input(client: TestClient) ->
     assert any("Notes to remember:" in item for item in summary_block["items"])
     assert "Sweden" in summary_block["metadata"]["destinations"]
     assert "Norway" in summary_block["metadata"]["destinations"]
+    assert "Bergen" in summary_block["metadata"]["destinations"]
+    assert "Maybe Bergen" not in summary_block["metadata"]["destinations"]
+    assert "Not" not in summary_block["metadata"]["destinations"]
     assert "august" in summary_block["metadata"]["dates"]
 
 

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -22,9 +22,7 @@ from trip_planner.persistence.models.session import PersistedPlanningSessionStat
 
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
-    monkeypatch.setenv(
-        "TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'planner.db'}"
-    )
+    monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'planner.db'}")
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -190,10 +188,11 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
     assert payload["messages"][1]["turn_metadata"]["plan_maturity"] == "partial_plan"
     planner_blocks = payload["messages"][1]["structured_blocks"]
     planner_block_kinds = {block["kind"] for block in planner_blocks}
-    assert {"summary", "question", "assumption", "debug"}.issubset(planner_block_kinds)
+    assert {"visible_sections", "summary", "question", "assumption", "diagnostic"}.issubset(
+        planner_block_kinds
+    )
     assert (
-        next(block for block in planner_blocks if block["kind"] == "debug")["hidden"]
-        is True
+        next(block for block in planner_blocks if block["kind"] == "diagnostic")["hidden"] is True
     )
     assert payload["messages"][1]["refs"]
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
@@ -317,12 +316,11 @@ def test_planner_turn_records_adaptive_triage_metadata(
     assert metadata["debug_routing_details"]["runtime_mode"] == "fallback"
     structured_kinds = {block["kind"] for block in planner_reply["structured_blocks"]}
     assert "summary" in structured_kinds
-    assert "debug" in structured_kinds
+    assert "diagnostic" in structured_kinds
+    assert "visible_sections" in structured_kinds
     assert (
         next(
-            block
-            for block in planner_reply["structured_blocks"]
-            if block["kind"] == "debug"
+            block for block in planner_reply["structured_blocks"] if block["kind"] == "diagnostic"
         )["hidden"]
         is True
     )
@@ -381,9 +379,7 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
     assert planner_reply["tool_calls"][0]["tool_name"] == "read_workspace_state"
     assert planner_reply["tool_calls"][0]["status"] == "completed"
     completed_tool_names = {
-        item["tool_name"]
-        for item in planner_reply["tool_calls"]
-        if item["status"] == "completed"
+        item["tool_name"] for item in planner_reply["tool_calls"] if item["status"] == "completed"
     }
     assert completed_tool_names == {
         "read_workspace_state",
@@ -393,10 +389,7 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
         "read_policy_state",
         "read_proposal_state",
     }
-    assert (
-        fake_model.requests[0]["available_tools"][0]["tool_name"]
-        == "read_workspace_state"
-    )
+    assert fake_model.requests[0]["available_tools"][0]["tool_name"] == "read_workspace_state"
     runtime_context = fake_model.requests[0]["runtime_context"]
     assert isinstance(runtime_context, dict)
     assert runtime_context["trip"]["trip_id"] == trip_id
@@ -476,9 +469,7 @@ def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(
 
     response = client.post(
         f"/api/planner/{trip_id}/turns",
-        json={
-            "message": "Ground your recommendation in persisted workspace and approval state."
-        },
+        json={"message": "Ground your recommendation in persisted workspace and approval state."},
     )
 
     assert response.status_code == 200
@@ -506,9 +497,9 @@ def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(
         tool_outputs["read_workspace_state"]["output"]["trip_title"]
         == workspace_payload["trip_record"]["trip"]["title"]
     )
-    assert tool_outputs["read_workspace_state"]["output"][
-        "pending_decision_count"
-    ] == len(workspace_payload["planner_panel_state"]["pending_decisions"])
+    assert tool_outputs["read_workspace_state"]["output"]["pending_decision_count"] == len(
+        workspace_payload["planner_panel_state"]["pending_decisions"]
+    )
     assert (
         tool_outputs["refresh_inventory"]["output"]["bundle_count"]
         == workspace_payload["inventory_summary"]["bundle_count"]
@@ -522,8 +513,7 @@ def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(
         == budget_payload["summary"]["planned_total"]
     )
     assert (
-        tool_outputs["read_policy_state"]["output"]["status"]
-        == policy_payload["summary"]["status"]
+        tool_outputs["read_policy_state"]["output"]["status"] == policy_payload["summary"]["status"]
     )
     assert (
         tool_outputs["read_proposal_state"]["output"]["status"]
@@ -572,9 +562,7 @@ def test_planner_turn_records_malformed_model_tool_arguments_as_visible_error(
         lambda _: FakePlannerChatModel(
             {
                 "content": "The budget tool received malformed arguments.",
-                "tool_calls": [
-                    {"tool_name": "update_budget_plan", "arguments": "not-a-dict"}
-                ],
+                "tool_calls": [{"tool_name": "update_budget_plan", "arguments": "not-a-dict"}],
             }
         )
     )
@@ -733,9 +721,7 @@ def test_planner_resume_regenerates_memory_from_raw_transcript(
     trip_id = _create_trip(client)
     first_turn = client.post(
         f"/api/planner/{trip_id}/turns",
-        json={
-            "message": "Keep the baseline narrow and summarize the current direction."
-        },
+        json={"message": "Keep the baseline narrow and summarize the current direction."},
     )
     assert first_turn.status_code == 200
 
@@ -746,9 +732,7 @@ def test_planner_resume_regenerates_memory_from_raw_transcript(
             )
         )
         db_session.execute(
-            delete(PersistedPlannerCheckpoint).where(
-                PersistedPlannerCheckpoint.trip_id == trip_id
-            )
+            delete(PersistedPlannerCheckpoint).where(PersistedPlannerCheckpoint.trip_id == trip_id)
         )
         session = db_session.get(PersistedPlanningSessionState, f"session:{trip_id}")
         assert session is not None
@@ -760,6 +744,4 @@ def test_planner_resume_regenerates_memory_from_raw_transcript(
     assert resumed.status_code == 200
     payload = resumed.json()
     assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
-    assert payload["planner_memory"]["artifacts"][0]["summary"].startswith(
-        "Turn 1 checkpoint"
-    )
+    assert payload["planner_memory"]["artifacts"][0]["summary"].startswith("Turn 1 checkpoint")

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -22,7 +22,9 @@ from trip_planner.persistence.models.session import PersistedPlanningSessionStat
 
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
-    monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'planner.db'}")
+    monkeypatch.setenv(
+        "TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'planner.db'}"
+    )
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -110,7 +112,9 @@ def _create_business_trip(client: TestClient) -> str:
     return response.json()["trip"]["trip_id"]
 
 
-def test_planner_session_endpoint_bootstraps_trip_scoped_session(client: TestClient) -> None:
+def test_planner_session_endpoint_bootstraps_trip_scoped_session(
+    client: TestClient,
+) -> None:
     trip_id = _create_trip(client)
 
     response = client.get(f"/api/planner/{trip_id}/session")
@@ -184,6 +188,13 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
     assert "Help me decide" in payload["messages"][0]["content"]
     assert "fallback" not in payload["messages"][1]["content"].lower()
     assert payload["messages"][1]["turn_metadata"]["plan_maturity"] == "partial_plan"
+    planner_blocks = payload["messages"][1]["structured_blocks"]
+    planner_block_kinds = {block["kind"] for block in planner_blocks}
+    assert {"summary", "question", "assumption", "debug"}.issubset(planner_block_kinds)
+    assert (
+        next(block for block in planner_blocks if block["kind"] == "debug")["hidden"]
+        is True
+    )
     assert payload["messages"][1]["refs"]
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
     assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
@@ -221,6 +232,37 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
         assert artifact is not None
         assert artifact.memory_artifact_id.startswith("planner-mem:")
         assert artifact.checkpoint_id == checkpoint.checkpoint_id
+
+
+def test_planner_turn_summarizes_scattered_traveler_input(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={
+            "message": (
+                "We're considering Sweden and Norway in August for 12 days. "
+                "Budget matters and we prefer scenic trains, low transfer days, and food markets. "
+                "Maybe Bergen, but I'm not sure. "
+                "Also remind me to check passport renewal later."
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    user_message = response.json()["messages"][0]
+    summary_block = user_message["structured_blocks"][0]
+    assert summary_block["kind"] == "traveler_input_summary"
+    assert "Traveler input summary" == summary_block["title"]
+    assert any("Destinations:" in item for item in summary_block["items"])
+    assert any("Timing:" in item for item in summary_block["items"])
+    assert any("Constraints:" in item for item in summary_block["items"])
+    assert any("Preferences:" in item for item in summary_block["items"])
+    assert any("Open questions:" in item for item in summary_block["items"])
+    assert any("Notes to remember:" in item for item in summary_block["items"])
+    assert "Sweden" in summary_block["metadata"]["destinations"]
+    assert "Norway" in summary_block["metadata"]["destinations"]
+    assert "august" in summary_block["metadata"]["dates"]
 
 
 @pytest.mark.parametrize(
@@ -273,13 +315,26 @@ def test_planner_turn_records_adaptive_triage_metadata(
     assert metadata["task_class"] == expected_task
     assert metadata["visible_response_blocks"]
     assert metadata["debug_routing_details"]["runtime_mode"] == "fallback"
+    structured_kinds = {block["kind"] for block in planner_reply["structured_blocks"]}
+    assert "summary" in structured_kinds
+    assert "debug" in structured_kinds
+    assert (
+        next(
+            block
+            for block in planner_reply["structured_blocks"]
+            if block["kind"] == "debug"
+        )["hidden"]
+        is True
+    )
     visible_content = planner_reply["content"].lower()
     assert "model routing" not in visible_content
     assert "provider" not in visible_content
     assert "fallback" not in visible_content
 
 
-def test_planner_turn_partial_reply_does_not_echo_internal_user_terms(client: TestClient) -> None:
+def test_planner_turn_partial_reply_does_not_echo_internal_user_terms(
+    client: TestClient,
+) -> None:
     trip_id = _create_trip(client)
 
     response = client.post(
@@ -326,7 +381,9 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
     assert planner_reply["tool_calls"][0]["tool_name"] == "read_workspace_state"
     assert planner_reply["tool_calls"][0]["status"] == "completed"
     completed_tool_names = {
-        item["tool_name"] for item in planner_reply["tool_calls"] if item["status"] == "completed"
+        item["tool_name"]
+        for item in planner_reply["tool_calls"]
+        if item["status"] == "completed"
     }
     assert completed_tool_names == {
         "read_workspace_state",
@@ -336,7 +393,10 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
         "read_policy_state",
         "read_proposal_state",
     }
-    assert fake_model.requests[0]["available_tools"][0]["tool_name"] == "read_workspace_state"
+    assert (
+        fake_model.requests[0]["available_tools"][0]["tool_name"]
+        == "read_workspace_state"
+    )
     runtime_context = fake_model.requests[0]["runtime_context"]
     assert isinstance(runtime_context, dict)
     assert runtime_context["trip"]["trip_id"] == trip_id
@@ -416,14 +476,16 @@ def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(
 
     response = client.post(
         f"/api/planner/{trip_id}/turns",
-        json={"message": "Ground your recommendation in persisted workspace and approval state."},
+        json={
+            "message": "Ground your recommendation in persisted workspace and approval state."
+        },
     )
 
     assert response.status_code == 200
     payload = response.json()
     planner_reply = payload["messages"][-1]
     assert payload["runtime"]["mode"] == "model"
-    assert "Tool results:" in planner_reply["content"]
+    assert "Tool results:" not in planner_reply["content"]
     tool_outputs = {item["tool_name"]: item for item in planner_reply["tool_calls"]}
     assert set(tool_outputs) == {
         "read_workspace_state",
@@ -444,9 +506,9 @@ def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(
         tool_outputs["read_workspace_state"]["output"]["trip_title"]
         == workspace_payload["trip_record"]["trip"]["title"]
     )
-    assert tool_outputs["read_workspace_state"]["output"]["pending_decision_count"] == len(
-        workspace_payload["planner_panel_state"]["pending_decisions"]
-    )
+    assert tool_outputs["read_workspace_state"]["output"][
+        "pending_decision_count"
+    ] == len(workspace_payload["planner_panel_state"]["pending_decisions"])
     assert (
         tool_outputs["refresh_inventory"]["output"]["bundle_count"]
         == workspace_payload["inventory_summary"]["bundle_count"]
@@ -460,7 +522,8 @@ def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(
         == budget_payload["summary"]["planned_total"]
     )
     assert (
-        tool_outputs["read_policy_state"]["output"]["status"] == policy_payload["summary"]["status"]
+        tool_outputs["read_policy_state"]["output"]["status"]
+        == policy_payload["summary"]["status"]
     )
     assert (
         tool_outputs["read_proposal_state"]["output"]["status"]
@@ -509,7 +572,9 @@ def test_planner_turn_records_malformed_model_tool_arguments_as_visible_error(
         lambda _: FakePlannerChatModel(
             {
                 "content": "The budget tool received malformed arguments.",
-                "tool_calls": [{"tool_name": "update_budget_plan", "arguments": "not-a-dict"}],
+                "tool_calls": [
+                    {"tool_name": "update_budget_plan", "arguments": "not-a-dict"}
+                ],
             }
         )
     )
@@ -560,7 +625,10 @@ def test_planner_turn_executes_explicit_tool_calls(client: TestClient) -> None:
                 {"tool_name": "read_budget_state"},
                 {
                     "tool_name": "update_budget_plan",
-                    "arguments": {"total_amount": 1200, "title": "Planner first-pass budget"},
+                    "arguments": {
+                        "total_amount": 1200,
+                        "title": "Planner first-pass budget",
+                    },
                 },
             ],
         },
@@ -573,7 +641,7 @@ def test_planner_turn_executes_explicit_tool_calls(client: TestClient) -> None:
     assert planner_reply["tool_calls"][0]["tool_name"] == "read_budget_state"
     assert planner_reply["tool_calls"][1]["tool_name"] == "update_budget_plan"
     assert planner_reply["tool_calls"][1]["mutates_state"] is True
-    assert "Tool results:" in planner_reply["content"]
+    assert "Tool results:" not in planner_reply["content"]
 
     with get_session_factory()() as db_session:
         stored = db_session.scalars(
@@ -652,16 +720,22 @@ def test_planner_resume_returns_prior_conversation_history(client: TestClient) -
     payload = resumed.json()
     assert payload["resumed_at"] is not None
     assert [message["role"] for message in payload["messages"]] == ["user", "planner"]
-    assert payload["messages"][1]["content"].startswith("Planner API kickoff has a useful starting point")
+    assert payload["messages"][1]["content"].startswith(
+        "Planner API kickoff has a useful starting point"
+    )
     assert payload["messages"][1]["turn_metadata"]["task_class"] == "first_turn_triage"
     assert payload["planner_memory"]["artifacts"][0]["title"] == "Planner checkpoint 1"
 
 
-def test_planner_resume_regenerates_memory_from_raw_transcript(client: TestClient) -> None:
+def test_planner_resume_regenerates_memory_from_raw_transcript(
+    client: TestClient,
+) -> None:
     trip_id = _create_trip(client)
     first_turn = client.post(
         f"/api/planner/{trip_id}/turns",
-        json={"message": "Keep the baseline narrow and summarize the current direction."},
+        json={
+            "message": "Keep the baseline narrow and summarize the current direction."
+        },
     )
     assert first_turn.status_code == 200
 
@@ -672,7 +746,9 @@ def test_planner_resume_regenerates_memory_from_raw_transcript(client: TestClien
             )
         )
         db_session.execute(
-            delete(PersistedPlannerCheckpoint).where(PersistedPlannerCheckpoint.trip_id == trip_id)
+            delete(PersistedPlannerCheckpoint).where(
+                PersistedPlannerCheckpoint.trip_id == trip_id
+            )
         )
         session = db_session.get(PersistedPlanningSessionState, f"session:{trip_id}")
         assert session is not None
@@ -684,4 +760,6 @@ def test_planner_resume_regenerates_memory_from_raw_transcript(client: TestClien
     assert resumed.status_code == 200
     payload = resumed.json()
     assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
-    assert payload["planner_memory"]["artifacts"][0]["summary"].startswith("Turn 1 checkpoint")
+    assert payload["planner_memory"]["artifacts"][0]["summary"].startswith(
+        "Turn 1 checkpoint"
+    )

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -28,10 +28,21 @@ class PlannerVisibleResponseBlock(BaseModel):
     items: list[str] = Field(default_factory=list)
 
 
+class PlannerStructuredBlock(BaseModel):
+    kind: str = Field(min_length=1, max_length=80)
+    title: str = Field(min_length=1, max_length=160)
+    body: str = ""
+    items: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    hidden: bool = False
+
+
 class PlannerTurnMetadata(BaseModel):
     plan_maturity: str
     task_class: str
-    visible_response_blocks: list[PlannerVisibleResponseBlock] = Field(default_factory=list)
+    visible_response_blocks: list[PlannerVisibleResponseBlock] = Field(
+        default_factory=list
+    )
     debug_routing_details: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -42,6 +53,7 @@ class PlannerMessageResponse(BaseModel):
     created_at: str
     refs: list[str] = Field(default_factory=list)
     tool_calls: list[PlannerToolCallResponse] = Field(default_factory=list)
+    structured_blocks: list[PlannerStructuredBlock] = Field(default_factory=list)
     turn_metadata: PlannerTurnMetadata | None = None
 
 

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -178,6 +178,8 @@ _NON_DESTINATION_CAPITALIZED_TOKENS = {
     "can",
     "could",
     "help",
+    "maybe",
+    "not",
     "please",
 }
 
@@ -223,7 +225,9 @@ def _extract_destination_mentions(message: str) -> list[str]:
     mentions: list[str] = []
     for match in re.finditer(r"\b[A-Z][A-Za-z]*(?:\s+[A-Z][A-Za-z]*){0,3}\b", message):
         words = match.group(0).split()
-        if any(word.lower() in _NON_DESTINATION_CAPITALIZED_TOKENS for word in words):
+        while words and words[0].lower() in _NON_DESTINATION_CAPITALIZED_TOKENS:
+            words = words[1:]
+        if not words:
             continue
         if any(word.lower() in _DATE_MARKERS for word in words):
             continue
@@ -233,7 +237,7 @@ def _extract_destination_mentions(message: str) -> list[str]:
             for word in words
         ):
             continue
-        mentions.append(match.group(0))
+        mentions.append(" ".join(words))
     return _dedupe_preserve_order(mentions)
 
 
@@ -1264,7 +1268,7 @@ def submit_planner_turn(
         tool_calls=reply.tool_calls,
         requested_tool_calls=reply.requested_tool_calls,
         structured_blocks=_ensure_top_level_planner_blocks(
-            blocks=reply.structured_blocks,
+            blocks=reply.structured_blocks or [],
             metadata=reply.turn_metadata or {},
             tool_calls=reply.tool_calls,
         ),

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import secrets
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -63,6 +64,7 @@ class PlannerConversationReply:
     refs: list[str]
     tool_calls: list[dict[str, Any]]
     requested_tool_calls: list[dict[str, Any]] | None = None
+    structured_blocks: list[dict[str, Any]] | None = None
     turn_metadata: dict[str, Any] | None = None
 
 
@@ -116,7 +118,54 @@ _CONSTRAINT_MARKERS = (
     "walking",
     "transfer",
 )
-_SYNTHESIS_MARKERS = ("compare", "option", "route", "itinerary", "plan", "summary", "decide")
+_SYNTHESIS_MARKERS = (
+    "compare",
+    "option",
+    "route",
+    "itinerary",
+    "plan",
+    "summary",
+    "decide",
+)
+_PREFERENCE_MARKERS = (
+    "prefer",
+    "want",
+    "like",
+    "love",
+    "avoid",
+    "interested",
+    "priority",
+    "important",
+    "pace",
+    "quiet",
+    "scenic",
+    "food",
+    "museum",
+    "nature",
+)
+_UNCERTAINTY_MARKERS = (
+    "maybe",
+    "not sure",
+    "unsure",
+    "could",
+    "might",
+    "probably",
+    "possibly",
+    "depends",
+    "?",
+)
+_NOTE_MARKERS = (
+    "also",
+    "note",
+    "remember",
+    "remind",
+    "later",
+    "future",
+    "unrelated",
+    "parking",
+    "passport",
+    "visa",
+)
 _NON_DESTINATION_CAPITALIZED_TOKENS = {
     "i",
     "i'd",
@@ -133,6 +182,25 @@ _NON_DESTINATION_CAPITALIZED_TOKENS = {
 }
 
 
+def _structured_block(
+    *,
+    kind: str,
+    title: str,
+    body: str = "",
+    items: list[str] | None = None,
+    metadata: dict[str, Any] | None = None,
+    hidden: bool = False,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "title": title,
+        "body": body,
+        "items": list(items or []),
+        "metadata": dict(metadata or {}),
+        "hidden": hidden,
+    }
+
+
 def _looks_like_destination_token(token: str, index: int) -> bool:
     if not token[:1].isupper():
         return False
@@ -140,6 +208,111 @@ def _looks_like_destination_token(token: str, index: int) -> bool:
     if lowered in _DATE_MARKERS:
         return False
     return index > 0 or lowered not in _NON_DESTINATION_CAPITALIZED_TOKENS
+
+
+def _dedupe_preserve_order(items: list[str]) -> list[str]:
+    return [
+        item
+        for item in dict.fromkeys(item.strip() for item in items if item.strip())
+        if item
+    ]
+
+
+def _split_user_clauses(message: str) -> list[str]:
+    clauses = re.split(r"(?:\n+|[.;]|(?:\s+-\s+))", message)
+    return [clause.strip(" ,") for clause in clauses if clause.strip(" ,")]
+
+
+def _extract_destination_mentions(message: str) -> list[str]:
+    mentions: list[str] = []
+    for match in re.finditer(r"\b[A-Z][A-Za-z]*(?:\s+[A-Z][A-Za-z]*){0,3}\b", message):
+        words = match.group(0).split()
+        if any(word.lower() in _NON_DESTINATION_CAPITALIZED_TOKENS for word in words):
+            continue
+        if any(word.lower() in _DATE_MARKERS for word in words):
+            continue
+        if any(
+            word.lower()
+            in _CONSTRAINT_MARKERS
+            + _PREFERENCE_MARKERS
+            + _UNCERTAINTY_MARKERS
+            + _NOTE_MARKERS
+            for word in words
+        ):
+            continue
+        mentions.append(match.group(0))
+    return _dedupe_preserve_order(mentions)
+
+
+def _extract_date_mentions(message: str) -> list[str]:
+    lowered = message.lower()
+    date_mentions = [
+        marker
+        for marker in _DATE_MARKERS
+        if re.search(rf"\b{re.escape(marker)}\b", lowered)
+        and marker not in {"days", "nights", "week"}
+    ]
+    date_mentions.extend(re.findall(r"\b\d{4}-\d{2}-\d{2}\b", message))
+    date_mentions.extend(re.findall(r"\b\d+\s+(?:days|nights|weeks)\b", lowered))
+    return _dedupe_preserve_order(date_mentions)
+
+
+def _matching_clauses(message: str, markers: tuple[str, ...]) -> list[str]:
+    matches: list[str] = []
+    for clause in _split_user_clauses(message):
+        lowered = clause.lower()
+        if any(marker in lowered for marker in markers):
+            matches.append(clause)
+    return _dedupe_preserve_order(matches)
+
+
+def _should_summarize_traveler_message(
+    message: str, summary: dict[str, list[str]]
+) -> bool:
+    signal_count = sum(len(items) for items in summary.values())
+    return (
+        len(message.split()) >= 28
+        or "\n" in message
+        or ";" in message
+        or signal_count >= 4
+    )
+
+
+def _traveler_input_summary_blocks(message: str) -> list[dict[str, Any]]:
+    summary = {
+        "destinations": _extract_destination_mentions(message),
+        "dates": _extract_date_mentions(message),
+        "constraints": _matching_clauses(message, _CONSTRAINT_MARKERS),
+        "preferences": _matching_clauses(message, _PREFERENCE_MARKERS),
+        "uncertainties": _matching_clauses(message, _UNCERTAINTY_MARKERS),
+        "notebook_notes": _matching_clauses(message, _NOTE_MARKERS),
+    }
+    if not _should_summarize_traveler_message(message, summary):
+        return []
+
+    items: list[str] = []
+    labels = {
+        "destinations": "Destinations",
+        "dates": "Timing",
+        "constraints": "Constraints",
+        "preferences": "Preferences",
+        "uncertainties": "Open questions",
+        "notebook_notes": "Notes to remember",
+    }
+    for key, label in labels.items():
+        values = summary[key]
+        if values:
+            items.append(f"{label}: {', '.join(values[:3])}")
+
+    return [
+        _structured_block(
+            kind="traveler_input_summary",
+            title="Traveler input summary",
+            body="Key details pulled out of the message so the next planner turn can keep them in view.",
+            items=items,
+            metadata=summary,
+        )
+    ]
 
 
 def _planner_turn_metadata(
@@ -152,7 +325,9 @@ def _planner_turn_metadata(
     raw_tokens = [token.strip(".,!?;:()[]{}\"'") for token in message.split()]
     tokens = [token.lower() for token in raw_tokens]
     destination_hits = sum(
-        1 for index, token in enumerate(raw_tokens) if _looks_like_destination_token(token, index)
+        1
+        for index, token in enumerate(raw_tokens)
+        if _looks_like_destination_token(token, index)
     )
     date_hits = sum(1 for marker in _DATE_MARKERS if marker in tokens)
     constraint_hits = sum(1 for marker in _CONSTRAINT_MARKERS if marker in lowered)
@@ -298,7 +473,184 @@ def _fallback_content_from_metadata(
     )
 
 
-def set_planner_chat_model_factory_for_tests(factory: PlannerChatModelFactory | None) -> None:
+def _first_sentence(content: str) -> str:
+    sentence = re.split(r"(?<=[.!?])\s+", content.strip(), maxsplit=1)[0].strip()
+    return sentence or content.strip()
+
+
+def _visible_block_items(
+    metadata: dict[str, Any],
+    *,
+    kinds: set[str],
+) -> list[str]:
+    items: list[str] = []
+    for block in list(metadata.get("visible_response_blocks") or []):
+        if str(block.get("kind") or "") in kinds:
+            items.extend(str(item) for item in list(block.get("items") or []))
+    return _dedupe_preserve_order(items)
+
+
+def _planner_response_structured_blocks(
+    *,
+    content: str,
+    metadata: dict[str, Any],
+    panel: dict[str, Any],
+    runtime_context: dict[str, Any],
+    tool_calls: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = []
+    decisions = list(panel.get("pending_decisions") or [])
+    options = list((panel.get("option_set") or {}).get("options") or [])
+    next_step_actions = list(panel.get("next_step_actions") or [])
+    runtime_comparison = runtime_context.get("runtime_scenario_comparison") or {}
+    scenarios = list(runtime_comparison.get("scenarios") or [])
+
+    summary_items = _visible_block_items(metadata, kinds={"summary", "guidance"})
+    blocks.append(
+        _structured_block(
+            kind="summary",
+            title="Planner summary",
+            body=_first_sentence(content),
+            items=summary_items[:3],
+        )
+    )
+
+    question_items = _visible_block_items(
+        metadata,
+        kinds={"clarifying_questions", "question", "questions"},
+    )
+    if decisions:
+        active_decision = decisions[0]
+        question_items.insert(
+            0, str(active_decision.get("prompt") or active_decision.get("title") or "")
+        )
+    if question_items:
+        blocks.append(
+            _structured_block(
+                kind="question",
+                title="Questions to settle",
+                items=_dedupe_preserve_order(question_items)[:4],
+            )
+        )
+
+    if decisions:
+        decision_items: list[str] = []
+        for decision in decisions[:3]:
+            prompt = str(decision.get("prompt") or decision.get("title") or "")
+            choices = ", ".join(
+                str(choice) for choice in list(decision.get("choices") or [])
+            )
+            decision_items.append(f"{prompt} Choices: {choices}" if choices else prompt)
+        blocks.append(
+            _structured_block(
+                kind="decision",
+                title="Open decisions",
+                items=_dedupe_preserve_order(decision_items),
+                metadata={
+                    "decision_ids": [item.get("decision_id") for item in decisions[:3]]
+                },
+            )
+        )
+
+    if options:
+        option_items = [
+            f"{option.get('label')}: {option.get('summary')}"
+            for option in options[:4]
+            if option.get("label") or option.get("summary")
+        ]
+        blocks.append(
+            _structured_block(
+                kind="route_option",
+                title="Route options in view",
+                items=_dedupe_preserve_order(option_items),
+                metadata={
+                    "option_ids": [item.get("option_id") for item in options[:4]]
+                },
+            )
+        )
+
+    comparison_items: list[str] = []
+    if len(scenarios) > 1:
+        for scenario in scenarios[:4]:
+            metrics = scenario.get("metrics") or {}
+            route_summary = scenario.get("route_summary") or "route details pending"
+            comparison_items.append(
+                (
+                    f"{scenario.get('title')}: {route_summary}; "
+                    f"{metrics.get('travel_minutes', 'pending')} travel minutes; "
+                    f"{metrics.get('transfers', 'pending')} transfers."
+                )
+            )
+    elif len(options) > 1:
+        comparison_items = [
+            f"{option.get('label')}: {option.get('summary')}"
+            for option in options[:4]
+            if option.get("label") or option.get("summary")
+        ]
+    if comparison_items:
+        blocks.append(
+            _structured_block(
+                kind="comparison",
+                title="Comparison frame",
+                items=_dedupe_preserve_order(comparison_items),
+            )
+        )
+
+    assumption_items = [
+        f"Planning maturity: {str(metadata.get('plan_maturity') or '').replace('_', ' ')}",
+        f"Current work type: {str(metadata.get('task_class') or '').replace('_', ' ')}",
+    ]
+    context_readiness = runtime_context.get("context_readiness") or {}
+    missing_sections = list(context_readiness.get("missing_sections") or [])
+    if missing_sections:
+        assumption_items.append(
+            f"Missing workspace context: {', '.join(missing_sections)}"
+        )
+    blocks.append(
+        _structured_block(
+            kind="assumption",
+            title="Working assumptions",
+            items=_dedupe_preserve_order(
+                [item for item in assumption_items if item.strip(": ")]
+            ),
+        )
+    )
+
+    next_action_items = _visible_block_items(
+        metadata, kinds={"next_steps", "next_action"}
+    )
+    next_action_items.extend(
+        str(action.get("description") or action.get("label") or "")
+        for action in next_step_actions[:3]
+    )
+    if next_action_items:
+        blocks.append(
+            _structured_block(
+                kind="next_action",
+                title="Next actions",
+                items=_dedupe_preserve_order(next_action_items)[:4],
+            )
+        )
+
+    blocks.append(
+        _structured_block(
+            kind="debug",
+            title="Planner diagnostics",
+            body="Routing details and tool traces are hidden from the normal traveler view.",
+            metadata={
+                "routing": metadata.get("debug_routing_details") or {},
+                "tool_call_count": len(tool_calls),
+                "tool_names": [item.get("tool_name") for item in tool_calls],
+            },
+            hidden=True,
+        )
+    )
+    return blocks
+
+
+def set_planner_chat_model_factory_for_tests(
+    factory: PlannerChatModelFactory | None,
+) -> None:
     global _PLANNER_CHAT_MODEL_FACTORY
     _PLANNER_CHAT_MODEL_FACTORY = factory
 
@@ -337,7 +689,9 @@ class DeterministicPlannerConversationRunnable:
         if decisions:
             active = decisions[0]
             choice_labels = ", ".join(active.get("choices") or [])
-            lines.append(f"Current blocking decision: {active['prompt']} Choices: {choice_labels}.")
+            lines.append(
+                f"Current blocking decision: {active['prompt']} Choices: {choice_labels}."
+            )
             refs.append(active["decision_id"])
         elif options:
             lead = options[0]
@@ -421,7 +775,9 @@ class _OpenAIPlannerChatModel:
 
 
 class ModelBackedPlannerConversationRunnable:
-    def __init__(self, config: PlannerRuntimeConfig, chat_model: PlannerChatModel) -> None:
+    def __init__(
+        self, config: PlannerRuntimeConfig, chat_model: PlannerChatModel
+    ) -> None:
         self._config = config
         self._chat_model = chat_model
 
@@ -438,9 +794,7 @@ class ModelBackedPlannerConversationRunnable:
         )
         content = str(raw.get("content") or "").strip()
         if not content:
-            content = (
-                "Planner model returned an empty response after reading the current trip context."
-            )
+            content = "Planner model returned an empty response after reading the current trip context."
         requested_tool_calls = [
             {
                 "tool_name": str(item.get("tool_name") or item.get("name") or ""),
@@ -482,6 +836,7 @@ def _message_payload(
     created_at: str,
     refs: list[str] | None = None,
     tool_calls: list[dict[str, Any]] | None = None,
+    structured_blocks: list[dict[str, Any]] | None = None,
     turn_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
@@ -491,6 +846,7 @@ def _message_payload(
         "created_at": created_at,
         "refs": list(refs or []),
         "tool_calls": list(tool_calls or []),
+        "structured_blocks": list(structured_blocks or []),
         "turn_metadata": turn_metadata,
     }
 
@@ -503,7 +859,11 @@ def _conversation_messages(
     records = db_session.scalars(
         select(PersistedPlannerAction)
         .where(PersistedPlannerAction.session_state_id == session_state_id)
-        .where(PersistedPlannerAction.action_type.in_(["planner_user_turn", "planner_response"]))
+        .where(
+            PersistedPlannerAction.action_type.in_(
+                ["planner_user_turn", "planner_response"]
+            )
+        )
         .order_by(
             PersistedPlannerAction.created_at.asc(),
             PersistedPlannerAction.planner_action_id.asc(),
@@ -517,6 +877,7 @@ def _conversation_messages(
         raw_refs = record.payload.get("refs", "")
         refs = [item for item in raw_refs.split(",") if item]
         tool_calls = list(record.payload.get("tool_calls") or [])
+        structured_blocks = list(record.payload.get("structured_blocks") or [])
         turn_metadata = record.payload.get("turn_metadata")
         if not isinstance(turn_metadata, dict):
             turn_metadata = None
@@ -528,6 +889,7 @@ def _conversation_messages(
                 created_at=record.occurred_at,
                 refs=refs,
                 tool_calls=tool_calls,
+                structured_blocks=structured_blocks,
                 turn_metadata=turn_metadata,
             )
         )
@@ -559,7 +921,10 @@ def _planner_runtime_context(
     required_sections = {
         "inventory_summary": workspace_payload.get("inventory_summary") or {},
         "scenario_search": workspace_payload.get("scenario_search") or {},
-        "runtime_scenario_comparison": workspace_payload.get("runtime_scenario_comparison") or {},
+        "runtime_scenario_comparison": workspace_payload.get(
+            "runtime_scenario_comparison"
+        )
+        or {},
         "budget_state": workspace_payload.get("budget_state") or {},
         "planner_memory": planner_memory,
     }
@@ -615,7 +980,9 @@ def _planner_session_payload(
         "planner_memory": planner_memory,
         "available_tools": list_planner_tools(),
         "activity_log": activity_log,
-        "messages": _conversation_messages(db_session, session_state_id=session_state_id),
+        "messages": _conversation_messages(
+            db_session, session_state_id=session_state_id
+        ),
     }
 
 
@@ -756,6 +1123,7 @@ def submit_planner_turn(
     session_record.last_updated_at = occurred_at
     session_record.notes = list(session.notes)
     record.updated_at = now
+    traveler_structured_blocks = _traveler_input_summary_blocks(normalized_message)
 
     user_activity_event_id = f"activity:{trip_id}:{secrets.token_hex(4)}"
     _append_activity_event(
@@ -766,7 +1134,10 @@ def submit_planner_turn(
         occurred_at=occurred_at,
         event_kind="planner_message",
         summary="Traveler submitted a planner conversation turn.",
-        metadata={"message_length": str(len(normalized_message))},
+        metadata={
+            "message_length": str(len(normalized_message)),
+            "structured_block_count": str(len(traveler_structured_blocks)),
+        },
     )
     _record_planner_action(
         db_session,
@@ -780,6 +1151,7 @@ def submit_planner_turn(
             "content": normalized_message,
             "refs": session.session_state_id,
             "tool_calls": [],
+            "structured_blocks": traveler_structured_blocks,
             "selected_planning_mode": session.selected_planning_mode,
         },
     )
@@ -834,6 +1206,7 @@ def submit_planner_turn(
             refs=reply.refs,
             tool_calls=reply.tool_calls,
             requested_tool_calls=reply.requested_tool_calls,
+            structured_blocks=reply.structured_blocks,
             turn_metadata=_planner_turn_metadata(
                 message=normalized_message,
                 runtime_config=runtime_config,
@@ -863,15 +1236,31 @@ def submit_planner_turn(
                 )
             )
     if executed_tool_calls:
-        tool_summary = " ".join(item["summary"] for item in executed_tool_calls)
         reply = PlannerConversationReply(
-            content=f"{reply.content} Tool results: {tool_summary}",
+            content=reply.content,
             refs=list(
                 dict.fromkeys(
-                    reply.refs + [ref for item in executed_tool_calls for ref in item["refs"]]
+                    reply.refs
+                    + [ref for item in executed_tool_calls for ref in item["refs"]]
                 )
             ),
             tool_calls=executed_tool_calls,
+            structured_blocks=reply.structured_blocks,
+            turn_metadata=reply.turn_metadata,
+        )
+    if not reply.structured_blocks:
+        reply = PlannerConversationReply(
+            content=reply.content,
+            refs=reply.refs,
+            tool_calls=reply.tool_calls,
+            requested_tool_calls=reply.requested_tool_calls,
+            structured_blocks=_planner_response_structured_blocks(
+                content=reply.content,
+                metadata=reply.turn_metadata or {},
+                panel=workspace_payload["planner_panel_state"],
+                runtime_context=runtime_context,
+                tool_calls=reply.tool_calls,
+            ),
             turn_metadata=reply.turn_metadata,
         )
 
@@ -899,6 +1288,7 @@ def submit_planner_turn(
             "content": reply.content,
             "refs": ",".join(reply.refs),
             "tool_calls": reply.tool_calls,
+            "structured_blocks": reply.structured_blocks,
             "turn_metadata": reply.turn_metadata,
             "selected_planning_mode": session.selected_planning_mode,
             "planning_stage": (

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -211,11 +211,7 @@ def _looks_like_destination_token(token: str, index: int) -> bool:
 
 
 def _dedupe_preserve_order(items: list[str]) -> list[str]:
-    return [
-        item
-        for item in dict.fromkeys(item.strip() for item in items if item.strip())
-        if item
-    ]
+    return [item for item in dict.fromkeys(item.strip() for item in items if item.strip()) if item]
 
 
 def _split_user_clauses(message: str) -> list[str]:
@@ -233,10 +229,7 @@ def _extract_destination_mentions(message: str) -> list[str]:
             continue
         if any(
             word.lower()
-            in _CONSTRAINT_MARKERS
-            + _PREFERENCE_MARKERS
-            + _UNCERTAINTY_MARKERS
-            + _NOTE_MARKERS
+            in _CONSTRAINT_MARKERS + _PREFERENCE_MARKERS + _UNCERTAINTY_MARKERS + _NOTE_MARKERS
             for word in words
         ):
             continue
@@ -266,16 +259,9 @@ def _matching_clauses(message: str, markers: tuple[str, ...]) -> list[str]:
     return _dedupe_preserve_order(matches)
 
 
-def _should_summarize_traveler_message(
-    message: str, summary: dict[str, list[str]]
-) -> bool:
+def _should_summarize_traveler_message(message: str, summary: dict[str, list[str]]) -> bool:
     signal_count = sum(len(items) for items in summary.values())
-    return (
-        len(message.split()) >= 28
-        or "\n" in message
-        or ";" in message
-        or signal_count >= 4
-    )
+    return len(message.split()) >= 28 or "\n" in message or ";" in message or signal_count >= 4
 
 
 def _traveler_input_summary_blocks(message: str) -> list[dict[str, Any]]:
@@ -325,9 +311,7 @@ def _planner_turn_metadata(
     raw_tokens = [token.strip(".,!?;:()[]{}\"'") for token in message.split()]
     tokens = [token.lower() for token in raw_tokens]
     destination_hits = sum(
-        1
-        for index, token in enumerate(raw_tokens)
-        if _looks_like_destination_token(token, index)
+        1 for index, token in enumerate(raw_tokens) if _looks_like_destination_token(token, index)
     )
     date_hits = sum(1 for marker in _DATE_MARKERS if marker in tokens)
     constraint_hits = sum(1 for marker in _CONSTRAINT_MARKERS if marker in lowered)
@@ -537,18 +521,14 @@ def _planner_response_structured_blocks(
         decision_items: list[str] = []
         for decision in decisions[:3]:
             prompt = str(decision.get("prompt") or decision.get("title") or "")
-            choices = ", ".join(
-                str(choice) for choice in list(decision.get("choices") or [])
-            )
+            choices = ", ".join(str(choice) for choice in list(decision.get("choices") or []))
             decision_items.append(f"{prompt} Choices: {choices}" if choices else prompt)
         blocks.append(
             _structured_block(
                 kind="decision",
                 title="Open decisions",
                 items=_dedupe_preserve_order(decision_items),
-                metadata={
-                    "decision_ids": [item.get("decision_id") for item in decisions[:3]]
-                },
+                metadata={"decision_ids": [item.get("decision_id") for item in decisions[:3]]},
             )
         )
 
@@ -563,9 +543,7 @@ def _planner_response_structured_blocks(
                 kind="route_option",
                 title="Route options in view",
                 items=_dedupe_preserve_order(option_items),
-                metadata={
-                    "option_ids": [item.get("option_id") for item in options[:4]]
-                },
+                metadata={"option_ids": [item.get("option_id") for item in options[:4]]},
             )
         )
 
@@ -603,22 +581,16 @@ def _planner_response_structured_blocks(
     context_readiness = runtime_context.get("context_readiness") or {}
     missing_sections = list(context_readiness.get("missing_sections") or [])
     if missing_sections:
-        assumption_items.append(
-            f"Missing workspace context: {', '.join(missing_sections)}"
-        )
+        assumption_items.append(f"Missing workspace context: {', '.join(missing_sections)}")
     blocks.append(
         _structured_block(
             kind="assumption",
             title="Working assumptions",
-            items=_dedupe_preserve_order(
-                [item for item in assumption_items if item.strip(": ")]
-            ),
+            items=_dedupe_preserve_order([item for item in assumption_items if item.strip(": ")]),
         )
     )
 
-    next_action_items = _visible_block_items(
-        metadata, kinds={"next_steps", "next_action"}
-    )
+    next_action_items = _visible_block_items(metadata, kinds={"next_steps", "next_action"})
     next_action_items.extend(
         str(action.get("description") or action.get("label") or "")
         for action in next_step_actions[:3]
@@ -632,20 +604,55 @@ def _planner_response_structured_blocks(
             )
         )
 
-    blocks.append(
-        _structured_block(
-            kind="debug",
-            title="Planner diagnostics",
-            body="Routing details and tool traces are hidden from the normal traveler view.",
-            metadata={
-                "routing": metadata.get("debug_routing_details") or {},
-                "tool_call_count": len(tool_calls),
-                "tool_names": [item.get("tool_name") for item in tool_calls],
-            },
-            hidden=True,
-        )
-    )
     return blocks
+
+
+def _ensure_top_level_planner_blocks(
+    *,
+    blocks: list[dict[str, Any]],
+    metadata: dict[str, Any],
+    tool_calls: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    normalized_blocks = [
+        block
+        for block in blocks
+        if str(block.get("kind") or "") not in {"visible_sections", "diagnostic", "debug"}
+    ]
+    visible_blocks = [block for block in normalized_blocks if not bool(block.get("hidden"))]
+    hidden_blocks = [block for block in normalized_blocks if bool(block.get("hidden"))]
+
+    section_items: list[str] = []
+    for block in visible_blocks:
+        title = str(block.get("title") or block.get("kind") or "").strip()
+        body = str(block.get("body") or "").strip()
+        first_item = str((block.get("items") or [""])[0]).strip()
+        summary = body or first_item
+        section_items.append(f"{title}: {summary}" if summary else title)
+
+    section_block = _structured_block(
+        kind="visible_sections",
+        title="Planner response sections",
+        body="Traveler-visible planning sections for this reply.",
+        items=_dedupe_preserve_order(section_items)[:6],
+        metadata={
+            "section_kinds": [str(block.get("kind") or "") for block in visible_blocks],
+            "section_count": len(visible_blocks),
+        },
+    )
+
+    diagnostic_block = _structured_block(
+        kind="diagnostic",
+        title="Planner diagnostics",
+        body="Routing details and tool traces are hidden from the normal traveler view.",
+        metadata={
+            "routing": metadata.get("debug_routing_details") or {},
+            "tool_call_count": len(tool_calls),
+            "tool_names": [item.get("tool_name") for item in tool_calls],
+            "hidden_block_kinds": [str(block.get("kind") or "") for block in hidden_blocks],
+        },
+        hidden=True,
+    )
+    return [section_block, *visible_blocks, *hidden_blocks, diagnostic_block]
 
 
 def set_planner_chat_model_factory_for_tests(
@@ -689,9 +696,7 @@ class DeterministicPlannerConversationRunnable:
         if decisions:
             active = decisions[0]
             choice_labels = ", ".join(active.get("choices") or [])
-            lines.append(
-                f"Current blocking decision: {active['prompt']} Choices: {choice_labels}."
-            )
+            lines.append(f"Current blocking decision: {active['prompt']} Choices: {choice_labels}.")
             refs.append(active["decision_id"])
         elif options:
             lead = options[0]
@@ -775,9 +780,7 @@ class _OpenAIPlannerChatModel:
 
 
 class ModelBackedPlannerConversationRunnable:
-    def __init__(
-        self, config: PlannerRuntimeConfig, chat_model: PlannerChatModel
-    ) -> None:
+    def __init__(self, config: PlannerRuntimeConfig, chat_model: PlannerChatModel) -> None:
         self._config = config
         self._chat_model = chat_model
 
@@ -794,7 +797,9 @@ class ModelBackedPlannerConversationRunnable:
         )
         content = str(raw.get("content") or "").strip()
         if not content:
-            content = "Planner model returned an empty response after reading the current trip context."
+            content = (
+                "Planner model returned an empty response after reading the current trip context."
+            )
         requested_tool_calls = [
             {
                 "tool_name": str(item.get("tool_name") or item.get("name") or ""),
@@ -859,11 +864,7 @@ def _conversation_messages(
     records = db_session.scalars(
         select(PersistedPlannerAction)
         .where(PersistedPlannerAction.session_state_id == session_state_id)
-        .where(
-            PersistedPlannerAction.action_type.in_(
-                ["planner_user_turn", "planner_response"]
-            )
-        )
+        .where(PersistedPlannerAction.action_type.in_(["planner_user_turn", "planner_response"]))
         .order_by(
             PersistedPlannerAction.created_at.asc(),
             PersistedPlannerAction.planner_action_id.asc(),
@@ -921,10 +922,7 @@ def _planner_runtime_context(
     required_sections = {
         "inventory_summary": workspace_payload.get("inventory_summary") or {},
         "scenario_search": workspace_payload.get("scenario_search") or {},
-        "runtime_scenario_comparison": workspace_payload.get(
-            "runtime_scenario_comparison"
-        )
-        or {},
+        "runtime_scenario_comparison": workspace_payload.get("runtime_scenario_comparison") or {},
         "budget_state": workspace_payload.get("budget_state") or {},
         "planner_memory": planner_memory,
     }
@@ -980,9 +978,7 @@ def _planner_session_payload(
         "planner_memory": planner_memory,
         "available_tools": list_planner_tools(),
         "activity_log": activity_log,
-        "messages": _conversation_messages(
-            db_session, session_state_id=session_state_id
-        ),
+        "messages": _conversation_messages(db_session, session_state_id=session_state_id),
     }
 
 
@@ -1240,8 +1236,7 @@ def submit_planner_turn(
             content=reply.content,
             refs=list(
                 dict.fromkeys(
-                    reply.refs
-                    + [ref for item in executed_tool_calls for ref in item["refs"]]
+                    reply.refs + [ref for item in executed_tool_calls for ref in item["refs"]]
                 )
             ),
             tool_calls=executed_tool_calls,
@@ -1263,6 +1258,18 @@ def submit_planner_turn(
             ),
             turn_metadata=reply.turn_metadata,
         )
+    reply = PlannerConversationReply(
+        content=reply.content,
+        refs=reply.refs,
+        tool_calls=reply.tool_calls,
+        requested_tool_calls=reply.requested_tool_calls,
+        structured_blocks=_ensure_top_level_planner_blocks(
+            blocks=reply.structured_blocks,
+            metadata=reply.turn_metadata or {},
+            tool_calls=reply.tool_calls,
+        ),
+        turn_metadata=reply.turn_metadata,
+    )
 
     planner_activity_event_id = f"activity:{trip_id}:{secrets.token_hex(4)}"
     _append_activity_event(


### PR DESCRIPTION
Closes #1126

## Summary
- Adds top-level structured planner message blocks with visible sections and hidden diagnostics.
- Extracts long/scattered traveler input into a structured summary block.
- Updates workspace conversation rendering to hide debug/tool details by default behind a diagnostics toggle.

## Validation
- python -m pytest -q tests/app/test_planner_routes.py tests/app/test_planner_turn_e2e.py
- npm --prefix frontend test -- --run src/routes/WorkspacePage.test.tsx
- npm --prefix frontend run build
- git diff --check