### PR TITLE
Issue #1159: route planner turns through task/effort classes

### DIFF
--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -230,10 +230,10 @@ Design ref: [`docs/langchain-planner-runtime-epic.md`](langchain-planner-runtime
 | App-tool registry and executor | `trip_planner/app/services/planner_tools.py`, `trip_planner/app/services/planner.py` (`_execute_model_tool_calls`) | `tests/app/test_planner_routes.py` | ✅ Implemented |
 | Memory and checkpoint persistence | `trip_planner/persistence/models/planner_memory.py`, `trip_planner/app/services/planner_memory.py` | `tests/app/test_planner_routes.py`, `tests/app/test_planner_turn_e2e.py` | 🟡 Partial (checkpoint and notebook memory; no semantic/vector recall) |
 | Planning mode selection (delegated / collaborative / revealed-preference / in-trip) | `frontend/src/components/planner/PlanningModeSelector.tsx`, `trip_planner/app/routes/workspace.py`, `trip_planner/app/services/workspace.py` | `frontend/src/components/planner/PlanningModeSelector.test.tsx`, `frontend/src/routes/WorkspacePage.test.tsx`, `tests/app/test_workspace.py` | ✅ Implemented |
-| Dynamic model routing by task complexity | — | — | ❌ Missing |
+| Dynamic model routing by task complexity | `trip_planner/app/services/planner_routing.py`, `trip_planner/app/services/planner.py` (`_planner_turn_metadata`) | `tests/app/test_planner_routing.py`, `tests/app/test_planner_routes.py` | ✅ Implemented |
 | Provider-rich planner tools (source retrieval, live routing/maps, source-quality scoring) | `trip_planner/app/services/planner_tools.py` (first-pass app tools only) | partial route/tool tests | 🟡 Partial |
 
-**Gap detail (follow-up issue candidate):** The runtime can execute explicit planner tools and persist their traces, but it still needs a model-routing policy that distinguishes fast conversational turns from deeper synthesis, richer source/map/provider-backed tools, and semantic planner memory that can reorient when a traveler says "I was working on lodging" or "put this in the Oslo file."
+**Gap detail (follow-up issue candidate):** The runtime executes explicit planner tools, persists their traces, and now routes each turn into a task class plus a fast/standard/deep model effort class biased by the selected planning mode. The remaining gaps are richer source/map/provider-backed tools and semantic planner memory that can reorient when a traveler says "I was working on lodging" or "put this in the Oslo file."
 
 ---
 
@@ -324,13 +324,12 @@ From [`docs/product-architecture-brief.md`](product-architecture-brief.md) and [
 
 These design commitments are still missing, partial, or not yet verified in a live provider environment. Each is a candidate for a follow-up issue:
 
-1. **Dynamic planner model routing** — `product-architecture-brief.md` §4 + `langchain-planner-runtime-epic.md`. Planning mode exists, but runtime model selection does not yet distinguish quick turns from deeper synthesis/planning turns. See §13 above.
-2. **Semantic planner memory and reorientation** — planner checkpoints and notebook state exist, but there is no semantic recall/reorientation layer for scattered traveler notes and "I was working on..." context shifts. See §13 above.
-3. **Provider-rich planner tools** — `planner_tools.py` exists for first-pass app state actions, but source retrieval, live routing/maps, and source-quality scoring are still not exposed as planner tools. See §13 above.
-4. **Live TPP transport verification** — `live-tpp-execution-reoptimization-epic.md`. All seams exist but no live HTTP round-trip is required by the default test matrix. See §15 above.
-5. **Source quality model implementation** — `source-quality-model.md` + `source-channel-strategy.md`. Design defined; no engine code.
-6. **Provider-rich timeline/map depth** — workspace timeline and map surfaces exist, but still need richer regional/local geometry, per-leg timing, and live provider readiness evidence. See §16 above.
-7. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
+1. **Semantic planner memory and reorientation** — planner checkpoints and notebook state exist, but there is no semantic recall/reorientation layer for scattered traveler notes and "I was working on..." context shifts. See §13 above.
+2. **Provider-rich planner tools** — `planner_tools.py` exists for first-pass app state actions, but source retrieval, live routing/maps, and source-quality scoring are still not exposed as planner tools. See §13 above.
+3. **Live TPP transport verification** — `live-tpp-execution-reoptimization-epic.md`. All seams exist but no live HTTP round-trip is required by the default test matrix. See §15 above.
+4. **Source quality model implementation** — `source-quality-model.md` + `source-channel-strategy.md`. Design defined; no engine code.
+5. **Provider-rich timeline/map depth** — workspace timeline and map surfaces exist, but still need richer regional/local geometry, per-leg timing, and live provider readiness evidence. See §16 above.
+6. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
 
 ---
 

--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -221,7 +221,7 @@ Issues: `#543` (epic), `#544`–`#548`
 
 Design ref: [`docs/langchain-planner-runtime-epic.md`](langchain-planner-runtime-epic.md)
 
-> **Partial.** The planner runtime now has a trip-scoped conversation API, persisted session/checkpoint records, a model-backed runnable, and an explicit app-tool registry/executor. The remaining gap is no longer "no planner tools"; it is that the first-pass registry covers workspace, budget, policy, proposal, decision, feedback, and planning-notebook state, while richer source retrieval, route-provider queries, dynamic model routing, and semantic reorientation remain follow-on work.
+> **Partial.** The planner runtime now has a trip-scoped conversation API, persisted session/checkpoint records, a model-backed runnable, an explicit app-tool registry/executor, and deterministic model-routing by task class and planning mode. The remaining gap is no longer "no planner tools"; it is that the first-pass registry covers workspace, budget, policy, proposal, decision, feedback, and planning-notebook state, while richer source retrieval, route-provider queries, and semantic reorientation remain follow-on work.
 
 | Commitment | Source | Tests | Status |
 |------------|--------|-------|--------|

--- a/docs/langchain-planner-runtime-epic.md
+++ b/docs/langchain-planner-runtime-epic.md
@@ -41,6 +41,38 @@ When those values are present, the planner conversation service creates a LangCh
 
 CI should cover the model-backed path with fake chat models rather than live provider credentials. Live provider checks belong in explicit integration runs.
 
+## Runtime Model Routing
+
+Each planner turn is classified into a task class and a discrete model
+effort class so traveler-facing interactions feel responsive while planning
+synthesis turns receive deeper attention. The policy lives in
+`trip_planner/app/services/planner_routing.py` and is consumed by
+`_planner_turn_metadata` in `trip_planner/app/services/planner.py`.
+
+- Task classes include `quick_acknowledgement`, `note_capture`, `focus_switch`,
+  `clarifying_question`, `first_turn_triage`, `planning_synthesis`,
+  `route_comparison`, `major_revision`, `policy_preparation`,
+  `research_tool_pass`, and `final_summary`.
+- Effort classes are `fast`, `standard`, and `deep`. Fast-class and deep-class
+  task classes pin the effort regardless of planning mode.
+- The selected planning mode biases the `standard` band only: `delegated`
+  prefers deeper autonomous synthesis, `in-trip` prefers a quick response,
+  and `collaborative` keeps the standard band. The bias never overrides an
+  explicit fast or deep task class.
+- The deterministic fallback path records `provider_state=fallback` and the
+  existing `fallback_reason` separately from the chosen effort class so
+  diagnostics distinguish "no provider" from a routing decision.
+
+Routing metadata is persisted on the planner turn under
+`turn_metadata.{task_class, effort_class, base_effort_class,
+selected_planning_mode, provider_state, fallback_reason}` and the
+diagnostic `debug_routing_details.routing_reasoning` field. Traveler-facing
+planner copy and visible response blocks do not surface these values. The
+unit policy lives in `tests/app/test_planner_routing.py`; route-level
+integration is covered in `tests/app/test_planner_routes.py`. Verifying
+without live credentials uses the existing fallback runtime plus the
+`FakePlannerChatModel` test seam in `tests/app/test_planner_routes.py`.
+
 ## Dependency Chain
 
 This epic depends on the persisted trip, workspace, and runtime seams established by the current app stack on `main`, especially the workspace route/service surfaces that now assemble persisted trip state, scenario search state, and planner panel payloads.

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -475,6 +475,11 @@ export type PlannerToolCallResponse = {
 export type PlannerTurnMetadata = {
   plan_maturity: string;
   task_class: string;
+  effort_class?: string;
+  base_effort_class?: string;
+  selected_planning_mode?: string | null;
+  provider_state?: string;
+  fallback_reason?: string | null;
   visible_response_blocks: Array<{
     kind: string;
     title: string;

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -340,6 +340,121 @@ def test_planner_turn_records_adaptive_triage_metadata(
     assert "fallback" not in visible_content
 
 
+def test_planner_turn_records_effort_class_and_provider_state_on_fallback(
+    client: TestClient,
+) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "We want five days in Kyoto in May with a moderate budget."},
+    )
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    metadata = planner_reply["turn_metadata"]
+    # Task class is unchanged (planning_synthesis); effort class is added; provider
+    # state and fallback_reason are recorded alongside without leaking into traveler copy.
+    assert metadata["task_class"] == "planning_synthesis"
+    assert metadata["effort_class"] == "deep"
+    assert metadata["base_effort_class"] == "deep"
+    assert metadata["provider_state"] == "fallback"
+    assert metadata["fallback_reason"] == "planner_model_not_configured"
+    assert metadata["selected_planning_mode"] == "collaborative"
+    assert metadata["debug_routing_details"]["routing_reasoning"]
+    visible_content = planner_reply["content"].lower()
+    assert "effort" not in visible_content
+    assert "deep" not in visible_content
+    assert "fast" not in visible_content
+
+
+def test_quick_acknowledgement_routes_to_fast_path(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Thanks!"},
+    )
+
+    assert response.status_code == 200
+    metadata = response.json()["messages"][-1]["turn_metadata"]
+    assert metadata["task_class"] == "quick_acknowledgement"
+    assert metadata["effort_class"] == "fast"
+
+
+def test_note_capture_message_routes_to_fast_path(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Remember this for later: passport expiration is in March"},
+    )
+
+    assert response.status_code == 200
+    metadata = response.json()["messages"][-1]["turn_metadata"]
+    assert metadata["task_class"] == "note_capture"
+    assert metadata["effort_class"] == "fast"
+
+
+def test_focus_switch_message_routes_to_fast_path(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Let's switch to lodging for now"},
+    )
+
+    assert response.status_code == 200
+    metadata = response.json()["messages"][-1]["turn_metadata"]
+    assert metadata["task_class"] == "focus_switch"
+    assert metadata["effort_class"] == "fast"
+
+
+def test_delegated_planning_mode_biases_standard_band_to_deep(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    mode_response = client.put(
+        f"/api/workspace/{trip_id}/planning-mode",
+        json={"planning_mode": "delegated"},
+    )
+    assert mode_response.status_code == 200, mode_response.text
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Maybe Japan with good food"},
+    )
+
+    assert response.status_code == 200
+    metadata = response.json()["messages"][-1]["turn_metadata"]
+    # Base task class is first_turn_triage (standard band); delegated mode bumps
+    # it to deep without changing the task class itself.
+    assert metadata["task_class"] == "first_turn_triage"
+    assert metadata["base_effort_class"] == "standard"
+    assert metadata["effort_class"] == "deep"
+    assert metadata["selected_planning_mode"] == "delegated"
+
+
+def test_delegated_planning_mode_does_not_override_fast_task(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    mode_response = client.put(
+        f"/api/workspace/{trip_id}/planning-mode",
+        json={"planning_mode": "delegated"},
+    )
+    assert mode_response.status_code == 200, mode_response.text
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "thanks"},
+    )
+
+    assert response.status_code == 200
+    metadata = response.json()["messages"][-1]["turn_metadata"]
+    # Quick acknowledgement is a fast-pinned task; delegated mode must not override it.
+    assert metadata["task_class"] == "quick_acknowledgement"
+    assert metadata["effort_class"] == "fast"
+
+
 def test_planner_turn_partial_reply_does_not_echo_internal_user_terms(
     client: TestClient,
 ) -> None:

--- a/tests/app/test_planner_routing.py
+++ b/tests/app/test_planner_routing.py
@@ -1,0 +1,295 @@
+"""Tests for the planner runtime model-routing policy.
+
+The policy maps planner turns into a discrete model effort class
+(``fast`` / ``standard`` / ``deep``) so traveler-facing interactions
+stay responsive while planning-heavy turns receive deeper synthesis.
+These tests cover the policy in isolation (pure inputs, deterministic
+outputs); the route-level integration with the fallback runtime and
+fake planner model is covered in ``test_planner_routes.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trip_planner.app.services.planner_routing import (
+    EFFORT_DEEP,
+    EFFORT_FAST,
+    EFFORT_STANDARD,
+    TASK_CLARIFYING_QUESTION,
+    TASK_FINAL_SUMMARY,
+    TASK_FIRST_TURN_TRIAGE,
+    TASK_FOCUS_SWITCH,
+    TASK_MAJOR_REVISION,
+    TASK_NOTE_CAPTURE,
+    TASK_PLANNING_SYNTHESIS,
+    TASK_POLICY_PREPARATION,
+    TASK_QUICK_ACKNOWLEDGEMENT,
+    TASK_RESEARCH_TOOL_PASS,
+    TASK_ROUTE_COMPARISON,
+    apply_planning_mode,
+    base_effort_for,
+    classify_task_class,
+    route_planner_turn,
+)
+
+# --- Fast-path task classification ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "thanks",
+        "Thanks!",
+        "ok",
+        "Okay",
+        "got it",
+        "sounds good",
+        "perfect",
+    ],
+)
+def test_quick_acknowledgement_messages_classify_as_fast(message: str) -> None:
+    decision = route_planner_turn(
+        message=message,
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="collaborative",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.task_class == TASK_QUICK_ACKNOWLEDGEMENT
+    assert decision.effort_class == EFFORT_FAST
+    assert decision.base_effort_class == EFFORT_FAST
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "Remember this for later: passport renewal is due in March",
+        "save this note about the hotel",
+        "note this address for the hotel",
+        "remind me to book the train",
+        "jot that down for the documents notebook",
+    ],
+)
+def test_note_capture_messages_classify_as_fast(message: str) -> None:
+    decision = route_planner_turn(
+        message=message,
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="collaborative",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.task_class == TASK_NOTE_CAPTURE
+    assert decision.effort_class == EFFORT_FAST
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_focus_present"),
+    [
+        ("Working on route now", True),
+        ("Let's switch to lodging", True),
+        ("Focusing on policy this turn", True),
+        ("Switch to budget", True),
+        ("moving on to activities", True),
+    ],
+)
+def test_focus_switch_messages_classify_as_fast(message: str, expected_focus_present: bool) -> None:
+    decision = route_planner_turn(
+        message=message,
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="collaborative",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.task_class == TASK_FOCUS_SWITCH
+    assert decision.effort_class == EFFORT_FAST
+    assert expected_focus_present
+
+
+# --- Deep-path task classification ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_task"),
+    [
+        ("Time for the final summary of the trip", TASK_FINAL_SUMMARY),
+        ("Let's wrap this up before approval", TASK_FINAL_SUMMARY),
+        ("I want to start over with a different plan", TASK_MAJOR_REVISION),
+        ("Major revision needed for the itinerary", TASK_MAJOR_REVISION),
+        ("Prepare the policy submission for my manager", TASK_POLICY_PREPARATION),
+        ("Begin business approval packet prep", TASK_POLICY_PREPARATION),
+        ("Look up direct flights from JFK to LIS", TASK_RESEARCH_TOOL_PASS),
+        ("Search for boutique hotels near the conference venue", TASK_RESEARCH_TOOL_PASS),
+    ],
+)
+def test_deep_task_classification(message: str, expected_task: str) -> None:
+    decision = route_planner_turn(
+        message=message,
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="collaborative",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.task_class == expected_task
+    assert decision.effort_class == EFFORT_DEEP
+    assert decision.base_effort_class == EFFORT_DEEP
+
+
+def test_explicit_deep_request_upgrades_triage_to_synthesis() -> None:
+    decision = route_planner_turn(
+        message="Please think this through carefully before answering",
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="collaborative",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.task_class == TASK_PLANNING_SYNTHESIS
+    assert decision.effort_class == EFFORT_DEEP
+
+
+def test_route_comparison_base_class_passes_through_to_deep() -> None:
+    decision = route_planner_turn(
+        message="Looking at the train and flight tradeoffs again",
+        base_task_class=TASK_ROUTE_COMPARISON,
+        planning_mode="collaborative",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.task_class == TASK_ROUTE_COMPARISON
+    assert decision.effort_class == EFFORT_DEEP
+
+
+# --- Planning-mode bias --------------------------------------------------
+
+
+def test_delegated_mode_bumps_standard_to_deep() -> None:
+    decision = route_planner_turn(
+        message="Help me plan a long weekend",
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="delegated",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.base_effort_class == EFFORT_STANDARD
+    assert decision.effort_class == EFFORT_DEEP
+    assert "delegated" in decision.reasoning
+
+
+def test_collaborative_mode_keeps_standard_standard() -> None:
+    decision = route_planner_turn(
+        message="Help me plan a long weekend",
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="collaborative",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.effort_class == EFFORT_STANDARD
+    assert "collaborative" in decision.reasoning
+
+
+def test_in_trip_mode_biases_to_fast_on_standard_band() -> None:
+    decision = route_planner_turn(
+        message="Help me plan a long weekend",
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="in-trip",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    assert decision.effort_class == EFFORT_FAST
+    assert "in_trip" in decision.reasoning
+
+
+def test_planning_mode_does_not_override_explicit_deep_task() -> None:
+    decision = route_planner_turn(
+        message="Compare options for the family route",
+        base_task_class=TASK_ROUTE_COMPARISON,
+        planning_mode="in-trip",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    # in-trip prefers fast, but explicit deep task wins.
+    assert decision.effort_class == EFFORT_DEEP
+    assert "route_comparison_pins_deep" in decision.reasoning
+
+
+def test_planning_mode_does_not_override_explicit_fast_task() -> None:
+    decision = route_planner_turn(
+        message="thanks",
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="delegated",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    # delegated would otherwise bump standard→deep; quick ack stays fast.
+    assert decision.effort_class == EFFORT_FAST
+    assert "quick_acknowledgement_pins_fast" in decision.reasoning
+
+
+# --- Fallback-state preservation -----------------------------------------
+
+
+def test_fallback_reason_recorded_separately_from_effort() -> None:
+    decision = route_planner_turn(
+        message="Compare the train and the flight",
+        base_task_class=TASK_ROUTE_COMPARISON,
+        planning_mode="delegated",
+        provider_state="fallback",
+        fallback_reason="planner_model_not_configured",
+    )
+    assert decision.effort_class == EFFORT_DEEP
+    assert decision.provider_state == "fallback"
+    assert decision.fallback_reason == "planner_model_not_configured"
+
+
+def test_payload_round_trips_all_diagnostic_fields() -> None:
+    decision = route_planner_turn(
+        message="thanks",
+        base_task_class=TASK_FIRST_TURN_TRIAGE,
+        planning_mode="collaborative",
+        provider_state="model",
+        fallback_reason=None,
+    )
+    payload = decision.to_payload()
+    assert payload["task_class"] == TASK_QUICK_ACKNOWLEDGEMENT
+    assert payload["effort_class"] == EFFORT_FAST
+    assert payload["base_effort_class"] == EFFORT_FAST
+    assert payload["selected_planning_mode"] == "collaborative"
+    assert payload["provider_state"] == "model"
+    assert payload["fallback_reason"] is None
+    assert payload["reasoning"]
+
+
+# --- Helpers can be used independently -----------------------------------
+
+
+def test_classify_task_class_preserves_base_when_no_marker_matches() -> None:
+    assert (
+        classify_task_class("we have June dates", base_task_class=TASK_FIRST_TURN_TRIAGE)
+        == TASK_FIRST_TURN_TRIAGE
+    )
+
+
+def test_clarifying_question_marker_only_demotes_lower_priority_classes() -> None:
+    assert (
+        classify_task_class("Could you clarify?", base_task_class=TASK_FIRST_TURN_TRIAGE)
+        == TASK_CLARIFYING_QUESTION
+    )
+    # Should not demote a planning_synthesis base.
+    assert (
+        classify_task_class("Could you clarify?", base_task_class=TASK_PLANNING_SYNTHESIS)
+        == TASK_PLANNING_SYNTHESIS
+    )
+
+
+def test_base_effort_for_returns_standard_for_unknown_task_class() -> None:
+    assert base_effort_for("not-a-real-task-class") == EFFORT_STANDARD
+
+
+def test_apply_planning_mode_default_when_mode_is_none() -> None:
+    effort, reason = apply_planning_mode(
+        EFFORT_STANDARD,
+        planning_mode=None,
+        task_class=TASK_FIRST_TURN_TRIAGE,
+    )
+    assert effort == EFFORT_STANDARD
+    assert reason == "default_standard"

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -40,6 +40,11 @@ class PlannerStructuredBlock(BaseModel):
 class PlannerTurnMetadata(BaseModel):
     plan_maturity: str
     task_class: str
+    effort_class: str | None = None
+    base_effort_class: str | None = None
+    selected_planning_mode: str | None = None
+    provider_state: str | None = None
+    fallback_reason: str | None = None
     visible_response_blocks: list[PlannerVisibleResponseBlock] = Field(default_factory=list)
     debug_routing_details: dict[str, Any] = Field(default_factory=dict)
 

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -18,6 +18,7 @@ from trip_planner.app.services.planner_memory import (
     ensure_planner_memory_persisted,
     refresh_planner_memory,
 )
+from trip_planner.app.services.planner_routing import route_planner_turn
 from trip_planner.app.services.planner_runtime_config import (
     PlannerRuntimeConfig,
     get_planner_runtime_config,
@@ -386,6 +387,7 @@ def _planner_turn_metadata(
     message: str,
     runtime_config: PlannerRuntimeConfig,
     turn_index: int,
+    planning_mode: str | None = None,
 ) -> dict[str, Any]:
     lowered = message.lower()
     raw_tokens = [token.strip(".,!?;:()[]{}\"'") for token in message.split()]
@@ -487,15 +489,31 @@ def _planner_turn_metadata(
             },
         ]
 
+    provider_state = "model" if runtime_config.mode == "model" else "fallback"
+    routing_decision = route_planner_turn(
+        message=message,
+        base_task_class=task_class,
+        planning_mode=planning_mode,
+        provider_state=provider_state,
+        fallback_reason=runtime_config.fallback_reason,
+    )
     return {
         "plan_maturity": plan_maturity,
-        "task_class": task_class,
+        "task_class": routing_decision.task_class,
+        "effort_class": routing_decision.effort_class,
+        "base_effort_class": routing_decision.base_effort_class,
+        "selected_planning_mode": planning_mode,
+        "provider_state": provider_state,
+        "fallback_reason": routing_decision.fallback_reason,
         "visible_response_blocks": blocks,
         "debug_routing_details": {
             "runtime_mode": runtime_config.mode,
             "runtime_provider": runtime_config.provider,
             "runtime_model": runtime_config.model,
             "turn_index": turn_index,
+            "routing_reasoning": routing_decision.reasoning,
+            "base_task_class": task_class,
+            "selected_planning_mode": planning_mode,
             "signals": {
                 "token_count": len(tokens),
                 "date_hits": date_hits,
@@ -863,6 +881,7 @@ class DeterministicPlannerConversationRunnable:
             message=request.message,
             runtime_config=get_planner_runtime_config(),
             turn_index=len(request.runtime_context.get("recent_activity") or []),
+            planning_mode=request.session.selected_planning_mode,
         )
         outputs = list(panel.get("outputs") or [])
         decisions = list(panel.get("pending_decisions") or [])
@@ -1026,6 +1045,7 @@ class ModelBackedPlannerConversationRunnable:
                 message=request.message,
                 runtime_config=self._config,
                 turn_index=len(request.runtime_context.get("recent_activity") or []),
+                planning_mode=request.session.selected_planning_mode,
             ),
         )
 
@@ -1428,6 +1448,7 @@ def submit_planner_turn(
                 message=normalized_message,
                 runtime_config=runtime_config,
                 turn_index=len(activity_log),
+                planning_mode=session.selected_planning_mode,
             ),
         )
     model_tool_calls = _execute_model_tool_calls(

--- a/trip_planner/app/services/planner_routing.py
+++ b/trip_planner/app/services/planner_routing.py
@@ -1,0 +1,231 @@
+"""Planner runtime model-routing policy.
+
+Maps planner turn task classes to a discrete model effort class
+(``fast`` / ``standard`` / ``deep``) so traveler interactions feel
+responsive while planning-heavy turns receive deeper synthesis. The
+policy is deterministic, takes pure inputs (message text, the existing
+maturity-derived base task class, the selected planning mode, and
+provider/fallback state), and returns a :class:`RoutingDecision` that
+the planner runtime persists on per-turn metadata for diagnostics and
+tests. Traveler-facing planner copy does not consume these values.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+EFFORT_FAST: Final = "fast"
+EFFORT_STANDARD: Final = "standard"
+EFFORT_DEEP: Final = "deep"
+
+EFFORT_CLASSES: Final = (EFFORT_FAST, EFFORT_STANDARD, EFFORT_DEEP)
+
+TASK_QUICK_ACKNOWLEDGEMENT: Final = "quick_acknowledgement"
+TASK_NOTE_CAPTURE: Final = "note_capture"
+TASK_FOCUS_SWITCH: Final = "focus_switch"
+TASK_CLARIFYING_QUESTION: Final = "clarifying_question"
+TASK_FIRST_TURN_TRIAGE: Final = "first_turn_triage"
+TASK_PLANNING_SYNTHESIS: Final = "planning_synthesis"
+TASK_ROUTE_COMPARISON: Final = "route_comparison"
+TASK_MAJOR_REVISION: Final = "major_revision"
+TASK_POLICY_PREPARATION: Final = "policy_preparation"
+TASK_RESEARCH_TOOL_PASS: Final = "research_tool_pass"
+TASK_FINAL_SUMMARY: Final = "final_summary"
+
+TASK_CLASSES: Final = (
+    TASK_QUICK_ACKNOWLEDGEMENT,
+    TASK_NOTE_CAPTURE,
+    TASK_FOCUS_SWITCH,
+    TASK_CLARIFYING_QUESTION,
+    TASK_FIRST_TURN_TRIAGE,
+    TASK_PLANNING_SYNTHESIS,
+    TASK_ROUTE_COMPARISON,
+    TASK_MAJOR_REVISION,
+    TASK_POLICY_PREPARATION,
+    TASK_RESEARCH_TOOL_PASS,
+    TASK_FINAL_SUMMARY,
+)
+
+_BASE_EFFORT_BY_TASK: Final[dict[str, str]] = {
+    TASK_QUICK_ACKNOWLEDGEMENT: EFFORT_FAST,
+    TASK_NOTE_CAPTURE: EFFORT_FAST,
+    TASK_FOCUS_SWITCH: EFFORT_FAST,
+    TASK_CLARIFYING_QUESTION: EFFORT_STANDARD,
+    TASK_FIRST_TURN_TRIAGE: EFFORT_STANDARD,
+    TASK_PLANNING_SYNTHESIS: EFFORT_DEEP,
+    TASK_ROUTE_COMPARISON: EFFORT_DEEP,
+    TASK_MAJOR_REVISION: EFFORT_DEEP,
+    TASK_POLICY_PREPARATION: EFFORT_DEEP,
+    TASK_RESEARCH_TOOL_PASS: EFFORT_DEEP,
+    TASK_FINAL_SUMMARY: EFFORT_DEEP,
+}
+
+_ACK_PATTERN = re.compile(
+    r"^(?:thanks|thank you|thx|ok|okay|got it|sounds good|great|perfect)[.! ]*$"
+)
+_NOTE_PATTERN = re.compile(
+    r"\b(?:remember (?:this|that)|save this|note this|remind me|jot (?:that|this) down)\b"
+)
+_FOCUS_PATTERN = re.compile(
+    r"\b(?:working on|focus(?:ing)? on|switch(?:ed)? to|let's switch to|moving on to)\s+"
+    r"(?:route|lodging|activities|budget|documents|policy)\b"
+)
+_FINAL_SUMMARY_PATTERN = re.compile(
+    r"\b(?:final summary|wrap (?:this|the trip) up|trip summary|"
+    r"finalize the (?:plan|itinerary)|close out the trip)\b"
+)
+_MAJOR_REVISION_PATTERN = re.compile(
+    r"\b(?:start over|rebuild the (?:plan|itinerary)|major (?:revision|change)|"
+    r"overhaul|scrap (?:this|the plan)|redo the plan)\b"
+)
+_POLICY_PREP_PATTERN = re.compile(
+    r"\b(?:policy (?:submission|approval|packet)|prepare (?:the )?(?:policy|approval)|"
+    r"business approval (?:packet|prep))\b"
+)
+_RESEARCH_PATTERN = re.compile(
+    r"\b(?:look up|search for|find sources|pull provider data|provider lookup|"
+    r"research (?:flights?|hotels?|restaurants?|the route))\b"
+)
+_DEEP_REQUEST_PATTERN = re.compile(
+    r"\b(?:think this through|deeper (?:look|review)|deep dive|reason carefully|"
+    r"take your time on this)\b"
+)
+_CLARIFYING_PATTERN = re.compile(
+    r"\b(?:could you clarify|what do you mean|can you explain|" r"i'?m not sure what you mean)\b"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingDecision:
+    """The result of routing one planner turn.
+
+    ``base_effort_class`` is the effort the task class alone implies;
+    ``effort_class`` is the final effort after applying any planning-mode
+    bias. ``fallback_reason`` is reported separately from ``effort_class``
+    so callers can see the model selection without losing the deterministic
+    fallback rationale when no provider is configured.
+    """
+
+    task_class: str
+    base_effort_class: str
+    effort_class: str
+    planning_mode: str | None
+    provider_state: str
+    fallback_reason: str | None
+    reasoning: str
+
+    def to_payload(self) -> dict[str, str | None]:
+        return {
+            "task_class": self.task_class,
+            "base_effort_class": self.base_effort_class,
+            "effort_class": self.effort_class,
+            "selected_planning_mode": self.planning_mode,
+            "provider_state": self.provider_state,
+            "fallback_reason": self.fallback_reason,
+            "reasoning": self.reasoning,
+        }
+
+
+def classify_task_class(message: str, *, base_task_class: str) -> str:
+    """Refine the maturity-derived base task class with explicit lexical markers.
+
+    Returns one of :data:`TASK_CLASSES`. The base task class — provided by
+    the existing turn-metadata heuristic — is preserved when no explicit
+    marker is found, so existing message-shape behavior is unchanged for
+    messages that do not match an explicit pattern.
+    """
+
+    lowered = message.lower().strip()
+    if not lowered:
+        return base_task_class
+    if _ACK_PATTERN.search(lowered):
+        return TASK_QUICK_ACKNOWLEDGEMENT
+    if _NOTE_PATTERN.search(lowered):
+        return TASK_NOTE_CAPTURE
+    if _FOCUS_PATTERN.search(lowered):
+        return TASK_FOCUS_SWITCH
+    if _FINAL_SUMMARY_PATTERN.search(lowered):
+        return TASK_FINAL_SUMMARY
+    if _MAJOR_REVISION_PATTERN.search(lowered):
+        return TASK_MAJOR_REVISION
+    if _POLICY_PREP_PATTERN.search(lowered):
+        return TASK_POLICY_PREPARATION
+    if _RESEARCH_PATTERN.search(lowered):
+        return TASK_RESEARCH_TOOL_PASS
+    if _DEEP_REQUEST_PATTERN.search(lowered):
+        if base_task_class in {TASK_FIRST_TURN_TRIAGE, TASK_CLARIFYING_QUESTION}:
+            return TASK_PLANNING_SYNTHESIS
+        return base_task_class
+    if _CLARIFYING_PATTERN.search(lowered) and base_task_class != TASK_PLANNING_SYNTHESIS:
+        return TASK_CLARIFYING_QUESTION
+    return base_task_class
+
+
+def base_effort_for(task_class: str) -> str:
+    """Return the unbiased effort class implied by ``task_class``."""
+
+    return _BASE_EFFORT_BY_TASK.get(task_class, EFFORT_STANDARD)
+
+
+def apply_planning_mode(
+    effort: str,
+    *,
+    planning_mode: str | None,
+    task_class: str,
+) -> tuple[str, str]:
+    """Bias the effort by planning mode without overriding explicit fast/deep.
+
+    Returns ``(effort_class, reasoning)``. Deep stays deep regardless of mode
+    (planning mode must not override explicit high-effort tasks). Fast stays
+    fast (quick acknowledgements / note capture / focus switches do not need
+    deep synthesis). Only the ``standard`` band is adjusted.
+    """
+
+    if effort == EFFORT_DEEP:
+        return EFFORT_DEEP, f"task_class_{task_class}_pins_deep"
+    if effort == EFFORT_FAST:
+        return EFFORT_FAST, f"task_class_{task_class}_pins_fast"
+    if planning_mode == "delegated":
+        return EFFORT_DEEP, "delegated_mode_prefers_autonomous_synthesis"
+    if planning_mode == "in-trip":
+        return EFFORT_FAST, "in_trip_mode_prefers_quick_response"
+    if planning_mode == "collaborative":
+        return EFFORT_STANDARD, "collaborative_mode_prefers_clarification"
+    return effort, "default_standard"
+
+
+def route_planner_turn(
+    *,
+    message: str,
+    base_task_class: str,
+    planning_mode: str | None,
+    provider_state: str,
+    fallback_reason: str | None,
+) -> RoutingDecision:
+    """Classify one planner turn into a task class and model effort class.
+
+    ``provider_state`` is ``"model"`` when a provider is configured and
+    ``"fallback"`` when the deterministic fallback runtime is selected.
+    ``fallback_reason`` (e.g. ``planner_model_not_configured``) is recorded
+    on the decision so diagnostics distinguish "no provider" from a chosen
+    effort class.
+    """
+
+    refined = classify_task_class(message, base_task_class=base_task_class)
+    base_effort = base_effort_for(refined)
+    final_effort, reasoning = apply_planning_mode(
+        base_effort,
+        planning_mode=planning_mode,
+        task_class=refined,
+    )
+    return RoutingDecision(
+        task_class=refined,
+        base_effort_class=base_effort,
+        effort_class=final_effort,
+        planning_mode=planning_mode,
+        provider_state=provider_state,
+        fallback_reason=fallback_reason,
+        reasoning=reasoning,
+    )


### PR DESCRIPTION
## Summary

Closes #1159.

Adds a deterministic runtime model-routing policy that classifies each planner turn into a **task class** and a **model effort class** (`fast` / `standard` / `deep`), so traveler-facing interactions feel responsive while planning-synthesis turns receive deeper attention. The selected planning mode biases the `standard` band only and never overrides an explicit fast or deep task class. The deterministic fallback path is preserved and records provider/fallback state alongside the chosen effort.

## What changes

- New module `trip_planner/app/services/planner_routing.py`:
  - Eleven task classes (`quick_acknowledgement`, `note_capture`, `focus_switch`, `clarifying_question`, `first_turn_triage`, `planning_synthesis`, `route_comparison`, `major_revision`, `policy_preparation`, `research_tool_pass`, `final_summary`).
  - Three effort classes (`fast` / `standard` / `deep`) with a deterministic mapping.
  - `apply_planning_mode(...)` biases only the standard band; deep/fast task classes are pinned.
  - Pure inputs (message, base task class from existing maturity heuristic, planning mode, provider state, fallback reason); deterministic outputs.
- `_planner_turn_metadata` in `trip_planner/app/services/planner.py` now consumes the policy and records:
  - `task_class`, `effort_class`, `base_effort_class`, `selected_planning_mode`, `provider_state`, `fallback_reason` at the top of `turn_metadata`.
  - `routing_reasoning`, `base_task_class`, and `selected_planning_mode` under `debug_routing_details` for diagnostics.
- `PlannerTurnMetadata` Pydantic + frontend TS types extended with the new optional fields.
- Docs: routing section added to `docs/langchain-planner-runtime-epic.md`; the §13 routing row in `docs/design-coverage-map.md` flips to ✅ Implemented and the follow-up bullet is removed from the long-tail list.

## Acceptance criteria mapping

- Simple acknowledgement / note capture / focus switch → `fast` ✓ (lexical patterns; covered by `test_planner_routing.py` and `test_planner_routes.py`).
- Route comparison / final summary / major revision / policy preparation / explicit "think this through" → `deep` ✓ (covered by unit tests + the existing maturity-based `planning_synthesis` path).
- Planning mode affects routing where appropriate without overriding explicit high-effort tasks ✓ (`delegated` bumps standard→deep; `in-trip` biases standard→fast; deep tasks stay deep; fast tasks stay fast).
- Per-turn metadata persists task class, effort class, provider/fallback state, and selected planning mode for developers ✓.
- Traveler-facing planner replies hide model/provider/fallback/debug language ✓ (existing block-hiding rules preserved; new fields live in metadata only).
- CI tests cover routing with fake models / no live credentials ✓ (`OPENAI_API_KEY` is never required; existing `FakePlannerChatModel` seam unchanged).
- Existing planner route / memory / fallback tests continue to pass ✓ (208/208 `tests/app/` pass locally).

## Test plan

- [x] `python -m pytest tests/app/test_planner_routing.py tests/app/test_planner_routes.py --no-cov` — 66 pass
- [x] `python -m pytest tests/app/ --no-cov` — 208 pass
- [x] `python -m ruff check trip_planner/app/services/planner_routing.py trip_planner/app/services/planner.py trip_planner/app/schemas/planner.py tests/app/test_planner_routing.py tests/app/test_planner_routes.py`
- [x] `python -m black --check` on changed files
- [x] `python -m mypy trip_planner/app/services/planner_routing.py trip_planner/app/services/planner.py trip_planner/app/schemas/planner.py` — Success
- [x] CI green on this PR (keepalive owns CI from here)