### PR TITLE
Issue #1160: add provider-rich planner tools

### DIFF
--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -221,7 +221,7 @@ Issues: `#543` (epic), `#544`–`#548`
 
 Design ref: [`docs/langchain-planner-runtime-epic.md`](langchain-planner-runtime-epic.md)
 
-> **Partial.** The planner runtime now has a trip-scoped conversation API, persisted session/checkpoint records, a model-backed runnable, an explicit app-tool registry/executor, and deterministic model-routing by task class and planning mode. The remaining gap is no longer "no planner tools"; it is that the first-pass registry covers workspace, budget, policy, proposal, decision, feedback, and planning-notebook state, while richer source retrieval, route-provider queries, and semantic reorientation remain follow-on work.
+> **Partial.** The planner runtime now has a trip-scoped conversation API, persisted session/checkpoint records, a model-backed runnable, an explicit app-tool registry/executor, deterministic model-routing by task class and planning mode, and provider-rich source/map/route read tools. The remaining gaps are executable source-quality scoring, semantic planner memory/reorientation, and live-provider verification.
 
 | Commitment | Source | Tests | Status |
 |------------|--------|-------|--------|
@@ -231,9 +231,9 @@ Design ref: [`docs/langchain-planner-runtime-epic.md`](langchain-planner-runtime
 | Memory and checkpoint persistence | `trip_planner/persistence/models/planner_memory.py`, `trip_planner/app/services/planner_memory.py` | `tests/app/test_planner_routes.py`, `tests/app/test_planner_turn_e2e.py` | 🟡 Partial (checkpoint and notebook memory; no semantic/vector recall) |
 | Planning mode selection (delegated / collaborative / revealed-preference / in-trip) | `frontend/src/components/planner/PlanningModeSelector.tsx`, `trip_planner/app/routes/workspace.py`, `trip_planner/app/services/workspace.py` | `frontend/src/components/planner/PlanningModeSelector.test.tsx`, `frontend/src/routes/WorkspacePage.test.tsx`, `tests/app/test_workspace.py` | ✅ Implemented |
 | Dynamic model routing by task complexity | `trip_planner/app/services/planner_routing.py`, `trip_planner/app/services/planner.py` (`_planner_turn_metadata`) | `tests/app/test_planner_routing.py`, `tests/app/test_planner_routes.py` | ✅ Implemented |
-| Provider-rich planner tools (source retrieval, live routing/maps, source-quality scoring) | `trip_planner/app/services/planner_tools.py` (first-pass app tools only) | partial route/tool tests | 🟡 Partial |
+| Provider-rich planner tools (source retrieval, route/map status, route comparison refresh, source-quality seam) | `trip_planner/app/services/planner_tools.py` | `tests/app/test_planner_routes.py` | ✅ Implemented |
 
-**Gap detail (follow-up issue candidate):** The runtime executes explicit planner tools, persists their traces, and now routes each turn into a task class plus a fast/standard/deep model effort class biased by the selected planning mode. The remaining gaps are richer source/map/provider-backed tools and semantic planner memory that can reorient when a traveler says "I was working on lodging" or "put this in the Oslo file."
+**Gap detail (follow-up issue candidate):** The runtime executes explicit planner tools, persists their traces, routes each turn into a task class plus a fast/standard/deep model effort class biased by the selected planning mode, and can inspect provider-rich source/map/route state. It still needs executable source-quality scoring, semantic planner memory that can reorient when a traveler says "I was working on lodging" or "put this in the Oslo file," and live-provider verification for configured environments.
 
 ---
 
@@ -325,7 +325,7 @@ From [`docs/product-architecture-brief.md`](product-architecture-brief.md) and [
 These design commitments are still missing, partial, or not yet verified in a live provider environment. Each is a candidate for a follow-up issue:
 
 1. **Semantic planner memory and reorientation** — planner checkpoints and notebook state exist, but there is no semantic recall/reorientation layer for scattered traveler notes and "I was working on..." context shifts. See §13 above.
-2. **Provider-rich planner tools** — `planner_tools.py` exists for first-pass app state actions, but source retrieval, live routing/maps, and source-quality scoring are still not exposed as planner tools. See §13 above.
+2. **Executable source-quality scoring** — provider-rich planner tools now expose source summaries, route/map status, route geometry, route comparison refresh, and an explicit source-quality `not_available` seam. The scoring engine itself remains a separate design commitment. See §13 above.
 3. **Live TPP transport verification** — `live-tpp-execution-reoptimization-epic.md`. All seams exist but no live HTTP round-trip is required by the default test matrix. See §15 above.
 4. **Source quality model implementation** — `source-quality-model.md` + `source-channel-strategy.md`. Design defined; no engine code.
 5. **Provider-rich timeline/map depth** — workspace timeline and map surfaces exist, but still need richer regional/local geometry, per-leg timing, and live provider readiness evidence. See §16 above.

--- a/docs/langchain-planner-runtime-epic.md
+++ b/docs/langchain-planner-runtime-epic.md
@@ -21,11 +21,11 @@ The first-pass planner runtime now exists and should be treated as the baseline 
 
 - `trip_planner/app/routes/planner.py` exposes trip-scoped session, resume, and turn endpoints.
 - `trip_planner/app/services/planner.py` owns deterministic fallback replies, the model-backed runnable, model-request metadata, structured planner blocks, explicit tool-call execution, and persisted turn payloads.
-- `trip_planner/app/services/planner_tools.py` exposes the current application tool registry for workspace state, inventory and scenario refresh, budget state and updates, policy/proposal reads, pending decisions, option feedback, and planning-notebook actions.
+- `trip_planner/app/services/planner_tools.py` exposes the current application tool registry for workspace state, inventory and scenario refresh, provider-rich source/map/route reads, bounded source-quality placeholders, budget state and updates, policy/proposal reads, pending decisions, option feedback, and planning-notebook actions.
 - `trip_planner/persistence/models/planner_memory.py` and `trip_planner/app/services/planner_memory.py` persist checkpoint and summary records that make planner sessions resumable.
 - `frontend/src/components/planner/PlanningModeSelector.tsx`, `trip_planner/app/routes/workspace.py`, and `trip_planner/app/services/workspace.py` persist the selected planning mode for delegated, collaborative, revealed-preference, and in-trip work.
 
-The remaining runtime gap is depth rather than absence. The repo still needs dynamic model routing, richer source/map/provider-backed planner tools, semantic recall for scattered planning notes, and live-provider verification for release confidence.
+The remaining runtime gap is depth rather than absence. The repo still needs semantic recall for scattered planning notes, executable source-quality scoring, and live-provider verification for release confidence.
 
 ## Runtime Configuration
 
@@ -72,6 +72,18 @@ unit policy lives in `tests/app/test_planner_routing.py`; route-level
 integration is covered in `tests/app/test_planner_routes.py`. Verifying
 without live credentials uses the existing fallback runtime plus the
 `FakePlannerChatModel` test seam in `tests/app/test_planner_routes.py`.
+
+## Provider-Rich Planner Tools
+
+The planner tool registry now includes read-only tools for provider-aware route and source inspection:
+
+- `read_source_summary` reads bounded source/provenance summaries from inventory and scenario contracts.
+- `read_map_provider_status` reports fallback, sparse-route, loading, provider-error, or ready map/provider state from the same route diagnostics consumed by the workspace map surface.
+- `read_route_geometry` exposes bounded route markers and rough route geometry for the active or requested route option.
+- `refresh_route_comparison` refreshes the deterministic workspace route-comparison payload instead of letting the model re-rank options in the prompt.
+- `read_source_quality_summary` returns an explicit `not_available` state until the executable source-quality scoring engine exists.
+
+All of these tools are non-mutating, include refs and bounded payloads, and are persisted in planner turn traces like the original workspace, budget, policy, and proposal tools.
 
 ## Dependency Chain
 

--- a/docs/next-issue-set.md
+++ b/docs/next-issue-set.md
@@ -48,6 +48,8 @@ This note captures the remaining gaps after the recent readiness, planner-runtim
 
 **Why it matters:** `planner_tools.py` is now real, but the model cannot yet request richer source or provider work. This limits how much the planner can revise a route based on fresh information.
 
+**Status:** Implemented for provider-rich tool seams. The planner can now call bounded source-summary, map-provider-status, route-geometry, and deterministic route-comparison refresh tools. Source-quality scoring remains a separate executable-engine gap; the planner tool returns an explicit `not_available` result until that service exists.
+
 **Scope:**
 
 - Add read-only tools for source retrieval and source-quality summaries.

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -647,6 +647,100 @@ def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(
     )
 
 
+def test_planner_turn_executes_provider_rich_read_only_tools(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={
+            "message": "Use richer tools to inspect sources, map status, and route refresh.",
+            "tool_calls": [
+                {"tool_name": "read_source_summary"},
+                {"tool_name": "read_map_provider_status"},
+                {"tool_name": "read_route_geometry"},
+                {"tool_name": "refresh_route_comparison"},
+                {"tool_name": "read_source_quality_summary"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    tool_outputs = {item["tool_name"]: item for item in planner_reply["tool_calls"]}
+    assert set(tool_outputs) == {
+        "read_source_summary",
+        "read_map_provider_status",
+        "read_route_geometry",
+        "refresh_route_comparison",
+        "read_source_quality_summary",
+    }
+    assert tool_outputs["read_source_summary"]["status"] == "completed"
+    assert tool_outputs["read_source_summary"]["mutates_state"] is False
+    assert tool_outputs["read_source_summary"]["output"]["source_refs"]
+    assert len(tool_outputs["read_source_summary"]["output"]["source_refs"]) <= 10
+    assert tool_outputs["read_map_provider_status"]["output"]["provider"]["status"] in {
+        "fallback",
+        "loading",
+        "provider-error",
+        "sparse-route",
+        "misconfigured",
+    }
+    assert tool_outputs["read_map_provider_status"]["output"]["route_state"] == "ready"
+    assert tool_outputs["read_route_geometry"]["status"] == "completed"
+    assert tool_outputs["read_route_geometry"]["output"]["rough_route_geometry"]
+    assert tool_outputs["refresh_route_comparison"]["output"]["scenarios"]
+    assert (
+        tool_outputs["refresh_route_comparison"]["output"]["lead_scenario_id"]
+        == response.json()["planner_panel_state"]["option_set"]["options"][0]["option_id"]
+    )
+    assert tool_outputs["read_source_quality_summary"]["status"] == "not_available"
+    assert tool_outputs["read_source_quality_summary"]["output"]["quality_state"] == "not_available"
+
+    with get_session_factory()() as db_session:
+        stored = db_session.scalars(
+            select(PersistedPlannerAction)
+            .where(PersistedPlannerAction.trip_id == trip_id)
+            .order_by(PersistedPlannerAction.occurred_at.asc())
+        ).all()
+        persisted_tool_names = {item["tool_name"] for item in stored[-1].payload["tool_calls"]}
+        assert persisted_tool_names == set(tool_outputs)
+        checkpoint = db_session.get(
+            PersistedPlannerCheckpoint,
+            response.json()["planner_memory"]["current_checkpoint_id"],
+        )
+        assert checkpoint is not None
+        assert checkpoint.metadata_payload["tool_call_count"] == 5
+
+
+def test_planner_turn_reports_sparse_provider_tool_state(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={
+            "message": "Inspect a route option that does not exist.",
+            "tool_calls": [
+                {
+                    "tool_name": "read_map_provider_status",
+                    "arguments": {"route_option_id": "route-option:missing"},
+                },
+                {
+                    "tool_name": "read_route_geometry",
+                    "arguments": {"route_option_id": "route-option:missing"},
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    tool_outputs = {item["tool_name"]: item for item in planner_reply["tool_calls"]}
+    assert tool_outputs["read_map_provider_status"]["status"] == "not_available"
+    assert tool_outputs["read_map_provider_status"]["output"]["route_state"] == "missing"
+    assert tool_outputs["read_route_geometry"]["status"] == "not_available"
+    assert tool_outputs["read_route_geometry"]["output"]["rough_route_geometry"] == []
+
+
 def test_planner_turn_records_model_tool_errors_without_fabricating_success(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -712,6 +712,45 @@ def test_planner_turn_executes_provider_rich_read_only_tools(client: TestClient)
         assert checkpoint.metadata_payload["tool_call_count"] == 5
 
 
+def test_planner_turn_reuses_workspace_payload_for_provider_rich_read_only_tools(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    from trip_planner.app.services import planner_tools
+
+    original_get_workspace_payload = planner_tools.get_workspace_payload
+    workspace_payload_call_count = 0
+
+    def counted_get_workspace_payload(*args: Any, **kwargs: Any) -> dict[str, Any] | None:
+        nonlocal workspace_payload_call_count
+        workspace_payload_call_count += 1
+        return original_get_workspace_payload(*args, **kwargs)
+
+    monkeypatch.setattr(
+        planner_tools,
+        "get_workspace_payload",
+        counted_get_workspace_payload,
+    )
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={
+            "message": "Inspect source and route state without rebuilding payloads.",
+            "tool_calls": [
+                {"tool_name": "read_source_summary"},
+                {"tool_name": "read_map_provider_status"},
+                {"tool_name": "read_route_geometry"},
+                {"tool_name": "refresh_route_comparison"},
+                {"tool_name": "read_source_quality_summary"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert workspace_payload_call_count == 1
+
+
 def test_planner_turn_reports_sparse_provider_tool_state(client: TestClient) -> None:
     trip_id = _create_trip(client)
 

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -25,6 +25,7 @@ from trip_planner.app.services.planner_runtime_config import (
 )
 from trip_planner.app.services.planner_tools import (
     execute_planner_tool_call,
+    get_cached_workspace_payload,
     list_planner_tools,
 )
 from trip_planner.preferences.autonomy import AutonomyGuardrails
@@ -38,7 +39,6 @@ from trip_planner.app.services.workspace import (
     _record_planner_action,
     _serialize_activity_record,
     _serialize_session_record,
-    get_workspace_payload,
 )
 from trip_planner.persistence.models.activity import (
     PersistedActivityLogEvent,
@@ -1187,9 +1187,10 @@ def _planner_session_payload(
     trip_id: str,
     resumed_at: str | None = None,
 ) -> dict[str, Any]:
-    workspace_payload = get_workspace_payload(db_session, user=user, trip_id=trip_id)
-    if workspace_payload is None:
-        raise WorkspacePlannerTripNotFoundError(f"Trip '{trip_id}' was not found.")
+    try:
+        workspace_payload = get_cached_workspace_payload(db_session, user=user, trip_id=trip_id)
+    except ValueError as error:
+        raise WorkspacePlannerTripNotFoundError(str(error)) from error
 
     session = workspace_payload["session"]
     session_state_id = session["session_state_id"]
@@ -1404,9 +1405,10 @@ def submit_planner_turn(
         )
         executed_tool_calls.append(result.to_dict())
 
-    workspace_payload = get_workspace_payload(db_session, user=user, trip_id=trip_id)
-    if workspace_payload is None:
-        raise WorkspacePlannerTripNotFoundError(f"Trip '{trip_id}' was not found.")
+    try:
+        workspace_payload = get_cached_workspace_payload(db_session, user=user, trip_id=trip_id)
+    except ValueError as error:
+        raise WorkspacePlannerTripNotFoundError(str(error)) from error
     session = PlanningSessionState.from_dict(_serialize_session_record(session_record))
     planner_memory = build_planner_memory_payload(
         db_session,

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -65,6 +65,26 @@ _TOOL_DEFINITIONS: tuple[PlannerToolDefinition, ...] = (
         description="Read the current scenario ranking and comparison outputs for the active trip.",
     ),
     PlannerToolDefinition(
+        tool_name="read_source_summary",
+        description="Read bounded source and provenance summaries from current workspace inventory and scenario contracts.",
+    ),
+    PlannerToolDefinition(
+        tool_name="read_source_quality_summary",
+        description="Read source quality scoring status when available, otherwise return a bounded not_available result.",
+    ),
+    PlannerToolDefinition(
+        tool_name="read_map_provider_status",
+        description="Read map/provider status and route readiness without requiring live map credentials.",
+    ),
+    PlannerToolDefinition(
+        tool_name="read_route_geometry",
+        description="Read bounded route geometry and marker readiness for the active or requested route option.",
+    ),
+    PlannerToolDefinition(
+        tool_name="refresh_route_comparison",
+        description="Refresh the deterministic route comparison payload used by the workspace.",
+    ),
+    PlannerToolDefinition(
         tool_name="read_budget_state",
         description="Read the persisted workspace budget summary for the active trip.",
     ),
@@ -135,6 +155,38 @@ def _workspace_payload(
 
 def _ref_list(*refs: str | None) -> list[str]:
     return [ref for ref in refs if ref]
+
+
+def _bounded_items(items: list[Any], limit: int) -> list[Any]:
+    return items[: max(0, min(limit, 20))]
+
+
+def _route_scenarios(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    return list((payload.get("runtime_scenario_comparison") or {}).get("scenarios") or [])
+
+
+def _select_route_scenario(
+    payload: dict[str, Any],
+    arguments: dict[str, Any],
+) -> dict[str, Any] | None:
+    scenarios = _route_scenarios(payload)
+    requested_id = str(
+        arguments.get("route_option_id") or arguments.get("scenario_id") or ""
+    ).strip()
+    if requested_id:
+        return next(
+            (
+                scenario
+                for scenario in scenarios
+                if scenario.get("route_option_id") == requested_id
+                or scenario.get("scenario_id") == requested_id
+            ),
+            None,
+        )
+    lead_id = (payload.get("runtime_scenario_comparison") or {}).get("lead_scenario_id")
+    return next(
+        (scenario for scenario in scenarios if scenario.get("scenario_id") == lead_id), None
+    ) or (scenarios[0] if scenarios else None)
 
 
 def _category_allocations(
@@ -237,6 +289,259 @@ def _refresh_scenarios(
         mutates_state=False,
         refs=_ref_list(
             payload["session"]["session_state_id"], runtime_comparison["lead_scenario_id"]
+        ),
+        output=output,
+    )
+
+
+def _read_source_summary(
+    db_session: Session,
+    user: AuthenticatedUser,
+    trip_id: str,
+    arguments: dict[str, Any],
+) -> PlannerToolResult:
+    del arguments
+    payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
+    inventory = payload["inventory_summary"]
+    scenario_search = payload["scenario_search"]
+    source_refs = list(
+        dict.fromkeys(
+            [
+                *list(scenario_search.get("source_refs") or []),
+                *[
+                    ref
+                    for scenario in list(scenario_search.get("scenarios") or [])
+                    for ref in list(scenario.get("source_refs") or [])
+                ],
+            ]
+        )
+    )
+    source_metadata = inventory.get("source_metadata") or {}
+    provenance_context = source_metadata.get("provenance_context") or {}
+    bundles = _bounded_items(list(inventory.get("bundles") or []), 5)
+    output = {
+        "source_type": source_metadata.get("source_type") or "unknown",
+        "adapter_name": source_metadata.get("adapter_name") or "",
+        "bundle_count": inventory.get("bundle_count", 0),
+        "source_refs": _bounded_items(source_refs, 10),
+        "source_result_set_id": scenario_search.get("source_result_set_id"),
+        "input_record_ids": _bounded_items(
+            list(provenance_context.get("input_record_ids") or []),
+            10,
+        ),
+        "issues": _bounded_items(
+            list((inventory.get("runtime_state") or {}).get("issues") or []),
+            5,
+        ),
+        "bundles": [
+            {
+                "bundle_id": item.get("bundle_id"),
+                "title": item.get("title"),
+                "destination_names": _bounded_items(list(item.get("destination_names") or []), 5),
+                "option_count": item.get("option_count", 0),
+            }
+            for item in bundles
+        ],
+    }
+    status = "completed" if source_refs or bundles else "not_available"
+    return PlannerToolResult(
+        tool_name="read_source_summary",
+        status=status,
+        summary=(
+            f"Read {len(output['source_refs'])} source reference(s) and "
+            f"{len(output['bundles'])} inventory bundle summary item(s)."
+            if status == "completed"
+            else "No source-backed workspace summary is available for this trip yet."
+        ),
+        mutates_state=False,
+        refs=_ref_list(payload["session"]["session_state_id"], *output["source_refs"]),
+        output=output,
+    )
+
+
+def _read_source_quality_summary(
+    db_session: Session,
+    user: AuthenticatedUser,
+    trip_id: str,
+    arguments: dict[str, Any],
+) -> PlannerToolResult:
+    del arguments
+    payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
+    inventory = payload["inventory_summary"]
+    runtime_state = inventory.get("runtime_state") or {}
+    quality_rows = []
+    for bundle in _bounded_items(list(inventory.get("bundles") or []), 5):
+        quality_rows.append(
+            {
+                "target_id": bundle.get("bundle_id"),
+                "target_title": bundle.get("title"),
+                "status": "not_available",
+                "score": None,
+                "summary": "Source quality scoring service is not implemented for this target yet.",
+            }
+        )
+    return PlannerToolResult(
+        tool_name="read_source_quality_summary",
+        status="not_available",
+        summary=(
+            "Source quality scoring is not implemented yet; returned bounded placeholder rows "
+            "for current workspace targets."
+        ),
+        mutates_state=False,
+        refs=_ref_list(payload["session"]["session_state_id"]),
+        output={
+            "quality_state": "not_available",
+            "runtime_inventory_status": runtime_state.get("status", "unknown"),
+            "rows": quality_rows,
+            "next_service": "source_quality_scoring",
+        },
+    )
+
+
+def _read_map_provider_status(
+    db_session: Session,
+    user: AuthenticatedUser,
+    trip_id: str,
+    arguments: dict[str, Any],
+) -> PlannerToolResult:
+    payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
+    scenario = _select_route_scenario(payload, arguments)
+    if scenario is None:
+        return PlannerToolResult(
+            tool_name="read_map_provider_status",
+            status="not_available",
+            summary="No route scenario is available for map/provider status.",
+            mutates_state=False,
+            refs=_ref_list(payload["session"]["session_state_id"]),
+            output={
+                "provider": {"kind": "fallback", "status": "sparse-route"},
+                "route_state": "missing",
+                "route_option_id": None,
+                "map_confidence": "none",
+            },
+        )
+    diagnostics = scenario.get("map_diagnostics") or {}
+    provider = diagnostics.get("provider") or {}
+    confidence = (scenario.get("map_view") or {}).get("confidence") or {}
+    provider_status = str(provider.get("status") or "fallback")
+    route_state = str(diagnostics.get("route_state") or "unknown")
+    return PlannerToolResult(
+        tool_name="read_map_provider_status",
+        status="completed" if route_state == "ready" else provider_status,
+        summary=(
+            f"Map provider state is {provider_status}; route geometry state is {route_state}."
+        ),
+        mutates_state=False,
+        refs=_ref_list(
+            payload["session"]["session_state_id"],
+            scenario.get("route_option_id"),
+            diagnostics.get("source_result_id"),
+        ),
+        output={
+            "route_option_id": scenario.get("route_option_id"),
+            "scenario_id": scenario.get("scenario_id"),
+            "provider": {
+                "kind": provider.get("kind") or "fallback",
+                "status": provider_status,
+                "details": provider.get("details") or "",
+            },
+            "route_state": route_state,
+            "route_warning": diagnostics.get("route_warning"),
+            "map_confidence": confidence.get("level", "unknown"),
+            "summary": confidence.get("summary") or scenario.get("summary"),
+        },
+    )
+
+
+def _read_route_geometry(
+    db_session: Session,
+    user: AuthenticatedUser,
+    trip_id: str,
+    arguments: dict[str, Any],
+) -> PlannerToolResult:
+    payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
+    scenario = _select_route_scenario(payload, arguments)
+    if scenario is None:
+        return PlannerToolResult(
+            tool_name="read_route_geometry",
+            status="not_available",
+            summary="No route scenario is available for geometry inspection.",
+            mutates_state=False,
+            refs=_ref_list(payload["session"]["session_state_id"]),
+            output={"route_option_id": None, "place_markers": [], "rough_route_geometry": []},
+        )
+    map_view = scenario.get("map_view") or {}
+    markers = _bounded_items(list(map_view.get("place_markers") or []), 12)
+    geometry = _bounded_items(list(map_view.get("rough_route_geometry") or []), 12)
+    status = "completed" if geometry else "sparse-route"
+    return PlannerToolResult(
+        tool_name="read_route_geometry",
+        status=status,
+        summary=(
+            f"Read {len(markers)} route marker(s) and {len(geometry)} route segment(s)."
+            if geometry
+            else "Route geometry is sparse; no route segments are available yet."
+        ),
+        mutates_state=False,
+        refs=_ref_list(payload["session"]["session_state_id"], scenario.get("route_option_id")),
+        output={
+            "route_option_id": scenario.get("route_option_id"),
+            "scenario_id": scenario.get("scenario_id"),
+            "active_scope": map_view.get("active_scope"),
+            "selected_segment_id": map_view.get("selected_segment_id"),
+            "place_markers": markers,
+            "rough_route_geometry": geometry,
+            "confidence": map_view.get("confidence") or {},
+        },
+    )
+
+
+def _refresh_route_comparison(
+    db_session: Session,
+    user: AuthenticatedUser,
+    trip_id: str,
+    arguments: dict[str, Any],
+) -> PlannerToolResult:
+    del arguments
+    payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
+    comparison = payload["runtime_scenario_comparison"]
+    scenarios = _bounded_items(list(comparison.get("scenarios") or []), 5)
+    output = {
+        "title": comparison.get("title"),
+        "summary": comparison.get("summary"),
+        "lead_scenario_id": comparison.get("lead_scenario_id"),
+        "comparison_axes": _bounded_items(list(comparison.get("comparison_axes") or []), 8),
+        "scenarios": [
+            {
+                "scenario_id": item.get("scenario_id"),
+                "route_option_id": item.get("route_option_id"),
+                "title": item.get("title"),
+                "rank": item.get("rank"),
+                "state": item.get("state"),
+                "status": item.get("status"),
+                "summary": item.get("summary"),
+                "route_summary": item.get("route_summary"),
+                "metrics": item.get("metrics") or {},
+                "delta": item.get("delta") or {},
+                "source_result_id": item.get("source_result_id"),
+            }
+            for item in scenarios
+        ],
+        "source_refs": _bounded_items(list(comparison.get("source_refs") or []), 10),
+    }
+    return PlannerToolResult(
+        tool_name="refresh_route_comparison",
+        status="completed" if scenarios else "not_available",
+        summary=(
+            f"Refreshed deterministic route comparison with {len(scenarios)} scenario row(s)."
+            if scenarios
+            else "No deterministic route comparison rows are available yet."
+        ),
+        mutates_state=False,
+        refs=_ref_list(
+            payload["session"]["session_state_id"],
+            comparison.get("lead_scenario_id"),
+            *output["source_refs"],
         ),
         output=output,
     )
@@ -590,6 +895,11 @@ _TOOL_HANDLERS: dict[str, PlannerToolHandler] = {
     "read_workspace_state": _read_workspace_state,
     "refresh_inventory": _refresh_inventory,
     "refresh_scenarios": _refresh_scenarios,
+    "read_source_summary": _read_source_summary,
+    "read_source_quality_summary": _read_source_quality_summary,
+    "read_map_provider_status": _read_map_provider_status,
+    "read_route_geometry": _read_route_geometry,
+    "refresh_route_comparison": _refresh_route_comparison,
     "read_budget_state": _read_budget_state,
     "update_budget_plan": _update_budget_plan,
     "read_policy_state": _read_policy_state,

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -147,10 +147,35 @@ def _workspace_payload(
     user: AuthenticatedUser,
     trip_id: str,
 ) -> dict[str, Any]:
+    cache = db_session.info.setdefault("_planner_workspace_payload_cache", {})
+    cache_key = (user.user_id, trip_id)
+    if cache_key in cache:
+        return cache[cache_key]
     payload = get_workspace_payload(db_session, user=user, trip_id=trip_id)
     if payload is None:
         raise ValueError(f"Trip '{trip_id}' was not found.")
+    cache[cache_key] = payload
     return payload
+
+
+def get_cached_workspace_payload(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> dict[str, Any]:
+    return _workspace_payload(db_session, user=user, trip_id=trip_id)
+
+
+def _clear_workspace_payload_cache(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> None:
+    cache = db_session.info.get("_planner_workspace_payload_cache")
+    if isinstance(cache, dict):
+        cache.pop((user.user_id, trip_id), None)
 
 
 def _ref_list(*refs: str | None) -> list[str]:
@@ -924,4 +949,9 @@ def execute_planner_tool_call(
     handler = _TOOL_HANDLERS.get(tool_name)
     if definition is None or handler is None:
         raise ValueError(f"Planner tool '{tool_name}' is not supported.")
-    return handler(db_session, user, trip_id, dict(arguments or {}))
+    if definition.mutates_state:
+        _clear_workspace_payload_cache(db_session, user=user, trip_id=trip_id)
+    result = handler(db_session, user, trip_id, dict(arguments or {}))
+    if definition.mutates_state:
+        _clear_workspace_payload_cache(db_session, user=user, trip_id=trip_id)
+    return result


### PR DESCRIPTION
Closes #1160

## Summary
- Add read-only planner tools for source summaries, source-quality availability, map/provider status, route geometry, and deterministic route-comparison refresh.
- Keep provider/tool outputs bounded, referenced, non-mutating, and persisted through the existing planner turn trace path.
- Update planner runtime docs and design coverage notes to reflect the new provider-rich tool seam and remaining source-quality engine gap.

## Validation
- python -m pytest tests/app/test_planner_routes.py --no-cov
- python -m pytest tests/app/ --no-cov
- ruff check trip_planner/app/services/planner_tools.py tests/app/test_planner_routes.py
- black --check trip_planner/app/services/planner_tools.py tests/app/test_planner_routes.py
- mypy trip_planner/app/services/planner_tools.py tests/app/test_planner_routes.py