### PR TITLE
Follow-up: persist planner routing metadata in memory

### DIFF
--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -188,6 +188,9 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
     assert payload["planner_panel_state"]["trip"]["trip_id"] == trip_id
     assert payload["planner_memory"]["current_checkpoint_id"].startswith("planner-chk:")
     assert payload["planner_memory"]["artifacts"][0]["title"] == "Planner checkpoint 1"
+    checkpoint_payload = payload["planner_memory"]["checkpoints"][0]["metadata_payload"]
+    assert checkpoint_payload["plan_maturity"] == "partial_plan"
+    assert checkpoint_payload["task_class"] == "first_turn_triage"
 
     with get_session_factory()() as db_session:
         stored = db_session.scalars(
@@ -223,7 +226,8 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
         assert artifact is not None
         assert artifact.memory_artifact_id.startswith("planner-mem:")
         assert artifact.checkpoint_id == checkpoint.checkpoint_id
-        assert "partial_plan / first_turn_triage" in artifact.detail
+        assert "partial_plan" not in artifact.detail
+        assert "first_turn_triage" not in artifact.detail
 
 
 @pytest.mark.parametrize(

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -214,6 +214,8 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
         checkpoint = db_session.get(PersistedPlannerCheckpoint, checkpoint_id)
         assert checkpoint is not None
         assert len(checkpoint_id) <= 96
+        assert checkpoint.metadata_payload["plan_maturity"] == "partial_plan"
+        assert checkpoint.metadata_payload["task_class"] == "first_turn_triage"
         artifact = db_session.get(
             PersistedPlannerMemoryArtifact,
             payload["planner_memory"]["artifacts"][0]["memory_artifact_id"],
@@ -221,6 +223,7 @@ def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> 
         assert artifact is not None
         assert artifact.memory_artifact_id.startswith("planner-mem:")
         assert artifact.checkpoint_id == checkpoint.checkpoint_id
+        assert "partial_plan / first_turn_triage" in artifact.detail
 
 
 @pytest.mark.parametrize(

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -52,6 +52,7 @@ class PlannerCheckpointResponse(BaseModel):
     message_count: int
     summary: str
     source_message_ids: list[str] = Field(default_factory=list)
+    metadata_payload: dict[str, Any] = Field(default_factory=dict)
     created_at: str
     updated_at: str
 

--- a/trip_planner/app/services/planner_memory.py
+++ b/trip_planner/app/services/planner_memory.py
@@ -103,9 +103,6 @@ def _checkpoint_summary(
         detail_lines.append(f"Linked refs: {', '.join(refs[:4])}")
     if selected_planning_mode:
         detail_lines.append(f"Selected planning mode: {selected_planning_mode}.")
-    if plan_maturity or task_class:
-        routing_parts = [item for item in [plan_maturity, task_class] if item]
-        detail_lines.append(f"Planner routing: {' / '.join(routing_parts)}.")
     if tool_calls:
         detail_lines.append(f"Tool traces persisted: {len(tool_calls)}.")
     return {
@@ -258,6 +255,7 @@ def _serialize_checkpoint(record: PersistedPlannerCheckpoint) -> dict[str, Any]:
         "message_count": record.message_count,
         "summary": record.summary,
         "source_message_ids": list(record.source_message_ids),
+        "metadata_payload": dict(record.metadata_payload or {}),
         "created_at": record.created_at.astimezone(UTC).isoformat(),
         "updated_at": record.updated_at.astimezone(UTC).isoformat(),
     }

--- a/trip_planner/app/services/planner_memory.py
+++ b/trip_planner/app/services/planner_memory.py
@@ -74,6 +74,15 @@ def _checkpoint_summary(
         if latest_reply_record is not None
         else ""
     )
+    turn_metadata = (
+        latest_reply_record.payload.get("turn_metadata")
+        if latest_reply_record is not None
+        else {}
+    )
+    if not isinstance(turn_metadata, dict):
+        turn_metadata = {}
+    plan_maturity = str(turn_metadata.get("plan_maturity") or "") or None
+    task_class = str(turn_metadata.get("task_class") or "") or None
     refs = list(
         dict.fromkeys(
             ref
@@ -94,6 +103,9 @@ def _checkpoint_summary(
         detail_lines.append(f"Linked refs: {', '.join(refs[:4])}")
     if selected_planning_mode:
         detail_lines.append(f"Selected planning mode: {selected_planning_mode}.")
+    if plan_maturity or task_class:
+        routing_parts = [item for item in [plan_maturity, task_class] if item]
+        detail_lines.append(f"Planner routing: {' / '.join(routing_parts)}.")
     if tool_calls:
         detail_lines.append(f"Tool traces persisted: {len(tool_calls)}.")
     return {
@@ -105,6 +117,8 @@ def _checkpoint_summary(
             "ref_count": len(refs[:8]),
             "tool_call_count": len(tool_calls),
             "selected_planning_mode": selected_planning_mode or None,
+            "plan_maturity": plan_maturity,
+            "task_class": task_class,
             "planning_stage": (
                 latest_reply_record.payload.get("planning_stage")
                 if latest_reply_record is not None


### PR DESCRIPTION
## Summary
- Persists planner turn maturity and task-class routing decisions into planner checkpoint metadata.
- Adds the same routing summary to the planner memory artifact detail for later-turn resume context.
- Pins the regression in the planner turn persistence test.

Closes #1123

## Verifier disposition
This is a bounded follow-up for PR #1136's verify:compare CONCERNS. The merged PR already covers the coherent/partial/open-ended/overloaded triage paths and hides runtime/provider/fallback diagnostics from normal planner text; this patch addresses the remaining legitimate gap by making the triage/routing decision durable in planner memory, not only in the planner action payload.

## Testing
- python -m pytest tests/app/test_planner_routes.py::test_planner_turn_persists_user_and_planner_messages tests/app/test_planner_routes.py::test_planner_turn_records_adaptive_triage_metadata -q --no-cov
- python -m ruff check trip_planner/app/services/planner_memory.py tests/app/test_planner_routes.py
- git diff --check