### PR TITLE
Issue #1162: deepen map route and timeline review

### DIFF
--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -275,19 +275,19 @@ Design ref: [`docs/live-tpp-execution-reoptimization-epic.md`](live-tpp-executio
 Design refs: [`docs/google-maps-platform-hardening-epic.md`](google-maps-platform-hardening-epic.md), [`docs/maps-timeline-comparison-epic.md`](maps-timeline-comparison-epic.md)  
 Issues: `#679` (epic), `#698`–`#700`
 
-> **Partial.** The map adapter boundary, bounded fallback rendering, Google Maps JavaScript provider path, global/local map-scope controls, workspace timeline rendering, and scenario comparison surfaces now exist. Remaining work is mostly product depth: live provider verification in configured environments, richer regional/local geometry, deeper option-marker detail, and a dedicated source-backed timeline contract beyond the current route-sequence adapter.
+> **Partial.** The map adapter boundary, bounded fallback rendering, Google Maps JavaScript provider path, global/regional/segment map-scope controls, workspace timeline rendering, shared route/segment focus, and scenario comparison surfaces now exist. Remaining work is mostly product depth: live provider verification in configured environments, deeper option-marker/source-quality detail, and real provider distance geometry beyond the current duration-first runtime segment payload.
 
 | Commitment | Source | Tests | Status |
 |------------|--------|-------|--------|
 | Google Maps JS adapter boundary + fallback rendering | `frontend/src/components/maps/TripMap.tsx`, `frontend/src/components/maps/mapSurface.ts` | `frontend/src/components/maps/mapSurface.test.ts`, `frontend/src/components/maps/TripMap.test.tsx`, `frontend/src/routes/WorkspacePage.test.tsx` | ✅ Implemented |
 | Route-context map contract (`docs/contracts/route-context-map-target.md`) | `docs/contracts/route-context-map-target.md`, `frontend/src/components/maps/mapSurface.ts`, `frontend/src/components/maps/TripMap.tsx` | `tests/contracts/test_route_context_map_target.py`, frontend map tests | ✅ Implemented |
-| Global/local map scope switching | `frontend/src/components/maps/mapSurface.ts`, `frontend/src/components/maps/TripMap.tsx` | `frontend/src/components/maps/mapSurface.test.ts`, `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (global/local shipped; richer regional geometry pending) |
-| Timeline view for trip structure + day sequencing (`#698`) | `frontend/src/routes/WorkspacePage.tsx` (`buildTimelineStops`, timeline section) | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (route-sequence adapter; no provider-rich per-leg timing) |
+| Global/regional/segment map scope switching | `frontend/src/components/maps/mapSurface.ts`, `frontend/src/components/maps/TripMap.tsx` | `frontend/src/components/maps/mapSurface.test.ts`, `frontend/src/components/maps/TripMap.test.tsx`, `frontend/src/routes/WorkspacePage.test.tsx` | ✅ Implemented |
+| Timeline view for trip structure + day sequencing (`#698`) | `frontend/src/routes/WorkspacePage.tsx` (`buildTimelineStops`, timeline section, segment focus notes) | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (segment timing/confidence shipped; source-backed per-stop timing still pending) |
 | Dedicated map surface for route + option context (`#699`) | `frontend/src/components/maps/TripMap.tsx`, `frontend/src/components/maps/mapSurface.ts` | frontend map/workspace tests | ✅ Implemented |
 | Saved-scenario + trip comparison views (`#700`) | `frontend/src/components/workspace/ScenarioComparison.tsx`, `components/trips/TripComparison.tsx`, `frontend/src/routes/WorkspacePage.tsx` | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (workspace-tested; targeted component tests still thin) |
 | Workspace timeline contract | `docs/workspace_timeline_contract.md`, `frontend/src/routes/WorkspacePage.tsx` | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial |
 
-**Gap detail (follow-up issue candidate):** The shipped timeline and map surfaces are good enough for workspace testing, but they still depend on route-sequence summaries and shaped scenario data rather than provider-rich timing, distance, and local-geometry outputs. The next issue should upgrade the route/timeline/map contract so a traveler can move cleanly between global trip outline, regional comparison, and precise segment review without losing context.
+**Gap detail (follow-up issue candidate):** The shipped timeline and map surfaces now let a traveler move between whole-trip outline, regional comparison, and precise segment review without losing selected route context. The next gap is deeper provider richness: live distance/geometry verification, source-quality scoring on route evidence, and more inspectable option-marker detail.
 
 ---
 
@@ -328,7 +328,7 @@ These design commitments are still missing, partial, or not yet verified in a li
 2. **Executable source-quality scoring** — provider-rich planner tools now expose source summaries, route/map status, route geometry, route comparison refresh, and an explicit source-quality `not_available` seam. The scoring engine itself remains a separate design commitment. See §13 above.
 3. **Live TPP transport verification** — `live-tpp-execution-reoptimization-epic.md`. All seams exist but no live HTTP round-trip is required by the default test matrix. See §15 above.
 4. **Source quality model implementation** — `source-quality-model.md` + `source-channel-strategy.md`. Design defined; no engine code.
-5. **Provider-rich timeline/map depth** — workspace timeline and map surfaces exist, but still need richer regional/local geometry, per-leg timing, and live provider readiness evidence. See §16 above.
+5. **Provider-rich timeline/map depth** — workspace timeline and map surfaces now share route/segment focus and per-leg timing/confidence, but still need live provider distance/geometry verification and richer source-backed option details. See §16 above.
 6. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
 
 ---

--- a/docs/frontend-route-visualization.md
+++ b/docs/frontend-route-visualization.md
@@ -19,10 +19,12 @@ Issue `#559` adds visualization-oriented shell surfaces that consume route and f
 
 - `frontend/src/components/maps/TripMap.tsx` is the current route/context map surface for workspace rendering, with provider-independent map state shaped in `frontend/src/components/maps/mapSurface.ts`.
 - The component consumes `runtime_scenario_comparison.scenarios[*].route_sequence`, `route_summary`, `metrics`, and `inventory_summary.bundles[*].destination_names`.
+- When present, `runtime_scenario_comparison.scenarios[*].map_view.place_markers` and `map_view.rough_route_geometry` are the preferred source for route-stop coordinates, selected segment identity, per-leg duration, distance, confidence, and unavailable-state copy. When they are absent, the frontend keeps using its bounded route-sequence adapter.
 - `feasibility_summary.assessments` remains the source of route-attention and bundle-readiness signals; the map surface may summarize those signals, but it must not recalculate feasibility in the browser.
-- Scenario preview changes are local presentation changes. The selected map preview should start from persisted workspace state and then update the rendered map surface without mutating backend route logic.
+- Scenario preview changes are local presentation changes. The selected route option now drives map, timeline, comparison, and planner-focus presentation without mutating backend route logic.
 - When `VITE_GOOGLE_MAPS_BROWSER_API_KEY` is configured, the workspace renders the Google Maps JavaScript adapter path for the selected scenario. The adapter receives already-shaped route segments, stop markers, option markers, selected-marker detail, and route-burden warnings from workspace data.
 - Missing map configuration, provider load errors, provider loading state, or sparse route data must fall back to the bounded route schematic with the same route context visible instead of blanking the workspace or falling back to a directions iframe.
+- The workspace route keeps three review scopes visible as distinct concerns: whole-trip outline, regional route review, and segment-level review. Segment focus is shared across the map, day-sequencing timeline, scenario comparison, and planner route-focus panel.
 - The workspace route should keep three review surfaces visible as distinct concerns: provider/fallback map state, day-sequencing timeline review, and a compact scenario tradeoff board for cost, travel burden, feasibility, and current policy posture.
 - Mobile rendering should stack those same review surfaces without hiding the route-state explanation or the scenario toggle affordances behind separate navigation.
 

--- a/docs/next-issue-set.md
+++ b/docs/next-issue-set.md
@@ -90,6 +90,8 @@ This note captures the remaining gaps after the recent readiness, planner-runtim
 
 **Why it matters:** The current map and timeline are usable and tested, but they still rely on shaped route summaries. Travelers need a rough whole-trip outline plus precise segment review for specific decisions.
 
+**Status (2026-05-11, issue #1162):** Implemented for the shared review-state and segment timing seam. Map scope now covers whole-trip, regional route, and segment-level review; selected route and segment state drive the map, day-plan timeline, scenario comparison, and planner route-focus panel. Runtime map geometry now carries duration/confidence/unavailable-state detail per segment. Remaining work is live provider distance/geometry verification and deeper source-backed marker detail.
+
 **Scope:**
 
 - Strengthen the map scope model from global/local into global, regional, and segment-level views.

--- a/docs/workspace_timeline_contract.md
+++ b/docs/workspace_timeline_contract.md
@@ -8,11 +8,12 @@ The workspace timeline surface intentionally derives from existing trip and scen
 - `session.current_saved_scenario_id` identifies the saved scenario the workspace should treat as active.
 - `saved_scenarios[].versions[].snapshot_refs.itinerary_scenario_id` links persisted saved-scenario history back to a route scenario.
 - `scenario_search.scenarios[].scenario_summary.route_sequence` provides the ordered route shape the UI renders as timeline stops.
+- `route_comparison.scenarios[].map_view.rough_route_geometry` may provide selected segment identity, per-leg duration, distance, confidence, and unavailable-state detail. When present, this augments the timeline and map segment review without introducing a separate itinerary persistence model.
 
 ## Current UI behavior
 
-The frontend matches the active saved scenario to a `ScenarioSearchResult` entry and then distributes the persisted trip duration across the ordered `route_sequence` stops. This keeps the timeline anchored to route/scenario output while richer per-leg timing data is still evolving.
+The frontend matches the active saved scenario to a runtime route-comparison entry and then distributes the persisted trip duration across the ordered `route_sequence` stops. Segment focus is shared with the map surface: switching route options updates the day plan, and switching segment-level review highlights the two timeline stops connected by the active route leg. If `map_view.rough_route_geometry` includes per-leg timing or confidence details, the timeline summary uses those fields; otherwise it keeps the bounded equal-distribution adapter.
 
 ## Forward-compatibility expectation
 
-When route/scenario producers start emitting explicit per-stop timing metadata, the workspace UI should keep using the same join points above and replace only the equal-distribution adapter. The timeline surface should continue to consume trip + saved-scenario + scenario-search state, not a parallel itinerary-only record.
+When route/scenario producers start emitting explicit per-stop timing metadata, the workspace UI should keep using the same join points above and replace only the equal-distribution adapter. The timeline surface should continue to consume trip + saved-scenario + route-comparison state, not a parallel itinerary-only record.

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -288,6 +288,10 @@ export type RuntimeScenarioComparison = {
         x2: number;
         y2: number;
         warning: string | null;
+        duration_minutes?: number | null;
+        distance_km?: number | null;
+        confidence?: "high" | "medium" | "low" | null;
+        unavailable_reason?: string | null;
       }>;
       confidence: {
         level: "high" | "medium" | "low";

--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { FeasibilitySummary, RuntimeScenarioComparison, WorkspaceData } from "../../api/workspace";
@@ -159,30 +160,44 @@ afterEach(() => {
 
 function renderTripMap(
   onSelectScenario = vi.fn(),
-  ledger?: WorkspaceData["planning_ledger"]
+  ledger?: WorkspaceData["planning_ledger"],
+  onSelectSegment = vi.fn()
 ) {
-  render(
-    <TripMap
-      comparison={comparison}
-      scenarioComparisonSummary="Rail-first stays the easiest route to compare against."
-      scenarioFocusAreas={["route_pace"]}
-      activeScenarioId="route-option:rail-first"
-      onSelectScenario={onSelectScenario}
-      bundles={bundles}
-      feasibilitySummary={feasibilitySummary}
-      tripPrimaryRegions={["Sweden", "Norway"]}
-      tripMode="business"
-      policyPosture="No approval packet yet"
-      planningLedger={ledger}
-      compactLayout={false}
-    />
-  );
-  return onSelectScenario;
+  function Harness() {
+    const [activeScope, setActiveScope] = useState<"global" | "regional" | "local">("regional");
+    const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
+    return (
+      <TripMap
+        comparison={comparison}
+        scenarioComparisonSummary="Rail-first stays the easiest route to compare against."
+        scenarioFocusAreas={["route_pace"]}
+        activeScenarioId="route-option:rail-first"
+        onSelectScenario={onSelectScenario}
+        bundles={bundles}
+        feasibilitySummary={feasibilitySummary}
+        tripPrimaryRegions={["Sweden", "Norway"]}
+        tripMode="business"
+        policyPosture="No approval packet yet"
+        planningLedger={ledger}
+        activeScope={activeScope}
+        selectedSegmentId={selectedSegmentId}
+        onScopeChange={setActiveScope}
+        onSelectSegment={(segmentId) => {
+          onSelectSegment(segmentId);
+          setSelectedSegmentId(segmentId);
+        }}
+        compactLayout={false}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return { onSelectScenario, onSelectSegment };
 }
 
 describe("TripMap", () => {
   it("switches map scopes without changing the selected route option", () => {
-    const onSelectScenario = renderTripMap();
+    const { onSelectScenario, onSelectSegment } = renderTripMap();
 
     const scopeControls = screen.getByLabelText("Map view scope");
     expect(within(scopeControls).getByRole("button", { name: "Route" })).toHaveAttribute(
@@ -195,9 +210,9 @@ describe("TripMap", () => {
     expect(screen.getByLabelText("Local segment selector")).toBeInTheDocument();
     expect(screen.getByText("Segment-level planning view")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Oslo to Bergen" }));
-    expect(screen.getByLabelText("Oslo to Bergen route drawing")).toHaveTextContent(
-      "1 shown segment"
+    fireEvent.click(screen.getByRole("button", { name: /Oslo to Bergen/ }));
+    expect(onSelectSegment).toHaveBeenCalledWith(
+      "route-option:rail-first-oslo-1-route-option:rail-first-bergen-2"
     );
 
     fireEvent.click(within(scopeControls).getByRole("button", { name: "Whole trip" }));
@@ -212,7 +227,7 @@ describe("TripMap", () => {
     renderTripMap();
 
     expect(screen.getByLabelText("Map view confidence")).toHaveTextContent(
-      "Approximate route shape"
+      "Regional route review"
     );
     expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Provider misconfigured/i)).not.toBeInTheDocument();
@@ -236,5 +251,13 @@ describe("TripMap", () => {
         name: /transport marker: Rail transfer anchors.*1 linked planning note/i,
       })
     ).toBeInTheDocument();
+  });
+
+  it("renders segment timing and confidence in traveler language", () => {
+    renderTripMap();
+
+    expect(screen.getByRole("heading", { name: "Segment focus" })).toBeInTheDocument();
+    expect(screen.getByText(/Stockholm to Oslo · 210 min/)).toBeInTheDocument();
+    expect(screen.getByText("Segment timing is estimated from ranked route data.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -23,6 +23,10 @@ export function TripMap({
   tripMode,
   policyPosture,
   planningLedger,
+  activeScope,
+  selectedSegmentId,
+  onScopeChange,
+  onSelectSegment,
   compactLayout,
 }: {
   comparison: RuntimeScenarioComparison;
@@ -36,6 +40,10 @@ export function TripMap({
   tripMode: string;
   policyPosture: string | null;
   planningLedger?: WorkspaceData["planning_ledger"];
+  activeScope: MapViewScope;
+  selectedSegmentId: string | null;
+  onScopeChange: (scope: MapViewScope) => void;
+  onSelectSegment: (segmentId: string | null) => void;
   compactLayout: boolean;
 }) {
   const activeScenario =
@@ -68,6 +76,10 @@ export function TripMap({
       tripMode={tripMode}
       policyPosture={policyPosture}
       planningLedger={planningLedger}
+      activeScope={activeScope}
+      selectedSegmentId={selectedSegmentId}
+      onScopeChange={onScopeChange}
+      onSelectSegment={onSelectSegment}
       compactLayout={compactLayout}
     />
   );
@@ -85,6 +97,10 @@ function ActiveTripMap({
   tripMode,
   policyPosture,
   planningLedger,
+  activeScope,
+  selectedSegmentId,
+  onScopeChange,
+  onSelectSegment,
   compactLayout,
 }: {
   activeScenario: TripMapScenario;
@@ -98,6 +114,10 @@ function ActiveTripMap({
   tripMode: string;
   policyPosture: string | null;
   planningLedger?: WorkspaceData["planning_ledger"];
+  activeScope: MapViewScope;
+  selectedSegmentId: string | null;
+  onScopeChange: (scope: MapViewScope) => void;
+  onSelectSegment: (segmentId: string | null) => void;
   compactLayout: boolean;
 }) {
   const googleMapsApiKey =
@@ -105,8 +125,6 @@ function ActiveTripMap({
     import.meta.env.VITE_GOOGLE_MAPS_EMBED_API_KEY;
   const providerLoadState =
     (import.meta.env.VITE_GOOGLE_MAPS_PROVIDER_STATE as MapProviderLoadState | undefined) ?? "ready";
-  const [activeScope, setActiveScope] = useState<MapViewScope>("regional");
-  const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
   const mapSurface = buildTripMapSurfaceModel({
     activeScenario,
     bundles,
@@ -139,16 +157,17 @@ function ActiveTripMap({
     setSelectedMarkerId(initialMarkerId);
   }, [activeScenario.scenario_id, initialMarkerId]);
 
-  useEffect(() => {
-    setSelectedSegmentId(null);
-  }, [activeScenario.scenario_id]);
-
   function handleScopeChange(nextScope: MapViewScope) {
-    setActiveScope(nextScope);
-    if (nextScope === "local" && selectedSegmentId == null) {
-      setSelectedSegmentId(mapSurface.routeSegments[0]?.id ?? null);
+    onScopeChange(nextScope);
+    if (nextScope === "local" && mapSurface.workspaceView.selectedSegmentId == null) {
+      onSelectSegment(mapSurface.routeSegments[0]?.id ?? null);
     }
   }
+
+  const selectedSegment =
+    mapSurface.routeSegments.find(
+      (segment) => segment.id === mapSurface.workspaceView.selectedSegmentId
+    ) ?? null;
 
   return (
     <section className="status-card map-card">
@@ -192,9 +211,10 @@ function ActiveTripMap({
                   : ""
               }`}
               aria-pressed={segment.id === mapSurface.workspaceView.selectedSegmentId}
-              onClick={() => setSelectedSegmentId(segment.id)}
+              onClick={() => onSelectSegment(segment.id)}
             >
               {segment.fromLabel} to {segment.toLabel}
+              {segment.durationMinutes != null ? ` · ${segment.durationMinutes} min` : ""}
             </button>
           ))}
         </div>
@@ -304,6 +324,30 @@ function ActiveTripMap({
               <dd>{formatEstimatedTotal(activeScenario.metrics.estimated_total)}</dd>
             </div>
           </dl>
+          {selectedSegment ? (
+            <article className="decision-card">
+              <h3>Segment focus</h3>
+              <p>
+                {selectedSegment.fromLabel} to {selectedSegment.toLabel}
+                {selectedSegment.durationMinutes != null
+                  ? ` · ${selectedSegment.durationMinutes} min`
+                  : ""}
+                {selectedSegment.distanceKm != null
+                  ? ` · ${selectedSegment.distanceKm.toFixed(1)} km`
+                  : ""}
+              </p>
+              <p className="muted-copy">
+                {selectedSegment.confidence === "high"
+                  ? "Provider detail is available for close segment review."
+                  : selectedSegment.confidence === "medium"
+                    ? "Segment timing is estimated from ranked route data."
+                    : "Segment detail needs more route or provider evidence."}
+              </p>
+              {selectedSegment.unavailableReason ? (
+                <p className="muted-copy">{selectedSegment.unavailableReason}</p>
+              ) : null}
+            </article>
+          ) : null}
           <article className="decision-card">
             <h3>Scenario comparison</h3>
             <p>{mapSurface.scenarioComparisonSummary}</p>

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -209,6 +209,113 @@ describe("mapSurface", () => {
     expect(localModel.scope.precisionLabel).toBe("Segment-level planning view");
   });
 
+  it("uses provider-rich map view segment details when the runtime payload supplies them", () => {
+    const model = buildTripMapSurfaceModel({
+      activeScenario: {
+        scenario_id: "scenario:provider",
+        route_option_id: "route-option:provider",
+        title: "Provider route",
+        rank: 1,
+        status: "lead",
+        summary: "Baseline",
+        comparison_note: "Lead route",
+        option_count: 2,
+        route_sequence: ["kyoto", "uji", "nara"],
+        route_summary: "kyoto -> uji -> nara",
+        recommended_for_selection: true,
+        feasible: true,
+        metrics: {
+          score: 0.91,
+          travel_minutes: 180,
+          transfers: 2,
+          estimated_total: null,
+        },
+        delta: {
+          score_delta: 0,
+          travel_minutes_delta: 0,
+          transfers_delta: 0,
+          estimated_total_delta: null,
+        },
+        highlights: ["Short regional route."],
+        map_view: {
+          active_scope: "regional",
+          active_route_option_id: "route-option:provider",
+          selected_segment_id: "segment:uji-nara",
+          place_markers: [
+            { id: "marker:kyoto", source_id: "kyoto", label: "Kyoto", route_index: 0, x: 0.1, y: 0.5 },
+            { id: "marker:uji", source_id: "uji", label: "Uji", route_index: 1, x: 0.45, y: 0.3 },
+            { id: "marker:nara", source_id: "nara", label: "Nara", route_index: 2, x: 0.85, y: 0.6 },
+          ],
+          rough_route_geometry: [
+            {
+              id: "segment:kyoto-uji",
+              from_marker_id: "marker:kyoto",
+              to_marker_id: "marker:uji",
+              from_label: "Kyoto",
+              to_label: "Uji",
+              x1: 0.1,
+              y1: 0.5,
+              x2: 0.45,
+              y2: 0.3,
+              warning: null,
+              duration_minutes: 42,
+              distance_km: 17.5,
+              confidence: "high",
+              unavailable_reason: null,
+            },
+            {
+              id: "segment:uji-nara",
+              from_marker_id: "marker:uji",
+              to_marker_id: "marker:nara",
+              from_label: "Uji",
+              to_label: "Nara",
+              x1: 0.45,
+              y1: 0.3,
+              x2: 0.85,
+              y2: 0.6,
+              warning: null,
+              duration_minutes: 58,
+              distance_km: null,
+              confidence: "medium",
+              unavailable_reason: "Provider distance is not available.",
+            },
+          ],
+          confidence: {
+            level: "high",
+            summary: "Provider detail is available.",
+          },
+        },
+      },
+      bundles: [],
+      feasibilitySummary: {
+        assessment_count: 0,
+        recommended_bundle_count: 0,
+        blocking_bundle_count: 0,
+        attention_bundle_count: 0,
+        notes: [],
+        assessments: [],
+      },
+      googleMapsApiKey: "test-key",
+      activeScope: "local",
+      selectedSegmentId: "segment:uji-nara",
+    });
+
+    expect(model.workspaceView.activeRouteOptionId).toBe("route-option:provider");
+    expect(model.visibleRouteStops.map((stop) => stop.label)).toEqual(["Uji", "Nara"]);
+    expect(model.visibleRouteSegments[0]).toMatchObject({
+      id: "segment:uji-nara",
+      durationMinutes: 58,
+      distanceKm: null,
+      confidence: "medium",
+      unavailableReason: "Provider distance is not available.",
+    });
+    expect(model.routeSegments[0]).toMatchObject({
+      durationMinutes: 42,
+      distanceKm: 17.5,
+      confidence: "high",
+    });
+  });
+
   it("connects directly linked ledger entries to map markers and route segments", () => {
     const baseInput = {
       activeScenario: {

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -323,10 +323,11 @@ function buildRouteSegments(
   const providerSegments = activeScenario.map_view?.rough_route_geometry ?? [];
   if (providerSegments.length > 0) {
     const stopById = new Map(routeStops.map((stop) => [stop.id, stop]));
-    return providerSegments.map((segment) => {
-      const fromStop = stopById.get(segment.from_marker_id);
-      const toStop = stopById.get(segment.to_marker_id);
-      return {
+    return providerSegments
+      .filter(
+        (segment) => stopById.has(segment.from_marker_id) && stopById.has(segment.to_marker_id)
+      )
+      .map((segment) => ({
         id: segment.id,
         fromStopId: segment.from_marker_id,
         toStopId: segment.to_marker_id,
@@ -342,10 +343,7 @@ function buildRouteSegments(
         confidence: segment.confidence ?? activeScenario.map_view?.confidence.level ?? "medium",
         unavailableReason: segment.unavailable_reason ?? null,
         focusCues: [],
-      };
-    }).filter(
-      (segment) => stopById.has(segment.fromStopId) || stopById.has(segment.toStopId)
-    );
+      }));
   }
 
   return routeStops.slice(0, -1).map((stop, index) => {

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -73,6 +73,10 @@ export type RouteSegment = {
   x2: number;
   y2: number;
   warning: string | null;
+  durationMinutes: number | null;
+  distanceKm: number | null;
+  confidence: MapGeometryConfidence;
+  unavailableReason: string | null;
   focusCues: MapFocusCue[];
 };
 
@@ -285,9 +289,71 @@ function buildDestinationContext({
   return Array.from(new Set([...fromRoute, ...fromBundles, ...fromTripFrame]));
 }
 
-function buildRouteSegments(routeStops: RouteStop[], routeWarning: string | null): RouteSegment[] {
+function buildRouteStops(activeScenario: TripMapScenario): RouteStop[] {
+  const providerMarkers = activeScenario.map_view?.place_markers ?? [];
+  if (providerMarkers.length > 0) {
+    return providerMarkers.map((marker, index) => ({
+      id: marker.id,
+      sourceId: marker.source_id,
+      label: marker.label,
+      description: describeStop(index, providerMarkers.length),
+      x: marker.x * 100,
+      y: marker.y * 100,
+    }));
+  }
+
+  return activeScenario.route_sequence.map((stop, index) => {
+    const coordinate = coordinateForRouteIndex(index, activeScenario.route_sequence.length);
+    return {
+      id: `${activeScenario.scenario_id}-${stop}-${index}`,
+      sourceId: stop,
+      label: humanizeStop(stop),
+      description: describeStop(index, activeScenario.route_sequence.length),
+      x: coordinate.x,
+      y: coordinate.y,
+    };
+  });
+}
+
+function buildRouteSegments(
+  activeScenario: TripMapScenario,
+  routeStops: RouteStop[],
+  routeWarning: string | null
+): RouteSegment[] {
+  const providerSegments = activeScenario.map_view?.rough_route_geometry ?? [];
+  if (providerSegments.length > 0) {
+    const stopById = new Map(routeStops.map((stop) => [stop.id, stop]));
+    return providerSegments.map((segment) => {
+      const fromStop = stopById.get(segment.from_marker_id);
+      const toStop = stopById.get(segment.to_marker_id);
+      return {
+        id: segment.id,
+        fromStopId: segment.from_marker_id,
+        toStopId: segment.to_marker_id,
+        fromLabel: segment.from_label,
+        toLabel: segment.to_label,
+        x1: segment.x1 * 100,
+        y1: segment.y1 * 100,
+        x2: segment.x2 * 100,
+        y2: segment.y2 * 100,
+        warning: segment.warning ?? routeWarning,
+        durationMinutes: segment.duration_minutes ?? null,
+        distanceKm: segment.distance_km ?? null,
+        confidence: segment.confidence ?? activeScenario.map_view?.confidence.level ?? "medium",
+        unavailableReason: segment.unavailable_reason ?? null,
+        focusCues: [],
+      };
+    }).filter(
+      (segment) => stopById.has(segment.fromStopId) || stopById.has(segment.toStopId)
+    );
+  }
+
   return routeStops.slice(0, -1).map((stop, index) => {
     const nextStop = routeStops[index + 1];
+    const fallbackMinutes =
+      routeStops.length > 1
+        ? Math.max(0, Math.round(activeScenario.metrics.travel_minutes / (routeStops.length - 1)))
+        : null;
     return {
       id: `${stop.id}-${nextStop.id}`,
       fromStopId: stop.id,
@@ -299,6 +365,11 @@ function buildRouteSegments(routeStops: RouteStop[], routeWarning: string | null
       x2: nextStop.x,
       y2: nextStop.y,
       warning: index === 0 ? routeWarning : null,
+      durationMinutes: fallbackMinutes,
+      distanceKm: null,
+      confidence: activeScenario.feasible ? "medium" : "low",
+      unavailableReason:
+        "Provider distance is not available; duration is estimated from ranked scenario timing.",
       focusCues: [],
     };
   });
@@ -426,7 +497,7 @@ function scopePresentationFor({
         ? `${selectedSegment.fromLabel} to ${selectedSegment.toLabel}`
         : "Local segment",
       summary: selectedSegment
-        ? `Focuses on the ${selectedSegment.fromLabel} to ${selectedSegment.toLabel} travel leg and nearby planning markers.`
+        ? `Focuses on the ${selectedSegment.fromLabel} to ${selectedSegment.toLabel} travel leg, timing estimate, and nearby planning markers.`
         : "Add another route stop before the map can focus on a local segment.",
       precisionLabel: selectedSegment ? "Segment-level planning view" : "Segment detail pending",
     };
@@ -435,8 +506,8 @@ function scopePresentationFor({
   return {
     activeScope,
     label: "Selected route option",
-    summary: "Shows the route option currently selected in the comparison workbench.",
-    precisionLabel: "Approximate route shape",
+    summary: "Shows the selected route option across its regional travel legs and comparison context.",
+    precisionLabel: "Regional route review",
   };
 }
 
@@ -772,17 +843,7 @@ export function buildTripMapSurfaceModel({
   selectedSegmentId?: string | null;
   planningLedger?: PlanningLedgerState | null;
 }): TripMapSurfaceModel {
-  const routeStops = activeScenario.route_sequence.map((stop, index) => {
-    const coordinate = coordinateForRouteIndex(index, activeScenario.route_sequence.length);
-    return {
-      id: `${activeScenario.scenario_id}-${stop}-${index}`,
-      sourceId: stop,
-      label: humanizeStop(stop),
-      description: describeStop(index, activeScenario.route_sequence.length),
-      x: coordinate.x,
-      y: coordinate.y,
-    };
-  });
+  const routeStops = buildRouteStops(activeScenario);
   const destinationContext = buildDestinationContext({
     bundles,
     routeStops,
@@ -799,7 +860,7 @@ export function buildTripMapSurfaceModel({
   const trimmedApiKey = googleMapsApiKey?.trim() ?? "";
   const routeWarning = deriveRouteWarning(activeScenario, feasibilitySummary);
   const resolvedPolicyPosture = tripMode === "leisure" ? null : policyPosture;
-  const routeSegments = buildRouteSegments(routeStops, routeWarning);
+  const routeSegments = buildRouteSegments(activeScenario, routeStops, routeWarning);
   const baseMarkers = buildMarkers({
     activeScenario,
     bundles,
@@ -889,7 +950,7 @@ export function buildTripMapSurfaceModel({
   });
   const workspaceView: MapWorkspaceView = {
     activeScope,
-    activeRouteOptionId: activeScenario.scenario_id,
+    activeRouteOptionId: activeScenario.route_option_id ?? activeScenario.scenario_id,
     selectedSegmentId: visibleMapContent.selectedSegment?.id ?? null,
     placeMarkers: visibleMapContent.markers,
     roughRouteGeometry: visibleMapContent.routeSegments,

--- a/frontend/src/components/workspace/ScenarioComparison.tsx
+++ b/frontend/src/components/workspace/ScenarioComparison.tsx
@@ -99,11 +99,17 @@ export function ScenarioComparison({
     selectedScenario?.scenario_id === leadScenario?.scenario_id
       ? comparison.scenarios.find((scenario) => scenario.scenario_id !== leadScenario?.scenario_id) ?? null
       : selectedScenario;
-  const comparedScenarios = [leadScenario, secondaryScenario].filter(
+  const comparisonCandidates = [
+    leadScenario,
+    selectedScenario,
+    secondaryScenario,
+    ...comparison.scenarios,
+  ];
+  const comparedScenarios = comparisonCandidates.filter(
     (scenario, index, scenarios): scenario is ComparisonScenario =>
       scenario !== null &&
       scenarios.findIndex((candidate) => candidate?.scenario_id === scenario.scenario_id) === index
-  );
+  ).slice(0, 4);
 
   if (comparison.scenarios.length === 0) {
     return (
@@ -141,11 +147,34 @@ export function ScenarioComparison({
         {comparedScenarios.map((scenario) => {
           const savedScenarioDetails = findSavedScenarioDetails(savedScenarios, scenario.scenario_id);
           return (
-            <article key={scenario.scenario_id} className="scenario-card">
-              <p className="scenario-kicker">{savedScenarioDetails?.label ?? scenario.status}</p>
+            <article
+              key={scenario.scenario_id}
+              className={`scenario-card${
+                scenario.scenario_id === selectedScenario?.scenario_id ? " scenario-card-active" : ""
+              }`}
+            >
+              <p className="scenario-kicker">
+                {scenario.scenario_id === leadScenario?.scenario_id
+                  ? "baseline"
+                  : savedScenarioDetails?.label ?? scenario.status}
+              </p>
               <h3>{savedScenarioDetails?.title ?? scenario.title}</h3>
               <p>{savedScenarioDetails?.summary ?? scenario.summary}</p>
               <p className="muted-copy">{scenario.comparison_note}</p>
+              <dl className="workspace-meta scenario-card-metrics">
+                <div>
+                  <dt>Time</dt>
+                  <dd>{formatMetricValue("travel_minutes", scenario)}</dd>
+                </div>
+                <div>
+                  <dt>Transfers</dt>
+                  <dd>{formatMetricValue("transfers", scenario)}</dd>
+                </div>
+                <div>
+                  <dt>Cost</dt>
+                  <dd>{formatMetricValue("estimated_total", scenario)}</dd>
+                </div>
+              </dl>
             </article>
           );
         })}

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1650,7 +1650,7 @@ describe("WorkspacePage", () => {
     expect(container.querySelector("iframe")).toBeNull();
     expect(screen.queryByTitle(/google maps/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Fallback option markers")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
+    expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
     expect(
       screen.getAllByText("High confidence: the route has enough map detail for close review.")
         .length
@@ -1685,7 +1685,7 @@ describe("WorkspacePage", () => {
       ).toBeInTheDocument();
     });
 
-    expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
+    expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
     expect(screen.queryByText("Google Maps JavaScript adapter")).not.toBeInTheDocument();
   });
 
@@ -1907,7 +1907,7 @@ describe("WorkspacePage", () => {
 
     expect(screen.getByText("Compact review keeps route, day plan, and next choices close together.")).toBeInTheDocument();
     await waitFor(() => {
-      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
+      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
     });
     expect(
       screen.getAllByText("Medium confidence: this is an approximate sketch from the current route stops.")
@@ -1928,7 +1928,7 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
+      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
     });
 
     expect(screen.queryByText(/Google Maps JavaScript is loading/)).not.toBeInTheDocument();
@@ -1946,7 +1946,7 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Approximate route shape");
+      expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
     });
 
     expect(screen.queryByText(/failed to load/)).not.toBeInTheDocument();

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -220,19 +220,24 @@ function routeSegmentFocusesFor(
   const markerById = new Map(markers.map((marker) => [marker.id, marker]));
   const providerSegments = scenario.map_view?.rough_route_geometry ?? [];
   if (providerSegments.length > 0) {
-    return providerSegments.map((segment, index) => {
+    return providerSegments.flatMap((segment) => {
       const fromMarker = markerById.get(segment.from_marker_id);
       const toMarker = markerById.get(segment.to_marker_id);
-      return {
-        id: segment.id,
-        fromLabel: segment.from_label,
-        toLabel: segment.to_label,
-        fromIndex: fromMarker?.route_index ?? index,
-        toIndex: toMarker?.route_index ?? index + 1,
-        durationMinutes: segment.duration_minutes ?? null,
-        confidence: segment.confidence ?? scenario.map_view?.confidence.level ?? "medium",
-        unavailableReason: segment.unavailable_reason ?? null,
-      };
+      if (fromMarker == null || toMarker == null) {
+        return [];
+      }
+      return [
+        {
+          id: segment.id,
+          fromLabel: segment.from_label,
+          toLabel: segment.to_label,
+          fromIndex: fromMarker.route_index,
+          toIndex: toMarker.route_index,
+          durationMinutes: segment.duration_minutes ?? null,
+          confidence: segment.confidence ?? scenario.map_view?.confidence.level ?? "medium",
+          unavailableReason: segment.unavailable_reason ?? null,
+        },
+      ];
     });
   }
 

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -28,12 +28,14 @@ import {
   type PlanningNotebookItem,
   type PlanningNotebookState,
   type RouteOptionActionType,
+  type RuntimeScenarioComparison,
   submitPlannerOptionFeedback,
   type SavedScenarioRecord,
   type WorkspaceData,
 } from "../api/workspace";
 import { WorkspaceBudgetPanel } from "../components/budget/WorkspaceBudgetPanel";
 import { TripMap } from "../components/maps/TripMap";
+import type { MapViewScope } from "../components/maps/mapSurface";
 import { PlanningModeSelector } from "../components/planner/PlanningModeSelector";
 import { PlannerSidePanelSurface } from "../components/planner/PlannerSidePanelSurface";
 import { TripComparison } from "../components/trips/TripComparison";
@@ -50,8 +52,20 @@ type LoaderData = {
 type TimelineStop = {
   key: string;
   label: string;
+  routeIndex: number;
   startDay: number;
   endDay: number;
+};
+
+type RouteSegmentFocus = {
+  id: string;
+  fromLabel: string;
+  toLabel: string;
+  fromIndex: number;
+  toIndex: number;
+  durationMinutes: number | null;
+  confidence: "high" | "medium" | "low";
+  unavailableReason: string | null;
 };
 
 type ScenarioReviewMetric = {
@@ -182,10 +196,106 @@ function buildTimelineStops(routeSequence: string[], tripDuration: number | null
     return {
       key: `${stop}-${index}`,
       label: titleCaseStop(stop),
+      routeIndex: index,
       startDay,
       endDay,
     };
   });
+}
+
+function fallbackSegmentId(scenarioId: string, routeSequence: string[], index: number): string {
+  const fromStop = routeSequence[index];
+  const toStop = routeSequence[index + 1];
+  return `${scenarioId}-${fromStop}-${index}-${scenarioId}-${toStop}-${index + 1}`;
+}
+
+function routeSegmentFocusesFor(
+  scenario: RuntimeScenarioComparison["scenarios"][number] | null
+): RouteSegmentFocus[] {
+  if (scenario == null) {
+    return [];
+  }
+
+  const markers = scenario.map_view?.place_markers ?? [];
+  const markerById = new Map(markers.map((marker) => [marker.id, marker]));
+  const providerSegments = scenario.map_view?.rough_route_geometry ?? [];
+  if (providerSegments.length > 0) {
+    return providerSegments.map((segment, index) => {
+      const fromMarker = markerById.get(segment.from_marker_id);
+      const toMarker = markerById.get(segment.to_marker_id);
+      return {
+        id: segment.id,
+        fromLabel: segment.from_label,
+        toLabel: segment.to_label,
+        fromIndex: fromMarker?.route_index ?? index,
+        toIndex: toMarker?.route_index ?? index + 1,
+        durationMinutes: segment.duration_minutes ?? null,
+        confidence: segment.confidence ?? scenario.map_view?.confidence.level ?? "medium",
+        unavailableReason: segment.unavailable_reason ?? null,
+      };
+    });
+  }
+
+  return scenario.route_sequence.slice(0, -1).map((fromStop, index) => ({
+    id: fallbackSegmentId(scenario.scenario_id, scenario.route_sequence, index),
+    fromLabel: titleCaseStop(fromStop),
+    toLabel: titleCaseStop(scenario.route_sequence[index + 1]),
+    fromIndex: index,
+    toIndex: index + 1,
+    durationMinutes:
+      scenario.route_sequence.length > 1
+        ? Math.max(0, Math.round(scenario.metrics.travel_minutes / (scenario.route_sequence.length - 1)))
+        : null,
+    confidence: scenario.feasible ? "medium" : "low",
+    unavailableReason:
+      "Provider distance is not available; duration is estimated from ranked scenario timing.",
+  }));
+}
+
+function resolveRouteSegmentFocus(
+  scenario: RuntimeScenarioComparison["scenarios"][number] | null,
+  selectedSegmentId: string | null
+): RouteSegmentFocus | null {
+  const segments = routeSegmentFocusesFor(scenario);
+  if (segments.length === 0) {
+    return null;
+  }
+  return segments.find((segment) => segment.id === selectedSegmentId) ?? segments[0];
+}
+
+function timelineFocusNotes(
+  ledger: WorkspaceData["planning_ledger"] | undefined,
+  scenario: RuntimeScenarioComparison["scenarios"][number] | null,
+  segment: RouteSegmentFocus | null
+): string[] {
+  const entries = ledger?.entries ?? [];
+  if (entries.length === 0 || scenario == null) {
+    return [];
+  }
+  const routeIds = new Set(
+    [scenario.scenario_id, scenario.route_option_id, segment?.id].filter(
+      (value): value is string => Boolean(value)
+    )
+  );
+  return entries
+    .filter((entry) => entry.status !== "superseded")
+    .filter((entry) => {
+      const metadata = entry.metadata ?? {};
+      const refs = [
+        entry.related_option_id,
+        entry.related_decision_id,
+        ...entry.source_refs,
+        metadata["route_option_id"],
+        metadata["scenario_id"],
+        metadata["route_segment_id"],
+        metadata["map_segment_id"],
+        metadata["selected_segment_id"],
+      ];
+      return refs.some((ref) => typeof ref === "string" && routeIds.has(ref));
+    })
+    .map((entry) => entry.summary.trim())
+    .filter(Boolean)
+    .slice(0, 3);
 }
 
 function useCompactWorkspaceLayout(): boolean {
@@ -809,6 +919,8 @@ function WorkspacePageContent({
   const [selectedScenarioId, setSelectedScenarioId] = useState(() =>
     resolveMapScenarioId(workspace)
   );
+  const [selectedMapScope, setSelectedMapScope] = useState<MapViewScope>("regional");
+  const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
   const [selectedTripComparisonId, setSelectedTripComparisonId] = useState<string | null>(
     () => trips.find((trip) => trip.trip_id !== workspace.trip_record.trip.trip_id)?.trip_id ?? null
   );
@@ -837,6 +949,8 @@ function WorkspacePageContent({
   useEffect(() => {
     setCurrentWorkspace(workspace);
     setSelectedScenarioId(resolveMapScenarioId(workspace));
+    setSelectedMapScope("regional");
+    setSelectedSegmentId(null);
     setShowWorkspaceDebugDetails(false);
   }, [workspace]);
 
@@ -908,6 +1022,12 @@ function WorkspacePageContent({
     activeScenario.scenario?.scenario_summary.route_sequence ??
     [];
   const timelineStops = buildTimelineStops(timelineRouteSequence, trip.trip_frame.duration_days);
+  const selectedRouteSegment = resolveRouteSegmentFocus(selectedRuntimeScenario, selectedSegmentId);
+  const selectedTimelineNotes = timelineFocusNotes(
+    currentWorkspace.planning_ledger,
+    selectedRuntimeScenario,
+    selectedRouteSegment
+  );
   const proposalFollowUp = currentWorkspace.proposal_state?.follow_up ?? null;
   const renderableProposalFollowUp = hasRenderableFollowUp(proposalFollowUp)
     ? proposalFollowUp
@@ -938,6 +1058,7 @@ function WorkspacePageContent({
   ].join(":");
   function handleScenarioSelection(scenarioId: string) {
     setSelectedScenarioId(scenarioId);
+    setSelectedSegmentId(null);
   }
 
   async function handlePlanningModeChange(mode: PlanningMode) {
@@ -1372,6 +1493,24 @@ function WorkspacePageContent({
                 : "Planning guide"}
             </span>
           </div>
+          {selectedRuntimeScenario ? (
+            <article className="planner-route-focus" aria-label="Planner route focus">
+              <p className="scenario-kicker">Route focus</p>
+              <h3>{selectedRuntimeScenario.title}</h3>
+              <p>
+                {selectedRouteSegment
+                  ? `${selectedRouteSegment.fromLabel} to ${selectedRouteSegment.toLabel}`
+                  : selectedRuntimeScenario.route_summary}
+              </p>
+              {selectedTimelineNotes.length > 0 ? (
+                <ul>
+                  {selectedTimelineNotes.map((note) => (
+                    <li key={note}>{note}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </article>
+          ) : null}
           <PlanningModeSelector
             value={currentWorkspace.session.selected_planning_mode}
             busy={planningModeBusy}
@@ -1485,6 +1624,10 @@ function WorkspacePageContent({
           tripMode={trip.mode}
           policyPosture={panelVisibility.showPolicyPosture ? scenarioPolicyPosture : null}
           planningLedger={currentWorkspace.planning_ledger}
+          activeScope={selectedMapScope}
+          selectedSegmentId={selectedRouteSegment?.id ?? null}
+          onScopeChange={setSelectedMapScope}
+          onSelectSegment={setSelectedSegmentId}
           compactLayout={isCompactLayout}
         />
 
@@ -1686,6 +1829,19 @@ function WorkspacePageContent({
                   </p>
                 </article>
                 <article className="timeline-summary-card">
+                  <p className="scenario-kicker">Segment focus</p>
+                  <h3>
+                    {selectedRouteSegment
+                      ? `${selectedRouteSegment.fromLabel} to ${selectedRouteSegment.toLabel}`
+                      : "No segment selected"}
+                  </h3>
+                  <p>
+                    {selectedRouteSegment?.durationMinutes != null
+                      ? `${selectedRouteSegment.durationMinutes} minutes in the selected route option.`
+                      : "Segment timing will appear when route geometry is available."}
+                  </p>
+                </article>
+                <article className="timeline-summary-card">
                   <p className="scenario-kicker">Pacing</p>
                   <h3>
                     {selectedRuntimeScenario == null
@@ -1711,9 +1867,24 @@ function WorkspacePageContent({
                   </p>
                 </article>
               </div>
+              {selectedTimelineNotes.length > 0 ? (
+                <div className="timeline-focus-notes" aria-label="Timeline linked planning notes">
+                  {selectedTimelineNotes.map((note) => (
+                    <span key={note}>{note}</span>
+                  ))}
+                </div>
+              ) : null}
               <ol className="timeline-list" aria-label="Trip timeline sequence">
-                {timelineStops.map((stop) => (
-                  <li key={stop.key} className="timeline-stop">
+                {timelineStops.map((stop) => {
+                  const isSegmentFocus =
+                    selectedRouteSegment != null &&
+                    (stop.routeIndex === selectedRouteSegment.fromIndex ||
+                      stop.routeIndex === selectedRouteSegment.toIndex);
+                  return (
+                  <li
+                    key={stop.key}
+                    className={`timeline-stop${isSegmentFocus ? " timeline-stop-focused" : ""}`}
+                  >
                     <div className="timeline-dayband">
                       <span>Day {stop.startDay}</span>
                       <span>Day {stop.endDay}</span>
@@ -1724,9 +1895,15 @@ function WorkspacePageContent({
                         Days {stop.startDay}-{stop.endDay} keep this stop visible in the selected
                         route review path.
                       </p>
+                      {isSegmentFocus ? (
+                        <p className="muted-copy">
+                          Highlighted for the selected segment-level review.
+                        </p>
+                      ) : null}
                     </div>
                   </li>
-                ))}
+                  );
+                })}
               </ol>
             </>
           )}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -410,6 +410,11 @@ a {
   background: rgba(19, 33, 44, 0.04);
 }
 
+.timeline-stop-focused {
+  border: 1px solid rgba(56, 117, 107, 0.35);
+  background: rgba(56, 117, 107, 0.08);
+}
+
 .timeline-stop h3,
 .scenario-card h3,
 .decision-card h3 {
@@ -466,8 +471,29 @@ a {
   min-height: 100%;
 }
 
+.timeline-focus-notes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.timeline-focus-notes span {
+  border: 1px solid rgba(56, 117, 107, 0.22);
+  border-radius: 8px;
+  background: rgba(56, 117, 107, 0.08);
+  color: #234f48;
+  font-weight: 700;
+  padding: 0.55rem 0.7rem;
+}
+
 .scenario-review-metrics {
   margin-top: 1rem;
+}
+
+.scenario-card-metrics {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 0.85rem;
 }
 
 .scenario-highlight-list {
@@ -841,6 +867,27 @@ a {
 .planner-conversation-form button:disabled {
   cursor: progress;
   opacity: 0.72;
+}
+
+.planner-route-focus {
+  border: 1px solid rgba(56, 117, 107, 0.2);
+  border-radius: 8px;
+  background: rgba(56, 117, 107, 0.08);
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 1rem;
+  padding: 0.9rem;
+}
+
+.planner-route-focus h3,
+.planner-route-focus p,
+.planner-route-focus ul {
+  margin: 0;
+}
+
+.planner-route-focus ul {
+  color: #365063;
+  padding-left: 1.1rem;
 }
 
 .budget-panel-card {

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -667,6 +667,12 @@ def test_workspace_scenario_comparison_endpoint_returns_runtime_surface(
     )
     assert payload["scenarios"][0]["map_view"]["place_markers"][0]["label"]
     assert payload["scenarios"][0]["map_view"]["rough_route_geometry"][0]["from_label"]
+    segment = payload["scenarios"][0]["map_view"]["rough_route_geometry"][0]
+    assert isinstance(segment["duration_minutes"], int)
+    assert segment["duration_minutes"] > 0
+    assert "distance_km" in segment
+    assert segment["confidence"] in {"high", "medium", "low"}
+    assert "unavailable_reason" in segment
     assert (
         payload["scenarios"][0]["map_view"]["selected_segment_id"]
         == payload["scenarios"][0]["map_view"]["rough_route_geometry"][0]["id"]

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -907,8 +907,18 @@ def _build_runtime_map_route_geometry(
     place_markers: list[dict[str, Any]],
     *,
     route_warning: str | None,
+    total_travel_minutes: int,
+    total_distance_km: float | None = None,
+    feasible: bool,
 ) -> list[dict[str, Any]]:
     segments: list[dict[str, Any]] = []
+    segment_count = max(1, len(place_markers) - 1)
+    per_segment_minutes = max(0, round(total_travel_minutes / segment_count))
+    per_segment_distance_km = (
+        round(total_distance_km / segment_count, 1)
+        if total_distance_km is not None and total_distance_km > 0
+        else None
+    )
     for index, marker in enumerate(place_markers[:-1]):
         next_marker = place_markers[index + 1]
         segments.append(
@@ -923,6 +933,14 @@ def _build_runtime_map_route_geometry(
                 "x2": next_marker["x"],
                 "y2": next_marker["y"],
                 "warning": route_warning if index == 0 else None,
+                "duration_minutes": per_segment_minutes,
+                "distance_km": per_segment_distance_km,
+                "confidence": "medium" if feasible else "low",
+                "unavailable_reason": (
+                    None
+                    if per_segment_distance_km is not None
+                    else "Provider distance is not available; duration is estimated from ranked scenario timing."
+                ),
             }
         )
     return segments
@@ -940,6 +958,9 @@ def _build_runtime_map_view_payload(
     rough_route_geometry = _build_runtime_map_route_geometry(
         place_markers,
         route_warning=route_warning,
+        total_travel_minutes=int(summary.get("total_travel_minutes") or 0),
+        total_distance_km=summary.get("total_distance_km"),
+        feasible=bool(summary.get("feasible", False)),
     )
     return {
         "active_scope": "regional",

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -908,8 +908,8 @@ def _build_runtime_map_route_geometry(
     *,
     route_warning: str | None,
     total_travel_minutes: int,
-    total_distance_km: float | None = None,
     feasible: bool,
+    total_distance_km: float | None = None,
 ) -> list[dict[str, Any]]:
     segments: list[dict[str, Any]] = []
     segment_count = max(1, len(place_markers) - 1)


### PR DESCRIPTION
Closes #1162

## Summary
- adds provider-rich route segment duration, distance, confidence, and unavailable-state fields to runtime map geometry
- carries selected route option and segment focus across the map, timeline, scenario comparison, and planner route-focus panel
- filters provider route segments to known marker endpoints before rendering segment focus details
- documents the shared map/timeline review-state contract and updates design coverage

## Validation
- npm test -- --run src/components/maps/mapSurface.test.ts src/components/maps/TripMap.test.tsx src/routes/WorkspacePage.test.tsx --reporter=dot
- npm run build
- python -m pytest tests/app/test_workspace.py::test_workspace_scenario_comparison_endpoint_returns_runtime_surface tests/contracts/test_route_context_map_target.py --no-cov
- ruff check trip_planner/app/services/workspace.py tests/app/test_workspace.py
- black --check trip_planner/app/services/workspace.py tests/app/test_workspace.py
- npm test -- --run src/components/maps/mapSurface.test.ts --reporter=dot
- git diff --check

Note: a targeted ScenarioComparison component test command was attempted, but no dedicated ScenarioComparison.test.tsx exists in this repo; the changed comparison card rendering is covered through WorkspacePage.test.tsx.