### PR TITLE
Issue #1124: Add durable planning ledger

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -316,6 +316,54 @@ export type PlannerMemoryState = {
   artifacts: PlannerMemoryArtifact[];
 };
 
+export type PlanningLedgerEntryType =
+  | "option_considered"
+  | "option_rejected"
+  | "decision"
+  | "assumption"
+  | "open_question"
+  | "constraint"
+  | "source_reference";
+
+export type PlanningLedgerEntryStatus =
+  | "active"
+  | "completed"
+  | "rejected"
+  | "superseded"
+  | "deferred";
+
+export type PlanningLedgerEntry = {
+  ledger_entry_id: string;
+  trip_id: string;
+  session_state_id: string;
+  item_type: PlanningLedgerEntryType;
+  status: PlanningLedgerEntryStatus;
+  category: string;
+  summary: string;
+  detail: string;
+  source_message_ids: string[];
+  source_refs: string[];
+  related_option_id: string | null;
+  related_decision_id: string | null;
+  supersedes_entry_id: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PlanningLedgerState = {
+  entries: PlanningLedgerEntry[];
+  summary: {
+    active_decisions: PlanningLedgerEntry[];
+    open_questions: PlanningLedgerEntry[];
+    active_options: PlanningLedgerEntry[];
+    rejected_options: PlanningLedgerEntry[];
+    constraints: PlanningLedgerEntry[];
+    assumptions: PlanningLedgerEntry[];
+    source_references: PlanningLedgerEntry[];
+  };
+};
+
 export type ActivityLogEntry = {
   activity_event_id: string;
   occurred_at: string;
@@ -441,6 +489,7 @@ export type WorkspaceData = {
   runtime_scenario_comparison: RuntimeScenarioComparison;
   activity_log: ActivityLogEntry[];
   planner_memory: PlannerMemoryState;
+  planning_ledger?: PlanningLedgerState;
   planner_panel_state: PlannerPanelState;
   runtime_state: {
     status: "ready" | "partial" | "empty";
@@ -664,6 +713,50 @@ export async function updateWorkspacePlanningMode(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ planning_mode: planningMode }),
+  });
+}
+
+export async function createPlanningLedgerEntry(
+  tripId: string,
+  payload: {
+    item_type: PlanningLedgerEntryType;
+    status?: PlanningLedgerEntryStatus;
+    category?: string;
+    summary: string;
+    detail?: string;
+    source_message_ids?: string[];
+    source_refs?: string[];
+    related_option_id?: string | null;
+    related_decision_id?: string | null;
+  }
+): Promise<PlanningLedgerEntry> {
+  return fetchJson<PlanningLedgerEntry>({
+    path: `/api/workspace/${tripId}/planning-ledger`,
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updatePlanningLedgerEntry(
+  tripId: string,
+  ledgerEntryId: string,
+  payload: Partial<Pick<
+    PlanningLedgerEntry,
+    "status" | "category" | "summary" | "detail" | "source_message_ids" | "source_refs" | "supersedes_entry_id"
+  >>
+): Promise<PlanningLedgerEntry> {
+  return fetchJson<PlanningLedgerEntry>({
+    path: `/api/workspace/${tripId}/planning-ledger/${ledgerEntryId}`,
+    method: "PATCH",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
   });
 }
 

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -638,6 +638,7 @@ function PlanningLedgerPanel({
     { label: "Rejected options", entries: resolvedLedger.summary.rejected_options },
     { label: "Constraints", entries: resolvedLedger.summary.constraints },
     { label: "Assumptions", entries: resolvedLedger.summary.assumptions },
+    { label: "Sources", entries: resolvedLedger.summary.source_references },
   ].filter((group) => group.entries.length > 0);
 
   return (

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -614,6 +614,61 @@ function PlannerConversationMessage({
   );
 }
 
+function PlanningLedgerPanel({
+  ledger,
+}: {
+  ledger: WorkspaceData["planning_ledger"] | undefined;
+}) {
+  const resolvedLedger = ledger ?? {
+    entries: [],
+    summary: {
+      active_decisions: [],
+      open_questions: [],
+      active_options: [],
+      rejected_options: [],
+      constraints: [],
+      assumptions: [],
+      source_references: [],
+    },
+  };
+  const summaryGroups = [
+    { label: "Decisions", entries: resolvedLedger.summary.active_decisions },
+    { label: "Open questions", entries: resolvedLedger.summary.open_questions },
+    { label: "Active options", entries: resolvedLedger.summary.active_options },
+    { label: "Rejected options", entries: resolvedLedger.summary.rejected_options },
+    { label: "Constraints", entries: resolvedLedger.summary.constraints },
+    { label: "Assumptions", entries: resolvedLedger.summary.assumptions },
+  ].filter((group) => group.entries.length > 0);
+
+  return (
+    <section className="status-card planning-ledger-card" aria-label="Planning ledger">
+      <p className="status-label">Ledger</p>
+      <h2>Planning ledger</h2>
+      {resolvedLedger.entries.length === 0 ? (
+        <p className="muted-copy">
+          Decisions, questions, constraints, and route option history will appear here.
+        </p>
+      ) : (
+        <div className="planning-ledger-grid">
+          {summaryGroups.map((group) => (
+            <section key={group.label} className="planning-ledger-group">
+              <h3>{group.label}</h3>
+              <ul>
+                {group.entries.slice(0, 4).map((entry) => (
+                  <li key={entry.ledger_entry_id}>
+                    <span>{entry.summary}</span>
+                    <small>{entry.status.replace("_", " ")}</small>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function WorkspacePage() {
   const { workspace, trips } = useLoaderData() as LoaderData;
   const resolve = useMemo(
@@ -1182,6 +1237,8 @@ function WorkspacePageContent({
           onSelectScenario={handleScenarioSelection}
           onRouteOptionAction={handleRouteOptionAction}
         />
+
+        <PlanningLedgerPanel ledger={currentWorkspace.planning_ledger} />
 
         <TripComparison
           currentTrip={currentWorkspace.trip_record.trip}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -129,6 +129,47 @@ a {
   grid-column: 1 / -1;
 }
 
+.planning-ledger-card {
+  grid-column: 1 / -1;
+}
+
+.planning-ledger-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.planning-ledger-group {
+  background: rgba(19, 33, 44, 0.04);
+  border: 1px solid rgba(19, 33, 44, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+}
+
+.planning-ledger-group h3 {
+  font-size: 1rem;
+  margin: 0 0 0.75rem;
+}
+
+.planning-ledger-group ul {
+  display: grid;
+  gap: 0.65rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.planning-ledger-group li {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.planning-ledger-group small {
+  color: #5e6a72;
+  font-size: 0.78rem;
+  text-transform: capitalize;
+}
+
 .planner-panel-host {
   margin-top: 1.25rem;
 }

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -409,6 +409,7 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
         == "balanced"
     )
     assert runtime_context["budget_state"]["summary"]["currency"] == "USD"
+    assert "planning_ledger" in runtime_context
     assert "policy_state" in runtime_context
     assert "proposal_state" in runtime_context
     assert "recent_activity" in runtime_context

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -198,6 +198,129 @@ def test_workspace_planning_mode_route_persists_mode(client: TestClient) -> None
     assert rejected.status_code == 400
 
 
+def test_workspace_planning_ledger_api_persists_entries_across_reload(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Ledger workshop",
+            "summary": "Persist trip planning decisions and questions.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-06-04",
+                "end_date": "2026-06-07",
+                "duration_days": 4,
+                "primary_regions": ["Lisbon"],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    saved = client.post(
+        f"/api/workspace/{trip_id}/planning-ledger",
+        json={
+            "item_type": "open_question",
+            "category": "lodging",
+            "summary": "Should the apartment be near Baixa or Alfama?",
+            "detail": "Traveler wants quieter evenings but quick transit.",
+        },
+    )
+    assert saved.status_code == 200, saved.text
+    entry = saved.json()
+    assert entry["status"] == "active"
+
+    patched = client.patch(
+        f"/api/workspace/{trip_id}/planning-ledger/{entry['ledger_entry_id']}",
+        json={"status": "completed"},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["status"] == "completed"
+
+    reloaded = client.get(f"/api/workspace/{trip_id}")
+    assert reloaded.status_code == 200
+    ledger_entries = reloaded.json()["planning_ledger"]["entries"]
+    assert ledger_entries[0]["summary"] == "Should the apartment be near Baixa or Alfama?"
+    assert ledger_entries[0]["status"] == "completed"
+
+
+def test_route_option_actions_create_durable_ledger_history(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Ledger route trip",
+            "summary": "Track rejected route options.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-06-04",
+                "end_date": "2026-06-07",
+                "duration_days": 4,
+                "primary_regions": ["Lisbon"],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+    response = client.get(f"/api/workspace/{trip_id}")
+    assert response.status_code == 200
+    scenario_id = response.json()["route_comparison"]["scenarios"][1]["scenario_id"]
+
+    updated = client.post(
+        f"/api/workspace/{trip_id}/route-options/{scenario_id}/action",
+        json={"action_type": "reject"},
+    )
+
+    assert updated.status_code == 200, updated.text
+    ledger = updated.json()["planning_ledger"]
+    assert ledger["summary"]["rejected_options"]
+    assert ledger["summary"]["rejected_options"][0]["related_option_id"] == scenario_id
+
+    reloaded = client.get(f"/api/workspace/{trip_id}")
+    assert reloaded.status_code == 200
+    assert reloaded.json()["planning_ledger"]["summary"]["rejected_options"][0][
+        "related_option_id"
+    ] == scenario_id
+
+
+def test_planner_turn_extracts_constraints_into_planning_ledger(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Planner ledger trip",
+            "summary": "Capture planner turn signals.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-07-01",
+                "end_date": "2026-07-06",
+                "duration_days": 6,
+                "primary_regions": ["Kyoto"],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    turn = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={
+            "message": (
+                "Remember we need a hotel near transit; budget should stay under 3500. "
+                "Maybe add a quiet food-focused day?"
+            )
+        },
+    )
+    assert turn.status_code == 200, turn.text
+
+    reloaded = client.get(f"/api/workspace/{trip_id}")
+    assert reloaded.status_code == 200
+    ledger_summary = reloaded.json()["planning_ledger"]["summary"]
+    assert ledger_summary["constraints"]
+    assert ledger_summary["open_questions"]
+
+
 def test_workspace_endpoint_surfaces_business_ranked_scenarios(client: TestClient) -> None:
     response = client.get("/api/workspace/trip-business-client-summit")
 

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -233,16 +233,24 @@ def test_workspace_planning_ledger_api_persists_entries_across_reload(
 
     patched = client.patch(
         f"/api/workspace/{trip_id}/planning-ledger/{entry['ledger_entry_id']}",
-        json={"status": "completed"},
+        json={
+            "status": "completed",
+            "related_option_id": "option:lisbon-central",
+            "related_decision_id": "decision:lodging-area",
+        },
     )
     assert patched.status_code == 200, patched.text
     assert patched.json()["status"] == "completed"
+    assert patched.json()["related_option_id"] == "option:lisbon-central"
+    assert patched.json()["related_decision_id"] == "decision:lodging-area"
 
     reloaded = client.get(f"/api/workspace/{trip_id}")
     assert reloaded.status_code == 200
     ledger_entries = reloaded.json()["planning_ledger"]["entries"]
     assert ledger_entries[0]["summary"] == "Should the apartment be near Baixa or Alfama?"
     assert ledger_entries[0]["status"] == "completed"
+    assert ledger_entries[0]["related_option_id"] == "option:lisbon-central"
+    assert ledger_entries[0]["related_decision_id"] == "decision:lodging-area"
 
 
 def test_route_option_actions_create_durable_ledger_history(client: TestClient) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -230,6 +230,9 @@ def test_workspace_planning_ledger_api_persists_entries_across_reload(
     assert saved.status_code == 200, saved.text
     entry = saved.json()
     assert entry["status"] == "active"
+    assert entry["ledger_entry_id"].startswith("ledger:")
+    assert len(entry["ledger_entry_id"]) <= 64
+    assert trip_id not in entry["ledger_entry_id"]
 
     patched = client.patch(
         f"/api/workspace/{trip_id}/planning-ledger/{entry['ledger_entry_id']}",
@@ -321,6 +324,13 @@ def test_planner_turn_extracts_constraints_into_planning_ledger(
         },
     )
     assert turn.status_code == 200, turn.text
+    planner_payload = turn.json()
+    planner_ledger_summary = planner_payload["planning_ledger"]["summary"]
+    assert planner_ledger_summary["constraints"]
+    planner_reply = planner_payload["messages"][-1]
+    assert "Planning ledger remembers" in planner_reply["content"]
+    structured_kinds = {block["kind"] for block in planner_reply["structured_blocks"]}
+    assert "planning_ledger" in structured_kinds
 
     reloaded = client.get(f"/api/workspace/{trip_id}")
     assert reloaded.status_code == 200

--- a/trip_planner/app/routes/workspace.py
+++ b/trip_planner/app/routes/workspace.py
@@ -3,6 +3,9 @@ from sqlalchemy.orm import Session
 
 from trip_planner.app.schemas.workspace import (
     PlanningModeUpdateRequest,
+    PlanningLedgerEntry,
+    PlanningLedgerEntryCreateRequest,
+    PlanningLedgerEntryUpdateRequest,
     PlannerDecisionAnswerRequest,
     PlannerOptionFeedbackRequest,
     RouteOptionActionRequest,
@@ -13,10 +16,12 @@ from trip_planner.app.services.auth import AuthenticatedUser, require_authentica
 from trip_planner.app.services.workspace import (
     WorkspaceTripNotFoundError,
     answer_workspace_planner_decision,
+    create_planning_ledger_entry,
     get_workspace_scenario_comparison_payload,
     get_workspace_payload,
     submit_workspace_route_option_action,
     submit_workspace_option_feedback,
+    update_planning_ledger_entry,
     update_workspace_planning_mode,
 )
 from trip_planner.persistence.db import get_db_session
@@ -76,6 +81,64 @@ def update_planning_mode(
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return WorkspaceResponse.model_validate(result)
+
+
+@router.post(
+    "/workspace/{trip_id}/planning-ledger",
+    response_model=PlanningLedgerEntry,
+)
+def create_workspace_planning_ledger_entry(
+    trip_id: str,
+    payload: PlanningLedgerEntryCreateRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> PlanningLedgerEntry:
+    try:
+        result = create_planning_ledger_entry(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            item_type=payload.item_type,
+            status=payload.status,
+            category=payload.category,
+            summary=payload.summary,
+            detail=payload.detail,
+            source_message_ids=payload.source_message_ids,
+            source_refs=payload.source_refs,
+            related_option_id=payload.related_option_id,
+            related_decision_id=payload.related_decision_id,
+        )
+    except WorkspaceTripNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return PlanningLedgerEntry.model_validate(result)
+
+
+@router.patch(
+    "/workspace/{trip_id}/planning-ledger/{ledger_entry_id}",
+    response_model=PlanningLedgerEntry,
+)
+def patch_workspace_planning_ledger_entry(
+    trip_id: str,
+    ledger_entry_id: str,
+    payload: PlanningLedgerEntryUpdateRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> PlanningLedgerEntry:
+    try:
+        result = update_planning_ledger_entry(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            ledger_entry_id=ledger_entry_id,
+            updates=payload.model_dump(exclude_unset=True),
+        )
+    except WorkspaceTripNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return PlanningLedgerEntry.model_validate(result)
 
 
 @router.post(

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -96,6 +96,7 @@ class PlannerSessionResponse(BaseModel):
     runtime: dict[str, Any] = Field(default_factory=dict)
     session: dict[str, Any]
     planner_panel_state: dict[str, Any]
+    planning_ledger: dict[str, Any] = Field(default_factory=dict)
     planner_memory: PlannerMemoryResponse
     available_tools: list[dict[str, Any]] = Field(default_factory=list)
     activity_log: list[dict[str, Any]] = Field(default_factory=list)

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -145,6 +145,48 @@ class WorkspaceViewModel(BaseModel):
     debug_state: WorkspaceDebugState
 
 
+class PlanningLedgerEntry(BaseModel):
+    ledger_entry_id: str
+    trip_id: str
+    session_state_id: str
+    item_type: Literal[
+        "option_considered",
+        "option_rejected",
+        "decision",
+        "assumption",
+        "open_question",
+        "constraint",
+        "source_reference",
+    ]
+    status: Literal["active", "completed", "rejected", "superseded", "deferred"]
+    category: str
+    summary: str
+    detail: str = ""
+    source_message_ids: list[str] = Field(default_factory=list)
+    source_refs: list[str] = Field(default_factory=list)
+    related_option_id: str | None = None
+    related_decision_id: str | None = None
+    supersedes_entry_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+
+
+class PlanningLedgerSummary(BaseModel):
+    active_decisions: list[PlanningLedgerEntry] = Field(default_factory=list)
+    open_questions: list[PlanningLedgerEntry] = Field(default_factory=list)
+    active_options: list[PlanningLedgerEntry] = Field(default_factory=list)
+    rejected_options: list[PlanningLedgerEntry] = Field(default_factory=list)
+    constraints: list[PlanningLedgerEntry] = Field(default_factory=list)
+    assumptions: list[PlanningLedgerEntry] = Field(default_factory=list)
+    source_references: list[PlanningLedgerEntry] = Field(default_factory=list)
+
+
+class PlanningLedgerState(BaseModel):
+    entries: list[PlanningLedgerEntry] = Field(default_factory=list)
+    summary: PlanningLedgerSummary = Field(default_factory=PlanningLedgerSummary)
+
+
 class WorkspaceResponse(BaseModel):
     trip_record: dict[str, Any] = Field(
         description="Persisted trip record payload for the workspace."
@@ -185,6 +227,10 @@ class WorkspaceResponse(BaseModel):
     )
     planner_panel_state: dict[str, Any] = Field(
         description="Workspace-scoped planner panel payload for the mounted side-panel UI.",
+    )
+    planning_ledger: PlanningLedgerState = Field(
+        default_factory=PlanningLedgerState,
+        description="Durable trip-scoped ledger of decisions, options, questions, assumptions, constraints, and sources.",
     )
     runtime_state: dict[str, Any] = Field(
         description="Top-level runtime readiness summary for the workspace surface.",
@@ -247,3 +293,33 @@ class RouteOptionActionRequest(BaseModel):
 
 class PlanningModeUpdateRequest(BaseModel):
     planning_mode: str = Field(min_length=1, max_length=32)
+
+
+class PlanningLedgerEntryCreateRequest(BaseModel):
+    item_type: Literal[
+        "option_considered",
+        "option_rejected",
+        "decision",
+        "assumption",
+        "open_question",
+        "constraint",
+        "source_reference",
+    ]
+    status: Literal["active", "completed", "rejected", "superseded", "deferred"] = "active"
+    category: str = Field(default="general", min_length=1, max_length=64)
+    summary: str = Field(min_length=1, max_length=280)
+    detail: str = Field(default="", max_length=4000)
+    source_message_ids: list[str] = Field(default_factory=list)
+    source_refs: list[str] = Field(default_factory=list)
+    related_option_id: str | None = Field(default=None, max_length=128)
+    related_decision_id: str | None = Field(default=None, max_length=96)
+
+
+class PlanningLedgerEntryUpdateRequest(BaseModel):
+    status: Literal["active", "completed", "rejected", "superseded", "deferred"] | None = None
+    category: str | None = Field(default=None, min_length=1, max_length=64)
+    summary: str | None = Field(default=None, min_length=1, max_length=280)
+    detail: str | None = Field(default=None, max_length=4000)
+    source_message_ids: list[str] | None = None
+    source_refs: list[str] | None = None
+    supersedes_entry_id: str | None = Field(default=None, max_length=96)

--- a/trip_planner/app/schemas/workspace.py
+++ b/trip_planner/app/schemas/workspace.py
@@ -322,4 +322,6 @@ class PlanningLedgerEntryUpdateRequest(BaseModel):
     detail: str | None = Field(default=None, max_length=4000)
     source_message_ids: list[str] | None = None
     source_refs: list[str] | None = None
+    related_option_id: str | None = Field(default=None, max_length=128)
+    related_decision_id: str | None = Field(default=None, max_length=96)
     supersedes_entry_id: str | None = Field(default=None, max_length=96)

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -29,6 +29,7 @@ from trip_planner.app.services.planner_tools import (
 from trip_planner.preferences.autonomy import AutonomyGuardrails
 from trip_planner.app.services.workspace import (
     WORKSPACE_ACTIVITY_LOG_LIMIT,
+    _add_planning_ledger_entry,
     _append_activity_event,
     _get_or_create_workspace_session_record,
     _get_owned_trip_record,
@@ -303,6 +304,74 @@ def _traveler_input_summary_blocks(message: str) -> list[dict[str, Any]]:
             metadata=summary,
         )
     ]
+
+
+def _record_traveler_message_ledger_entries(
+    db_session: Session,
+    *,
+    trip_id: str,
+    session_state_id: str,
+    message: str,
+    activity_event_id: str,
+    structured_blocks: list[dict[str, Any]],
+) -> None:
+    lowered = message.lower()
+    metadata = (
+        structured_blocks[0].get("metadata", {})
+        if structured_blocks
+        and structured_blocks[0].get("kind") == "traveler_input_summary"
+        else {}
+    )
+    for constraint in list(metadata.get("constraints") or [])[:3]:
+        _add_planning_ledger_entry(
+            db_session,
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+            item_type="constraint",
+            summary=str(constraint),
+            source_refs=[activity_event_id],
+            metadata={"source": "planner_turn"},
+        )
+    for question in list(metadata.get("uncertainties") or [])[:3]:
+        _add_planning_ledger_entry(
+            db_session,
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+            item_type="open_question",
+            summary=str(question),
+            source_refs=[activity_event_id],
+            metadata={"source": "planner_turn"},
+        )
+    for note in list(metadata.get("notebook_notes") or [])[:3]:
+        _add_planning_ledger_entry(
+            db_session,
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+            item_type="assumption",
+            summary=str(note),
+            source_refs=[activity_event_id],
+            metadata={"source": "planner_turn"},
+        )
+    if "decide" in lowered or "decision" in lowered:
+        _add_planning_ledger_entry(
+            db_session,
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+            item_type="decision",
+            summary=_first_sentence(message)[:280],
+            source_refs=[activity_event_id],
+            metadata={"source": "planner_turn"},
+        )
+    if "source" in lowered or "link" in lowered or "reference" in lowered:
+        _add_planning_ledger_entry(
+            db_session,
+            trip_id=trip_id,
+            session_state_id=session_state_id,
+            item_type="source_reference",
+            summary=_first_sentence(message)[:280],
+            source_refs=[activity_event_id],
+            metadata={"source": "planner_turn"},
+        )
 
 
 def _planner_turn_metadata(
@@ -1154,6 +1223,14 @@ def submit_planner_turn(
             "structured_blocks": traveler_structured_blocks,
             "selected_planning_mode": session.selected_planning_mode,
         },
+    )
+    _record_traveler_message_ledger_entries(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        message=normalized_message,
+        activity_event_id=user_activity_event_id,
+        structured_blocks=traveler_structured_blocks,
     )
 
     executed_tool_calls: list[dict[str, Any]] = []

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -561,6 +561,8 @@ def _planner_response_structured_blocks(
     next_step_actions = list(panel.get("next_step_actions") or [])
     runtime_comparison = runtime_context.get("runtime_scenario_comparison") or {}
     scenarios = list(runtime_comparison.get("scenarios") or [])
+    planning_ledger = runtime_context.get("planning_ledger") or {}
+    ledger_summary = planning_ledger.get("summary") or {}
 
     summary_items = _visible_block_items(metadata, kinds={"summary", "guidance"})
     blocks.append(
@@ -587,6 +589,37 @@ def _planner_response_structured_blocks(
                 kind="question",
                 title="Questions to settle",
                 items=_dedupe_preserve_order(question_items)[:4],
+            )
+        )
+
+    ledger_items: list[str] = []
+    ledger_entry_ids: list[str] = []
+    for label, key in (
+        ("Decision", "active_decisions"),
+        ("Open question", "open_questions"),
+        ("Option in view", "active_options"),
+        ("Rejected option", "rejected_options"),
+        ("Constraint", "constraints"),
+        ("Assumption", "assumptions"),
+        ("Source", "source_references"),
+    ):
+        for entry in list(ledger_summary.get(key) or [])[:2]:
+            summary = str(entry.get("summary") or "").strip()
+            if not summary:
+                continue
+            ledger_items.append(f"{label}: {summary}")
+            ledger_entry_ids.append(str(entry.get("ledger_entry_id") or ""))
+    if ledger_items:
+        blocks.append(
+            _structured_block(
+                kind="planning_ledger",
+                title="Planning memory",
+                items=_dedupe_preserve_order(ledger_items)[:6],
+                metadata={
+                    "ledger_entry_ids": [
+                        item for item in _dedupe_preserve_order(ledger_entry_ids) if item
+                    ][:6]
+                },
             )
         )
 
@@ -756,6 +789,9 @@ class DeterministicPlannerConversationRunnable:
         outputs = list(panel.get("outputs") or [])
         decisions = list(panel.get("pending_decisions") or [])
         options = list((panel.get("option_set") or {}).get("options") or [])
+        ledger_summary = (
+            (request.runtime_context.get("planning_ledger") or {}).get("summary") or {}
+        )
 
         lines = [
             _fallback_content_from_metadata(
@@ -786,6 +822,31 @@ class DeterministicPlannerConversationRunnable:
             latest_titles = ", ".join(output["title"] for output in outputs[:2])
             lines.append(f"Latest workspace signals: {latest_titles}.")
             refs.extend(output["output_id"] for output in outputs[:2])
+
+        ledger_focus: list[str] = []
+        for label, key in (
+            ("decision", "active_decisions"),
+            ("open question", "open_questions"),
+            ("option in view", "active_options"),
+            ("rejected option", "rejected_options"),
+            ("constraint", "constraints"),
+            ("assumption", "assumptions"),
+        ):
+            entries = list(ledger_summary.get(key) or [])
+            if not entries:
+                continue
+            first = entries[0]
+            summary = str(first.get("summary") or "").strip()
+            if not summary:
+                continue
+            ledger_focus.append(f"{label}: {summary}")
+            refs.append(str(first.get("ledger_entry_id") or ""))
+        if ledger_focus:
+            lines.append(
+                "Planning ledger remembers "
+                + "; ".join(_dedupe_preserve_order(ledger_focus)[:3])
+                + "."
+            )
 
         deduped_refs = list(dict.fromkeys(refs))
         return PlannerConversationReply(
@@ -999,12 +1060,14 @@ def _planner_runtime_context(
         "budget_state": workspace_payload.get("budget_state") or {},
         "planner_memory": planner_memory,
     }
+    planning_ledger = workspace_payload.get("planning_ledger") or {}
     missing_sections = [key for key, value in required_sections.items() if not value]
     return {
         "trip": panel["trip"],
         "pending_decisions": panel.get("pending_decisions") or [],
         "option_set": panel.get("option_set") or {},
         "outputs": panel.get("outputs") or [],
+        "planning_ledger": planning_ledger,
         **required_sections,
         "policy_state": workspace_payload.get("policy_state") or {},
         "proposal_state": workspace_payload.get("proposal_state") or {},
@@ -1048,6 +1111,7 @@ def _planner_session_payload(
         "runtime": get_planner_runtime_config().to_payload(),
         "session": session,
         "planner_panel_state": workspace_payload["planner_panel_state"],
+        "planning_ledger": workspace_payload.get("planning_ledger") or {},
         "planner_memory": planner_memory,
         "available_tools": list_planner_tools(),
         "activity_log": activity_log,

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -3148,7 +3148,14 @@ def update_planning_ledger_entry(
         if status not in PLANNING_LEDGER_STATUSES:
             raise ValueError(f"status must be one of {', '.join(PLANNING_LEDGER_STATUSES)}")
         entry.status = status
-    for field in ("category", "summary", "detail", "supersedes_entry_id"):
+    for field in (
+        "category",
+        "summary",
+        "detail",
+        "related_option_id",
+        "related_decision_id",
+        "supersedes_entry_id",
+    ):
         if updates.get(field) is not None:
             setattr(entry, field, updates[field])
     if updates.get("source_message_ids") is not None:

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -49,6 +49,7 @@ from trip_planner.persistence.models.activity import (
     PersistedActivityLogEvent,
     PersistedPlannerAction,
 )
+from trip_planner.persistence.models.planning_ledger import PersistedPlanningLedgerEntry
 from trip_planner.persistence.models.scenario import (
     PersistedSavedScenario,
 )
@@ -78,6 +79,23 @@ class WorkspaceFixture:
 
 
 WORKSPACE_ACTIVITY_LOG_LIMIT = 50
+PLANNING_LEDGER_LIMIT = 100
+PLANNING_LEDGER_ITEM_TYPES: tuple[str, ...] = (
+    "option_considered",
+    "option_rejected",
+    "decision",
+    "assumption",
+    "open_question",
+    "constraint",
+    "source_reference",
+)
+PLANNING_LEDGER_STATUSES: tuple[str, ...] = (
+    "active",
+    "completed",
+    "rejected",
+    "superseded",
+    "deferred",
+)
 ROUTE_OPTION_STATES: tuple[str, ...] = (
     "active",
     "baseline",
@@ -1521,12 +1539,121 @@ def _workspace_activity_outputs(
     return outputs
 
 
+def _serialize_ledger_entry(record: PersistedPlanningLedgerEntry) -> dict[str, Any]:
+    return {
+        "ledger_entry_id": record.ledger_entry_id,
+        "trip_id": record.trip_id,
+        "session_state_id": record.session_state_id,
+        "item_type": record.item_type,
+        "status": record.status,
+        "category": record.category,
+        "summary": record.summary,
+        "detail": record.detail,
+        "source_message_ids": list(record.source_message_ids or []),
+        "source_refs": list(record.source_refs or []),
+        "related_option_id": record.related_option_id,
+        "related_decision_id": record.related_decision_id,
+        "supersedes_entry_id": record.supersedes_entry_id,
+        "metadata": dict(record.metadata_payload or {}),
+        "created_at": _isoformat(record.created_at),
+        "updated_at": _isoformat(record.updated_at),
+    }
+
+
+def _planning_ledger_summary(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    active = [entry for entry in entries if entry["status"] == "active"]
+    return {
+        "active_decisions": [
+            entry for entry in active if entry["item_type"] == "decision"
+        ],
+        "open_questions": [
+            entry for entry in active if entry["item_type"] == "open_question"
+        ],
+        "active_options": [
+            entry for entry in active if entry["item_type"] == "option_considered"
+        ],
+        "rejected_options": [
+            entry for entry in entries if entry["item_type"] == "option_rejected"
+        ],
+        "constraints": [
+            entry for entry in active if entry["item_type"] == "constraint"
+        ],
+        "assumptions": [
+            entry for entry in active if entry["item_type"] == "assumption"
+        ],
+        "source_references": [
+            entry for entry in active if entry["item_type"] == "source_reference"
+        ],
+    }
+
+
+def _planning_ledger_state(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"entries": entries, "summary": _planning_ledger_summary(entries)}
+
+
+def _ledger_category_for_type(item_type: str) -> str:
+    if item_type in {"option_considered", "option_rejected"}:
+        return "route_options"
+    if item_type == "open_question":
+        return "questions"
+    if item_type == "source_reference":
+        return "sources"
+    return item_type
+
+
+def _add_planning_ledger_entry(
+    db_session: Session,
+    *,
+    trip_id: str,
+    session_state_id: str,
+    item_type: str,
+    summary: str,
+    status: str = "active",
+    category: str | None = None,
+    detail: str = "",
+    source_message_ids: list[str] | None = None,
+    source_refs: list[str] | None = None,
+    related_option_id: str | None = None,
+    related_decision_id: str | None = None,
+    supersedes_entry_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> PersistedPlanningLedgerEntry:
+    if item_type not in PLANNING_LEDGER_ITEM_TYPES:
+        raise ValueError(
+            f"item_type must be one of {', '.join(PLANNING_LEDGER_ITEM_TYPES)}"
+        )
+    if status not in PLANNING_LEDGER_STATUSES:
+        raise ValueError(f"status must be one of {', '.join(PLANNING_LEDGER_STATUSES)}")
+    now = datetime.now(UTC)
+    entry = PersistedPlanningLedgerEntry(
+        ledger_entry_id=f"ledger:{trip_id}:{secrets.token_hex(5)}",
+        trip_id=trip_id,
+        session_state_id=session_state_id,
+        item_type=item_type,
+        status=status,
+        category=category or _ledger_category_for_type(item_type),
+        summary=summary[:280],
+        detail=detail,
+        source_message_ids=list(source_message_ids or []),
+        source_refs=list(source_refs or []),
+        related_option_id=related_option_id,
+        related_decision_id=related_decision_id,
+        supersedes_entry_id=supersedes_entry_id,
+        metadata_payload=dict(metadata or {}),
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(entry)
+    return entry
+
+
 def _build_persisted_trip_workspace(
     record: PersistedTrip,
     *,
     session: dict[str, Any] | None = None,
     saved_scenarios: list[dict[str, Any]] | None = None,
     activity_log: list[dict[str, Any]] | None = None,
+    planning_ledger: dict[str, Any] | None = None,
     planner_memory: dict[str, Any] | None = None,
     budget_state: dict[str, Any] | None = None,
     policy_context: dict[str, Any] | None = None,
@@ -1628,6 +1755,7 @@ def _build_persisted_trip_workspace(
         "route_comparison": runtime_scenario_comparison,
         "runtime_scenario_comparison": runtime_scenario_comparison,
         "activity_log": resolved_activity_log,
+        "planning_ledger": planning_ledger or _planning_ledger_state([]),
         "planner_memory": planner_memory
         or {
             "current_checkpoint_id": resolved_session.get("current_checkpoint_id"),
@@ -2694,6 +2822,7 @@ def get_workspace_payload(
             "route_comparison": runtime_scenario_comparison,
             "runtime_scenario_comparison": runtime_scenario_comparison,
             "activity_log": [],
+            "planning_ledger": _planning_ledger_state([]),
             "planner_memory": {
                 "current_checkpoint_id": session.current_checkpoint_id,
                 "checkpoints": [],
@@ -2804,6 +2933,12 @@ def get_workspace_payload(
         .order_by(PersistedActivityLogEvent.occurred_at.desc())
         .limit(WORKSPACE_ACTIVITY_LOG_LIMIT)
     ).all()
+    ledger_records = db_session.scalars(
+        select(PersistedPlanningLedgerEntry)
+        .where(PersistedPlanningLedgerEntry.trip_id == trip_id)
+        .order_by(PersistedPlanningLedgerEntry.updated_at.desc())
+        .limit(PLANNING_LEDGER_LIMIT)
+    ).all()
     feasibility_summary = build_feasibility_summary_payload(persisted_inventory_bundles)
     return _build_persisted_trip_workspace(
         record,
@@ -2825,6 +2960,9 @@ def get_workspace_payload(
             for scenario in persisted_saved_scenarios
         ],
         activity_log=[_serialize_activity_record(item) for item in activity_records],
+        planning_ledger=_planning_ledger_state(
+            [_serialize_ledger_entry(item) for item in ledger_records]
+        ),
         planner_memory=build_planner_memory_payload(
             db_session,
             trip_id=trip_id,
@@ -2947,6 +3085,80 @@ def update_workspace_planning_mode(
     if payload is None:
         raise WorkspaceTripNotFoundError(f"Trip '{trip_id}' was not found.")
     return payload
+
+
+def create_planning_ledger_entry(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    item_type: str,
+    summary: str,
+    status: str = "active",
+    category: str = "general",
+    detail: str = "",
+    source_message_ids: list[str] | None = None,
+    source_refs: list[str] | None = None,
+    related_option_id: str | None = None,
+    related_decision_id: str | None = None,
+) -> dict[str, Any]:
+    record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    session_record = _get_or_create_workspace_session_record(db_session, record=record)
+    entry = _add_planning_ledger_entry(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session_record.session_state_id,
+        item_type=item_type,
+        status=status,
+        category=category,
+        summary=summary,
+        detail=detail,
+        source_message_ids=source_message_ids,
+        source_refs=source_refs,
+        related_option_id=related_option_id,
+        related_decision_id=related_decision_id,
+        metadata={"created_by": "workspace_api"},
+    )
+    record.updated_at = datetime.now(UTC)
+    db_session.commit()
+    db_session.refresh(entry)
+    return _serialize_ledger_entry(entry)
+
+
+def update_planning_ledger_entry(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    ledger_entry_id: str,
+    updates: dict[str, Any],
+) -> dict[str, Any]:
+    _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    entry = db_session.scalar(
+        select(PersistedPlanningLedgerEntry)
+        .where(PersistedPlanningLedgerEntry.trip_id == trip_id)
+        .where(PersistedPlanningLedgerEntry.ledger_entry_id == ledger_entry_id)
+    )
+    if entry is None:
+        raise WorkspaceTripNotFoundError(
+            f"Ledger entry '{ledger_entry_id}' was not found."
+        )
+    if updates.get("status") is not None:
+        status = str(updates["status"])
+        if status not in PLANNING_LEDGER_STATUSES:
+            raise ValueError(f"status must be one of {', '.join(PLANNING_LEDGER_STATUSES)}")
+        entry.status = status
+    for field in ("category", "summary", "detail", "supersedes_entry_id"):
+        if updates.get(field) is not None:
+            setattr(entry, field, updates[field])
+    if updates.get("source_message_ids") is not None:
+        entry.source_message_ids = list(updates["source_message_ids"])
+    if updates.get("source_refs") is not None:
+        entry.source_refs = list(updates["source_refs"])
+    entry.updated_at = datetime.now(UTC)
+    db_session.commit()
+    db_session.refresh(entry)
+    return _serialize_ledger_entry(entry)
 
 
 def _current_workspace_option_set(
@@ -3098,6 +3310,19 @@ def answer_workspace_planner_decision(
         choice=choice,
         payload={"decision_title": matching.title},
     )
+    _add_planning_ledger_entry(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        item_type="decision",
+        status="completed",
+        category="decisions",
+        summary=f"{matching.title}: {choice}",
+        detail=matching.prompt,
+        source_refs=[activity_event_id],
+        related_decision_id=decision_id,
+        metadata={"choice": choice},
+    )
     db_session.commit()
     return get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}
 
@@ -3224,6 +3449,29 @@ def submit_workspace_option_feedback(
         option_set_id=option_set_id,
         option_id=option_id,
         payload={"summary": summary},
+    )
+    ledger_type = "option_rejected" if action_type == "reject" else "option_considered"
+    ledger_status = (
+        "rejected"
+        if action_type == "reject"
+        else "completed"
+        if action_type == "accept"
+        else "deferred"
+        if action_type == "save_as_fallback"
+        else "active"
+    )
+    _add_planning_ledger_entry(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        item_type=ledger_type,
+        status=ledger_status,
+        summary=summary,
+        detail=f"Planner panel feedback action: {action_type}",
+        source_refs=[activity_event_id],
+        related_option_id=option_id,
+        related_decision_id=decision_id,
+        metadata={"action_type": action_type, "option_set_id": option_set_id},
     )
     db_session.commit()
     return get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}
@@ -3371,6 +3619,28 @@ def submit_workspace_route_option_action(
             "summary": summary,
             "route_option_action": action_type,
         },
+    )
+    ledger_type = "option_rejected" if action_type == "reject" else "option_considered"
+    ledger_status = (
+        "rejected"
+        if action_type == "reject"
+        else "completed"
+        if action_type == "make_baseline"
+        else "deferred"
+        if action_type == "keep"
+        else "active"
+    )
+    _add_planning_ledger_entry(
+        db_session,
+        trip_id=trip_id,
+        session_state_id=session.session_state_id,
+        item_type=ledger_type,
+        status=ledger_status,
+        summary=summary,
+        detail=f"Route option action: {action_type}",
+        source_refs=[activity_event_id],
+        related_option_id=option_id,
+        metadata={"action_type": action_type, "option_set_id": option_set_id},
     )
     db_session.commit()
     return get_workspace_payload(db_session, user=user, trip_id=trip_id) or {}

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1626,7 +1626,7 @@ def _add_planning_ledger_entry(
         raise ValueError(f"status must be one of {', '.join(PLANNING_LEDGER_STATUSES)}")
     now = datetime.now(UTC)
     entry = PersistedPlanningLedgerEntry(
-        ledger_entry_id=f"ledger:{trip_id}:{secrets.token_hex(5)}",
+        ledger_entry_id=f"ledger:{secrets.token_hex(16)}",
         trip_id=trip_id,
         session_state_id=session_state_id,
         item_type=item_type,

--- a/trip_planner/persistence/alembic/versions/20260510_01_planning_ledger.py
+++ b/trip_planner/persistence/alembic/versions/20260510_01_planning_ledger.py
@@ -1,0 +1,87 @@
+"""add persisted planning ledger entries
+
+Revision ID: 20260510_01
+Revises: 20260507_01
+Create Date: 2026-05-10 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260510_01"
+down_revision = "20260507_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "persisted_planning_ledger_entries",
+        sa.Column("ledger_entry_id", sa.String(length=96), primary_key=True),
+        sa.Column(
+            "trip_id",
+            sa.String(length=96),
+            sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("session_state_id", sa.String(length=96), nullable=False),
+        sa.Column("item_type", sa.String(length=48), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("category", sa.String(length=64), nullable=False),
+        sa.Column("summary", sa.String(length=280), nullable=False),
+        sa.Column("detail", sa.Text(), nullable=False),
+        sa.Column("source_message_ids", sa.JSON(), nullable=False),
+        sa.Column("source_refs", sa.JSON(), nullable=False),
+        sa.Column("related_option_id", sa.String(length=128), nullable=True),
+        sa.Column("related_decision_id", sa.String(length=96), nullable=True),
+        sa.Column("supersedes_entry_id", sa.String(length=96), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        op.f("ix_persisted_planning_ledger_entries_trip_id"),
+        "persisted_planning_ledger_entries",
+        ["trip_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_planning_ledger_entries_session_state_id"),
+        "persisted_planning_ledger_entries",
+        ["session_state_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_planning_ledger_entries_item_type"),
+        "persisted_planning_ledger_entries",
+        ["item_type"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_persisted_planning_ledger_entries_status"),
+        "persisted_planning_ledger_entries",
+        ["status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_persisted_planning_ledger_entries_status"),
+        table_name="persisted_planning_ledger_entries",
+    )
+    op.drop_index(
+        op.f("ix_persisted_planning_ledger_entries_item_type"),
+        table_name="persisted_planning_ledger_entries",
+    )
+    op.drop_index(
+        op.f("ix_persisted_planning_ledger_entries_session_state_id"),
+        table_name="persisted_planning_ledger_entries",
+    )
+    op.drop_index(
+        op.f("ix_persisted_planning_ledger_entries_trip_id"),
+        table_name="persisted_planning_ledger_entries",
+    )
+    op.drop_table("persisted_planning_ledger_entries")

--- a/trip_planner/persistence/alembic/versions/20260510_01_planning_ledger.py
+++ b/trip_planner/persistence/alembic/versions/20260510_01_planning_ledger.py
@@ -19,14 +19,14 @@ depends_on = None
 def upgrade() -> None:
     op.create_table(
         "persisted_planning_ledger_entries",
-        sa.Column("ledger_entry_id", sa.String(length=96), primary_key=True),
+        sa.Column("ledger_entry_id", sa.String(length=64), primary_key=True),
         sa.Column(
             "trip_id",
             sa.String(length=96),
             sa.ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("session_state_id", sa.String(length=96), nullable=False),
+        sa.Column("session_state_id", sa.String(length=128), nullable=False),
         sa.Column("item_type", sa.String(length=48), nullable=False),
         sa.Column("status", sa.String(length=32), nullable=False),
         sa.Column("category", sa.String(length=64), nullable=False),
@@ -65,9 +65,19 @@ def upgrade() -> None:
         ["status"],
         unique=False,
     )
+    op.create_index(
+        op.f("ix_persisted_planning_ledger_entries_trip_updated_at"),
+        "persisted_planning_ledger_entries",
+        ["trip_id", "updated_at"],
+        unique=False,
+    )
 
 
 def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_persisted_planning_ledger_entries_trip_updated_at"),
+        table_name="persisted_planning_ledger_entries",
+    )
     op.drop_index(
         op.f("ix_persisted_planning_ledger_entries_status"),
         table_name="persisted_planning_ledger_entries",

--- a/trip_planner/persistence/db.py
+++ b/trip_planner/persistence/db.py
@@ -87,6 +87,7 @@ def ensure_database_ready(url: str | None = None) -> None:
 
     from trip_planner.persistence.models import budget  # noqa: F401
     from trip_planner.persistence.models import planner_memory  # noqa: F401
+    from trip_planner.persistence.models import planning_ledger  # noqa: F401
     from trip_planner.persistence.models import (  # noqa: F401
         activity,
         account,

--- a/trip_planner/persistence/models/__init__.py
+++ b/trip_planner/persistence/models/__init__.py
@@ -14,6 +14,7 @@ from trip_planner.persistence.models.planner_memory import (
     PersistedPlannerCheckpoint,
     PersistedPlannerMemoryArtifact,
 )
+from trip_planner.persistence.models.planning_ledger import PersistedPlanningLedgerEntry
 from trip_planner.persistence.models.policy import PersistedPolicyState
 from trip_planner.persistence.models.proposal import PersistedProposalState
 from trip_planner.persistence.models.scenario import PersistedSavedScenario
@@ -32,6 +33,7 @@ __all__ = [
     "PersistedPlannerCheckpoint",
     "PersistedPlannerAction",
     "PersistedPlannerMemoryArtifact",
+    "PersistedPlanningLedgerEntry",
     "PersistedPlanningSessionState",
     "PersistedPolicyState",
     "PersistedProposalState",

--- a/trip_planner/persistence/models/planning_ledger.py
+++ b/trip_planner/persistence/models/planning_ledger.py
@@ -18,12 +18,12 @@ def _utcnow() -> datetime:
 class PersistedPlanningLedgerEntry(Base):
     __tablename__ = "persisted_planning_ledger_entries"
 
-    ledger_entry_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    ledger_entry_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     trip_id: Mapped[str] = mapped_column(
         ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
         index=True,
     )
-    session_state_id: Mapped[str] = mapped_column(String(96), index=True)
+    session_state_id: Mapped[str] = mapped_column(String(128), index=True)
     item_type: Mapped[str] = mapped_column(String(48), index=True)
     status: Mapped[str] = mapped_column(String(32), index=True, default="active")
     category: Mapped[str] = mapped_column(String(64), default="general")

--- a/trip_planner/persistence/models/planning_ledger.py
+++ b/trip_planner/persistence/models/planning_ledger.py
@@ -1,0 +1,41 @@
+"""SQLAlchemy model for durable trip planning ledger entries."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from trip_planner.persistence.db import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class PersistedPlanningLedgerEntry(Base):
+    __tablename__ = "persisted_planning_ledger_entries"
+
+    ledger_entry_id: Mapped[str] = mapped_column(String(96), primary_key=True)
+    trip_id: Mapped[str] = mapped_column(
+        ForeignKey("persisted_trips.trip_id", ondelete="CASCADE"),
+        index=True,
+    )
+    session_state_id: Mapped[str] = mapped_column(String(96), index=True)
+    item_type: Mapped[str] = mapped_column(String(48), index=True)
+    status: Mapped[str] = mapped_column(String(32), index=True, default="active")
+    category: Mapped[str] = mapped_column(String(64), default="general")
+    summary: Mapped[str] = mapped_column(String(280))
+    detail: Mapped[str] = mapped_column(Text, default="")
+    source_message_ids: Mapped[list[str]] = mapped_column(JSON, default=list)
+    source_refs: Mapped[list[str]] = mapped_column(JSON, default=list)
+    related_option_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    related_decision_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    supersedes_entry_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    metadata_payload: Mapped[dict[str, Any]] = mapped_column("metadata", JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, onupdate=_utcnow
+    )


### PR DESCRIPTION
Closes #1124

## Summary
- add persisted trip-scoped planning ledger entries with migration, workspace API schema, and create/update endpoints
- include ledger summaries in workspace payloads and render decisions, questions, options, constraints, and assumptions in the workspace
- record ledger history from planner decisions, option feedback, route option actions, and planner-turn signal extraction

## Validation
- python -m pytest tests/app/test_workspace.py --no-cov
- npm --prefix frontend test -- WorkspacePage.test.tsx
- npm --prefix frontend run build
- python -m pytest tests/app/test_workspace.py tests/app/test_planner_routes.py --no-cov
- git diff --check