### PR TITLE
Align Black config and document next issue set

### DIFF
--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -4,7 +4,7 @@ This document maps every major design commitment in `trip-planner` to source cod
 It distinguishes docs-only claims from tested implementations so weekly reviews can assess real delivery status
 without re-reading every design doc.
 
-**Last updated:** 2026-04-30  
+**Last updated:** 2026-05-11
 **Test suite baseline:** 524 passed, 1 xfailed (was 3; two resolved by issue #1046 audit — see `tests/planner/MIGRATIONS.md`)  
 **Source baseline:** 159 Python modules (~21.5 K LOC), 84 test modules (~18 K LOC), 38 TypeScript/React files
 
@@ -221,16 +221,19 @@ Issues: `#543` (epic), `#544`–`#548`
 
 Design ref: [`docs/langchain-planner-runtime-epic.md`](langchain-planner-runtime-epic.md)
 
-> **Partial / deferred.** The `ModelBackedPlannerConversationRunnable` exists and wires `langchain_openai.ChatOpenAI` behind a protocol seam. The seam is configurable and tested at the integration level, but no LangChain tool chain or memory chain is wired up. This is the main post-#676 deferred integration.
+> **Partial.** The planner runtime now has a trip-scoped conversation API, persisted session/checkpoint records, a model-backed runnable, and an explicit app-tool registry/executor. The remaining gap is no longer "no planner tools"; it is that the first-pass registry covers workspace, budget, policy, proposal, decision, feedback, and planning-notebook state, while richer source retrieval, route-provider queries, dynamic model routing, and semantic reorientation remain follow-on work.
 
 | Commitment | Source | Tests | Status |
 |------------|--------|-------|--------|
 | Planner protocol seam (configurable model) | `trip_planner/app/services/planner.py` (`PlannerChatModel`, `ModelBackedPlannerConversationRunnable`) | `tests/app/test_planner_routes.py` | ✅ Implemented |
-| LangChain tool chain (source retrieval, scoring, budget, maps, policy) | — | — | ❌ Missing |
-| Memory chain across planner turns | `trip_planner/app/services/planner.py` (`_conversation_messages`) | partial | 🟡 Partial (message history; no vector memory) |
-| Planning mode selection (delegated / collaborative / revealed-preference / in-trip) | `docs/product-architecture-brief.md` §4 | — | 📄 Docs-only |
+| Trip-scoped planner session + conversation API | `trip_planner/app/routes/planner.py`, `trip_planner/app/services/planner.py` | `tests/app/test_planner_routes.py`, `tests/app/test_planner_turn_e2e.py` | ✅ Implemented |
+| App-tool registry and executor | `trip_planner/app/services/planner_tools.py`, `trip_planner/app/services/planner.py` (`_execute_model_tool_calls`) | `tests/app/test_planner_routes.py` | ✅ Implemented |
+| Memory and checkpoint persistence | `trip_planner/persistence/models/planner_memory.py`, `trip_planner/app/services/planner_memory.py` | `tests/app/test_planner_routes.py`, `tests/app/test_planner_turn_e2e.py` | 🟡 Partial (checkpoint and notebook memory; no semantic/vector recall) |
+| Planning mode selection (delegated / collaborative / revealed-preference / in-trip) | `frontend/src/components/planner/PlanningModeSelector.tsx`, `trip_planner/app/routes/workspace.py`, `trip_planner/app/services/workspace.py` | `frontend/src/components/planner/PlanningModeSelector.test.tsx`, `frontend/src/routes/WorkspacePage.test.tsx`, `tests/app/test_workspace.py` | ✅ Implemented |
+| Dynamic model routing by task complexity | — | — | ❌ Missing |
+| Provider-rich planner tools (source retrieval, live routing/maps, source-quality scoring) | `trip_planner/app/services/planner_tools.py` (first-pass app tools only) | partial route/tool tests | 🟡 Partial |
 
-**Gap detail (follow-up issue candidate):** The LangChain tool registry is not implemented. `planner.py` constructs a message payload and sends it to the model, but there are no explicit tools registered for source retrieval, itinerary scoring, budget calculation, map/routing queries, or policy requirement assembly. The runtime config lists tool capability flags (`source_retrieval_enabled`, `itinerary_scoring_enabled`, etc.) but they do not resolve to callable tools. This is a clearly scoped gap: implement `trip_planner/app/services/planner_tools.py` that exposes each domain service as a LangChain-compatible tool and registers it in `ModelBackedPlannerConversationRunnable`.
+**Gap detail (follow-up issue candidate):** The runtime can execute explicit planner tools and persist their traces, but it still needs a model-routing policy that distinguishes fast conversational turns from deeper synthesis, richer source/map/provider-backed tools, and semantic planner memory that can reorient when a traveler says "I was working on lodging" or "put this in the Oslo file."
 
 ---
 
@@ -272,18 +275,19 @@ Design ref: [`docs/live-tpp-execution-reoptimization-epic.md`](live-tpp-executio
 Design refs: [`docs/google-maps-platform-hardening-epic.md`](google-maps-platform-hardening-epic.md), [`docs/maps-timeline-comparison-epic.md`](maps-timeline-comparison-epic.md)  
 Issues: `#679` (epic), `#698`–`#700`
 
-> **Partial.** The map adapter boundary and fallback rendering are implemented. The route-context map contract shipped as a doc + fixture-validation contract (PR #1008) plus the `frontend/src/components/maps/mapSurface.ts` TypeScript surface; the original `test_map_target_uses_typed_route_context_contract` xfail (which incorrectly asserted on a Python type export from `trip_planner.contracts`) was deleted by the issue #1046 audit (2026-04-30) and recorded in `tests/planner/MIGRATIONS.md`. Timeline view (`#698`) and the dedicated map surface UI (`#699`) remain missing.
+> **Partial.** The map adapter boundary, bounded fallback rendering, Google Maps JavaScript provider path, global/local map-scope controls, workspace timeline rendering, and scenario comparison surfaces now exist. Remaining work is mostly product depth: live provider verification in configured environments, richer regional/local geometry, deeper option-marker detail, and a dedicated source-backed timeline contract beyond the current route-sequence adapter.
 
 | Commitment | Source | Tests | Status |
 |------------|--------|-------|--------|
-| Google Maps JS adapter boundary + fallback rendering | `frontend/src/components/maps/TripMap.tsx`, `mapSurface.ts` | `frontend/src/components/maps/mapSurface.test.ts` | ✅ Implemented |
-| Route-context map contract (`docs/contracts/route-context-map-target.md`) | `docs/contracts/route-context-map-target.md`, `frontend/src/components/maps/mapSurface.ts` | `tests/contracts/test_route_context_map_target.py` | 🟡 Partial (contract tested; UI not wired) |
-| Timeline view for trip structure + day sequencing (`#698`) | — | — | ❌ Missing |
-| Dedicated map surface for route + option context (`#699`) | — | — | ❌ Missing |
-| Saved-scenario + trip comparison views (`#700`) | `frontend/src/components/workspace/ScenarioComparison.tsx`, `components/trips/TripComparison.tsx` | — | 🟡 Partial (components exist; no dedicated tests) |
-| Workspace timeline contract | `docs/workspace_timeline_contract.md` | — | 📄 Docs-only |
+| Google Maps JS adapter boundary + fallback rendering | `frontend/src/components/maps/TripMap.tsx`, `frontend/src/components/maps/mapSurface.ts` | `frontend/src/components/maps/mapSurface.test.ts`, `frontend/src/components/maps/TripMap.test.tsx`, `frontend/src/routes/WorkspacePage.test.tsx` | ✅ Implemented |
+| Route-context map contract (`docs/contracts/route-context-map-target.md`) | `docs/contracts/route-context-map-target.md`, `frontend/src/components/maps/mapSurface.ts`, `frontend/src/components/maps/TripMap.tsx` | `tests/contracts/test_route_context_map_target.py`, frontend map tests | ✅ Implemented |
+| Global/local map scope switching | `frontend/src/components/maps/mapSurface.ts`, `frontend/src/components/maps/TripMap.tsx` | `frontend/src/components/maps/mapSurface.test.ts`, `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (global/local shipped; richer regional geometry pending) |
+| Timeline view for trip structure + day sequencing (`#698`) | `frontend/src/routes/WorkspacePage.tsx` (`buildTimelineStops`, timeline section) | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (route-sequence adapter; no provider-rich per-leg timing) |
+| Dedicated map surface for route + option context (`#699`) | `frontend/src/components/maps/TripMap.tsx`, `frontend/src/components/maps/mapSurface.ts` | frontend map/workspace tests | ✅ Implemented |
+| Saved-scenario + trip comparison views (`#700`) | `frontend/src/components/workspace/ScenarioComparison.tsx`, `components/trips/TripComparison.tsx`, `frontend/src/routes/WorkspacePage.tsx` | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (workspace-tested; targeted component tests still thin) |
+| Workspace timeline contract | `docs/workspace_timeline_contract.md`, `frontend/src/routes/WorkspacePage.tsx` | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial |
 
-**Gap detail (follow-up issue candidate):** The itinerary timeline view (`#698`) has a contract document (`docs/workspace_timeline_contract.md`) but no implementation. A minimal deliverable would be a `TimelineView` React component consuming the `WorkspaceTimeline` contract shape already defined in the doc, plus a backend route or workspace payload extension that exposes per-day itinerary data. This is self-contained enough to be a single issue.
+**Gap detail (follow-up issue candidate):** The shipped timeline and map surfaces are good enough for workspace testing, but they still depend on route-sequence summaries and shaped scenario data rather than provider-rich timing, distance, and local-geometry outputs. The next issue should upgrade the route/timeline/map contract so a traveler can move cleanly between global trip outline, regional comparison, and precise segment review without losing context.
 
 ---
 
@@ -311,28 +315,28 @@ From [`docs/product-architecture-brief.md`](product-architecture-brief.md) and [
 | Audit trail (created_at, updated_at, version on mutable records) | `trip_planner/persistence/models/` | ✅ Implemented |
 | Append-only scenario history | `trip_planner/state/scenarios.py` | ✅ Implemented |
 | Trip references artifacts (no inlining) | `trip_planner/contracts/trip.py` (`TripArtifactRefs`) | ✅ Implemented |
-| Explicit deferred seams (TPP transport, Maps key, LangChain tools) | `tests/app/test_full_product_verification.py` (skip checks) | ✅ Implemented |
+| Explicit deferred seams (TPP transport, Maps key, provider-rich planner tools) | `tests/app/test_full_product_verification.py` (skip checks) | ✅ Implemented |
 | Five bounded modules (preferences, options, itinerary, budget, business_policy_export) | `trip_planner/` subdirectory layout | ✅ Implemented |
 
 ---
 
-## Summary: Docs-Only Claims (no source file)
+## Summary: Remaining Follow-Up Claims
 
-These design commitments have no corresponding source implementation. Each is a candidate for a follow-up issue:
+These design commitments are still missing, partial, or not yet verified in a live provider environment. Each is a candidate for a follow-up issue:
 
-1. **LangChain tool registry** — `product-architecture-brief.md` §4 + `langchain-planner-runtime-epic.md`. No `planner_tools.py`; tool capability flags are inert. See §13 above.
-2. **Timeline view** — `workspace_timeline_contract.md` + `maps-timeline-comparison-epic.md` `#698`. No frontend component. See §16 above.
-3. **Dedicated map route surface** — `maps-timeline-comparison-epic.md` `#699`. Map boundary exists but no typed-contract-backed route surface. See §16 above.
-4. **Live TPP transport** — `live-tpp-execution-reoptimization-epic.md`. All seams exist but no live HTTP call. See §15 above.
+1. **Dynamic planner model routing** — `product-architecture-brief.md` §4 + `langchain-planner-runtime-epic.md`. Planning mode exists, but runtime model selection does not yet distinguish quick turns from deeper synthesis/planning turns. See §13 above.
+2. **Semantic planner memory and reorientation** — planner checkpoints and notebook state exist, but there is no semantic recall/reorientation layer for scattered traveler notes and "I was working on..." context shifts. See §13 above.
+3. **Provider-rich planner tools** — `planner_tools.py` exists for first-pass app state actions, but source retrieval, live routing/maps, and source-quality scoring are still not exposed as planner tools. See §13 above.
+4. **Live TPP transport verification** — `live-tpp-execution-reoptimization-epic.md`. All seams exist but no live HTTP round-trip is required by the default test matrix. See §15 above.
 5. **Source quality model implementation** — `source-quality-model.md` + `source-channel-strategy.md`. Design defined; no engine code.
-6. **Planning mode selection UX** — `product-architecture-brief.md` §4 (delegated / collaborative / revealed-preference / in-trip modes). No frontend mode selector or backend routing.
+6. **Provider-rich timeline/map depth** — workspace timeline and map surfaces exist, but still need richer regional/local geometry, per-leg timing, and live provider readiness evidence. See §16 above.
 7. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
 
 ---
 
 ## How to Use This Map in Weekly Reviews
 
-1. Check the **xfailed tests** first: `pytest -q tests/planner/test_planner_turn_acceptance.py` shows the one remaining deferred area (ranking and route_comparison in the workspace payload — see §11).
+1. Check the **planner/runtime acceptance tests** first: `pytest -q tests/planner/test_planner_turn_acceptance.py tests/app/test_planner_routes.py tests/app/test_full_product_verification.py`.
 2. The **Docs-only** rows in each section identify items that are design commitments but not yet scheduled work.
 3. **Partial** rows identify items where code exists but is seeded/fixture-backed — these are the next implementation lane.
-4. The **Summary: Docs-Only Claims** section lists everything that would require a new issue before implementation can start.
+4. The **Summary: Remaining Follow-Up Claims** section lists the highest-priority gaps that should become new issues or verification tasks.

--- a/docs/langchain-planner-runtime-epic.md
+++ b/docs/langchain-planner-runtime-epic.md
@@ -17,14 +17,15 @@ It is complete when:
 
 ## Current Runtime Posture
 
-The repo already contains planner-facing design and UI contract surfaces, but it does not yet expose a first-class planner runtime:
+The first-pass planner runtime now exists and should be treated as the baseline rather than a deferred design:
 
-- `bundle/planner/mock-state.js`, `bundle/planner/side-panel.js`, and `bundle/planner/orchestration-contracts.d.ts` define the mounted planner panel shape and demo payloads
-- `docs/product-architecture-brief.md` and `docs/contracts/planning-autonomy.md` define the intended LangChain and autonomy behaviors
-- `trip_planner/preferences/autonomy.py` already converts autonomy preferences into concrete planner pacing metadata
-- `trip_planner/app/routes/workspace.py` and `trip_planner/app/services/workspace.py` expose workspace planner decision and option-feedback endpoints, but they do not yet provide a trip-scoped conversation API, planner tool runner, or persisted planner checkpoint trail
+- `trip_planner/app/routes/planner.py` exposes trip-scoped session, resume, and turn endpoints.
+- `trip_planner/app/services/planner.py` owns deterministic fallback replies, the model-backed runnable, model-request metadata, structured planner blocks, explicit tool-call execution, and persisted turn payloads.
+- `trip_planner/app/services/planner_tools.py` exposes the current application tool registry for workspace state, inventory and scenario refresh, budget state and updates, policy/proposal reads, pending decisions, option feedback, and planning-notebook actions.
+- `trip_planner/persistence/models/planner_memory.py` and `trip_planner/app/services/planner_memory.py` persist checkpoint and summary records that make planner sessions resumable.
+- `frontend/src/components/planner/PlanningModeSelector.tsx`, `trip_planner/app/routes/workspace.py`, and `trip_planner/app/services/workspace.py` persist the selected planning mode for delegated, collaborative, revealed-preference, and in-trip work.
 
-That means the repo can render planner state and accept bounded planner interactions, but it still lacks the runtime layer that owns conversational planning, explicit tool use, and long-lived planner memory for arbitrary persisted trips.
+The remaining runtime gap is depth rather than absence. The repo still needs dynamic model routing, richer source/map/provider-backed planner tools, semantic recall for scattered planning notes, and live-provider verification for release confidence.
 
 ## Runtime Configuration
 
@@ -44,13 +45,13 @@ CI should cover the model-backed path with fake chat models rather than live pro
 
 This epic depends on the persisted trip, workspace, and runtime seams established by the current app stack on `main`, especially the workspace route/service surfaces that now assemble persisted trip state, scenario search state, and planner panel payloads.
 
-Within the epic itself, the expected order is:
+Within the epic itself, the first-pass delivery order was:
 
 1. `#760` trip-scoped planner session and conversation API
 2. `#761` tool-backed planner actions for inventory, ranking, budget, and policy state
 3. `#762` persisted planner checkpoints, summaries, and user-visible memory
 
-Issue `#761` should build on the session and conversation seam from `#760` instead of introducing a separate planner entrypoint. Issue `#762` should build on the conversation and tool-action seams from `#760` and `#761` so persisted memory reflects real planner state transitions rather than UI-only snapshots.
+The implementation follows that ordering: `#761` builds on the session and conversation seam from `#760`, and `#762` builds on the conversation and tool-action seams from `#760` and `#761` so persisted memory reflects real planner state transitions rather than UI-only snapshots.
 
 ## Shared Design Rules
 
@@ -74,10 +75,10 @@ Every child issue in this epic should preserve these rules:
 
 ## Contract Surface
 
-The first pass of this epic should stabilize the following surfaces before broader multi-agent or provider-specific work expands:
+The first pass of this epic stabilized the following surfaces before broader multi-agent or provider-specific work expands:
 
-- `trip_planner/app/routes/workspace.py` and adjacent app routes for trip-scoped planner API entrypoints
-- `trip_planner/app/services/workspace.py` plus new planner-specific service seams for conversation orchestration and tool execution
+- `trip_planner/app/routes/workspace.py`, `trip_planner/app/routes/planner.py`, and adjacent app routes for trip-scoped planner API entrypoints
+- `trip_planner/app/services/workspace.py`, `trip_planner/app/services/planner.py`, and `trip_planner/app/services/planner_tools.py` for conversation orchestration and tool execution
 - persisted planner/session models alongside the existing trip and planning-session persistence surfaces
 - `trip_planner/preferences/autonomy.py` and `docs/contracts/planning-autonomy.md` as the planner pacing and checkpoint contract inputs
 - `bundle/planner/orchestration-contracts.d.ts` and `bundle/planner/side-panel.js` as consumers of runtime planner state rather than mock-only state

--- a/docs/local-testing-plan.md
+++ b/docs/local-testing-plan.md
@@ -19,6 +19,12 @@ That baseline is still required, but it is not the whole production-readiness st
 Run `make install` once from a clean checkout to create `.venv` and install all deps, then run these commands from the repo root:
 
 ```bash
+.venv/bin/black --check .
+```
+
+Black's local config is centralized in `pyproject.toml` with `line-length = 100`, matching the remote automation. Older local commands that passed `--line-length 100` explicitly are equivalent, but the flag should no longer be needed from a correctly synced checkout and refreshed `.venv`.
+
+```bash
 make runtime-production-check
 ```
 

--- a/docs/next-issue-set.md
+++ b/docs/next-issue-set.md
@@ -1,0 +1,137 @@
+# Next Issue Set
+
+This note captures the remaining gaps after the recent readiness, planner-runtime, notebook, planning-mode, map, and workspace-polish work. It is intentionally issue-shaped so the next round can be opened as focused GitHub issues instead of bundled into one broad cleanup PR.
+
+## 1. Add Planner Model Routing Policy
+
+**Goal:** Route quick traveler turns to a low-latency model path and route synthesis, comparison, and major planning updates to a deeper model path.
+
+**Why it matters:** The UI now exposes planning modes, but runtime model choice is still mostly configuration-level. A product planner needs fast acknowledgement for simple turns and visibly more careful reasoning when the traveler asks for route comparison, tradeoff synthesis, or a durable plan update.
+
+**Scope:**
+
+- Add a backend policy that classifies planner turns by task type, selected planning mode, and requested action.
+- Preserve deterministic fallback behavior when no provider is configured.
+- Persist model-routing metadata on planner turns so the UI and tests can distinguish quick turns from deeper planning turns without exposing developer language to travelers.
+- Add fake-model tests for low-latency and deeper-routing branches.
+
+**Acceptance criteria:**
+
+- Simple acknowledgement, note capture, and notebook-focus turns use the fast path.
+- route comparison, final summary, major itinerary revision, policy submission preparation, and "think this through" prompts use the deeper path.
+- The planner response records route/model-class metadata in a developer-facing payload while hiding it from normal traveler copy.
+- Tests prove routing is mode-aware and provider-free in CI.
+
+## 2. Build Semantic Planner Memory And Reorientation
+
+**Goal:** Let a traveler scatter notes during planning and later say "I was working on lodging in Oslo" or "put this in the future list" and have the planner and UI reorient to the right planning file.
+
+**Why it matters:** Planning is non-linear. The current notebook tools can capture, focus, read, and complete items, but the system still needs a stronger memory layer for category inference, ambiguous references, and UI reorientation.
+
+**Scope:**
+
+- Add structured memory categories for lodging, transport, activities, budget, route options, policy, documents, and future questions.
+- Add semantic matching or deterministic fallback matching from traveler phrasing to notebook items/categories.
+- Expose focused memory state in the workspace so the relevant list, route option, or planning panel becomes active without menu-clicking.
+- Add completed-item history for major planning categories.
+
+**Acceptance criteria:**
+
+- "Remember this for hotels" creates or updates a lodging notebook item.
+- "I was working on the Oslo stay" focuses the matching lodging item and returns nearby open/completed items.
+- Completed items remain visible in completed-history views and can be reopened.
+- Ambiguous references prompt a user-friendly clarification instead of silently filing the note incorrectly.
+
+## 3. Expand Provider-Rich Planner Tools
+
+**Goal:** Move beyond first-pass app-state tools by exposing source retrieval, route/map provider checks, source-quality scoring, and route comparison refresh as planner-callable tools.
+
+**Why it matters:** `planner_tools.py` is now real, but the model cannot yet request richer source or provider work. This limits how much the planner can revise a route based on fresh information.
+
+**Scope:**
+
+- Add read-only tools for source retrieval and source-quality summaries.
+- Add route/map provider-status and route-geometry tools that consume existing map-surface and runtime scenario contracts.
+- Add route-comparison refresh tools that update scenario rankings without bypassing existing deterministic services.
+- Keep tool outputs bounded, referenced, and persisted in planner traces.
+
+**Acceptance criteria:**
+
+- The planner can request route options, source-quality notes, and map-provider status through named tools.
+- Unsupported provider states return visible bounded errors, not fabricated success.
+- Tool traces remain persisted and testable through planner routes.
+
+## 4. Verify Live TPP Integration End To End
+
+**Goal:** Run the trip-planner to Travel-Plan-Permission round trip against a live or sibling TPP service and record the required setup.
+
+**Why it matters:** Contract and seam tests pass, but default readiness still skips live TPP when `TPP_BASE_URL` or `TPP_REPO_PATH` is absent. Release confidence needs at least one documented live verification lane.
+
+**Scope:**
+
+- Confirm local sibling startup through `TPP_REPO_PATH`.
+- Confirm remote startup through `TPP_BASE_URL`, `TPP_ACCESS_TOKEN`, and `TPP_OIDC_PROVIDER`.
+- Add or update docs for expected env vars, failure modes, and captured logs.
+- Record whether the current deployed Render/Netlify setup can exercise the business policy flow without local developer commands.
+
+**Acceptance criteria:**
+
+- `make full-product-check` reports live TPP readiness, not `SKIPPED`, in at least one configured environment.
+- Failures include actionable service command, env var, and recent log context.
+- The traveler-facing UI keeps policy failure details understandable without developer jargon.
+
+## 5. Deepen Map, Route, And Timeline Presentation
+
+**Goal:** Make map/timeline surfaces support a coherent global, regional, and local review flow.
+
+**Why it matters:** The current map and timeline are usable and tested, but they still rely on shaped route summaries. Travelers need a rough whole-trip outline plus precise segment review for specific decisions.
+
+**Scope:**
+
+- Strengthen the map scope model from global/local into global, regional, and segment-level views.
+- Carry selected route option and selected segment state across map, timeline, scenario comparison, and planner conversation.
+- Add provider-rich per-leg timing/distance when available and keep graceful fallback when unavailable.
+- Add UI states that explain confidence and precision in traveler language.
+
+**Acceptance criteria:**
+
+- Switching a route option updates map, timeline, scenario cards, and planner context together.
+- Switching to a segment-level view highlights the relevant route leg, markers, notes, and open decisions.
+- Missing provider geometry still leaves a useful schematic and comparison board.
+
+## 6. Implement Source Quality Scoring
+
+**Goal:** Turn `source-quality-model.md` and `source-channel-strategy.md` into executable scoring and explanation code.
+
+**Why it matters:** The planner should not treat raw ratings, stale articles, review snippets, and official provider data as equivalent. Source confidence needs to influence ranking and traveler-facing explanations.
+
+**Scope:**
+
+- Add a source-quality engine that scores freshness, channel fit, provenance, conflict state, and traveler relevance.
+- Wire source-quality signals into ranking explanations and planner source summaries.
+- Add tests for stale, conflicting, official, crowd-review, and sparse-source scenarios.
+
+**Acceptance criteria:**
+
+- Candidate and route explanations include source-confidence language.
+- Stale or conflicting inputs reduce confidence without deleting useful options.
+- Source-quality behavior is deterministic and covered by tests.
+
+## 7. Finish Product UX Cleanup For Traveler Comfort
+
+**Goal:** Remove remaining developer-shaped copy and make the workspace feel like a planning product rather than an implementation surface.
+
+**Why it matters:** The app now hides several raw provider/debug labels, but the next pass should make traveler input formatting, planner reply formatting, help affordances, and route-option comparison feel intentional.
+
+**Scope:**
+
+- Add a compact, expandable "How to use this workspace" help section.
+- Improve traveler input formatting for scattered notes, route comparisons, decisions, and checklist actions.
+- Improve planner reply formatting with clear summaries, options considered, rejected options, next actions, and durable references.
+- Keep a hidden developer-facing diagnostic trail for debugging.
+
+**Acceptance criteria:**
+
+- Normal workspace usage does not surface raw IDs, provider labels, tool names, or runtime terms.
+- Planner replies consistently separate next step, options, tradeoffs, saved notes, and open questions.
+- Hover/tooltips explain planning mode and map controls in traveler-friendly language.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ exclude_lines = [
 ]
 
 [tool.black]
+line-length = 100
 extend-exclude = '''
 (
   /\.venv/


### PR DESCRIPTION
## Summary
- Set local Black configuration to line length 100 in pyproject.toml so bare local checks match remote automation.
- Updated planner/runtime and design coverage docs to reflect implemented planner tools, planning mode, map, and timeline work.
- Added docs/next-issue-set.md with detailed remaining gaps for the next issue round.

## Verification
- .venv/bin/black --check .
- .venv/bin/ruff check .
- git diff --check origin/main...HEAD