### PR TITLE
Issue #1130: expose gated workspace diagnostics

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -926,7 +926,8 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Ready for approval")).toBeInTheDocument();
     expect(screen.getAllByText("Advance to approval").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Options and readiness signals" })).toBeInTheDocument();
-    expect(screen.getByText("Conference Hotel")).toBeInTheDocument();
+    expect(screen.queryByText("Conference Hotel")).not.toBeInTheDocument();
+    expect(screen.queryByText("proposal-state:trip-leisure-kyoto-draft")).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Planner notes to keep" })).toBeInTheDocument();
     expect(screen.getByText("Planner checkpoint 1")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Compare this workspace with other saved trips" })).toBeInTheDocument();
@@ -1492,26 +1493,48 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Seoul gallery weekend is stored as a leisure trip with 1 traveler(s).")).toBeInTheDocument();
   });
 
-  it("falls back to plain number formatting when comparable currency codes are invalid", async () => {
+  it("reveals raw proposal diagnostics only through advanced diagnostics", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({
         ...workspacePayload,
-        proposal_state: {
-          ...workspacePayload.proposal_state,
-          proposal: {
-            ...workspacePayload.proposal_state.proposal,
-            comparables: [
-              {
-                ...workspacePayload.proposal_state.proposal.comparables[0],
-                estimated_cost: {
-                  ...workspacePayload.proposal_state.proposal.comparables[0].estimated_cost,
-                  currency: "INVALID",
-                },
-              },
-            ],
+        view_model: {
+          user_summary: {
+            trip_title: workspacePayload.trip_record.trip.title,
+            trip_mode: "leisure",
+            mode_label: "Leisure trip",
+            status: "ready",
+            headline: "Your trip plan is ready to review.",
+            decided: ["2 saved scenario draft(s)"],
+            uncertain: [],
+          },
+          next_step: {
+            title: "Review and pick a scenario",
+            summary:
+              "Compare the saved scenarios and choose one to keep planning around.",
+            action_label: "Open scenario comparison",
+            action_target: "scenario-comparison",
+            blocked: false,
+          },
+          panel_visibility: {
+            show_budget_panel: true,
+            show_policy_posture: true,
+            show_proposal_panel: true,
+            show_approval_readiness_panel: true,
+          },
+          policy_presentation: {
+            active_policy_state: true,
+            posture_label: "Ready for approval",
+            approval_status_label: "Ready for approval",
+            next_step_label: "Advance to approval",
+            summary: "Policy evaluation passed and the approval packet is ready.",
+          },
+          business_summary: null,
+          debug_state: {
+            sections: {},
           },
         },
       }),
+      trips: Promise.resolve(tripComparisonPayload),
     });
 
     renderWorkspacePage();
@@ -1519,8 +1542,16 @@ describe("WorkspacePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Options and readiness signals" })).toBeInTheDocument();
     });
+    expect(screen.getByText("Advanced diagnostics")).toBeInTheDocument();
+    expect(screen.queryByText("Proposal diagnostics")).not.toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toContain("proposal_state_id");
 
-    expect(screen.getByText(/Marriott via Navan · 245/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Advanced diagnostics"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Proposal diagnostics" })).toBeInTheDocument();
+    });
+    expect(document.body.textContent ?? "").toContain("proposal_state_id");
   });
 
   it("shows an empty-state message when no route sequence is available", async () => {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1243,9 +1243,11 @@ describe("WorkspacePage", () => {
         "Keep Uji, but reduce transfer pressure."
       );
     });
-    expect(
-      screen.getByText("Keep the Uji day trip and compare fewer evening moves before the next checkpoint.")
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText("Keep the Uji day trip and compare fewer evening moves before the next checkpoint.")
+      ).toBeInTheDocument();
+    });
     expect(screen.getByText("coherent plan")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Planner summary" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Questions to settle" })).toBeInTheDocument();

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1059,7 +1059,7 @@ describe("WorkspacePage", () => {
     fireEvent.click(screen.getByText("Advanced diagnostics"));
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Proposal state" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Proposal diagnostics" })).toBeInTheDocument();
     });
     expect(document.body.textContent ?? "").toContain("proposal_state_id");
   });
@@ -2264,7 +2264,12 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Needs exception")).toBeInTheDocument();
     expect(screen.getAllByText("Reoptimize plan").length).toBeGreaterThan(0);
     expect(screen.getByText("Use a compliant downtown property")).toBeInTheDocument();
-    expect(screen.getByText("Nightly lodging exceeds the allowed cap.")).toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toContain("Nightly lodging exceeds the allowed cap.");
+
+    fireEvent.click(screen.getByText("Advanced diagnostics"));
+    await waitFor(() => {
+      expect(document.body.textContent ?? "").toContain("Nightly lodging exceeds the allowed cap.");
+    });
   });
 
   it("surfaces exception guidance and approval requirements from live policy results", async () => {
@@ -2344,7 +2349,16 @@ describe("WorkspacePage", () => {
     expect(
       screen.getByText("Exception rationale: The client workshop starts before the first compliant arrival window."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Schedule exception requires manager approval.")).toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toContain(
+      "Schedule exception requires manager approval.",
+    );
+
+    fireEvent.click(screen.getByText("Advanced diagnostics"));
+    await waitFor(() => {
+      expect(document.body.textContent ?? "").toContain(
+        "Schedule exception requires manager approval.",
+      );
+    });
   });
 
   it("skips the follow-up card when legacy records expose an empty follow-up object", async () => {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -961,6 +961,108 @@ describe("WorkspacePage", () => {
     expect(screen.queryByText("Policy posture")).not.toBeInTheDocument();
   });
 
+  it("keeps business approval readiness visible in user-facing language", async () => {
+    const businessWorkspace: WorkspaceData = {
+      ...workspacePayload,
+      trip_record: {
+        ...workspacePayload.trip_record,
+        trip: {
+          ...workspacePayload.trip_record.trip,
+          trip_id: "trip-business-tokyo-summit",
+          title: "Tokyo client summit",
+          summary: "Business trip with approval-ready policy posture.",
+          mode: "business",
+          status: "active",
+          trip_frame: {
+            ...workspacePayload.trip_record.trip.trip_frame,
+            duration_days: 5,
+            primary_regions: ["Tokyo", "Yokohama"],
+          },
+        },
+      },
+      planner_panel_state: {
+        ...workspacePayload.planner_panel_state,
+        trip: {
+          ...workspacePayload.planner_panel_state.trip,
+          trip_id: "trip-business-tokyo-summit",
+          title: "Tokyo client summit",
+          mode: "business",
+          status: "active",
+        },
+      },
+      view_model: {
+        user_summary: {
+          trip_title: "Tokyo client summit",
+          trip_mode: "business",
+          mode_label: "Business trip",
+          status: "ready",
+          headline: "Approval readiness is available for this trip.",
+          decided: ["Approval packet is ready."],
+          uncertain: [],
+        },
+        next_step: {
+          title: "Review approval packet",
+          summary: "Policy evaluation passed and the packet can move to approval handling.",
+          action_label: "Advance to approval",
+          action_target: "approval",
+          blocked: false,
+        },
+        panel_visibility: {
+          show_budget_panel: true,
+          show_policy_posture: true,
+          show_proposal_panel: true,
+          show_approval_readiness_panel: true,
+        },
+        policy_presentation: {
+          active_policy_state: true,
+          posture_label: "Ready for approval",
+          approval_status_label: "Ready for approval",
+          next_step_label: "Advance to approval",
+          summary: "Policy evaluation passed and the approval packet is ready.",
+        },
+        business_summary: {
+          approval_status: "approved",
+          headline: "Approval packet is ready",
+          blockers: [],
+        },
+        debug_state: {
+          sections: {
+            proposal_state: {
+              title: "Proposal state",
+              payload: workspacePayload.proposal_state,
+            },
+          },
+        },
+      },
+    };
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(businessWorkspace),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("heading", { name: "Tokyo client summit" }).length).toBeGreaterThan(0);
+    });
+
+    expect(screen.getByText("Business trip")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Review approval packet" })).toBeInTheDocument();
+    expect(screen.getByText("Approval readiness is available for this trip.")).toBeInTheDocument();
+    expect(screen.getAllByText("Ready for approval").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Advance to approval").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Approval posture").length).toBeGreaterThan(0);
+    expect(screen.getByText("Advanced diagnostics")).toBeInTheDocument();
+    expect(document.body.textContent ?? "").not.toContain("proposal_state_id");
+
+    fireEvent.click(screen.getByText("Advanced diagnostics"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Proposal state" })).toBeInTheDocument();
+    });
+    expect(document.body.textContent ?? "").toContain("proposal_state_id");
+  });
+
   it("persists planning mode selections through the workspace API", async () => {
     const user = userEvent.setup();
     mockedUseLoaderData.mockReturnValue({

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1554,6 +1554,53 @@ describe("WorkspacePage", () => {
     expect(document.body.textContent ?? "").toContain("proposal_state_id");
   });
 
+  it("closes advanced diagnostics when the workspace changes", async () => {
+    const firstWorkspace: WorkspaceData = {
+      ...workspacePayload,
+      proposal_state: {
+        ...workspacePayload.proposal_state,
+        proposal_state_id: "proposal-state-first",
+      },
+    };
+    const nextWorkspace: WorkspaceData = {
+      ...workspacePayload,
+      proposal_state: {
+        ...workspacePayload.proposal_state,
+        proposal_state_id: "proposal-state-next",
+      },
+    };
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(firstWorkspace),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    const { rerender } = renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Advanced diagnostics")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("Advanced diagnostics"));
+    await waitFor(() => {
+      expect(document.body.textContent ?? "").toContain("proposal-state-first");
+    });
+
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve(nextWorkspace),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+    rerender(
+      <TestMemoryRouter>
+        <WorkspacePage />
+      </TestMemoryRouter>
+    );
+
+    await waitFor(() => {
+      const disclosure = document.querySelector(".workspace-debug-disclosure");
+      expect(disclosure).not.toHaveAttribute("open");
+    });
+    expect(document.body.textContent ?? "").not.toContain("proposal-state-next");
+  });
+
   it("shows an empty-state message when no route sequence is available", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1148,6 +1148,7 @@ function WorkspacePageContent({
         {productView && Object.keys(productView.debug_state.sections).length > 0 ? (
           <details
             className="workspace-debug-disclosure"
+            open={showWorkspaceDebugDetails}
             onToggle={(event) => setShowWorkspaceDebugDetails(event.currentTarget.open)}
           >
             <summary>Advanced diagnostics</summary>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -895,6 +895,11 @@ function WorkspacePageContent({
     }
     return sections;
   }, [productView?.debug_state.sections, currentWorkspace.proposal_state]);
+  const workspaceDebugDisclosureKey = [
+    trip.trip_id,
+    currentWorkspace.proposal_state?.proposal_state_id ?? "no-proposal",
+    Object.keys(workspaceDebugSections).sort().join("|"),
+  ].join(":");
   function handleScenarioSelection(scenarioId: string) {
     setSelectedScenarioId(scenarioId);
   }
@@ -1157,6 +1162,7 @@ function WorkspacePageContent({
         </details>
         {Object.keys(workspaceDebugSections).length > 0 ? (
           <details
+            key={workspaceDebugDisclosureKey}
             className="workspace-debug-disclosure"
             open={showWorkspaceDebugDetails}
             onToggle={(event) => setShowWorkspaceDebugDetails(event.currentTarget.open)}

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -885,6 +885,16 @@ function WorkspacePageContent({
         );
   const scenarioPolicyPosture = formatPolicyPosture(currentWorkspace);
   const panelVisibility = deriveWorkspacePanelVisibility(currentWorkspace);
+  const workspaceDebugSections = useMemo(() => {
+    const sections = { ...(productView?.debug_state.sections ?? {}) };
+    if (currentWorkspace.proposal_state != null) {
+      sections.proposal_state = {
+        title: "Proposal diagnostics",
+        payload: currentWorkspace.proposal_state,
+      };
+    }
+    return sections;
+  }, [productView?.debug_state.sections, currentWorkspace.proposal_state]);
   function handleScenarioSelection(scenarioId: string) {
     setSelectedScenarioId(scenarioId);
   }
@@ -1145,7 +1155,7 @@ function WorkspacePageContent({
             </article>
           </div>
         </details>
-        {productView && Object.keys(productView.debug_state.sections).length > 0 ? (
+        {Object.keys(workspaceDebugSections).length > 0 ? (
           <details
             className="workspace-debug-disclosure"
             open={showWorkspaceDebugDetails}
@@ -1153,13 +1163,13 @@ function WorkspacePageContent({
           >
             <summary>Advanced diagnostics</summary>
             <p className="muted-copy">
-              {Object.keys(productView.debug_state.sections).length} debug section
-              {Object.keys(productView.debug_state.sections).length === 1 ? "" : "s"} available for
+              {Object.keys(workspaceDebugSections).length} debug section
+              {Object.keys(workspaceDebugSections).length === 1 ? "" : "s"} available for
               troubleshooting.
             </p>
             {showWorkspaceDebugDetails ? (
               <div className="workspace-debug-section-list">
-                {Object.entries(productView.debug_state.sections).map(([sectionId, section]) => (
+                {Object.entries(workspaceDebugSections).map(([sectionId, section]) => (
                   <article key={sectionId} className="workspace-debug-section">
                     <h3>{section.title}</h3>
                     <pre>{JSON.stringify(section.payload, null, 2)}</pre>
@@ -1713,38 +1723,6 @@ function WorkspacePageContent({
                   <p>{alternative.rationale}</p>
                 </article>
               ))}
-              {(currentWorkspace.proposal_state.proposal.comparables ?? []).map((comparable) => (
-                <article
-                  key={`${comparable.category}-${comparable.label}`}
-                  className="decision-card"
-                >
-                  <h3>{comparable.label}</h3>
-                  <p>
-                    {comparable.vendor} via {comparable.booking_channel} ·{" "}
-                    {formatCurrency(
-                      comparable.estimated_cost.typical_amount,
-                      comparable.estimated_cost.currency
-                    )}
-                  </p>
-                  <p className="muted-copy">{comparable.notes.join(" ")}</p>
-                </article>
-              ))}
-              {(currentWorkspace.proposal_state.evaluation.evaluation_result?.approval_requirements ?? []).map(
-                (requirement) => (
-                  <article key={requirement.role} className="decision-card">
-                    <h3>{requirement.role}</h3>
-                    <p>{requirement.reason}</p>
-                  </article>
-                )
-              )}
-              {(currentWorkspace.proposal_state.evaluation.evaluation_result?.failure_reasons ?? []).map(
-                (failure) => (
-                  <article key={failure.code} className="decision-card">
-                    <h3>{failure.code.replace(/_/g, " ")}</h3>
-                    <p>{failure.message}</p>
-                  </article>
-                )
-              )}
             </div>
           )}
           </section>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -789,6 +789,7 @@ function WorkspacePageContent({
   const [plannerBusyLabel, setPlannerBusyLabel] = useState<string | null>(null);
   const [planningModeBusy, setPlanningModeBusy] = useState(false);
   const [planningModeError, setPlanningModeError] = useState<string | null>(null);
+  const [showWorkspaceDebugDetails, setShowWorkspaceDebugDetails] = useState(false);
   const [budgetError, setBudgetError] = useState<string | null>(null);
   const [budgetBusyLabel, setBudgetBusyLabel] = useState<string | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
@@ -800,6 +801,7 @@ function WorkspacePageContent({
   useEffect(() => {
     setCurrentWorkspace(workspace);
     setSelectedScenarioId(resolveMapScenarioId(workspace));
+    setShowWorkspaceDebugDetails(false);
   }, [workspace]);
 
   useEffect(() => {
@@ -1144,13 +1146,26 @@ function WorkspacePageContent({
           </div>
         </details>
         {productView && Object.keys(productView.debug_state.sections).length > 0 ? (
-          <details className="workspace-debug-disclosure">
+          <details
+            className="workspace-debug-disclosure"
+            onToggle={(event) => setShowWorkspaceDebugDetails(event.currentTarget.open)}
+          >
             <summary>Advanced diagnostics</summary>
             <p className="muted-copy">
               {Object.keys(productView.debug_state.sections).length} debug section
               {Object.keys(productView.debug_state.sections).length === 1 ? "" : "s"} available for
               troubleshooting.
             </p>
+            {showWorkspaceDebugDetails ? (
+              <div className="workspace-debug-section-list">
+                {Object.entries(productView.debug_state.sections).map(([sectionId, section]) => (
+                  <article key={sectionId} className="workspace-debug-section">
+                    <h3>{section.title}</h3>
+                    <pre>{JSON.stringify(section.payload, null, 2)}</pre>
+                  </article>
+                ))}
+              </div>
+            ) : null}
           </details>
         ) : null}
       </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -327,6 +327,48 @@ a {
   font-size: 0.96rem;
 }
 
+.workspace-debug-disclosure {
+  margin-top: 1rem;
+  max-width: 56rem;
+}
+
+.workspace-debug-disclosure summary {
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.workspace-debug-section-list {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 0.9rem;
+}
+
+.workspace-debug-section {
+  border: 1px solid rgba(19, 33, 44, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.68);
+  padding: 0.85rem;
+}
+
+.workspace-debug-section h3 {
+  margin: 0 0 0.55rem;
+  font-size: 0.96rem;
+}
+
+.workspace-debug-section pre {
+  max-height: 320px;
+  overflow: auto;
+  margin: 0;
+  border-radius: 8px;
+  background: rgba(19, 33, 44, 0.06);
+  color: #13212c;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  padding: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .workspace-meta {
   display: grid;
   gap: 0.9rem;


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1130 -->

Closes #1130

## Summary
- lazy-render advanced workspace diagnostics only after the user opens the disclosure, keeping normal traveler/business copy free of raw policy IDs
- add a business-mode workspace test proving approval readiness remains visible in user-facing language
- verify raw proposal diagnostics become available through the advanced diagnostics affordance

## Validation
- `npm --prefix frontend test -- src/routes/WorkspacePage.test.tsx`
- `npm --prefix frontend run build`
- `pytest -q tests/app/test_workspace.py::test_workspace_endpoint_includes_typed_view_model_for_leisure_trip tests/app/test_workspace.py::test_workspace_endpoint_includes_typed_view_model_for_business_trip tests/app/test_workspace.py::test_workspace_view_model_keeps_active_leisure_policy_state_visible tests/app/test_workspace.py::test_workspace_view_model_debug_sections_preserve_raw_payload_shapes`
- `git diff --check`