### PR TITLE
Issue #1128: Add route option comparison workbench

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -239,7 +239,9 @@ export type RuntimeScenarioComparison = {
     purpose?: string;
     confidence?: number;
     unresolved_questions?: string[];
+    open_question?: string | null;
     available_actions?: RouteOptionAction[];
+    available_action?: RouteOptionAction | null;
     summary: string;
     comparison_note: string;
     option_count: number;

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -26,6 +26,14 @@ export type TripRecord = {
 };
 
 export type PlanningMode = "delegated" | "collaborative" | "revealed-preference" | "in-trip";
+export type RouteOptionState = "active" | "baseline" | "fallback" | "rejected" | "needs_research";
+export type RouteOptionActionType = "make_baseline" | "keep" | "reject" | "reopen" | "revise";
+
+export type RouteOptionAction = {
+  action_type: RouteOptionActionType;
+  label: string;
+  description: string;
+};
 
 export type SessionState = {
   current_saved_scenario_id: string | null;
@@ -226,6 +234,12 @@ export type RuntimeScenarioComparison = {
     title: string;
     rank: number;
     status: string;
+    state?: RouteOptionState;
+    route_option_id?: string;
+    purpose?: string;
+    confidence?: number;
+    unresolved_questions?: string[];
+    available_actions?: RouteOptionAction[];
     summary: string;
     comparison_note: string;
     option_count: number;
@@ -667,6 +681,24 @@ export async function submitPlannerOptionFeedback(
     body: JSON.stringify({
       action_type: actionType,
       decision_id: decisionId,
+    }),
+  });
+}
+
+export async function submitRouteOptionAction(
+  tripId: string,
+  optionId: string,
+  actionType: RouteOptionActionType
+): Promise<WorkspaceData> {
+  return fetchJson<WorkspaceData>({
+    path: `/api/workspace/${tripId}/route-options/${optionId}/action`,
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      action_type: actionType,
     }),
   });
 }

--- a/frontend/src/components/workspace/RouteOptionWorkbench.test.tsx
+++ b/frontend/src/components/workspace/RouteOptionWorkbench.test.tsx
@@ -1,0 +1,182 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { RuntimeScenarioComparison } from "../../api/workspace";
+import { RouteOptionWorkbench } from "./RouteOptionWorkbench";
+
+const comparison: RuntimeScenarioComparison = {
+  title: "Scandinavia route comparison",
+  summary: "Three route options are ready for side-by-side review.",
+  lead_scenario_id: "route-option:rail-first",
+  comparison_axes: [
+    { key: "score", label: "Planner score", direction: "higher_better" },
+    { key: "travel_minutes", label: "Travel minutes", direction: "lower_better" },
+  ],
+  scenarios: [
+    {
+      scenario_id: "route-option:rail-first",
+      route_option_id: "route-option:rail-first",
+      title: "Rail-first route",
+      rank: 1,
+      status: "recommended",
+      state: "baseline",
+      purpose: "Use Rail-first route as the route everything else is compared against.",
+      confidence: 0.88,
+      unresolved_questions: [],
+      available_actions: [
+        {
+          action_type: "keep",
+          label: "Keep for later",
+          description: "Preserve this route as a backup option without making it the main plan.",
+        },
+      ],
+      summary: "A low-friction rail sequence through the main cities.",
+      comparison_note: "Lead route for the current workspace comparison set.",
+      option_count: 3,
+      route_sequence: ["stockholm", "oslo", "bergen"],
+      route_summary: "stockholm -> oslo -> bergen",
+      recommended_for_selection: true,
+      feasible: true,
+      metrics: {
+        score: 0.88,
+        travel_minutes: 420,
+        transfers: 3,
+        estimated_total: { currency: "USD", typical_amount: 3600 },
+      },
+      delta: {
+        score_delta: 0,
+        travel_minutes_delta: 0,
+        transfers_delta: 0,
+        estimated_total_delta: 0,
+      },
+      highlights: ["Balanced movement with clear rail legs."],
+    },
+    {
+      scenario_id: "route-option:fjord-focus",
+      route_option_id: "route-option:fjord-focus",
+      title: "Fjord-focus route",
+      rank: 2,
+      status: "alternative",
+      state: "active",
+      purpose: "Compare Fjord-focus route as an active alternative.",
+      confidence: 0.74,
+      unresolved_questions: ["Can the longer scenic transfer still fit the trip pace?"],
+      available_actions: [
+        {
+          action_type: "make_baseline",
+          label: "Make baseline",
+          description: "Use this route as the main plan while keeping alternatives visible.",
+        },
+        {
+          action_type: "reject",
+          label: "Reject",
+          description: "Move this route to history so it stops competing with active options.",
+        },
+      ],
+      summary: "A scenic route with more time near Bergen.",
+      comparison_note: "Alternative route preserved for direct scenario comparison.",
+      option_count: 4,
+      route_sequence: ["oslo", "flam", "bergen"],
+      route_summary: "oslo -> flam -> bergen",
+      recommended_for_selection: false,
+      feasible: true,
+      metrics: {
+        score: 0.74,
+        travel_minutes: 510,
+        transfers: 5,
+        estimated_total: { currency: "USD", typical_amount: 3900 },
+      },
+      delta: {
+        score_delta: -0.14,
+        travel_minutes_delta: 90,
+        transfers_delta: 2,
+        estimated_total_delta: 300,
+      },
+      highlights: ["More scenery with more transfers."],
+    },
+    {
+      scenario_id: "route-option:flight-hop",
+      route_option_id: "route-option:flight-hop",
+      title: "Flight-hop route",
+      rank: 3,
+      status: "alternative",
+      state: "rejected",
+      purpose: "Keep Flight-hop route in history so the rejection reason is not lost.",
+      confidence: 0.38,
+      unresolved_questions: ["Does the airport transfer burden defeat the route benefit?"],
+      available_actions: [
+        {
+          action_type: "reopen",
+          label: "Reopen",
+          description: "Move this route back into the active comparison set.",
+        },
+      ],
+      summary: "A faster route with more airport overhead.",
+      comparison_note: "Alternative route preserved for direct scenario comparison.",
+      option_count: 2,
+      route_sequence: ["stockholm", "bergen", "oslo"],
+      route_summary: "stockholm -> bergen -> oslo",
+      recommended_for_selection: false,
+      feasible: true,
+      metrics: {
+        score: 0.64,
+        travel_minutes: 390,
+        transfers: 6,
+        estimated_total: { currency: "USD", typical_amount: 4200 },
+      },
+      delta: {
+        score_delta: -0.24,
+        travel_minutes_delta: -30,
+        transfers_delta: 3,
+        estimated_total_delta: 600,
+      },
+      highlights: ["Faster in minutes but harder to execute."],
+    },
+  ],
+  source_refs: ["scenario-search:scandinavia"],
+};
+
+describe("RouteOptionWorkbench", () => {
+  it("renders three route options and dispatches route actions", () => {
+    const onSelectScenario = vi.fn();
+    const onRouteOptionAction = vi.fn();
+
+    render(
+      <RouteOptionWorkbench
+        comparison={comparison}
+        selectedScenarioId="route-option:rail-first"
+        busyLabel={null}
+        errorMessage={null}
+        onSelectScenario={onSelectScenario}
+        onRouteOptionAction={onRouteOptionAction}
+      />
+    );
+
+    expect(screen.getByLabelText("Route option comparison workbench")).toBeInTheDocument();
+    expect(screen.getByLabelText("Rail-first route route option")).toHaveTextContent("Baseline");
+    expect(screen.getByLabelText("Fjord-focus route route option")).toHaveTextContent(
+      "74% confidence"
+    );
+    expect(screen.getByLabelText("Flight-hop route route option")).toHaveTextContent("Rejected");
+
+    fireEvent.click(
+      within(screen.getByLabelText("Fjord-focus route route option")).getByRole("button", {
+        name: "Make baseline",
+      })
+    );
+    fireEvent.click(
+      within(screen.getByLabelText("Flight-hop route route option")).getByRole("button", {
+        name: "Reopen",
+      })
+    );
+    fireEvent.click(
+      within(screen.getByLabelText("Rail-first route route option")).getByRole("button", {
+        name: "View route",
+      })
+    );
+
+    expect(onRouteOptionAction).toHaveBeenCalledWith("route-option:fjord-focus", "make_baseline");
+    expect(onRouteOptionAction).toHaveBeenCalledWith("route-option:flight-hop", "reopen");
+    expect(onSelectScenario).toHaveBeenCalledWith("route-option:rail-first");
+  });
+});

--- a/frontend/src/components/workspace/RouteOptionWorkbench.tsx
+++ b/frontend/src/components/workspace/RouteOptionWorkbench.tsx
@@ -1,0 +1,268 @@
+import type {
+  RouteOptionAction,
+  RouteOptionActionType,
+  RouteOptionState,
+  RuntimeScenarioComparison,
+} from "../../api/workspace";
+
+type RouteOptionScenario = RuntimeScenarioComparison["scenarios"][number];
+
+const STATE_LABELS: Record<RouteOptionState, string> = {
+  active: "Active option",
+  baseline: "Baseline",
+  fallback: "Kept for later",
+  rejected: "Rejected",
+  needs_research: "Needs revision",
+};
+
+const FALLBACK_ACTIONS: Record<RouteOptionState, RouteOptionAction[]> = {
+  active: [
+    {
+      action_type: "make_baseline",
+      label: "Make baseline",
+      description: "Use this route as the main plan while keeping alternatives visible.",
+    },
+    {
+      action_type: "keep",
+      label: "Keep for later",
+      description: "Preserve this route as a backup option without making it the main plan.",
+    },
+    {
+      action_type: "reject",
+      label: "Reject",
+      description: "Move this route to history so it stops competing with active options.",
+    },
+    {
+      action_type: "revise",
+      label: "Revise",
+      description: "Ask the planner to improve this route before the next checkpoint.",
+    },
+  ],
+  baseline: [
+    {
+      action_type: "keep",
+      label: "Keep for later",
+      description: "Preserve this route as a backup option without making it the main plan.",
+    },
+    {
+      action_type: "reject",
+      label: "Reject",
+      description: "Move this route to history so it stops competing with active options.",
+    },
+    {
+      action_type: "revise",
+      label: "Revise",
+      description: "Ask the planner to improve this route before the next checkpoint.",
+    },
+  ],
+  fallback: [
+    {
+      action_type: "make_baseline",
+      label: "Make baseline",
+      description: "Use this route as the main plan while keeping alternatives visible.",
+    },
+    {
+      action_type: "reject",
+      label: "Reject",
+      description: "Move this route to history so it stops competing with active options.",
+    },
+    {
+      action_type: "revise",
+      label: "Revise",
+      description: "Ask the planner to improve this route before the next checkpoint.",
+    },
+  ],
+  rejected: [
+    {
+      action_type: "reopen",
+      label: "Reopen",
+      description: "Move this route back into the active comparison set.",
+    },
+  ],
+  needs_research: [
+    {
+      action_type: "make_baseline",
+      label: "Make baseline",
+      description: "Use this route as the main plan while keeping alternatives visible.",
+    },
+    {
+      action_type: "keep",
+      label: "Keep for later",
+      description: "Preserve this route as a backup option without making it the main plan.",
+    },
+    {
+      action_type: "reject",
+      label: "Reject",
+      description: "Move this route to history so it stops competing with active options.",
+    },
+    {
+      action_type: "revise",
+      label: "Revise",
+      description: "Ask the planner to improve this route before the next checkpoint.",
+    },
+  ],
+};
+
+function routeOptionId(scenario: RouteOptionScenario): string {
+  return scenario.route_option_id ?? scenario.scenario_id;
+}
+
+function routeOptionState(
+  scenario: RouteOptionScenario,
+  leadScenarioId: string | null
+): RouteOptionState {
+  if (scenario.state) {
+    return scenario.state;
+  }
+  if (scenario.scenario_id === leadScenarioId) {
+    return "baseline";
+  }
+  if (scenario.status === "fallback") {
+    return "fallback";
+  }
+  if (scenario.status === "blocked") {
+    return "needs_research";
+  }
+  return "active";
+}
+
+function formatConfidence(confidence: number | undefined): string {
+  if (confidence == null) {
+    return "Confidence pending";
+  }
+  return `${Math.round(confidence * 100)}% confidence`;
+}
+
+function formatMetric(scenario: RouteOptionScenario): string {
+  const estimatedTotal = scenario.metrics.estimated_total;
+  const cost =
+    estimatedTotal == null
+      ? "cost pending"
+      : new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: estimatedTotal.currency,
+          maximumFractionDigits: 0,
+        }).format(estimatedTotal.typical_amount);
+  return `${scenario.metrics.travel_minutes} min, ${scenario.metrics.transfers} transfer${
+    scenario.metrics.transfers === 1 ? "" : "s"
+  }, ${cost}`;
+}
+
+export function RouteOptionWorkbench({
+  comparison,
+  selectedScenarioId,
+  busyLabel,
+  errorMessage,
+  onSelectScenario,
+  onRouteOptionAction,
+}: {
+  comparison: RuntimeScenarioComparison;
+  selectedScenarioId: string | null;
+  busyLabel: string | null;
+  errorMessage: string | null;
+  onSelectScenario: (scenarioId: string) => void;
+  onRouteOptionAction: (optionId: string, actionType: RouteOptionActionType) => void;
+}) {
+  const scenarios = comparison.scenarios.slice(0, 4);
+
+  if (scenarios.length === 0) {
+    return (
+      <section className="status-card route-workbench-card">
+        <p className="status-label">Route options</p>
+        <h2>Route comparison is not ready</h2>
+        <p className="muted-copy">
+          The workspace needs route options before it can compare alternatives.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="status-card route-workbench-card">
+      <div className="route-workbench-header">
+        <div>
+          <p className="status-label">Route options</p>
+          <h2>Compare possible route plans</h2>
+          <p>
+            Keep three or four route ideas visible while deciding what should become the
+            working baseline.
+          </p>
+        </div>
+        <span className="planner-conversation-pill">
+          {scenarios.length} option{scenarios.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      {busyLabel ? <p className="muted-copy">{busyLabel}</p> : null}
+      {errorMessage ? <p className="planner-inline-error">{errorMessage}</p> : null}
+      <div className="route-option-grid" aria-label="Route option comparison workbench">
+        {scenarios.map((scenario) => {
+          const state = routeOptionState(scenario, comparison.lead_scenario_id);
+          const optionId = routeOptionId(scenario);
+          const actions = scenario.available_actions ?? FALLBACK_ACTIONS[state];
+          const isSelected = scenario.scenario_id === selectedScenarioId;
+
+          return (
+            <article
+              key={scenario.scenario_id}
+              className={`route-option-card route-option-card--${state}${
+                isSelected ? " route-option-card-selected" : ""
+              }`}
+              aria-label={`${scenario.title} route option`}
+            >
+              <div className="route-option-card-header">
+                <p className="scenario-kicker">{STATE_LABELS[state]}</p>
+                <button
+                  type="button"
+                  className="map-toggle-chip"
+                  aria-pressed={isSelected}
+                  onClick={() => onSelectScenario(scenario.scenario_id)}
+                >
+                  View route
+                </button>
+              </div>
+              <h3>{scenario.title}</h3>
+              <p>{scenario.purpose ?? scenario.summary}</p>
+              <dl className="workspace-meta route-option-metrics">
+                <div>
+                  <dt>Shape</dt>
+                  <dd>{scenario.route_summary}</dd>
+                </div>
+                <div>
+                  <dt>Friction</dt>
+                  <dd>{formatMetric(scenario)}</dd>
+                </div>
+                <div>
+                  <dt>Confidence</dt>
+                  <dd>{formatConfidence(scenario.confidence)}</dd>
+                </div>
+              </dl>
+              {(scenario.unresolved_questions ?? []).length > 0 ? (
+                <div className="route-option-questions">
+                  <p className="scenario-kicker">Open questions</p>
+                  <ul>
+                    {(scenario.unresolved_questions ?? []).map((question) => (
+                      <li key={question}>{question}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              <div className="route-option-actions" aria-label={`${scenario.title} route actions`}>
+                {actions.map((action) => (
+                  <button
+                    key={`${optionId}-${action.action_type}`}
+                    type="button"
+                    title={action.description}
+                    disabled={Boolean(busyLabel)}
+                    onClick={() => onRouteOptionAction(optionId, action.action_type)}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -12,6 +12,7 @@ import {
   saveWorkspaceBudget,
   submitPlannerTurn,
   submitPlannerOptionFeedback,
+  submitRouteOptionAction,
   updateWorkspacePlanningMode,
   type PlannerSessionResponse,
   type WorkspaceData,
@@ -27,6 +28,7 @@ vi.mock("../api/workspace", async () => {
     answerPlannerDecision: vi.fn(),
     fetchPlannerSession: vi.fn(),
     submitPlannerOptionFeedback: vi.fn(),
+    submitRouteOptionAction: vi.fn(),
     submitPlannerTurn: vi.fn(),
     updateWorkspacePlanningMode: vi.fn(),
     saveWorkspaceBudget: vi.fn(),
@@ -47,6 +49,7 @@ const mockedUseLoaderData = vi.mocked(useLoaderData);
 const mockedAnswerPlannerDecision = vi.mocked(answerPlannerDecision);
 const mockedFetchPlannerSession = vi.mocked(fetchPlannerSession);
 const mockedSubmitPlannerOptionFeedback = vi.mocked(submitPlannerOptionFeedback);
+const mockedSubmitRouteOptionAction = vi.mocked(submitRouteOptionAction);
 const mockedSubmitPlannerTurn = vi.mocked(submitPlannerTurn);
 const mockedUpdateWorkspacePlanningMode = vi.mocked(updateWorkspacePlanningMode);
 const mockedSaveWorkspaceBudget = vi.mocked(saveWorkspaceBudget);
@@ -775,6 +778,7 @@ describe("WorkspacePage", () => {
   beforeEach(() => {
     mockedFetchPlannerSession.mockResolvedValue(plannerSessionPayload);
     mockedSubmitPlannerTurn.mockResolvedValue(plannerSessionPayload);
+    mockedSubmitRouteOptionAction.mockResolvedValue(workspacePayload);
   });
 
   afterEach(() => {
@@ -789,6 +793,7 @@ describe("WorkspacePage", () => {
     mockedAnswerPlannerDecision.mockReset();
     mockedFetchPlannerSession.mockReset();
     mockedSubmitPlannerOptionFeedback.mockReset();
+    mockedSubmitRouteOptionAction.mockReset();
     mockedSubmitPlannerTurn.mockReset();
     mockedUpdateWorkspacePlanningMode.mockReset();
     mockedSaveWorkspaceBudget.mockReset();
@@ -1423,6 +1428,7 @@ describe("WorkspacePage", () => {
   it("renders the fallback map state and compact review copy on small screens", async () => {
     stubMatchMedia(true);
     vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "");
+    vi.stubEnv("VITE_GOOGLE_MAPS_EMBED_API_KEY", "");
     vi.stubEnv("VITE_GOOGLE_MAPS_PROVIDER_STATE", "missing");
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve(workspacePayload),

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -9,6 +9,7 @@ import {
   refreshWorkspaceProposalStatus,
   saveWorkspaceBudget,
   submitPlannerTurn,
+  submitRouteOptionAction,
   updateWorkspacePlanningMode,
   type ActualSpendEventUpsertPayload,
   type BudgetPlanUpsertPayload,
@@ -17,6 +18,7 @@ import {
   type PlannerSessionResponse,
   type PlannerStructuredBlock,
   type PlanningMode,
+  type RouteOptionActionType,
   submitPlannerOptionFeedback,
   type SavedScenarioRecord,
   type WorkspaceData,
@@ -26,6 +28,7 @@ import { TripMap } from "../components/maps/TripMap";
 import { PlanningModeSelector } from "../components/planner/PlanningModeSelector";
 import { PlannerSidePanelSurface } from "../components/planner/PlannerSidePanelSurface";
 import { TripComparison } from "../components/trips/TripComparison";
+import { RouteOptionWorkbench } from "../components/workspace/RouteOptionWorkbench";
 import { ScenarioComparison } from "../components/workspace/ScenarioComparison";
 import { AsyncRouteContent } from "../lib/routes/AsyncRouteContent";
 
@@ -640,6 +643,8 @@ function WorkspacePageContent({
   const [budgetBusyLabel, setBudgetBusyLabel] = useState<string | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
   const [proposalBusyLabel, setProposalBusyLabel] = useState<string | null>(null);
+  const [routeOptionError, setRouteOptionError] = useState<string | null>(null);
+  const [routeOptionBusyLabel, setRouteOptionBusyLabel] = useState<string | null>(null);
   const plannerSessionLoadVersion = useRef(0);
   const isCompactLayout = useCompactWorkspaceLayout();
   useEffect(() => {
@@ -787,6 +792,23 @@ function WorkspacePageContent({
       setPlannerError(error instanceof Error ? error.message : "Planner feedback update failed.");
     } finally {
       setPlannerBusyLabel(null);
+    }
+  }
+
+  async function handleRouteOptionAction(optionId: string, actionType: RouteOptionActionType) {
+    setRouteOptionError(null);
+    setRouteOptionBusyLabel("Saving route option...");
+    plannerSessionLoadVersion.current += 1;
+    try {
+      const nextWorkspace = await submitRouteOptionAction(trip.trip_id, optionId, actionType);
+      startTransition(() => {
+        setCurrentWorkspace(nextWorkspace);
+        setSelectedScenarioId(resolveMapScenarioId(nextWorkspace));
+      });
+    } catch (error) {
+      setRouteOptionError(error instanceof Error ? error.message : "Route option update failed.");
+    } finally {
+      setRouteOptionBusyLabel(null);
     }
   }
 
@@ -1096,6 +1118,15 @@ function WorkspacePageContent({
           savedScenarios={currentWorkspace.saved_scenarios}
           selectedScenarioId={selectedScenarioId}
           onSelectScenario={handleScenarioSelection}
+        />
+
+        <RouteOptionWorkbench
+          comparison={routeComparison}
+          selectedScenarioId={selectedScenarioId}
+          busyLabel={routeOptionBusyLabel}
+          errorMessage={routeOptionError}
+          onSelectScenario={handleScenarioSelection}
+          onRouteOptionAction={handleRouteOptionAction}
         />
 
         <TripComparison

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -125,6 +125,10 @@ a {
   grid-column: 1 / -1;
 }
 
+.route-workbench-card {
+  grid-column: 1 / -1;
+}
+
 .planner-panel-host {
   margin-top: 1.25rem;
 }
@@ -341,6 +345,86 @@ a {
 
 .scenario-highlight-list {
   margin-top: 1rem;
+}
+
+.route-workbench-header,
+.route-option-card-header {
+  align-items: start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.route-option-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 1.25rem;
+}
+
+.route-option-card {
+  background: rgba(19, 33, 44, 0.04);
+  border: 1px solid rgba(19, 33, 44, 0.08);
+  border-radius: 20px;
+  display: grid;
+  gap: 0.9rem;
+  min-height: 100%;
+  padding: 1rem;
+}
+
+.route-option-card-selected,
+.route-option-card--baseline {
+  background: rgba(56, 117, 107, 0.08);
+  border-color: rgba(56, 117, 107, 0.35);
+}
+
+.route-option-card--fallback {
+  background: rgba(132, 86, 35, 0.08);
+}
+
+.route-option-card--rejected {
+  opacity: 0.78;
+}
+
+.route-option-card--needs_research {
+  border-color: rgba(132, 86, 35, 0.3);
+}
+
+.route-option-metrics {
+  margin-top: 0;
+}
+
+.route-option-questions ul {
+  margin: 0.35rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.route-option-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.route-option-actions button {
+  border: 1px solid rgba(19, 33, 44, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.76);
+  color: #13212c;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.route-option-actions button:hover {
+  border-color: rgba(56, 117, 107, 0.55);
+}
+
+.route-option-actions button:focus-visible {
+  border-color: rgba(56, 117, 107, 0.7);
+  outline: 3px solid rgba(56, 117, 107, 0.32);
+  outline-offset: 2px;
 }
 
 .scenario-kicker {
@@ -977,6 +1061,11 @@ a {
 }
 
 @media (max-width: 640px) {
+  .route-workbench-header,
+  .route-option-card-header {
+    display: grid;
+  }
+
   .map-scenario-toggle {
     display: grid;
     grid-template-columns: 1fr;

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -1955,6 +1955,111 @@ def test_workspace_option_feedback_reuses_recent_presentation_ids(client: TestCl
     )
 
 
+def test_workspace_route_option_actions_update_comparison_and_ledger(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Scandinavia route workbench",
+            "summary": "Keep multiple route options available for comparison.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-07-04",
+                "end_date": "2026-07-12",
+                "duration_days": 9,
+                "primary_regions": ["Stockholm", "Oslo", "Bergen"],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    initial = client.get(f"/api/workspace/{trip_id}")
+    assert initial.status_code == 200
+    initial_payload = initial.json()
+    route_options = initial_payload["route_comparison"]["scenarios"]
+    assert route_options
+    assert len(route_options) >= 2
+    assert len(route_options) <= 4
+    assert route_options[0]["state"] == "baseline"
+    assert route_options[0]["purpose"]
+    assert isinstance(route_options[0]["confidence"], float)
+    assert isinstance(route_options[0]["unresolved_questions"], list)
+    assert route_options[0]["available_actions"]
+
+    candidate = route_options[min(1, len(route_options) - 1)]
+    candidate_id = candidate["route_option_id"]
+    baseline_response = client.post(
+        f"/api/workspace/{trip_id}/route-options/{candidate_id}/action",
+        json={"action_type": "make_baseline"},
+    )
+
+    assert baseline_response.status_code == 200, baseline_response.text
+    baseline_payload = baseline_response.json()
+    assert baseline_payload["route_comparison"]["lead_scenario_id"] == candidate_id
+    baseline_row = next(
+        item
+        for item in baseline_payload["route_comparison"]["scenarios"]
+        if item["route_option_id"] == candidate_id
+    )
+    assert baseline_row["state"] == "baseline"
+    assert baseline_payload["activity_log"][0]["event_kind"] == "decision_recorded"
+    assert "comparison baseline" in baseline_payload["activity_log"][0]["summary"]
+
+    rejected_id = route_options[0]["route_option_id"]
+    rejected_response = client.post(
+        f"/api/workspace/{trip_id}/route-options/{rejected_id}/action",
+        json={"action_type": "reject"},
+    )
+
+    assert rejected_response.status_code == 200, rejected_response.text
+    rejected_payload = rejected_response.json()
+    rejected_row = next(
+        item
+        for item in rejected_payload["route_comparison"]["scenarios"]
+        if item["route_option_id"] == rejected_id
+    )
+    assert rejected_row["state"] == "rejected"
+    assert [action["action_type"] for action in rejected_row["available_actions"]] == ["reopen"]
+    assert rejected_payload["activity_log"][0]["event_kind"] == "option_rejected"
+
+    reopened_response = client.post(
+        f"/api/workspace/{trip_id}/route-options/{rejected_id}/action",
+        json={"action_type": "reopen"},
+    )
+
+    assert reopened_response.status_code == 200, reopened_response.text
+    reopened_payload = reopened_response.json()
+    reopened_row = next(
+        item
+        for item in reopened_payload["route_comparison"]["scenarios"]
+        if item["route_option_id"] == rejected_id
+    )
+    assert reopened_row["state"] in {"active", "fallback"}
+    assert any(
+        action["action_type"] == "make_baseline"
+        for action in reopened_row["available_actions"]
+    )
+
+    reloaded = client.get(f"/api/workspace/{trip_id}")
+    assert reloaded.status_code == 200
+    assert reloaded.json()["route_comparison"]["lead_scenario_id"] == candidate_id
+
+    with get_session_factory()() as db_session:
+        actions = db_session.scalars(
+            select(PersistedPlannerAction)
+            .where(PersistedPlannerAction.trip_id == trip_id)
+            .order_by(PersistedPlannerAction.occurred_at.desc())
+        ).all()
+
+    assert actions[0].action_type == "route_option_reopen"
+    assert actions[1].action_type == "route_option_reject"
+    assert actions[2].action_type == "route_option_make_baseline"
+    assert actions[2].option_id == candidate_id
+    assert actions[2].payload["route_option_action"] == "make_baseline"
+
+
 def test_workspace_option_feedback_rejects_unknown_option_id(client: TestClient) -> None:
     created = client.post(
         "/api/trips",

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -1986,7 +1986,14 @@ def test_workspace_route_option_actions_update_comparison_and_ledger(
     assert route_options[0]["purpose"]
     assert isinstance(route_options[0]["confidence"], float)
     assert isinstance(route_options[0]["unresolved_questions"], list)
+    assert "open_question" in route_options[0]
     assert route_options[0]["available_actions"]
+    assert "available_action" in route_options[0]
+    if route_options[0]["unresolved_questions"]:
+        assert route_options[0]["open_question"] == route_options[0]["unresolved_questions"][0]
+    else:
+        assert route_options[0]["open_question"] is None
+    assert route_options[0]["available_action"] == route_options[0]["available_actions"][0]
 
     candidate = route_options[min(1, len(route_options) - 1)]
     candidate_id = candidate["route_option_id"]

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -1955,6 +1955,62 @@ def test_workspace_option_feedback_reuses_recent_presentation_ids(client: TestCl
     )
 
 
+def _route_option_scenario(
+    scenario_id: str,
+    *,
+    feasible: bool,
+    recommended: bool,
+    rank: int,
+) -> dict[str, Any]:
+    return {
+        "scenario_id": scenario_id,
+        "source_result_id": f"source:{scenario_id}",
+        "title": f"Route {rank}",
+        "rank": rank,
+        "score": 0.9 - (rank / 10),
+        "supporting_option_ids": [f"option:{rank}"],
+        "objective_refs": [],
+        "unresolved_tradeoffs": [],
+        "scenario_summary": {
+            "headline": f"Route {rank} summary",
+            "scenario_kind": "alternative",
+            "recommended_for_selection": recommended,
+            "feasible": feasible,
+            "route_sequence": ["Stockholm", "Oslo"],
+            "total_travel_minutes": 120 + rank,
+            "total_transfer_count": rank,
+            "estimated_total": {"amount": 1000 + rank, "currency": "USD"},
+        },
+    }
+
+
+def test_runtime_route_options_hold_blocked_scenarios_for_research() -> None:
+    comparison = workspace_service._build_runtime_scenario_comparison(
+        trip_id="trip-route-blocked",
+        trip_title="Blocked route comparison",
+        scenario_search={
+            "title": "Route comparison",
+            "source_refs": ["test"],
+            "scenarios": [
+                _route_option_scenario(
+                    "scenario:blocked", feasible=False, recommended=True, rank=1
+                ),
+                _route_option_scenario(
+                    "scenario:open", feasible=True, recommended=False, rank=2
+                ),
+            ],
+        },
+        session=None,
+    )
+
+    blocked = comparison["scenarios"][0]
+    assert blocked["status"] == "blocked"
+    assert blocked["state"] == "needs_research"
+    assert "make_baseline" not in [
+        action["action_type"] for action in blocked["available_actions"]
+    ]
+
+
 def test_workspace_route_option_actions_update_comparison_and_ledger(
     client: TestClient,
 ) -> None:
@@ -2048,6 +2104,7 @@ def test_workspace_route_option_actions_update_comparison_and_ledger(
         action["action_type"] == "make_baseline"
         for action in reopened_row["available_actions"]
     )
+    assert f"reopened:{rejected_id}" not in json.dumps(reopened_payload)
 
     reloaded = client.get(f"/api/workspace/{trip_id}")
     assert reloaded.status_code == 200

--- a/trip_planner/app/routes/workspace.py
+++ b/trip_planner/app/routes/workspace.py
@@ -5,6 +5,7 @@ from trip_planner.app.schemas.workspace import (
     PlanningModeUpdateRequest,
     PlannerDecisionAnswerRequest,
     PlannerOptionFeedbackRequest,
+    RouteOptionActionRequest,
     ScenarioComparisonSurfaceResponse,
     WorkspaceResponse,
 )
@@ -14,6 +15,7 @@ from trip_planner.app.services.workspace import (
     answer_workspace_planner_decision,
     get_workspace_scenario_comparison_payload,
     get_workspace_payload,
+    submit_workspace_route_option_action,
     submit_workspace_option_feedback,
     update_workspace_planning_mode,
 )
@@ -45,7 +47,9 @@ def read_workspace_scenario_comparison(
     user: AuthenticatedUser = Depends(require_authenticated_user),
     db_session: Session = Depends(get_db_session),
 ) -> ScenarioComparisonSurfaceResponse:
-    payload = get_workspace_scenario_comparison_payload(db_session, user=user, trip_id=trip_id)
+    payload = get_workspace_scenario_comparison_payload(
+        db_session, user=user, trip_id=trip_id
+    )
     if payload is None:
         raise HTTPException(
             status_code=404, detail=f"Workspace for trip '{trip_id}' was not found."
@@ -75,7 +79,8 @@ def update_planning_mode(
 
 
 @router.post(
-    "/workspace/{trip_id}/planner/decisions/{decision_id}/answer", response_model=WorkspaceResponse
+    "/workspace/{trip_id}/planner/decisions/{decision_id}/answer",
+    response_model=WorkspaceResponse,
 )
 def answer_planner_decision(
     trip_id: str,
@@ -100,7 +105,8 @@ def answer_planner_decision(
 
 
 @router.post(
-    "/workspace/{trip_id}/planner/options/{option_id}/feedback", response_model=WorkspaceResponse
+    "/workspace/{trip_id}/planner/options/{option_id}/feedback",
+    response_model=WorkspaceResponse,
 )
 def record_planner_option_feedback(
     trip_id: str,
@@ -117,6 +123,32 @@ def record_planner_option_feedback(
             option_id=option_id,
             action_type=payload.action_type,
             decision_id=payload.decision_id,
+        )
+    except WorkspaceTripNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return WorkspaceResponse.model_validate(result)
+
+
+@router.post(
+    "/workspace/{trip_id}/route-options/{option_id}/action",
+    response_model=WorkspaceResponse,
+)
+def record_route_option_action(
+    trip_id: str,
+    option_id: str,
+    payload: RouteOptionActionRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> WorkspaceResponse:
+    try:
+        result = submit_workspace_route_option_action(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            option_id=option_id,
+            action_type=payload.action_type,
         )
     except WorkspaceTripNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -55,7 +55,9 @@ class WorkspaceUserSummary(BaseModel):
     trip_mode: Literal["leisure", "business"] = Field(
         description="Workspace product mode used to gate user-facing copy."
     )
-    mode_label: str = Field(description="User-friendly mode label (e.g. 'Leisure trip').")
+    mode_label: str = Field(
+        description="User-friendly mode label (e.g. 'Leisure trip')."
+    )
     status: Literal["ready", "partial", "empty"] = Field(
         description="High-level workspace status used for top-level framing."
     )
@@ -237,6 +239,10 @@ class PlannerOptionFeedbackRequest(BaseModel):
         "do_more_before_asking_again",
     ]
     decision_id: str | None = Field(default=None, max_length=96)
+
+
+class RouteOptionActionRequest(BaseModel):
+    action_type: Literal["make_baseline", "keep", "reject", "reopen", "revise"]
 
 
 class PlanningModeUpdateRequest(BaseModel):

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -743,6 +743,8 @@ def _route_option_state(
 ) -> str:
     if scenario_id in rejected_option_ids:
         return "rejected"
+    if status == "blocked":
+        return "needs_research"
     if scenario_id == selected_option_id or (
         selected_option_id is None and scenario_id == lead_scenario_id
     ):
@@ -810,6 +812,8 @@ def _route_option_unresolved_questions(
 
 
 def _route_option_available_actions(state: str) -> list[dict[str, str]]:
+    if state not in ROUTE_OPTION_STATES:
+        raise ValueError(f"state must be one of {', '.join(ROUTE_OPTION_STATES)}")
     if state == "rejected":
         return [
             {
@@ -820,7 +824,7 @@ def _route_option_available_actions(state: str) -> list[dict[str, str]]:
         ]
 
     actions: list[dict[str, str]] = []
-    if state != "baseline":
+    if state not in {"baseline", "needs_research"}:
         actions.append(
             {
                 "action_type": "make_baseline",
@@ -3226,7 +3230,7 @@ def submit_workspace_option_feedback(
 
 
 def _without_route_option_notes(notes: list[str], option_id: str) -> list[str]:
-    managed_prefixes = ("fallback:", "needs_research:", "reopened:")
+    managed_prefixes = ("fallback:", "needs_research:")
     managed_tokens = {f"{prefix}{option_id}" for prefix in managed_prefixes}
     return [note for note in notes if note not in managed_tokens]
 
@@ -3300,7 +3304,6 @@ def submit_workspace_route_option_action(
         presentation.rejected_option_ids = [
             item for item in presentation.rejected_option_ids if item != option_id
         ]
-        presentation.notes.append(f"reopened:{option_id}")
         event_kind = "decision_recorded"
         summary = f"Traveler reopened route option '{option_id}' for comparison."
     else:

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -928,6 +928,11 @@ def _build_runtime_scenario_comparison(
             fallback_option_ids=fallback_option_ids,
             needs_research_option_ids=needs_research_option_ids,
         )
+        unresolved_questions = _route_option_unresolved_questions(
+            scenario=scenario,
+            state=state,
+        )
+        available_actions = _route_option_available_actions(state)
         rows.append(
             {
                 "scenario_id": scenario["scenario_id"],
@@ -942,11 +947,10 @@ def _build_runtime_scenario_comparison(
                     scenario=scenario,
                 ),
                 "confidence": _route_option_confidence(scenario=scenario, state=state),
-                "unresolved_questions": _route_option_unresolved_questions(
-                    scenario=scenario,
-                    state=state,
-                ),
-                "available_actions": _route_option_available_actions(state),
+                "unresolved_questions": unresolved_questions,
+                "available_actions": available_actions,
+                "open_question": unresolved_questions[0] if unresolved_questions else None,
+                "available_action": available_actions[0] if available_actions else None,
                 "summary": summary["headline"],
                 "comparison_note": (
                     "Lead route for the current workspace comparison set."

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import secrets
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -77,6 +78,20 @@ class WorkspaceFixture:
 
 
 WORKSPACE_ACTIVITY_LOG_LIMIT = 50
+ROUTE_OPTION_STATES: tuple[str, ...] = (
+    "active",
+    "baseline",
+    "fallback",
+    "rejected",
+    "needs_research",
+)
+ROUTE_OPTION_ACTIONS: tuple[str, ...] = (
+    "make_baseline",
+    "keep",
+    "reject",
+    "reopen",
+    "revise",
+)
 _BOOTSTRAP_SCENARIO_SCORE_BY_LABEL = {
     "baseline": 0.82,
     "fallback": 0.68,
@@ -119,11 +134,15 @@ def _load_trip_record(name: str) -> PersistedTripRecord:
     return PersistedTripRecord.from_dict(_load_json(_state_fixture_dir("trips") / name))
 
 
-def _load_saved_scenarios(name: str) -> tuple[list[SavedScenarioRecord], ScenarioComparison | None]:
+def _load_saved_scenarios(
+    name: str,
+) -> tuple[list[SavedScenarioRecord], ScenarioComparison | None]:
     payload = _load_json(_state_fixture_dir("scenarios") / name)
     records = [SavedScenarioRecord.from_dict(item) for item in payload["records"]]
     comparison = payload.get("comparison")
-    return records, ScenarioComparison.from_dict(comparison) if comparison is not None else None
+    return records, (
+        ScenarioComparison.from_dict(comparison) if comparison is not None else None
+    )
 
 
 def _load_session(name: str) -> PlanningSessionState:
@@ -145,7 +164,8 @@ def _canonicalize_saved_scenario_ids(
         matches = [
             record.saved_scenario_id
             for record in saved_scenarios
-            if set(record.saved_scenario_id.split(":")[-1].split("-")) == candidate_tokens
+            if set(record.saved_scenario_id.split(":")[-1].split("-"))
+            == candidate_tokens
         ]
         if len(matches) == 1:
             return matches[0]
@@ -153,7 +173,9 @@ def _canonicalize_saved_scenario_ids(
 
     session.current_saved_scenario_id = normalize(session.current_saved_scenario_id)
     for decision in session.pending_decisions:
-        decision.related_saved_scenario_id = normalize(decision.related_saved_scenario_id)
+        decision.related_saved_scenario_id = normalize(
+            decision.related_saved_scenario_id
+        )
 
 
 def _leisure_search_result(trip_id: str) -> ScenarioSearchResult:
@@ -239,7 +261,9 @@ def _leisure_search_result(trip_id: str) -> ScenarioSearchResult:
                         summary="The fallback opens more nightlife at the cost of extra transfers.",
                         factor_keys=["breadth", "transfer_cost"],
                         machine_context={"planner_mode": "leisure"},
-                        human_summary=["Broader exploration, slightly more travel fatigue."],
+                        human_summary=[
+                            "Broader exploration, slightly more travel fatigue."
+                        ],
                         source_refs=["ranked-results:kyoto-spring"],
                     )
                 ],
@@ -279,7 +303,10 @@ def _business_search_result(trip_id: str) -> ScenarioSearchResult:
                     route_sequence=["home", "client-site", "conference-hotel"],
                     notes=["compliant-first"],
                 ),
-                supporting_option_ids=["option:approved-rail", "option:conference-hotel"],
+                supporting_option_ids=[
+                    "option:approved-rail",
+                    "option:conference-hotel",
+                ],
                 objective_refs=["objective:client-summit"],
                 explanation_records=[
                     ExplanationRecord(
@@ -368,6 +395,181 @@ def _build_scenario_search(
     )
 
 
+def _generated_route_sequence(route_sequence: list[str], *, variant: str) -> list[str]:
+    clean_sequence = [stop for stop in route_sequence if stop]
+    if not clean_sequence:
+        clean_sequence = ["first-base", "comparison-stop"]
+    if variant == "reverse":
+        return (
+            list(reversed(clean_sequence))
+            if len(clean_sequence) > 1
+            else [
+                clean_sequence[0],
+                "nearby-base",
+            ]
+        )
+    if len(clean_sequence) == 1:
+        return [clean_sequence[0], "nearby-base", clean_sequence[0]]
+    return [*clean_sequence, clean_sequence[0]]
+
+
+def _adjust_estimated_total(
+    estimated_total: dict[str, Any] | None,
+    *,
+    delta: float,
+) -> dict[str, Any] | None:
+    if not isinstance(estimated_total, dict):
+        return estimated_total
+    typical_amount = estimated_total.get("typical_amount")
+    if typical_amount is None:
+        return estimated_total
+    adjusted = dict(estimated_total)
+    adjusted["typical_amount"] = round(max(0.0, float(typical_amount) + delta), 2)
+    return adjusted
+
+
+def _route_option_variant(
+    *,
+    base_scenario: dict[str, Any],
+    trip_id: str,
+    variant: str,
+    rank: int,
+    title: str,
+    headline: str,
+    tradeoff_summary: str,
+    score_delta: float,
+    travel_minutes_delta: int,
+    transfer_delta: int,
+    estimated_total_delta: float,
+    scenario_kind: str,
+) -> dict[str, Any]:
+    generated = deepcopy(base_scenario)
+    base_summary = dict(base_scenario.get("scenario_summary") or {})
+    base_route = list(base_summary.get("route_sequence") or [])
+    generated_id = f"scenario:{trip_id}:route-option:{variant}"
+    generated["scenario_id"] = generated_id
+    generated["title"] = title
+    generated["rank"] = rank
+    generated["source_result_id"] = (
+        f"{base_scenario.get('source_result_id', generated_id)}:{variant}"
+    )
+    generated["score"] = round(
+        max(0.05, min(0.98, float(base_scenario.get("score", 0.5)) + score_delta)), 2
+    )
+    generated["scenario_summary"] = {
+        **base_summary,
+        "headline": headline,
+        "scenario_kind": scenario_kind,
+        "recommended_for_selection": False,
+        "estimated_total": _adjust_estimated_total(
+            base_summary.get("estimated_total"),
+            delta=estimated_total_delta,
+        ),
+        "total_travel_minutes": max(
+            0,
+            int(base_summary.get("total_travel_minutes") or 0) + travel_minutes_delta,
+        ),
+        "total_transfer_count": max(
+            0,
+            int(base_summary.get("total_transfer_count") or 0) + transfer_delta,
+        ),
+        "route_sequence": _generated_route_sequence(base_route, variant=variant),
+        "notes": [
+            *list(base_summary.get("notes") or []),
+            "generated_route_option",
+        ],
+    }
+    generated["unresolved_tradeoffs"] = [
+        *list(base_scenario.get("unresolved_tradeoffs") or []),
+        {
+            "tradeoff_id": f"tradeoff:{trip_id}:route-option:{variant}",
+            "code": f"generated_{variant}_route",
+            "summary": tradeoff_summary,
+            "severity": "warning",
+            "blocking": False,
+            "related_ids": [str(base_scenario.get("scenario_id") or "")],
+            "notes": [
+                "Generated as a rough comparison route until deeper planner research runs."
+            ],
+        },
+    ]
+    generated["notes"] = [
+        *list(base_scenario.get("notes") or []),
+        "Generated as a rough route option from the current workspace route shape.",
+    ]
+    return generated
+
+
+def _ensure_route_option_search_depth(
+    record: PersistedTrip,
+    scenario_search: dict[str, Any],
+) -> dict[str, Any]:
+    scenarios = list(scenario_search.get("scenarios") or [])
+    if len(scenarios) >= 3 or not scenarios:
+        return scenario_search
+
+    expanded = dict(scenario_search)
+    expanded_scenarios = [deepcopy(scenario) for scenario in scenarios]
+    base_scenario = scenarios[0]
+    next_rank = len(expanded_scenarios) + 1
+    if len(expanded_scenarios) < 3:
+        expanded_scenarios.append(
+            _route_option_variant(
+                base_scenario=base_scenario,
+                trip_id=record.trip_id,
+                variant="reverse",
+                rank=next_rank,
+                title="Reverse-order route option",
+                headline="Same anchors in a different order to test pacing and arrival flow.",
+                tradeoff_summary=(
+                    "Reversing the order may improve arrival rhythm, but the planner still "
+                    "needs to validate local transfer timing."
+                ),
+                score_delta=-0.08,
+                travel_minutes_delta=45,
+                transfer_delta=1,
+                estimated_total_delta=120.0,
+                scenario_kind="alternative",
+            )
+        )
+        next_rank += 1
+    if len(expanded_scenarios) < 3:
+        expanded_scenarios.append(
+            _route_option_variant(
+                base_scenario=base_scenario,
+                trip_id=record.trip_id,
+                variant="loop",
+                rank=next_rank,
+                title="Loop route option",
+                headline="Return through the starting anchor to preserve a fallback exit path.",
+                tradeoff_summary=(
+                    "The loop keeps a recovery path open but adds movement that may not be "
+                    "worth it for the final plan."
+                ),
+                score_delta=-0.14,
+                travel_minutes_delta=90,
+                transfer_delta=2,
+                estimated_total_delta=240.0,
+                scenario_kind="fallback",
+            )
+        )
+
+    expanded["scenarios"] = expanded_scenarios[:4]
+    expanded["explanation"] = [
+        *list(expanded.get("explanation") or []),
+        "Route option workbench generated rough alternatives so the traveler can compare more than one path.",
+    ]
+    expanded["source_refs"] = list(
+        dict.fromkeys(
+            [
+                *list(expanded.get("source_refs") or []),
+                f"route-options:{record.trip_id}",
+            ]
+        )
+    )
+    return expanded
+
+
 def _build_runtime_scenario_search_for_trip(
     *,
     record: PersistedTrip,
@@ -384,15 +586,18 @@ def _build_runtime_scenario_search_for_trip(
         return _empty_workspace_scenario_search()
 
     if inventory_bundles:
-        return _build_scenario_search(
-            trip_id=record.trip_id,
-            trip_mode=record.mode,
-            bundles=inventory_bundles,
-            trip_title=record.title,
-            primary_regions=tuple(record.primary_regions),
-            duration_days=record.duration_days,
-            traveler_party_kind=record.traveler_party_kind,
-        ).to_dict()
+        return _ensure_route_option_search_depth(
+            record,
+            _build_scenario_search(
+                trip_id=record.trip_id,
+                trip_mode=record.mode,
+                bundles=inventory_bundles,
+                trip_title=record.title,
+                primary_regions=tuple(record.primary_regions),
+                duration_days=record.duration_days,
+                traveler_party_kind=record.traveler_party_kind,
+            ).to_dict(),
+        )
 
     if saved_scenarios:
         return _build_saved_scenario_runtime_search(
@@ -438,7 +643,9 @@ def _comparison_highlights(
     lead: dict[str, Any],
 ) -> list[str]:
     summary = scenario["scenario_summary"]
-    route_sequence = " -> ".join(summary.get("route_sequence") or []) or "route sequence pending"
+    route_sequence = (
+        " -> ".join(summary.get("route_sequence") or []) or "route sequence pending"
+    )
     highlights = [
         f"Route: {route_sequence}.",
         f"Travel {summary['total_travel_minutes']} minutes with {summary['total_transfer_count']} transfer(s).",
@@ -448,10 +655,12 @@ def _comparison_highlights(
     else:
         score_delta = round(float(scenario["score"]) - float(lead["score"]), 2)
         travel_delta = (
-            summary["total_travel_minutes"] - lead["scenario_summary"]["total_travel_minutes"]
+            summary["total_travel_minutes"]
+            - lead["scenario_summary"]["total_travel_minutes"]
         )
         transfers_delta = (
-            summary["total_transfer_count"] - lead["scenario_summary"]["total_transfer_count"]
+            summary["total_transfer_count"]
+            - lead["scenario_summary"]["total_transfer_count"]
         )
         delta_parts = [f"Score {score_delta:+.2f} versus the lead scenario."]
         if travel_delta:
@@ -460,7 +669,9 @@ def _comparison_highlights(
             delta_parts.append(f"Transfers {transfers_delta:+d} versus lead.")
         estimated_total_delta = _estimated_total_delta(scenario, lead)
         if estimated_total_delta is not None:
-            delta_parts.append(f"Estimated total {estimated_total_delta:+.2f} versus lead.")
+            delta_parts.append(
+                f"Estimated total {estimated_total_delta:+.2f} versus lead."
+            )
         highlights.append(" ".join(delta_parts))
     highlights.extend(
         tradeoff["summary"] for tradeoff in scenario.get("unresolved_tradeoffs", [])[:2]
@@ -468,18 +679,208 @@ def _comparison_highlights(
     return highlights
 
 
+def _latest_presentation_for_option_set(
+    session: dict[str, Any] | None,
+    option_set_id: str,
+) -> dict[str, Any] | None:
+    if session is None:
+        return None
+    presentations = session.get("recent_option_presentations", [])
+    if not isinstance(presentations, list):
+        return None
+    for presentation in reversed(presentations):
+        if (
+            isinstance(presentation, dict)
+            and presentation.get("option_set_id") == option_set_id
+        ):
+            return presentation
+    return None
+
+
+def _note_option_ids(notes: list[Any], prefix: str) -> set[str]:
+    marker = f"{prefix}:"
+    return {
+        note.split(":", 1)[1]
+        for note in notes
+        if isinstance(note, str) and note.startswith(marker) and note.split(":", 1)[1]
+    }
+
+
+def _session_route_option_state(
+    session: dict[str, Any] | None,
+    option_set_id: str,
+) -> tuple[set[str], str | None, set[str], set[str]]:
+    presentation = _latest_presentation_for_option_set(session, option_set_id)
+    if presentation is None:
+        return set(), None, set(), set()
+
+    rejected_option_ids = {
+        item
+        for item in presentation.get("rejected_option_ids", [])
+        if isinstance(item, str)
+    }
+    selected_option_id = presentation.get("selected_option_id")
+    if not isinstance(selected_option_id, str) or selected_option_id == "":
+        selected_option_id = None
+    notes = list(presentation.get("notes") or [])
+    return (
+        rejected_option_ids,
+        selected_option_id,
+        _note_option_ids(notes, "fallback"),
+        _note_option_ids(notes, "needs_research"),
+    )
+
+
+def _route_option_state(
+    *,
+    scenario_id: str,
+    status: str,
+    lead_scenario_id: str,
+    rejected_option_ids: set[str],
+    selected_option_id: str | None,
+    fallback_option_ids: set[str],
+    needs_research_option_ids: set[str],
+) -> str:
+    if scenario_id in rejected_option_ids:
+        return "rejected"
+    if scenario_id == selected_option_id or (
+        selected_option_id is None and scenario_id == lead_scenario_id
+    ):
+        return "baseline"
+    if scenario_id in needs_research_option_ids:
+        return "needs_research"
+    if scenario_id in fallback_option_ids or status == "fallback":
+        return "fallback"
+    return "active"
+
+
+def _route_option_purpose(*, state: str, status: str, scenario: dict[str, Any]) -> str:
+    title = scenario.get("title") or "This route"
+    if state == "baseline":
+        return f"Use {title} as the route everything else is compared against."
+    if state == "fallback":
+        return f"Keep {title} available as a backup or later comparison lane."
+    if state == "rejected":
+        return f"Keep {title} in history so the reason for rejecting it is not lost."
+    if state == "needs_research":
+        return (
+            f"Send {title} back for a focused revision before treating it as settled."
+        )
+    if status == "recommended":
+        return f"Compare {title} as a strong candidate before making it the baseline."
+    return f"Compare {title} as an active alternative while the route is still taking shape."
+
+
+def _route_option_confidence(*, scenario: dict[str, Any], state: str) -> float:
+    try:
+        confidence = float(scenario.get("score", 0.5))
+    except (TypeError, ValueError):
+        confidence = 0.5
+    summary = scenario.get("scenario_summary") or {}
+    if not summary.get("feasible", True):
+        confidence = min(confidence, 0.35)
+    if state == "needs_research":
+        confidence = min(confidence, 0.55)
+    if state == "rejected":
+        confidence = min(confidence, 0.4)
+    for tradeoff in scenario.get("unresolved_tradeoffs", []):
+        if tradeoff.get("severity") == "critical" or tradeoff.get("blocking"):
+            confidence = min(confidence, 0.58)
+    return round(max(0.05, min(confidence, 0.98)), 2)
+
+
+def _route_option_unresolved_questions(
+    *, scenario: dict[str, Any], state: str
+) -> list[str]:
+    summary = scenario.get("scenario_summary") or {}
+    questions: list[str] = []
+    if not summary.get("route_sequence"):
+        questions.append("Which stops should anchor this route?")
+    if summary.get("estimated_total") is None:
+        questions.append("What rough cost range should this route assume?")
+    for tradeoff in scenario.get("unresolved_tradeoffs", [])[:2]:
+        tradeoff_summary = tradeoff.get("summary")
+        if isinstance(tradeoff_summary, str) and tradeoff_summary:
+            questions.append(f"Can this tradeoff work for the trip: {tradeoff_summary}")
+    if state == "needs_research":
+        questions.append(
+            "What should the planner change before comparing this route again?"
+        )
+    return questions[:3]
+
+
+def _route_option_available_actions(state: str) -> list[dict[str, str]]:
+    if state == "rejected":
+        return [
+            {
+                "action_type": "reopen",
+                "label": "Reopen",
+                "description": "Move this route back into the active comparison set.",
+            }
+        ]
+
+    actions: list[dict[str, str]] = []
+    if state != "baseline":
+        actions.append(
+            {
+                "action_type": "make_baseline",
+                "label": "Make baseline",
+                "description": "Use this route as the main plan while keeping alternatives visible.",
+            }
+        )
+    if state != "fallback":
+        actions.append(
+            {
+                "action_type": "keep",
+                "label": "Keep for later",
+                "description": "Preserve this route as a backup option without making it the main plan.",
+            }
+        )
+    actions.extend(
+        [
+            {
+                "action_type": "reject",
+                "label": "Reject",
+                "description": "Move this route to history so it stops competing with active options.",
+            },
+            {
+                "action_type": "revise",
+                "label": "Revise",
+                "description": "Ask the planner to improve this route before the next checkpoint.",
+            },
+        ]
+    )
+    return actions
+
+
 def _build_runtime_scenario_comparison(
     *,
     trip_id: str,
     trip_title: str,
     scenario_search: dict[str, Any],
+    session: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     scenarios = list(scenario_search.get("scenarios", []))
+    option_set_id = _bootstrap_option_set_id(trip_id)
+    (
+        rejected_option_ids,
+        selected_option_id,
+        fallback_option_ids,
+        needs_research_option_ids,
+    ) = _session_route_option_state(session, option_set_id)
     comparison_axes = [
         {"key": "score", "label": "Planner score", "direction": "higher_better"},
-        {"key": "travel_minutes", "label": "Travel minutes", "direction": "lower_better"},
+        {
+            "key": "travel_minutes",
+            "label": "Travel minutes",
+            "direction": "lower_better",
+        },
         {"key": "transfers", "label": "Transfers", "direction": "lower_better"},
-        {"key": "estimated_total", "label": "Estimated total", "direction": "lower_better"},
+        {
+            "key": "estimated_total",
+            "label": "Estimated total",
+            "direction": "lower_better",
+        },
     ]
     if not scenarios:
         return {
@@ -495,17 +896,57 @@ def _build_runtime_scenario_comparison(
             "source_refs": list(scenario_search.get("source_refs") or []),
         }
 
-    lead = scenarios[0]
+    scenario_ids = {scenario["scenario_id"] for scenario in scenarios}
+    if (
+        selected_option_id not in scenario_ids
+        or selected_option_id in rejected_option_ids
+    ):
+        selected_option_id = None
+    lead = (
+        next(
+            (
+                scenario
+                for scenario in scenarios
+                if selected_option_id is not None
+                and scenario["scenario_id"] == selected_option_id
+            ),
+            None,
+        )
+        or scenarios[0]
+    )
     rows = []
     for scenario in scenarios:
         summary = scenario["scenario_summary"]
         estimated_total = summary.get("estimated_total")
+        status = _comparison_status_label(scenario)
+        state = _route_option_state(
+            scenario_id=scenario["scenario_id"],
+            status=status,
+            lead_scenario_id=lead["scenario_id"],
+            rejected_option_ids=rejected_option_ids,
+            selected_option_id=selected_option_id,
+            fallback_option_ids=fallback_option_ids,
+            needs_research_option_ids=needs_research_option_ids,
+        )
         rows.append(
             {
                 "scenario_id": scenario["scenario_id"],
+                "route_option_id": scenario["scenario_id"],
                 "title": scenario["title"],
                 "rank": scenario["rank"],
-                "status": _comparison_status_label(scenario),
+                "status": status,
+                "state": state,
+                "purpose": _route_option_purpose(
+                    state=state,
+                    status=status,
+                    scenario=scenario,
+                ),
+                "confidence": _route_option_confidence(scenario=scenario, state=state),
+                "unresolved_questions": _route_option_unresolved_questions(
+                    scenario=scenario,
+                    state=state,
+                ),
+                "available_actions": _route_option_available_actions(state),
                 "summary": summary["headline"],
                 "comparison_note": (
                     "Lead route for the current workspace comparison set."
@@ -530,7 +971,9 @@ def _build_runtime_scenario_comparison(
                     "estimated_total": estimated_total,
                 },
                 "delta": {
-                    "score_delta": round(float(scenario["score"]) - float(lead["score"]), 2),
+                    "score_delta": round(
+                        float(scenario["score"]) - float(lead["score"]), 2
+                    ),
                     "travel_minutes_delta": (
                         summary["total_travel_minutes"]
                         - lead["scenario_summary"]["total_travel_minutes"]
@@ -653,12 +1096,16 @@ def _default_workspace_decisions(trip_id: str) -> list[PendingDecision]:
             ],
             blocking=True,
             related_option_set_id=f"option-set:{trip_id}:workspace-bootstrap",
-            notes=["Workspace bootstrap decision seeded for persisted planner interaction."],
+            notes=[
+                "Workspace bootstrap decision seeded for persisted planner interaction."
+            ],
         )
     ]
 
 
-def _default_workspace_presentation(trip_id: str, shown_at: str) -> OptionPresentationRecord:
+def _default_workspace_presentation(
+    trip_id: str, shown_at: str
+) -> OptionPresentationRecord:
     return OptionPresentationRecord(
         presentation_id=f"presentation:{trip_id}:workspace-bootstrap",
         option_set_id=f"option-set:{trip_id}:workspace-bootstrap",
@@ -684,7 +1131,9 @@ def _default_workspace_session(record: PersistedTrip) -> PlanningSessionState:
         mode=record.mode,
         started_at=_isoformat(record.created_at),
         updated_at=timestamp,
-        recent_option_presentations=[_default_workspace_presentation(record.trip_id, timestamp)],
+        recent_option_presentations=[
+            _default_workspace_presentation(record.trip_id, timestamp)
+        ],
         pending_decisions=_default_workspace_decisions(record.trip_id),
         activity_log_id=f"activity-log:{record.trip_id}",
         active_budget_plan_id=record.budget_state_id,
@@ -825,11 +1274,15 @@ def _bootstrap_saved_scenario_records(
                         "keeps a broader comparison lane available."
                     ),
                     "focus_areas": ["scope", "comparison-readiness"],
-                    "notes": ["Bootstrap comparison scaffold for persisted workspace rendering."],
+                    "notes": [
+                        "Bootstrap comparison scaffold for persisted workspace rendering."
+                    ],
                 }
             ],
             "tags": ["workspace-bootstrap", "preferred"],
-            "notes": ["Created automatically during the first persisted workspace bootstrap."],
+            "notes": [
+                "Created automatically during the first persisted workspace bootstrap."
+            ],
         }
     )
     fallback = SavedScenarioRecord.from_dict(
@@ -855,7 +1308,9 @@ def _bootstrap_saved_scenario_records(
             ],
             "comparisons": [],
             "tags": ["workspace-bootstrap", "fallback"],
-            "notes": ["Created automatically during the first persisted workspace bootstrap."],
+            "notes": [
+                "Created automatically during the first persisted workspace bootstrap."
+            ],
         }
     )
     return baseline, fallback
@@ -875,7 +1330,9 @@ def _saved_scenario_priority(saved_scenario: dict[str, Any]) -> tuple[int, str]:
     return priority, version.get("title", saved_scenario["saved_scenario_id"])
 
 
-def _ordered_saved_scenarios(saved_scenarios: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _ordered_saved_scenarios(
+    saved_scenarios: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
     return sorted(saved_scenarios, key=_saved_scenario_priority)
 
 
@@ -956,9 +1413,13 @@ def _build_saved_scenario_runtime_search(
                     "route_sequence": route_sequence,
                     "notes": list(version.get("notes") or []),
                 },
-                "supporting_option_ids": list(version["snapshot_refs"].get("option_set_ids") or []),
+                "supporting_option_ids": list(
+                    version["snapshot_refs"].get("option_set_ids") or []
+                ),
                 "objective_refs": [
-                    ref for ref in [version["snapshot_refs"].get("objective_id")] if ref is not None
+                    ref
+                    for ref in [version["snapshot_refs"].get("objective_id")]
+                    if ref is not None
                 ],
                 "unresolved_tradeoffs": (
                     [
@@ -1126,13 +1587,15 @@ def _build_persisted_trip_workspace(
             inventory_status=inventory_status,
         )
     )
-    resolved_feasibility_summary = feasibility_summary or build_feasibility_summary_payload(
-        resolved_inventory_bundles
+    resolved_feasibility_summary = (
+        feasibility_summary
+        or build_feasibility_summary_payload(resolved_inventory_bundles)
     )
     runtime_scenario_comparison = _build_runtime_scenario_comparison(
         trip_id=record.trip_id,
         trip_title=trip_record["trip"]["title"],
         scenario_search=resolved_scenario_search,
+        session=resolved_session,
     )
     ranking = build_scenario_ranking_payload(
         trip_id=record.trip_id,
@@ -1328,11 +1791,11 @@ def _build_workspace_view_model(
     business_summary: dict[str, Any] | None = None
     if resolved_mode == "business":
         proposal_state = payload.get("proposal_state") or {}
-        proposal_state = (
-            proposal_state if isinstance(proposal_state, dict) else {}
-        )
+        proposal_state = proposal_state if isinstance(proposal_state, dict) else {}
         proposal_summary = proposal_state.get("summary") or {}
-        proposal_summary = proposal_summary if isinstance(proposal_summary, dict) else {}
+        proposal_summary = (
+            proposal_summary if isinstance(proposal_summary, dict) else {}
+        )
         approval_ready = bool(proposal_summary.get("approval_ready"))
         evaluation_status = str(
             proposal_summary.get("evaluation_result_status")
@@ -1432,7 +1895,9 @@ def _build_workspace_runtime_state(
         }
     return {
         "status": str(inventory_runtime_state.get("status") or "empty"),
-        "title": str(inventory_runtime_state.get("title") or "Workspace runtime is still empty"),
+        "title": str(
+            inventory_runtime_state.get("title") or "Workspace runtime is still empty"
+        ),
         "summary": str(
             inventory_runtime_state.get("summary")
             or "Trip context is not complete enough for runtime workspace assembly yet."
@@ -1457,6 +1922,7 @@ def _build_runtime_scenario_comparison_payload(
             fixture = None
     if fixture is not None:
         trip_record = _load_trip_record(fixture.trip_fixture)
+        session = _load_session(fixture.session_fixture)
         inventory_bundles = assemble_inventory_bundles_for_trip(
             trip_id=trip_id,
             trip_mode=trip_record.trip.mode,
@@ -1474,6 +1940,7 @@ def _build_runtime_scenario_comparison_payload(
             trip_id=trip_id,
             trip_title=trip_record.trip.title,
             scenario_search=scenario_search.to_dict(),
+            session=session.to_dict(),
         )
 
     try:
@@ -1481,6 +1948,7 @@ def _build_runtime_scenario_comparison_payload(
     except WorkspaceTripNotFoundError:
         return None
 
+    session_record = _get_or_create_workspace_session_record(db_session, record=record)
     persisted_saved_scenarios_records = list(
         db_session.scalars(
             select(PersistedSavedScenario)
@@ -1489,7 +1957,6 @@ def _build_runtime_scenario_comparison_payload(
         ).all()
     )
     if not persisted_saved_scenarios_records:
-        session_record = _get_or_create_workspace_session_record(db_session, record=record)
         persisted_saved_scenarios_records = _create_bootstrap_saved_scenarios(
             db_session,
             record=record,
@@ -1508,8 +1975,12 @@ def _build_runtime_scenario_comparison_payload(
         }
         for scenario in persisted_saved_scenarios_records
     ]
-    persisted_inventory_bundles, inventory_summary = _build_workspace_inventory_inputs(record)
-    inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
+    persisted_inventory_bundles, inventory_summary = _build_workspace_inventory_inputs(
+        record
+    )
+    inventory_status = str(
+        (inventory_summary.get("runtime_state") or {}).get("status") or "empty"
+    )
     return _build_runtime_scenario_comparison(
         trip_id=trip_id,
         trip_title=record.title,
@@ -1519,6 +1990,7 @@ def _build_runtime_scenario_comparison_payload(
             saved_scenarios=persisted_saved_scenarios,
             inventory_status=inventory_status,
         ),
+        session=_serialize_session_record(session_record),
     )
 
 
@@ -1635,7 +2107,10 @@ def _sync_workspace_session_record(
         ):
             decision["related_saved_scenario_id"] = ordered_ids[0]
             decision["related_option_set_id"] = option_set_id
-            session_record.pending_decisions = [decision, *session_record.pending_decisions[1:]]
+            session_record.pending_decisions = [
+                decision,
+                *session_record.pending_decisions[1:],
+            ]
             updated = True
 
     if updated:
@@ -1672,7 +2147,9 @@ def _build_planner_panel_state(
 ) -> dict[str, Any]:
     scenarios = list(scenario_search.get("scenarios", []))
     primary_regions = list(trip["trip_frame"].get("primary_regions") or [])
-    region_summary = ", ".join(primary_regions[:2]) if primary_regions else "the current trip frame"
+    region_summary = (
+        ", ".join(primary_regions[:2]) if primary_regions else "the current trip frame"
+    )
 
     if scenarios:
         option_set = {
@@ -1682,8 +2159,16 @@ def _build_planner_panel_state(
             "scope": "scenario_selection",
             "title": scenario_search.get("title") or "Workspace planner scenarios",
             "comparison_axes": [
-                {"key": "score", "label": "Planner score", "direction": "higher_better"},
-                {"key": "travel_minutes", "label": "Travel minutes", "direction": "lower_better"},
+                {
+                    "key": "score",
+                    "label": "Planner score",
+                    "direction": "higher_better",
+                },
+                {
+                    "key": "travel_minutes",
+                    "label": "Travel minutes",
+                    "direction": "lower_better",
+                },
                 {"key": "transfers", "label": "Transfers", "direction": "lower_better"},
             ],
             "explanation": list(scenario_search.get("explanation") or [])
@@ -1697,9 +2182,12 @@ def _build_planner_panel_state(
                     "label": scenario["title"],
                     "summary": scenario["scenario_summary"]["headline"],
                     "drawbacks": [
-                        tradeoff["summary"] for tradeoff in scenario.get("unresolved_tradeoffs", [])
+                        tradeoff["summary"]
+                        for tradeoff in scenario.get("unresolved_tradeoffs", [])
                     ]
-                    or ["No explicit unresolved tradeoffs were recorded for this scenario yet."],
+                    or [
+                        "No explicit unresolved tradeoffs were recorded for this scenario yet."
+                    ],
                     "explanation": [
                         f"Rank #{scenario['rank']} with score {scenario['score']:.2f}.",
                         f"Route sequence: {' -> '.join(scenario['scenario_summary'].get('route_sequence', [])) or 'not surfaced yet'}.",
@@ -1730,8 +2218,16 @@ def _build_planner_panel_state(
             "scope": "trip_setup",
             "title": "Planner workspace bootstrap",
             "comparison_axes": [
-                {"key": "scope", "label": "Planning scope", "direction": "higher_better"},
-                {"key": "specificity", "label": "Trip specificity", "direction": "higher_better"},
+                {
+                    "key": "scope",
+                    "label": "Planning scope",
+                    "direction": "higher_better",
+                },
+                {
+                    "key": "specificity",
+                    "label": "Trip specificity",
+                    "direction": "higher_better",
+                },
             ],
             "explanation": [
                 "This starter panel is seeded from the persisted trip record until ranked planner scenarios exist.",
@@ -1755,7 +2251,9 @@ def _build_planner_panel_state(
                     "kind": "trip_setup",
                     "label": "Broaden the first planner pass",
                     "summary": "Expand regions, dates, or traveler notes before the first ranked scenario run.",
-                    "drawbacks": ["A broader scope can delay the first saved scenario comparison."],
+                    "drawbacks": [
+                        "A broader scope can delay the first saved scenario comparison."
+                    ],
                     "explanation": [
                         "Best when the trip shell is real but still intentionally under-specified.",
                     ],
@@ -1788,9 +2286,11 @@ def _build_planner_panel_state(
             },
         ]
 
-    rejected_option_ids, selected_option_id, fallback_option_ids = _session_feedback_state(
-        session,
-        option_set["option_set_id"],
+    rejected_option_ids, selected_option_id, fallback_option_ids = (
+        _session_feedback_state(
+            session,
+            option_set["option_set_id"],
+        )
     )
     option_set["options"] = [
         {
@@ -1805,10 +2305,13 @@ def _build_planner_panel_state(
                 )
             ),
             "explanation": (
-                ["You already chose this direction in the workspace."] + option["explanation"]
+                ["You already chose this direction in the workspace."]
+                + option["explanation"]
                 if option["option_id"] == selected_option_id
                 else (
-                    ["This option was kept as an explicit fallback for later comparison."]
+                    [
+                        "This option was kept as an explicit fallback for later comparison."
+                    ]
                     + option["explanation"]
                     if option["option_id"] in fallback_option_ids
                     else option["explanation"]
@@ -1826,7 +2329,8 @@ def _build_planner_panel_state(
             "prompt": decision["prompt"],
             "choices": (
                 list(decision["choices"])
-                if isinstance(decision.get("choices"), (list, tuple)) and decision["choices"]
+                if isinstance(decision.get("choices"), (list, tuple))
+                and decision["choices"]
                 else [
                     "Keep the current direction.",
                     "Compare another planner-backed option first.",
@@ -1882,7 +2386,8 @@ def _build_planner_panel_state(
 
     proposal_state = (
         dict(proposal_context["proposal_state"])
-        if proposal_context is not None and proposal_context.get("proposal_state") is not None
+        if proposal_context is not None
+        and proposal_context.get("proposal_state") is not None
         else None
     )
     if proposal_state is not None:
@@ -1893,12 +2398,15 @@ def _build_planner_panel_state(
             else None
         )
         proposal = (
-            dict(proposal_state["proposal"]) if proposal_state.get("proposal") is not None else None
+            dict(proposal_state["proposal"])
+            if proposal_state.get("proposal") is not None
+            else None
         )
     else:
         policy_evaluation = (
             dict(policy_context["policy_evaluation"])
-            if policy_context is not None and policy_context.get("policy_evaluation") is not None
+            if policy_context is not None
+            and policy_context.get("policy_evaluation") is not None
             else None
         )
         proposal = (
@@ -1917,7 +2425,9 @@ def _build_planner_panel_state(
                     "positive"
                     if policy_evaluation["status"] == "compliant"
                     else (
-                        "critical" if policy_evaluation["status"] == "non_compliant" else "caution"
+                        "critical"
+                        if policy_evaluation["status"] == "non_compliant"
+                        else "caution"
                     )
                 ),
                 "highlights": list(policy_evaluation.get("notes") or [])[:3],
@@ -1935,7 +2445,9 @@ def _build_planner_panel_state(
             },
         )
     policy_summary = (
-        dict(policy_context.get("summary") or {}) if isinstance(policy_context, dict) else {}
+        dict(policy_context.get("summary") or {})
+        if isinstance(policy_context, dict)
+        else {}
     )
     policy_transport_error = (
         dict(policy_summary.get("transport_error") or {})
@@ -1943,7 +2455,9 @@ def _build_planner_panel_state(
         else {}
     )
     policy_error_code = policy_transport_error.get("error_code")
-    if policy_summary.get("status") == "stored_policy_fallback" and policy_error_code in {
+    if policy_summary.get(
+        "status"
+    ) == "stored_policy_fallback" and policy_error_code in {
         "breaker_open",
         "timeout",
     }:
@@ -1984,7 +2498,11 @@ def _build_planner_panel_state(
                 "status": (
                     "positive"
                     if summary.get("approval_ready")
-                    else ("caution" if summary.get("evaluation_transport_status") else "neutral")
+                    else (
+                        "caution"
+                        if summary.get("evaluation_transport_status")
+                        else "neutral"
+                    )
                 ),
                 "highlights": list(summary.get("highlights") or [])[:3],
             }
@@ -2016,7 +2534,12 @@ def _build_planner_panel_state(
                         "output_id": f"output:{trip['trip_id']}:proposal-transport-fallback",
                         "title": notice_title,
                         "body": notice_body,
-                        "tags": ["proposal", "transport", "stored-policy", trip["mode"]],
+                        "tags": [
+                            "proposal",
+                            "transport",
+                            "stored-policy",
+                            trip["mode"],
+                        ],
                         "status": "caution",
                         "highlights": [
                             f"error_code={error_code}",
@@ -2048,8 +2571,10 @@ def _build_planner_panel_state(
                 0,
                 {
                     "action_id": f"action:{trip['trip_id']}:proposal-follow-up",
-                    "action_kind": follow_up.get("recommended_action") or "review_follow_up",
-                    "label": follow_up.get("recommended_label") or "Review proposal follow-up",
+                    "action_kind": follow_up.get("recommended_action")
+                    or "review_follow_up",
+                    "label": follow_up.get("recommended_label")
+                    or "Review proposal follow-up",
                     "description": follow_up.get("summary")
                     or "Inspect the persisted follow-up lane for the latest policy result.",
                     "emphasis": "primary",
@@ -2079,7 +2604,9 @@ def _build_planner_panel_state(
                 1,
                 session["interaction_state"].get("auto_advance_research_passes", 1) + 1,
             ),
-            "target_options_before_checkpoint": max(2, min(3, len(option_set["options"]))),
+            "target_options_before_checkpoint": max(
+                2, min(3, len(option_set["options"]))
+            ),
             "surface_options_early": session["interaction_state"].get(
                 "option_preview_timing",
                 "balanced",
@@ -2108,7 +2635,9 @@ def get_workspace_payload(
             fixture = None
     if fixture is not None:
         trip_record = _load_trip_record(fixture.trip_fixture)
-        saved_scenarios, scenario_comparison = _load_saved_scenarios(fixture.scenarios_fixture)
+        saved_scenarios, scenario_comparison = _load_saved_scenarios(
+            fixture.scenarios_fixture
+        )
         session = _load_session(fixture.session_fixture)
         _canonicalize_saved_scenario_ids(session, saved_scenarios)
         inventory_assembly_input = _build_inventory_assembly_input(
@@ -2134,6 +2663,7 @@ def get_workspace_payload(
             trip_id=trip_id,
             trip_title=trip_record.trip.title,
             scenario_search=scenario_search.to_dict(),
+            session=session.to_dict(),
         )
         ranking = build_scenario_ranking_payload(
             trip_id=trip_id,
@@ -2148,7 +2678,9 @@ def get_workspace_payload(
             "trip_record": trip_record.to_dict(),
             "session": session.to_dict(),
             "saved_scenarios": [record.to_dict() for record in saved_scenarios],
-            "scenario_comparison": scenario_comparison.to_dict() if scenario_comparison else None,
+            "scenario_comparison": (
+                scenario_comparison.to_dict() if scenario_comparison else None
+            ),
             "scenario_search": scenario_search.to_dict(),
             "ranking": ranking,
             "route_comparison": runtime_scenario_comparison,
@@ -2210,8 +2742,12 @@ def get_workspace_payload(
             session_record=session_record,
         )
         bootstrap_updated = True
-    persisted_inventory_bundles, inventory_summary = _build_workspace_inventory_inputs(record)
-    inventory_status = str((inventory_summary.get("runtime_state") or {}).get("status") or "empty")
+    persisted_inventory_bundles, inventory_summary = _build_workspace_inventory_inputs(
+        record
+    )
+    inventory_status = str(
+        (inventory_summary.get("runtime_state") or {}).get("status") or "empty"
+    )
     runtime_search = _build_runtime_scenario_search_for_trip(
         record=record,
         inventory_bundles=persisted_inventory_bundles,
@@ -2263,7 +2799,11 @@ def get_workspace_payload(
     feasibility_summary = build_feasibility_summary_payload(persisted_inventory_bundles)
     return _build_persisted_trip_workspace(
         record,
-        session=(_serialize_session_record(session_record) if session_record is not None else None),
+        session=(
+            _serialize_session_record(session_record)
+            if session_record is not None
+            else None
+        ),
         saved_scenarios=[
             {
                 "saved_scenario_id": scenario.saved_scenario_id,
@@ -2355,7 +2895,9 @@ def _get_or_create_workspace_session_record(
         recent_option_presentations=[
             item.to_dict() for item in default_session.recent_option_presentations
         ],
-        pending_decisions=[item.to_dict() for item in default_session.pending_decisions],
+        pending_decisions=[
+            item.to_dict() for item in default_session.pending_decisions
+        ],
         status=default_session.status,
         selected_planning_mode=default_session.selected_planning_mode,
         current_checkpoint_id=default_session.current_checkpoint_id,
@@ -2409,8 +2951,12 @@ def _current_workspace_option_set(
         if session.recent_option_presentations
         else _default_workspace_presentation(trip_id, session.updated_at)
     )
-    option_set_id = presentation.option_set_id or f"option-set:{trip_id}:workspace-bootstrap"
-    option_ids = [option_id for option_id in presentation.surfaced_option_ids if option_id]
+    option_set_id = (
+        presentation.option_set_id or f"option-set:{trip_id}:workspace-bootstrap"
+    )
+    option_ids = [
+        option_id for option_id in presentation.surfaced_option_ids if option_id
+    ]
     return option_set_id, option_ids
 
 
@@ -2489,20 +3035,32 @@ def answer_workspace_planner_decision(
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
     matching = next(
-        (decision for decision in session.pending_decisions if decision.decision_id == decision_id),
+        (
+            decision
+            for decision in session.pending_decisions
+            if decision.decision_id == decision_id
+        ),
         None,
     )
     if matching is None:
-        raise ValueError(f"Decision '{decision_id}' was not found in the workspace session.")
+        raise ValueError(
+            f"Decision '{decision_id}' was not found in the workspace session."
+        )
     if choice not in matching.choices:
-        raise ValueError(f"Choice '{choice}' is not valid for decision '{decision_id}'.")
+        raise ValueError(
+            f"Choice '{choice}' is not valid for decision '{decision_id}'."
+        )
 
     session.pending_decisions = [
-        decision for decision in session.pending_decisions if decision.decision_id != decision_id
+        decision
+        for decision in session.pending_decisions
+        if decision.decision_id != decision_id
     ]
     session.updated_at = _isoformat(datetime.now(UTC))
     session.notes.append(f"decision:{decision_id}:{choice}")
-    session_record.pending_decisions = [item.to_dict() for item in session.pending_decisions]
+    session_record.pending_decisions = [
+        item.to_dict() for item in session.pending_decisions
+    ]
     session_record.notes = list(session.notes)
     session_record.last_updated_at = session.updated_at
     record.updated_at = datetime.now(UTC)
@@ -2548,7 +3106,9 @@ def submit_workspace_option_feedback(
     record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
     session_record = _get_or_create_workspace_session_record(db_session, record=record)
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
-    option_set_id, valid_option_ids = _current_workspace_option_set(session, trip_id=trip_id)
+    option_set_id, valid_option_ids = _current_workspace_option_set(
+        session, trip_id=trip_id
+    )
     if option_id not in valid_option_ids:
         raise ValueError(
             f"Option '{option_id}' is not available in the current workspace option set."
@@ -2574,23 +3134,25 @@ def submit_workspace_option_feedback(
             item for item in presentation.rejected_option_ids if item != option_id
         ]
         event_kind = "decision_recorded"
-        summary = f"Traveler accepted option '{option_id}' from the workspace planner panel."
+        summary = (
+            f"Traveler accepted option '{option_id}' from the workspace planner panel."
+        )
     elif action_type == "reject":
         if option_id not in presentation.rejected_option_ids:
             presentation.rejected_option_ids.append(option_id)
         if presentation.selected_option_id == option_id:
             presentation.selected_option_id = None
         event_kind = "option_rejected"
-        summary = f"Traveler rejected option '{option_id}' from the workspace planner panel."
+        summary = (
+            f"Traveler rejected option '{option_id}' from the workspace planner panel."
+        )
     elif action_type == "save_as_fallback":
         presentation.notes = [
             note for note in presentation.notes if not note.startswith("fallback:")
         ]
         presentation.notes.append(f"fallback:{option_id}")
         event_kind = "decision_recorded"
-        summary = (
-            f"Traveler saved option '{option_id}' as a fallback in the workspace planner panel."
-        )
+        summary = f"Traveler saved option '{option_id}' as a fallback in the workspace planner panel."
     else:
         session.interaction_state.auto_advance_research_passes += 1
         event_kind = "rerank_requested"
@@ -2600,7 +3162,10 @@ def submit_workspace_option_feedback(
     session.recent_option_presentations = [presentation]
     session.updated_at = _isoformat(datetime.now(UTC))
     session.notes.append(f"feedback:{action_type}:{option_id}")
-    if action_type in {"revise", "do_more_before_asking_again"} and not session.pending_decisions:
+    if (
+        action_type in {"revise", "do_more_before_asking_again"}
+        and not session.pending_decisions
+    ):
         session.pending_decisions = [
             PendingDecision(
                 decision_id=f"decision:{trip_id}:follow-up",
@@ -2619,7 +3184,9 @@ def submit_workspace_option_feedback(
     session_record.recent_option_presentations = [
         item.to_dict() for item in session.recent_option_presentations
     ]
-    session_record.pending_decisions = [item.to_dict() for item in session.pending_decisions]
+    session_record.pending_decisions = [
+        item.to_dict() for item in session.pending_decisions
+    ]
     session_record.interaction_state = session.interaction_state.to_dict()
     session_record.notes = list(session.notes)
     session_record.last_updated_at = session.updated_at
@@ -2649,6 +3216,154 @@ def submit_workspace_option_feedback(
         option_set_id=option_set_id,
         option_id=option_id,
         payload={"summary": summary},
+    )
+    db_session.commit()
+    return get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}
+
+
+def _without_route_option_notes(notes: list[str], option_id: str) -> list[str]:
+    managed_prefixes = ("fallback:", "needs_research:", "reopened:")
+    managed_tokens = {f"{prefix}{option_id}" for prefix in managed_prefixes}
+    return [note for note in notes if note not in managed_tokens]
+
+
+def submit_workspace_route_option_action(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    option_id: str,
+    action_type: str,
+) -> dict[str, Any]:
+    if action_type not in ROUTE_OPTION_ACTIONS:
+        raise ValueError(
+            f"action_type must be one of {', '.join(ROUTE_OPTION_ACTIONS)}"
+        )
+
+    record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    session_record = _get_or_create_workspace_session_record(db_session, record=record)
+    session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
+    option_set_id, valid_option_ids = _current_workspace_option_set(
+        session, trip_id=trip_id
+    )
+    if option_id not in valid_option_ids:
+        raise ValueError(
+            f"Route option '{option_id}' is not available in the current workspace comparison."
+        )
+
+    presentation = (
+        session.recent_option_presentations[0]
+        if session.recent_option_presentations
+        else _default_workspace_presentation(trip_id, session.updated_at)
+    )
+    presentation.surfaced_option_ids = valid_option_ids
+    presentation.option_set_id = option_set_id
+    if presentation.highlighted_option_id not in valid_option_ids:
+        presentation.highlighted_option_id = valid_option_ids[0]
+    if presentation.selected_option_id not in valid_option_ids:
+        presentation.selected_option_id = None
+    presentation.rejected_option_ids = [
+        item for item in presentation.rejected_option_ids if item in valid_option_ids
+    ]
+    presentation.notes = _without_route_option_notes(
+        list(presentation.notes), option_id
+    )
+
+    if action_type == "make_baseline":
+        presentation.selected_option_id = option_id
+        presentation.rejected_option_ids = [
+            item for item in presentation.rejected_option_ids if item != option_id
+        ]
+        event_kind = "decision_recorded"
+        summary = f"Traveler made route option '{option_id}' the comparison baseline."
+    elif action_type == "keep":
+        presentation.rejected_option_ids = [
+            item for item in presentation.rejected_option_ids if item != option_id
+        ]
+        if presentation.selected_option_id == option_id:
+            presentation.selected_option_id = None
+        presentation.notes.append(f"fallback:{option_id}")
+        event_kind = "decision_recorded"
+        summary = f"Traveler kept route option '{option_id}' for later comparison."
+    elif action_type == "reject":
+        if option_id not in presentation.rejected_option_ids:
+            presentation.rejected_option_ids.append(option_id)
+        if presentation.selected_option_id == option_id:
+            presentation.selected_option_id = None
+        event_kind = "option_rejected"
+        summary = f"Traveler rejected route option '{option_id}'."
+    elif action_type == "reopen":
+        presentation.rejected_option_ids = [
+            item for item in presentation.rejected_option_ids if item != option_id
+        ]
+        presentation.notes.append(f"reopened:{option_id}")
+        event_kind = "decision_recorded"
+        summary = f"Traveler reopened route option '{option_id}' for comparison."
+    else:
+        presentation.rejected_option_ids = [
+            item for item in presentation.rejected_option_ids if item != option_id
+        ]
+        presentation.notes.append(f"needs_research:{option_id}")
+        session.interaction_state.auto_advance_research_passes += 1
+        event_kind = "rerank_requested"
+        summary = f"Traveler asked the planner to revise route option '{option_id}'."
+
+    presentation.summary = summary
+    session.recent_option_presentations = [presentation]
+    session.updated_at = _isoformat(datetime.now(UTC))
+    session.notes.append(f"route-option:{action_type}:{option_id}")
+    if action_type == "revise" and not session.pending_decisions:
+        session.pending_decisions = [
+            PendingDecision(
+                decision_id=f"decision:{trip_id}:route-option-revision",
+                title="Confirm route revision focus",
+                prompt="Should the planner revise this route before comparing options again?",
+                created_at=session.updated_at,
+                choices=[
+                    "Revise this route option.",
+                    "Keep comparing the current options.",
+                ],
+                related_option_set_id=option_set_id,
+                notes=["Generated after a route-option revision request."],
+            )
+        ]
+
+    session_record.recent_option_presentations = [
+        item.to_dict() for item in session.recent_option_presentations
+    ]
+    session_record.pending_decisions = [
+        item.to_dict() for item in session.pending_decisions
+    ]
+    session_record.interaction_state = session.interaction_state.to_dict()
+    session_record.notes = list(session.notes)
+    session_record.last_updated_at = session.updated_at
+    record.updated_at = datetime.now(UTC)
+    activity_event_id = f"activity:{trip_id}:{secrets.token_hex(4)}"
+    occurred_at = _isoformat(datetime.now(UTC))
+    _append_activity_event(
+        db_session,
+        activity_event_id=activity_event_id,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        occurred_at=occurred_at,
+        event_kind=event_kind,
+        summary=summary,
+        related_option_set_id=option_set_id,
+        metadata={"action_type": action_type, "option_id": option_id},
+    )
+    _record_planner_action(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        activity_event_id=activity_event_id,
+        occurred_at=occurred_at,
+        action_type=f"route_option_{action_type}",
+        option_set_id=option_set_id,
+        option_id=option_id,
+        payload={
+            "summary": summary,
+            "route_option_action": action_type,
+        },
     )
     db_session.commit()
     return get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}


### PR DESCRIPTION
Closes #1128

## Summary
- Add route-option state, confidence, purpose, open-question, and available-action fields to workspace route comparison payloads.
- Generate rough fallback route options when the runtime ranking layer only returns one scenario, so the workbench can compare multiple paths.
- Add route-option actions for make baseline, keep, reject, reopen, and revise, persisted through session option presentation state, activity log entries, and planner action records.
- Add a traveler-facing RouteOptionWorkbench with side-by-side cards, hover descriptions on actions, mobile stacking, and workspace wiring.

## Validation
- python -m ruff check trip_planner/app/services/workspace.py trip_planner/app/routes/workspace.py trip_planner/app/schemas/workspace.py tests/app/test_workspace.py
- python -m mypy trip_planner/app/services/workspace.py trip_planner/app/routes/workspace.py trip_planner/app/schemas/workspace.py
- python -m pytest -q tests/app/test_workspace.py
- npm --prefix frontend test -- --run src/components/workspace/RouteOptionWorkbench.test.tsx src/routes/WorkspacePage.test.tsx
- npm --prefix frontend run build
- git diff --check