### PR TITLE
Issue #1127: Rework workspace traveler guidance

### DIFF
--- a/frontend/src/components/planner/PlanningModeSelector.test.tsx
+++ b/frontend/src/components/planner/PlanningModeSelector.test.tsx
@@ -24,7 +24,7 @@ describe("PlanningModeSelector", () => {
     ).toBeGreaterThan(0);
     expect(screen.getByLabelText(/Delegated/).closest("label")).toHaveAttribute(
       "title",
-      expect.stringContaining("organize the options")
+      expect.stringContaining("organize options")
     );
 
     await user.click(screen.getByRole("radio", { name: /In-trip/ }));

--- a/frontend/src/components/planner/PlanningModeSelector.test.tsx
+++ b/frontend/src/components/planner/PlanningModeSelector.test.tsx
@@ -20,7 +20,7 @@ describe("PlanningModeSelector", () => {
 
     expect(screen.getByRole("radio", { name: /Collaborative/ })).toBeChecked();
     expect(
-      screen.getAllByText(/quick questions, visible tradeoffs, and frequent chances to steer/).length
+      screen.getAllByText(/quick questions, visible tradeoffs, and frequent checkpoints/).length
     ).toBeGreaterThan(0);
     expect(screen.getByLabelText(/Delegated/).closest("label")).toHaveAttribute(
       "title",

--- a/frontend/src/components/planner/PlanningModeSelector.test.tsx
+++ b/frontend/src/components/planner/PlanningModeSelector.test.tsx
@@ -20,8 +20,11 @@ describe("PlanningModeSelector", () => {
 
     expect(screen.getByRole("radio", { name: /Collaborative/ })).toBeChecked();
     expect(
-      screen.getAllByText(/quick questions, visible tradeoffs, and frequent checkpoints/).length
-    ).toBeGreaterThan(0);
+      screen.getByText(/quick questions, visible tradeoffs, and frequent checkpoints/)
+    ).toBeInTheDocument();
+    expect(screen.queryAllByText(/quick questions, visible tradeoffs, and frequent checkpoints/)).toHaveLength(
+      1
+    );
     expect(screen.getByLabelText(/Delegated/).closest("label")).toHaveAttribute(
       "title",
       expect.stringContaining("organize options")

--- a/frontend/src/components/planner/PlanningModeSelector.test.tsx
+++ b/frontend/src/components/planner/PlanningModeSelector.test.tsx
@@ -19,6 +19,13 @@ describe("PlanningModeSelector", () => {
     );
 
     expect(screen.getByRole("radio", { name: /Collaborative/ })).toBeChecked();
+    expect(
+      screen.getAllByText(/quick questions, visible tradeoffs, and frequent chances to steer/).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByLabelText(/Delegated/).closest("label")).toHaveAttribute(
+      "title",
+      expect.stringContaining("organize the options")
+    );
 
     await user.click(screen.getByRole("radio", { name: /In-trip/ }));
 

--- a/frontend/src/components/planner/PlanningModeSelector.tsx
+++ b/frontend/src/components/planner/PlanningModeSelector.tsx
@@ -11,26 +11,26 @@ const PLANNING_MODE_OPTIONS: PlanningModeOption[] = [
   {
     value: "delegated",
     label: "Delegated",
-    summary: "The planner drafts the next pass for you.",
-    help: "Use this when you want the planner to organize the options, make a recommendation, and bring back a short decision for review.",
+    summary: "Planner leads and returns a clear next step.",
+    help: "Use this when you want your planner to organize options, make a recommendation, and return one next decision to confirm.",
   },
   {
     value: "collaborative",
     label: "Collaborative",
-    summary: "You and the planner work step by step.",
-    help: "Use this when you want quick questions, visible tradeoffs, and frequent chances to steer before the plan changes.",
+    summary: "Traveler and planner work together step by step.",
+    help: "Use this when you want quick questions, visible tradeoffs, and frequent checkpoints before the trip plan changes.",
   },
   {
     value: "revealed-preference",
     label: "Revealed preference",
-    summary: "Compare choices so your preferences become clearer.",
-    help: "Use this when you are not sure what you prefer yet and want the planner to show route, lodging, pace, or budget tradeoffs.",
+    summary: "Compare options to uncover what matters most.",
+    help: "Use this when you are still deciding and want your planner to surface route, lodging, pace, or budget tradeoffs.",
   },
   {
     value: "in-trip",
     label: "In-trip",
-    summary: "Adapt the plan while travel is underway.",
-    help: "Use this when something changed during the trip and you need practical adjustments without rebuilding everything.",
+    summary: "Adjust the trip while you are already traveling.",
+    help: "Use this when plans changed mid-trip and you need practical adjustments without rebuilding everything.",
   },
 ];
 
@@ -52,10 +52,10 @@ export function PlanningModeSelector({
   return (
     <section className="planning-mode-selector" aria-labelledby="planning-mode-selector-title">
       <div className="planning-mode-selector-header">
-        <p className="scenario-kicker">Planner style</p>
+        <p className="scenario-kicker">Traveler control</p>
         <h3 id="planning-mode-selector-title">How should the planner work?</h3>
         <p className="muted-copy">
-          Choose how much initiative the planner should take on the next planning pass.
+          Choose how much initiative your planner should take for the next trip step.
         </p>
       </div>
       <div className="planning-mode-options" role="radiogroup" aria-label="Planning mode">
@@ -85,7 +85,7 @@ export function PlanningModeSelector({
         ))}
       </div>
       <p className="planning-mode-active-summary">
-        Current mode: {activeOption.help}
+        Active guidance: {activeOption.help}
       </p>
       {busy ? <p className="muted-copy">Saving planning mode...</p> : null}
       {error ? <p className="planner-inline-error">{error}</p> : null}

--- a/frontend/src/components/planner/PlanningModeSelector.tsx
+++ b/frontend/src/components/planner/PlanningModeSelector.tsx
@@ -73,14 +73,11 @@ export function PlanningModeSelector({
               value={option.value}
               checked={option.value === value}
               disabled={busy}
-              aria-describedby={`planning-mode-${option.value}-summary planning-mode-${option.value}-help`}
+              aria-describedby={`planning-mode-${option.value}-summary`}
               onChange={() => onChange(option.value)}
             />
             <span>{option.label}</span>
             <small id={`planning-mode-${option.value}-summary`}>{option.summary}</small>
-            <small id={`planning-mode-${option.value}-help`} className="planning-mode-detail">
-              {option.help}
-            </small>
           </label>
         ))}
       </div>

--- a/frontend/src/components/planner/PlanningModeSelector.tsx
+++ b/frontend/src/components/planner/PlanningModeSelector.tsx
@@ -4,28 +4,33 @@ type PlanningModeOption = {
   value: PlanningMode;
   label: string;
   summary: string;
+  help: string;
 };
 
 const PLANNING_MODE_OPTIONS: PlanningModeOption[] = [
   {
     value: "delegated",
     label: "Delegated",
-    summary: "Planner leads the next pass.",
+    summary: "The planner drafts the next pass for you.",
+    help: "Use this when you want the planner to organize the options, make a recommendation, and bring back a short decision for review.",
   },
   {
     value: "collaborative",
     label: "Collaborative",
-    summary: "Planner and traveler iterate together.",
+    summary: "You and the planner work step by step.",
+    help: "Use this when you want quick questions, visible tradeoffs, and frequent chances to steer before the plan changes.",
   },
   {
     value: "revealed-preference",
     label: "Revealed preference",
-    summary: "Options expose tradeoffs for choice.",
+    summary: "Compare choices so your preferences become clearer.",
+    help: "Use this when you are not sure what you prefer yet and want the planner to show route, lodging, pace, or budget tradeoffs.",
   },
   {
     value: "in-trip",
     label: "In-trip",
-    summary: "Adjust live constraints and pacing.",
+    summary: "Adapt the plan while travel is underway.",
+    help: "Use this when something changed during the trip and you need practical adjustments without rebuilding everything.",
   },
 ];
 
@@ -40,11 +45,18 @@ export function PlanningModeSelector({
   error?: string | null;
   onChange: (mode: PlanningMode) => void;
 }) {
+  const activeOption =
+    PLANNING_MODE_OPTIONS.find((option) => option.value === value) ??
+    PLANNING_MODE_OPTIONS[0];
+
   return (
     <section className="planning-mode-selector" aria-labelledby="planning-mode-selector-title">
       <div className="planning-mode-selector-header">
-        <p className="scenario-kicker">Planner control</p>
-        <h3 id="planning-mode-selector-title">Planning mode</h3>
+        <p className="scenario-kicker">Planner style</p>
+        <h3 id="planning-mode-selector-title">How should the planner work?</h3>
+        <p className="muted-copy">
+          Choose how much initiative the planner should take on the next planning pass.
+        </p>
       </div>
       <div className="planning-mode-options" role="radiogroup" aria-label="Planning mode">
         {PLANNING_MODE_OPTIONS.map((option) => (
@@ -53,6 +65,7 @@ export function PlanningModeSelector({
             className={`planning-mode-option${
               option.value === value ? " planning-mode-option-active" : ""
             }`}
+            title={option.help}
           >
             <input
               type="radio"
@@ -60,13 +73,20 @@ export function PlanningModeSelector({
               value={option.value}
               checked={option.value === value}
               disabled={busy}
+              aria-describedby={`planning-mode-${option.value}-summary planning-mode-${option.value}-help`}
               onChange={() => onChange(option.value)}
             />
             <span>{option.label}</span>
-            <small>{option.summary}</small>
+            <small id={`planning-mode-${option.value}-summary`}>{option.summary}</small>
+            <small id={`planning-mode-${option.value}-help`} className="planning-mode-detail">
+              {option.help}
+            </small>
           </label>
         ))}
       </div>
+      <p className="planning-mode-active-summary">
+        Current mode: {activeOption.help}
+      </p>
       {busy ? <p className="muted-copy">Saving planning mode...</p> : null}
       {error ? <p className="planner-inline-error">{error}</p> : null}
     </section>

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -880,7 +880,7 @@ describe("WorkspacePage", () => {
     expect(within(routeContextMap).getAllByText("Kyoto").length).toBeGreaterThan(0);
     expect(within(routeContextMap).getAllByText("Uji").length).toBeGreaterThan(0);
     expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Plan this trip" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Traveler planning workspace" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "How should the planner work?" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: /Collaborative/ })).toBeChecked();
     await waitFor(() => {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -840,11 +840,17 @@ describe("WorkspacePage", () => {
     expect(
       screen.getByText("Compare the saved scenarios and choose one to keep planning around.")
     ).toBeInTheDocument();
+    const helpDisclosure = screen.getByText("How to use this trip workspace").closest("details");
+    expect(helpDisclosure).not.toBeNull();
+    expect(helpDisclosure).not.toHaveAttribute("open");
 
     const renderedText = document.body.textContent ?? "";
     const forbiddenRawLabels = [
       "runtime provider",
       "fallback mode",
+      "trip-scoped",
+      "runtime-backed",
+      "api client",
       "policy_state_id",
       "proposal_state_id",
       "session_state_id",
@@ -874,29 +880,28 @@ describe("WorkspacePage", () => {
     expect(within(routeContextMap).getAllByText("Kyoto").length).toBeGreaterThan(0);
     expect(within(routeContextMap).getAllByText("Uji").length).toBeGreaterThan(0);
     expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
-    expect(screen.getByText("Trip-scoped planner surface")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Planning mode" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Plan this trip" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "How should the planner work?" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: /Collaborative/ })).toBeChecked();
     await waitFor(() => {
       expect(mockedFetchPlannerSession).toHaveBeenCalledWith("trip-leisure-kyoto-draft");
     });
-    expect(screen.getByRole("heading", { name: "Message the trip planner" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Message your planner" })).toBeInTheDocument();
     await waitFor(() => {
       expect(
         screen.getByText("Compare the Kyoto baseline against the Osaka fallback before locking the plan.")
       ).toBeInTheDocument();
     });
-    expect(screen.getByText("read workspace state")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Compare routes" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Planner tools available")).not.toBeInTheDocument();
     expect(routeContextMap).toBeInTheDocument();
     expect(screen.getByText("Destination context")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Trip rhythm and day sequencing" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Trip rhythm and day sequence" })).toBeInTheDocument();
     expect(screen.getByLabelText("Timeline summary")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Review-ready scenario tradeoffs" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Review route tradeoffs" })).toBeInTheDocument();
     expect(screen.getByLabelText("Scenario review board")).toBeInTheDocument();
     expect(screen.getAllByText("Policy posture").length).toBeGreaterThan(0);
-    expect(
-      screen.getByRole("heading", { name: workspacePayload.inventory_summary.runtime_state.title })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Places and options to review" })).toBeInTheDocument();
     expect(screen.getAllByText("Osaka arrival buffer").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Kyoto cultural anchor").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();
@@ -904,7 +909,7 @@ describe("WorkspacePage", () => {
     expect(screen.getAllByText("Advance to approval").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Comparables and readiness signals" })).toBeInTheDocument();
     expect(screen.getByText("Conference Hotel")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "User-visible planner checkpoints" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Planner notes to keep" })).toBeInTheDocument();
     expect(screen.getByText("Planner checkpoint 1")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Compare this workspace with other saved trips" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Compare 2. Kyoto plus Osaka fallback" })).toBeInTheDocument();
@@ -934,7 +939,7 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Planning mode" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "How should the planner work?" })).toBeInTheDocument();
     });
     await user.click(screen.getByRole("radio", { name: /Delegated/ }));
 
@@ -1088,8 +1093,8 @@ describe("WorkspacePage", () => {
       expect(screen.getByText("Can you summarize what I should compare next?")).toBeInTheDocument();
     });
 
-    await user.type(screen.getByLabelText("Message"), "Keep Uji, but reduce transfer pressure.");
-    await user.click(screen.getByRole("button", { name: "Send planner turn" }));
+    await user.type(screen.getByLabelText("Message the planner"), "Keep Uji, but reduce transfer pressure.");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() => {
       expect(mockedSubmitPlannerTurn).toHaveBeenCalledWith(
@@ -1114,7 +1119,27 @@ describe("WorkspacePage", () => {
     await user.click(screen.getByRole("button", { name: "Diagnostics" }));
     expect(screen.getByText("Planner diagnostics")).toBeInTheDocument();
     expect(screen.getByText("read_workspace_state: Read the current workspace state.")).toBeInTheDocument();
-    expect(screen.getByLabelText("Message")).toHaveValue("");
+    expect(screen.getByLabelText("Message the planner")).toHaveValue("");
+  });
+
+  it("fills traveler-friendly prompt suggestions into the planner message box", async () => {
+    const user = userEvent.setup();
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(workspacePayload),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Summarize decisions" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Summarize decisions" }));
+
+    expect(screen.getByLabelText("Message the planner")).toHaveValue(
+      "Summarize what we have decided, what is still open, and what you recommend next."
+    );
   });
 
   it("labels the planner panel as deterministic fallback when runtime metadata is absent", async () => {
@@ -1126,14 +1151,14 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Planner runtime state")).toBeInTheDocument();
+      expect(screen.getByLabelText("Planner availability")).toBeInTheDocument();
     });
 
-    const runtime = screen.getByLabelText("Planner runtime state");
-    expect(within(runtime).getByText("Deterministic fallback planner")).toHaveClass(
+    const runtime = screen.getByLabelText("Planner availability");
+    expect(within(runtime).getByText("Guided planner")).toHaveClass(
       "planner-runtime-pill--fallback"
     );
-    expect(within(runtime).getByText("Fallback")).toBeInTheDocument();
+    expect(within(runtime).getByText("Planning guide")).toBeInTheDocument();
   });
 
   it("merges fetched planner session state into the workspace surface", async () => {
@@ -1166,12 +1191,12 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Planner runtime state")).toBeInTheDocument();
+      expect(screen.getByLabelText("Planner availability")).toBeInTheDocument();
     });
 
-    const runtime = screen.getByLabelText("Planner runtime state");
+    const runtime = screen.getByLabelText("Planner availability");
     await waitFor(() => {
-      expect(within(runtime).getByText("Model-backed planner")).toHaveClass(
+      expect(within(runtime).getByText("AI-assisted planner")).toHaveClass(
         "planner-runtime-pill--ready"
       );
     });
@@ -1199,12 +1224,12 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Planner runtime state")).toBeInTheDocument();
+      expect(screen.getByLabelText("Planner availability")).toBeInTheDocument();
     });
 
-    const runtime = screen.getByLabelText("Planner runtime state");
-    expect(within(runtime).getByText("Model-backed planner")).toHaveClass("planner-runtime-pill--ready");
-    expect(within(runtime).getByText("Model-backed")).toBeInTheDocument();
+    const runtime = screen.getByLabelText("Planner availability");
+    expect(within(runtime).getByText("AI-assisted planner")).toHaveClass("planner-runtime-pill--ready");
+    expect(within(runtime).getByText("Live assistance")).toBeInTheDocument();
   });
 
   it("updates the map surface when a different scenario preview is selected", async () => {
@@ -1408,11 +1433,11 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByText("Timeline data is not ready")).toBeInTheDocument();
+      expect(screen.getByText("Day plan is not ready yet")).toBeInTheDocument();
     });
     expect(
       screen.getByText(
-        "Trip context is ready now, so the next planning pass can attach saved scenarios and timeline stops."
+        "Ask the planner to compare routes or draft a first sequence of stops."
       )
     ).toBeInTheDocument();
     await waitFor(() => {
@@ -1432,10 +1457,10 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Compact scenario tradeoffs" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Compact route tradeoffs" })).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Compact review stack keeps map, timeline, and tradeoff calls visible on smaller screens.")).toBeInTheDocument();
+    expect(screen.getByText("Compact review keeps route, day plan, and next choices close together.")).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByText("Textual fallback route path")).toBeInTheDocument();
     });
@@ -1545,13 +1570,13 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Review-ready scenario tradeoffs" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Review route tradeoffs" })).toBeInTheDocument();
     });
 
     expect(screen.queryByLabelText("Scenario review board")).not.toBeInTheDocument();
     expect(
       screen.getByText(
-        "No runtime scenarios are available yet, so there is nothing to review in the scenario board."
+        "No route ideas are available yet, so there is nothing to compare."
       )
     ).toBeInTheDocument();
   });
@@ -1646,10 +1671,8 @@ describe("WorkspacePage", () => {
 
     expect(screen.getByText("Dates not set yet")).toBeInTheDocument();
     expect(screen.getByText("Duration not set yet")).toBeInTheDocument();
-    expect(screen.getByText("Runtime inventory is partially specified")).toBeInTheDocument();
-    expect(
-      screen.getByText("Runtime bundle assembly is waiting on the rest of the trip frame.")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Options need more trip detail")).toBeInTheDocument();
+    expect(screen.getByText("The planner needs a little more trip detail before it can group options.")).toBeInTheDocument();
     await waitFor(() => {
       expect(getPlannerHost().shadowRoot?.querySelector('[aria-label="Planner side panel"]')).toBeTruthy();
     });
@@ -2558,7 +2581,7 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Workspace request failed" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Trip workspace could not load" })).toBeInTheDocument();
     });
 
     expect(screen.getByText("Backend warming up")).toBeInTheDocument();

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -46,6 +46,11 @@ type ScenarioReviewMetric = {
   value: string;
 };
 
+type PlannerPromptSuggestion = {
+  label: string;
+  draft: string;
+};
+
 type ProposalLifecycleState =
   | "pending"
   | "deferred"
@@ -60,6 +65,29 @@ type ProposalLifecyclePresentation = {
   title: string;
   summary: string;
 };
+
+const PLANNER_PROMPT_SUGGESTIONS: PlannerPromptSuggestion[] = [
+  {
+    label: "Compare routes",
+    draft: "Compare the strongest route options and tell me the main tradeoffs.",
+  },
+  {
+    label: "Remember a note",
+    draft: "Please remember this for later: ",
+  },
+  {
+    label: "Revisit lodging",
+    draft: "Revisit lodging options with budget, location, and transfer friction in mind.",
+  },
+  {
+    label: "Summarize decisions",
+    draft: "Summarize what we have decided, what is still open, and what you recommend next.",
+  },
+  {
+    label: "Show rejected ideas",
+    draft: "Show route or lodging ideas we considered and rejected, with the reason for each.",
+  },
+];
 
 function formatDateRange(startDate: string | null, endDate: string | null): string {
   if (!startDate && !endDate) {
@@ -595,13 +623,13 @@ export function WorkspacePage() {
       resolve={resolve}
       loading={{
         label: "Workspace",
-        title: "Loading persisted trip state",
-        message: "Hydrating trip, session, and saved-scenario records for the timeline surface.",
+        title: "Opening your trip workspace",
+        message: "Loading the latest route ideas, notes, budget, and planning state.",
       }}
       error={{
         label: "Workspace",
-        title: "Workspace request failed",
-        message: "The shared API client could not load the workspace payload.",
+        title: "Trip workspace could not load",
+        message: "Refresh the page or try again after the latest trip data is available.",
       }}
     >
       {([resolvedWorkspace, resolvedTrips]) => (
@@ -817,6 +845,11 @@ function WorkspacePageContent({
     }
   }
 
+  function handlePlannerPromptSuggestion(draft: string) {
+    setPlannerConversationDraft(draft);
+    setPlannerConversationError(null);
+  }
+
   async function handleBudgetSave(payload: BudgetPlanUpsertPayload) {
     setBudgetError(null);
     setBudgetBusyLabel("Saving workspace budget...");
@@ -872,7 +905,7 @@ function WorkspacePageContent({
     >
       <div className="workspace-hero status-card">
         <p className="status-label">
-          {productView?.user_summary.mode_label ?? "Workspace timeline"}
+          {productView?.user_summary.mode_label ?? "Trip workspace"}
         </p>
         <h2>{productView?.user_summary.trip_title ?? trip.title}</h2>
         <p>{productView?.user_summary.headline ?? trip.summary}</p>
@@ -945,16 +978,33 @@ function WorkspacePageContent({
         </dl>
         <p className="workspace-hero-emphasis">
           {isCompactLayout
-            ? "Compact review stack keeps map, timeline, and tradeoff calls visible on smaller screens."
-            : "Review-ready workspace keeps route context, daily pacing, and tradeoffs visible at once."}
+            ? "Compact review keeps route, day plan, and next choices close together."
+            : "Use this workspace to compare options, keep notes, and move the trip toward a clear next decision."}
         </p>
+        <details className="workspace-help-disclosure">
+          <summary>How to use this trip workspace</summary>
+          <div className="workspace-help-grid">
+            <article>
+              <h3>Check the next decision</h3>
+              <p>Start with the trip status and open choices before asking for deeper planning.</p>
+            </article>
+            <article>
+              <h3>Compare options</h3>
+              <p>Use the map, route tradeoffs, day plan, and saved ideas to compare what is possible.</p>
+            </article>
+            <article>
+              <h3>Keep side notes</h3>
+              <p>Send scattered reminders to the planner; they can be sorted into later planning work.</p>
+            </article>
+          </div>
+        </details>
         {productView && Object.keys(productView.debug_state.sections).length > 0 ? (
           <details className="workspace-debug-disclosure">
             <summary>Advanced diagnostics</summary>
             <p className="muted-copy">
               {Object.keys(productView.debug_state.sections).length} debug section
-              {Object.keys(productView.debug_state.sections).length === 1 ? "" : "s"} available in the
-              workspace payload.
+              {Object.keys(productView.debug_state.sections).length === 1 ? "" : "s"} available for
+              troubleshooting.
             </p>
           </details>
         ) : null}
@@ -962,24 +1012,25 @@ function WorkspacePageContent({
 
       <div className="workspace-grid">
         <section className="status-card planner-panel-card">
-          <p className="status-label">Planner panel</p>
-          <h2>Trip-scoped planner surface</h2>
+          <p className="status-label">Planner</p>
+          <h2>Plan this trip</h2>
           <p className="muted-copy">
-            {currentWorkspace.planner_panel_state.planner_behavior.runtime_summary ??
-              "The existing planner side panel now mounts inside the workspace route and reads trip-scoped API data."}
+            Use the planner to compare options, remember notes, and decide what should happen next.
           </p>
-          <div className="planner-runtime-row" aria-label="Planner runtime state">
+          <div className="planner-runtime-row" aria-label="Planner availability">
             <span
               className={`planner-runtime-pill planner-runtime-pill--${
                 currentWorkspace.planner_panel_state.planner_behavior.runtime_status ?? "fallback"
               }`}
             >
-              {currentWorkspace.planner_panel_state.planner_behavior.runtime_label ?? "Deterministic fallback planner"}
+              {currentWorkspace.planner_panel_state.planner_behavior.runtime_mode === "model"
+                ? "AI-assisted planner"
+                : "Guided planner"}
             </span>
             <span className="planner-runtime-mode">
               {currentWorkspace.planner_panel_state.planner_behavior.runtime_mode === "model"
-                ? "Model-backed"
-                : "Fallback"}
+                ? "Live assistance"
+                : "Planning guide"}
             </span>
           </div>
           <PlanningModeSelector
@@ -999,11 +1050,11 @@ function WorkspacePageContent({
           <section className="planner-conversation-card" aria-label="Planner conversation">
             <div className="planner-conversation-header">
               <div>
-                <p className="scenario-kicker">Conversation runtime</p>
-                <h3>Message the trip planner</h3>
+                <p className="scenario-kicker">Conversation</p>
+                <h3>Message your planner</h3>
                 <p>
-                  Turns are persisted through the trip-scoped planner API and refresh the same
-                  panel state, memory, and activity trail used by the workspace.
+                  Ask for comparisons, summaries, reminders, or a focused next step. The answer
+                  stays with this trip.
                 </p>
               </div>
               <div className="planner-conversation-actions">
@@ -1031,8 +1082,7 @@ function WorkspacePageContent({
               {plannerSession == null || plannerSession.messages.length === 0 ? (
                 <article className="planner-message planner-message-empty">
                   <p>
-                    No conversation turns have been persisted yet. Send a message to start the
-                    runtime-backed planner thread for this trip.
+                    No planner conversation yet. Send a message to start shaping this trip.
                   </p>
                 </article>
               ) : (
@@ -1045,25 +1095,29 @@ function WorkspacePageContent({
                 ))
               )}
             </div>
-            {plannerSession?.available_tools.length ? (
-              <div className="planner-tool-strip" aria-label="Planner tools available">
-                {plannerSession.available_tools.slice(0, 4).map((tool) => (
-                  <span key={tool.tool_name}>{tool.tool_name.replace(/_/g, " ")}</span>
-                ))}
-              </div>
-            ) : null}
+            <div className="planner-prompt-suggestions" aria-label="Planner prompt suggestions">
+              {PLANNER_PROMPT_SUGGESTIONS.map((suggestion) => (
+                <button
+                  key={suggestion.label}
+                  type="button"
+                  onClick={() => handlePlannerPromptSuggestion(suggestion.draft)}
+                >
+                  {suggestion.label}
+                </button>
+              ))}
+            </div>
             <form className="planner-conversation-form" onSubmit={handlePlannerTurnSubmit}>
               <label>
-                Message
+                Message the planner
                 <textarea
                   value={plannerConversationDraft}
                   onChange={(event) => setPlannerConversationDraft(event.target.value)}
-                  placeholder="Ask the planner what to compare, revise, or inspect next."
+                  placeholder="Ask what to compare, what to remember, or what decision comes next."
                   rows={3}
                 />
               </label>
               <button type="submit" disabled={Boolean(plannerConversationBusyLabel)}>
-                Send planner turn
+                Send message
               </button>
             </form>
           </section>
@@ -1202,15 +1256,23 @@ function WorkspacePageContent({
         </section>
 
         <section className="status-card">
-          <p className="status-label">Inventory bundles</p>
-          <h2>{workspace.inventory_summary.runtime_state.title}</h2>
-          <p>{workspace.inventory_summary.runtime_state.summary}</p>
+          <p className="status-label">Things to consider</p>
+          <h2>
+            {workspace.inventory_summary.bundle_count > 0
+              ? "Places and options to review"
+              : "Options need more trip detail"}
+          </h2>
+          <p>
+            {workspace.inventory_summary.bundle_count > 0
+              ? "Grouped lodging, transport, and activity ideas are ready to inspect."
+              : "Add dates, trip length, or route direction so the planner can group useful options."}
+          </p>
           <p className="muted-copy">{workspace.inventory_summary.notes[0]}</p>
           {workspace.inventory_summary.bundle_count === 0 ? (
             <p className="muted-copy">
               {workspace.inventory_summary.runtime_state.status === "partial"
-                ? "Runtime bundle assembly is waiting on the rest of the trip frame."
-                : "Bundle assembly has not started yet for this trip."}
+                ? "The planner needs a little more trip detail before it can group options."
+                : "No option groups have been created for this trip yet."}
             </p>
           ) : (
             <div className="scenario-stack">
@@ -1230,20 +1292,20 @@ function WorkspacePageContent({
         </section>
 
         <section className="status-card">
-          <p className="status-label">Timeline</p>
+          <p className="status-label">Day plan</p>
           {timelineStops.length === 0 || activeScenario.scenario === null ? (
             <>
-              <h2>Timeline data is not ready</h2>
+              <h2>Day plan is not ready yet</h2>
               <p>
-                The workspace needs a scenario route sequence before it can render day-by-day pacing.
+                Choose or build a route idea before reviewing day-by-day pacing.
               </p>
               <p className="muted-copy">
-                Trip context is ready now, so the next planning pass can attach saved scenarios and timeline stops.
+                Ask the planner to compare routes or draft a first sequence of stops.
               </p>
             </>
           ) : (
             <>
-              <h2>{isCompactLayout ? "Compact day-by-day review" : "Trip rhythm and day sequencing"}</h2>
+              <h2>{isCompactLayout ? "Compact day-by-day review" : "Trip rhythm and day sequence"}</h2>
               <p>{selectedRuntimeScenario?.summary ?? activeScenario.scenario.scenario_summary.headline}</p>
               <div className="timeline-summary-grid" aria-label="Timeline summary">
                 <article className="timeline-summary-card">
@@ -1281,7 +1343,7 @@ function WorkspacePageContent({
                   </h3>
                   <p>
                     {selectedRuntimeScenario?.comparison_note ??
-                      "Option-level details update when scenario comparison data is available."}
+                      "Details update as route ideas become clearer."}
                   </p>
                 </article>
               </div>
@@ -1296,7 +1358,7 @@ function WorkspacePageContent({
                       <h3>{stop.label}</h3>
                       <p>
                         Days {stop.startDay}-{stop.endDay} keep this stop visible in the selected
-                        scenario review path.
+                        route review path.
                       </p>
                     </div>
                   </li>
@@ -1307,11 +1369,11 @@ function WorkspacePageContent({
         </section>
 
         <section className="status-card">
-          <p className="status-label">Scenario review board</p>
-          <h2>{isCompactLayout ? "Compact scenario tradeoffs" : "Review-ready scenario tradeoffs"}</h2>
+          <p className="status-label">Route tradeoffs</p>
+          <h2>{isCompactLayout ? "Compact route tradeoffs" : "Review route tradeoffs"}</h2>
           <p>
             Cost, route burden, feasibility, and policy posture stay scannable here without
-            forcing the traveler into raw scenario notes.
+            forcing you into raw planning notes.
           </p>
           {routeComparison.scenarios.length > 0 ? (
             <div className="scenario-review-grid" aria-label="Scenario review board">
@@ -1353,14 +1415,14 @@ function WorkspacePageContent({
           ) : (
             <p className="muted-copy">
               {currentWorkspace.runtime_state.status === "partial"
-                ? "Runtime comparison is waiting on richer trip inputs before scenario review can start."
-                : "No runtime scenarios are available yet, so there is nothing to review in the scenario board."}
+                ? "Add a little more trip detail before route comparison can start."
+                : "No route ideas are available yet, so there is nothing to compare."}
             </p>
           )}
         </section>
 
         <section className="status-card">
-          <p className="status-label">Scenario context</p>
+          <p className="status-label">Saved ideas</p>
           <h2>{currentWorkspace.scenario_search.title}</h2>
           <div className="scenario-stack">
             {currentWorkspace.saved_scenarios.map((savedScenario) => {
@@ -1381,8 +1443,8 @@ function WorkspacePageContent({
             })}
             {currentWorkspace.saved_scenarios.length === 0 ? (
               <p className="muted-copy">
-                No saved scenarios exist yet. The mounted planner panel carries the bootstrap context until planner
-                history is persisted.
+                No saved route ideas exist yet. Ask the planner to compare routes or save a
+                promising direction.
               </p>
             ) : null}
           </div>
@@ -1391,8 +1453,8 @@ function WorkspacePageContent({
 
       <div className="workspace-grid">
         <section className="status-card">
-          <p className="status-label">Session state</p>
-          <h2>Current planning posture</h2>
+          <p className="status-label">Planning settings</p>
+          <h2>Current collaboration style</h2>
           <dl className="workspace-meta">
             <div>
               <dt>Interaction</dt>
@@ -1409,7 +1471,7 @@ function WorkspacePageContent({
           </dl>
           <div className="decision-stack">
             {currentWorkspace.session.pending_decisions.length === 0 ? (
-              <p className="muted-copy">No blocking decisions are currently waiting on the traveler.</p>
+              <p className="muted-copy">No blocking decisions are waiting for you right now.</p>
             ) : (
               currentWorkspace.session.pending_decisions.map((decision) => (
                 <article key={decision.decision_id} className="decision-card">
@@ -1422,7 +1484,7 @@ function WorkspacePageContent({
         </section>
 
         <section className="status-card">
-          <p className="status-label">Comparison</p>
+          <p className="status-label">Saved comparison</p>
           <h2>{currentWorkspace.scenario_comparison?.summary ?? "No comparison saved yet"}</h2>
           {currentWorkspace.scenario_comparison ? (
             <>
@@ -1434,7 +1496,7 @@ function WorkspacePageContent({
               </ul>
             </>
           ) : (
-            <p className="muted-copy">The workspace will surface durable scenario tradeoff comparisons here.</p>
+            <p className="muted-copy">Saved route tradeoff comparisons will appear here.</p>
           )}
         </section>
 
@@ -1513,16 +1575,16 @@ function WorkspacePageContent({
         </section>
 
         <section className="status-card">
-          <p className="status-label">Planner memory</p>
+          <p className="status-label">Planning notes</p>
           <h2>
             {currentWorkspace.planner_memory.artifacts.length > 0
-              ? "User-visible planner checkpoints"
-              : "Planner memory has not been summarized yet"}
+              ? "Planner notes to keep"
+              : "No planner notes have been saved yet"}
           </h2>
           {currentWorkspace.planner_memory.artifacts.length === 0 ? (
             <p className="muted-copy">
-              The workspace will surface durable planner summaries here after the first persisted
-              planner conversation turn.
+              Important summaries and remembered decisions will appear here after the first planner
+              conversation.
             </p>
           ) : (
             <div className="decision-stack">
@@ -1538,11 +1600,11 @@ function WorkspacePageContent({
         </section>
 
         <section className="status-card">
-          <p className="status-label">Activity trail</p>
-          <h2>Persisted planner actions</h2>
+          <p className="status-label">Recent activity</p>
+          <h2>Latest trip planning actions</h2>
           <div className="decision-stack">
             {currentWorkspace.activity_log.length === 0 ? (
-              <p className="muted-copy">Planner actions will appear here after the first persisted decision or feedback event.</p>
+              <p className="muted-copy">Planner actions will appear here after the first decision or feedback event.</p>
             ) : (
               currentWorkspace.activity_log.slice(0, 4).map((entry) => (
                 <article key={entry.activity_event_id} className="decision-card">

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -979,22 +979,22 @@ function WorkspacePageContent({
         <p className="workspace-hero-emphasis">
           {isCompactLayout
             ? "Compact review keeps route, day plan, and next choices close together."
-            : "Use this workspace to compare options, keep notes, and move the trip toward a clear next decision."}
+            : "Use this trip workspace to compare options, capture traveler notes, and move toward one clear next step."}
         </p>
         <details className="workspace-help-disclosure">
           <summary>How to use this trip workspace</summary>
           <div className="workspace-help-grid">
             <article>
               <h3>Check the next decision</h3>
-              <p>Start with the trip status and open choices before asking for deeper planning.</p>
+              <p>Start with trip status and open choices, then ask your planner for the next action to take.</p>
             </article>
             <article>
               <h3>Compare options</h3>
-              <p>Use the map, route tradeoffs, day plan, and saved ideas to compare what is possible.</p>
+              <p>Use the map, route tradeoffs, day plan, and saved ideas to compare what fits this traveler goal.</p>
             </article>
             <article>
-              <h3>Keep side notes</h3>
-              <p>Send scattered reminders to the planner; they can be sorted into later planning work.</p>
+              <h3>Capture reminders</h3>
+              <p>Send reminders to your planner so they stay with this trip and can be pulled into the next revision.</p>
             </article>
           </div>
         </details>
@@ -1013,9 +1013,9 @@ function WorkspacePageContent({
       <div className="workspace-grid">
         <section className="status-card planner-panel-card">
           <p className="status-label">Planner</p>
-          <h2>Plan this trip</h2>
+          <h2>Traveler planning workspace</h2>
           <p className="muted-copy">
-            Use the planner to compare options, remember notes, and decide what should happen next.
+            Use your planner to compare options, keep context, and decide the next best trip step.
           </p>
           <div className="planner-runtime-row" aria-label="Planner availability">
             <span
@@ -1053,7 +1053,7 @@ function WorkspacePageContent({
                 <p className="scenario-kicker">Conversation</p>
                 <h3>Message your planner</h3>
                 <p>
-                  Ask for comparisons, summaries, reminders, or a focused next step. The answer
+                  Ask for comparisons, summaries, reminders, or a specific next step. The answer
                   stays with this trip.
                 </p>
               </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -216,18 +216,6 @@ a {
   line-height: 1.35;
 }
 
-.planning-mode-detail {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 160ms ease;
-}
-
-.planning-mode-option:hover .planning-mode-detail,
-.planning-mode-option:focus-within .planning-mode-detail,
-.planning-mode-option-active .planning-mode-detail {
-  max-height: 8rem;
-}
-
 .planning-mode-option-active {
   background: #e8f2ef;
   border-color: rgba(56, 117, 107, 0.55);
@@ -633,10 +621,14 @@ a {
   padding: 0.5rem 0.75rem;
 }
 
-.planner-prompt-suggestions button:hover,
-.planner-prompt-suggestions button:focus-visible {
+.planner-prompt-suggestions button:hover {
   border-color: rgba(56, 117, 107, 0.55);
-  outline: none;
+}
+
+.planner-prompt-suggestions button:focus-visible {
+  border-color: rgba(56, 117, 107, 0.7);
+  outline: 3px solid rgba(56, 117, 107, 0.32);
+  outline-offset: 2px;
 }
 
 .planner-conversation-form {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -179,6 +179,10 @@ a {
   margin: 0;
 }
 
+.planning-mode-selector-header p {
+  margin-bottom: 0;
+}
+
 .planning-mode-options {
   display: grid;
   gap: 0.6rem;
@@ -192,7 +196,7 @@ a {
   cursor: pointer;
   display: grid;
   gap: 0.25rem;
-  min-height: 96px;
+  min-height: 112px;
   padding: 0.8rem;
 }
 
@@ -212,10 +216,28 @@ a {
   line-height: 1.35;
 }
 
+.planning-mode-detail {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 160ms ease;
+}
+
+.planning-mode-option:hover .planning-mode-detail,
+.planning-mode-option:focus-within .planning-mode-detail,
+.planning-mode-option-active .planning-mode-detail {
+  max-height: 8rem;
+}
+
 .planning-mode-option-active {
   background: #e8f2ef;
   border-color: rgba(56, 117, 107, 0.55);
   box-shadow: inset 0 0 0 1px rgba(56, 117, 107, 0.18);
+}
+
+.planning-mode-active-summary {
+  margin: 0.75rem 0 0;
+  color: #365063;
+  font-size: 0.92rem;
 }
 
 .workspace-hero {
@@ -236,6 +258,40 @@ a {
   margin: 1rem 0 0;
   max-width: 42rem;
   color: #365063;
+}
+
+.workspace-help-disclosure {
+  margin-top: 1rem;
+  max-width: 56rem;
+}
+
+.workspace-help-disclosure summary {
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.workspace-help-grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 0.9rem;
+}
+
+.workspace-help-grid article {
+  border: 1px solid rgba(19, 33, 44, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.58);
+  padding: 0.85rem;
+}
+
+.workspace-help-grid h3,
+.workspace-help-grid p {
+  margin: 0;
+}
+
+.workspace-help-grid h3 {
+  margin-bottom: 0.35rem;
+  font-size: 0.96rem;
 }
 
 .workspace-meta {
@@ -557,6 +613,30 @@ a {
   background: rgba(19, 33, 44, 0.08);
   font-size: 0.82rem;
   text-transform: capitalize;
+}
+
+.planner-prompt-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.planner-prompt-suggestions button {
+  border: 1px solid rgba(19, 33, 44, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #24394a;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 0.5rem 0.75rem;
+}
+
+.planner-prompt-suggestions button:hover,
+.planner-prompt-suggestions button:focus-visible {
+  border-color: rgba(56, 117, 107, 0.55);
+  outline: none;
 }
 
 .planner-conversation-form {


### PR DESCRIPTION
Closes #1127

## Summary
- Reworks workspace and planner copy toward traveler-facing labels and next-step language.
- Adds a collapsed "How to use this trip workspace" help disclosure and prompt suggestion buttons.
- Expands planning mode cards with hover/focus-accessible behavior descriptions and active-mode guidance.

## Validation
- npm --prefix frontend test -- --run src/components/planner/PlanningModeSelector.test.tsx src/routes/WorkspacePage.test.tsx
- npm --prefix frontend run build
- git diff --check
