### PR TITLE
Follow-up: cover planning ledger verifier gaps

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -18,6 +18,7 @@ import {
   submitRouteOptionAction,
   updateNotebookItem,
   updateWorkspacePlanningMode,
+  type PlanningLedgerEntry,
   type PlannerSessionResponse,
   type WorkspaceData,
 } from "../api/workspace";
@@ -893,6 +894,85 @@ describe("WorkspacePage", () => {
     for (const label of forbiddenRawLabels) {
       expect(renderedText.toLowerCase()).not.toContain(label.toLowerCase());
     }
+  });
+
+  it("renders planning ledger summary buckets including rejected options and sources", async () => {
+    const ledgerTimestamp = "2026-04-12T06:10:00+00:00";
+    const makeLedgerEntry = (
+      overrides: Partial<PlanningLedgerEntry>
+    ): PlanningLedgerEntry => ({
+      ledger_entry_id: "ledger:test-entry",
+      trip_id: "trip-leisure-kyoto-draft",
+      session_state_id: "session:trip-leisure-kyoto-draft",
+      item_type: "decision",
+      status: "active",
+      category: "decision",
+      summary: "Keep Kyoto as the baseline.",
+      detail: "",
+      source_message_ids: [],
+      source_refs: [],
+      related_option_id: null,
+      related_decision_id: null,
+      supersedes_entry_id: null,
+      metadata: {},
+      created_at: ledgerTimestamp,
+      updated_at: ledgerTimestamp,
+      ...overrides,
+    });
+    const decisionEntry = makeLedgerEntry({
+      ledger_entry_id: "ledger:decision",
+      item_type: "decision",
+      summary: "Keep Kyoto as the baseline.",
+    });
+    const rejectedEntry = makeLedgerEntry({
+      ledger_entry_id: "ledger:rejected-option",
+      item_type: "option_rejected",
+      status: "rejected",
+      category: "route_options",
+      summary: "Reject Osaka-heavy fallback for this trip.",
+      related_option_id: "scenario:trip-leisure-kyoto-draft:2",
+    });
+    const sourceEntry = makeLedgerEntry({
+      ledger_entry_id: "ledger:source",
+      item_type: "source_reference",
+      category: "sources",
+      summary: "Traveler preferred lower transfer pressure.",
+      source_refs: ["planner-action:trip-leisure-kyoto-draft:user-2"],
+    });
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        planning_ledger: {
+          entries: [decisionEntry, rejectedEntry, sourceEntry],
+          summary: {
+            active_decisions: [decisionEntry],
+            open_questions: [],
+            active_options: [],
+            rejected_options: [rejectedEntry],
+            constraints: [],
+            assumptions: [],
+            source_references: [sourceEntry],
+          },
+        },
+      }),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    const ledgerPanel = await screen.findByLabelText("Planning ledger");
+    expect(within(ledgerPanel).getByRole("heading", { name: "Decisions" })).toBeInTheDocument();
+    expect(within(ledgerPanel).getByText("Keep Kyoto as the baseline.")).toBeInTheDocument();
+    expect(
+      within(ledgerPanel).getByRole("heading", { name: "Rejected options" })
+    ).toBeInTheDocument();
+    expect(
+      within(ledgerPanel).getByText("Reject Osaka-heavy fallback for this trip.")
+    ).toBeInTheDocument();
+    expect(within(ledgerPanel).getByRole("heading", { name: "Sources" })).toBeInTheDocument();
+    expect(
+      within(ledgerPanel).getByText("Traveler preferred lower transfer pressure.")
+    ).toBeInTheDocument();
   });
 
   it("renders timeline structure from persisted trip and scenario state", async () => {

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -531,6 +531,15 @@ def test_workspace_planning_ledger_rejects_supersedes_cycles(
     assert blank_target.status_code == 200, blank_target.text
     assert blank_target.json()["supersedes_entry_id"] is None
 
+    with get_session_factory()() as db_session:
+        with pytest.raises(ValueError, match="existing ledger entry"):
+            workspace_service._validate_planning_ledger_supersedes_target(
+                db_session,
+                trip_id=trip_id,
+                ledger_entry_id=second_id,
+                supersedes_entry_id="   ",
+            )
+
 
 def test_route_option_actions_create_durable_ledger_history(client: TestClient) -> None:
     created = client.post(

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -422,6 +422,116 @@ def test_workspace_planning_notebook_rejects_invalid_category(client: TestClient
     assert rejected.status_code == 422
 
 
+def test_workspace_planning_ledger_rejects_supersedes_cycles(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Ledger supersedes trip",
+            "summary": "Prevent circular ledger history.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-06-04",
+                "end_date": "2026-06-07",
+                "duration_days": 4,
+                "primary_regions": ["Lisbon"],
+            },
+        },
+    )
+    assert created.status_code == 201
+    trip_id = created.json()["trip"]["trip_id"]
+
+    first = client.post(
+        f"/api/workspace/{trip_id}/planning-ledger",
+        json={
+            "item_type": "decision",
+            "category": "lodging",
+            "summary": "Stay near Baixa.",
+        },
+    )
+    assert first.status_code == 200, first.text
+    first_id = first.json()["ledger_entry_id"]
+    second = client.post(
+        f"/api/workspace/{trip_id}/planning-ledger",
+        json={
+            "item_type": "decision",
+            "category": "lodging",
+            "summary": "Stay near Alfama instead.",
+        },
+    )
+    assert second.status_code == 200, second.text
+    second_id = second.json()["ledger_entry_id"]
+
+    valid_chain = client.patch(
+        f"/api/workspace/{trip_id}/planning-ledger/{second_id}",
+        json={"supersedes_entry_id": first_id},
+    )
+    assert valid_chain.status_code == 200, valid_chain.text
+    assert valid_chain.json()["supersedes_entry_id"] == first_id
+
+    self_cycle = client.patch(
+        f"/api/workspace/{trip_id}/planning-ledger/{first_id}",
+        json={"supersedes_entry_id": first_id},
+    )
+    assert self_cycle.status_code == 400
+    assert "same ledger entry" in self_cycle.json()["detail"]
+
+    indirect_cycle = client.patch(
+        f"/api/workspace/{trip_id}/planning-ledger/{first_id}",
+        json={"supersedes_entry_id": second_id},
+    )
+    assert indirect_cycle.status_code == 400
+    assert "cycle" in indirect_cycle.json()["detail"]
+
+    missing_target = client.patch(
+        f"/api/workspace/{trip_id}/planning-ledger/{first_id}",
+        json={"supersedes_entry_id": "ledger:does-not-exist"},
+    )
+    assert missing_target.status_code == 400
+    assert "existing ledger entry" in missing_target.json()["detail"]
+
+    other_trip = client.post(
+        "/api/trips",
+        json={
+            "title": "Other ledger trip",
+            "summary": "Keep supersedes chains scoped to one trip.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-06-08",
+                "end_date": "2026-06-10",
+                "duration_days": 3,
+                "primary_regions": ["Porto"],
+            },
+        },
+    )
+    assert other_trip.status_code == 201
+    other_trip_id = other_trip.json()["trip"]["trip_id"]
+    other_entry = client.post(
+        f"/api/workspace/{other_trip_id}/planning-ledger",
+        json={
+            "item_type": "decision",
+            "category": "lodging",
+            "summary": "Stay near Ribeira.",
+        },
+    )
+    assert other_entry.status_code == 200, other_entry.text
+
+    other_trip_target = client.patch(
+        f"/api/workspace/{trip_id}/planning-ledger/{first_id}",
+        json={"supersedes_entry_id": other_entry.json()["ledger_entry_id"]},
+    )
+    assert other_trip_target.status_code == 400
+    assert "existing ledger entry" in other_trip_target.json()["detail"]
+
+    blank_target = client.patch(
+        f"/api/workspace/{trip_id}/planning-ledger/{second_id}",
+        json={"supersedes_entry_id": "   "},
+    )
+    assert blank_target.status_code == 200, blank_target.text
+    assert blank_target.json()["supersedes_entry_id"] is None
+
+
 def test_route_option_actions_create_durable_ledger_history(client: TestClient) -> None:
     created = client.post(
         "/api/trips",

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1785,6 +1785,8 @@ def _validate_planning_ledger_supersedes_target(
     ledger_entry_id: str,
     supersedes_entry_id: str,
 ) -> None:
+    if not supersedes_entry_id.strip():
+        raise ValueError("supersedes_entry_id must reference an existing ledger entry.")
     if supersedes_entry_id == ledger_entry_id:
         raise ValueError("supersedes_entry_id cannot reference the same ledger entry.")
 

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1778,6 +1778,32 @@ def _add_planning_ledger_entry(
     return entry
 
 
+def _validate_planning_ledger_supersedes_target(
+    db_session: Session,
+    *,
+    trip_id: str,
+    ledger_entry_id: str,
+    supersedes_entry_id: str,
+) -> None:
+    if supersedes_entry_id == ledger_entry_id:
+        raise ValueError("supersedes_entry_id cannot reference the same ledger entry.")
+
+    seen: set[str] = {ledger_entry_id}
+    current_id: str | None = supersedes_entry_id
+    while current_id:
+        if current_id in seen:
+            raise ValueError("supersedes_entry_id cannot create a cycle.")
+        seen.add(current_id)
+        current = db_session.scalar(
+            select(PersistedPlanningLedgerEntry)
+            .where(PersistedPlanningLedgerEntry.trip_id == trip_id)
+            .where(PersistedPlanningLedgerEntry.ledger_entry_id == current_id)
+        )
+        if current is None:
+            raise ValueError("supersedes_entry_id must reference an existing ledger entry.")
+        current_id = current.supersedes_entry_id
+
+
 def _build_persisted_trip_workspace(
     record: PersistedTrip,
     *,
@@ -3339,13 +3365,27 @@ def update_planning_ledger_entry(
         if status not in PLANNING_LEDGER_STATUSES:
             raise ValueError(f"status must be one of {', '.join(PLANNING_LEDGER_STATUSES)}")
         entry.status = status
+    if "supersedes_entry_id" in updates:
+        raw_supersedes_entry_id = updates["supersedes_entry_id"]
+        supersedes_entry_id = (
+            None
+            if raw_supersedes_entry_id is None
+            else str(raw_supersedes_entry_id).strip() or None
+        )
+        if supersedes_entry_id is not None:
+            _validate_planning_ledger_supersedes_target(
+                db_session,
+                trip_id=trip_id,
+                ledger_entry_id=ledger_entry_id,
+                supersedes_entry_id=supersedes_entry_id,
+            )
+        entry.supersedes_entry_id = supersedes_entry_id
     for field in (
         "category",
         "summary",
         "detail",
         "related_option_id",
         "related_decision_id",
-        "supersedes_entry_id",
     ):
         if updates.get(field) is not None:
             setattr(entry, field, updates[field])


### PR DESCRIPTION
## Summary

Closes #1124

Follow-up to merged PR #1150 after provider comparison returned CONCERNS/CONCERNS. This PR keeps the scope bounded to the verifier gaps around durable planning ledger test coverage and supersedes-chain safety.

## Changes

- Add explicit validation that `supersedes_entry_id` references an existing same-trip ledger entry and cannot point to itself or form an indirect cycle.
- Add backend regression coverage for valid supersedes chains plus self/indirect cycle rejection.
- Add WorkspacePage coverage that the planning ledger renders decisions, rejected option history, and source-reference buckets.

## Validation

- `python -m pytest tests/app/test_workspace.py::test_workspace_planning_ledger_api_persists_entries_across_reload tests/app/test_workspace.py::test_workspace_planning_ledger_rejects_supersedes_cycles tests/app/test_workspace.py::test_route_option_actions_create_durable_ledger_history tests/app/test_workspace.py::test_planner_turn_extracts_constraints_into_planning_ledger -q --no-cov` -> 4 passed
- `npm --prefix frontend test -- WorkspacePage.test.tsx` -> 37 passed
- `python -m ruff check trip_planner/app/services/workspace.py tests/app/test_workspace.py` -> passed
- `python -m mypy trip_planner/app/services/workspace.py` -> passed
- `git diff --check` -> passed
