### PR TITLE
Issue #1163: implement deterministic source-quality scoring engine

### DIFF
--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -134,8 +134,8 @@ Design ref: [`docs/ranking-route-search-epic.md`](ranking-route-search-epic.md)
 |------------|--------|-------|--------|
 | Leisure ranking | `trip_planner/ranking/leisure.py` | `tests/ranking/` | ✅ Implemented |
 | Business ranking | `trip_planner/ranking/business.py` | `tests/ranking/` | ✅ Implemented |
-| Ranking explanations | `trip_planner/ranking/explanations.py` | — | 🟡 Partial |
-| Source quality model | `docs/source-quality-model.md` | — | 📄 Docs-only |
+| Ranking explanations | `trip_planner/ranking/explanations.py` | `tests/ranking/test_source_confidence_explanation.py` | 🟡 Partial |
+| Source quality model | `trip_planner/sources/quality.py` + `docs/source-quality-model.md` | `tests/sources/test_source_quality.py` | ✅ Implemented |
 | Source channel strategy | `docs/source-channel-strategy.md` | — | 📄 Docs-only |
 
 ---
@@ -325,9 +325,9 @@ From [`docs/product-architecture-brief.md`](product-architecture-brief.md) and [
 These design commitments are still missing, partial, or not yet verified in a live provider environment. Each is a candidate for a follow-up issue:
 
 1. **Semantic planner memory and reorientation** — planner checkpoints and notebook state exist, but there is no semantic recall/reorientation layer for scattered traveler notes and "I was working on..." context shifts. See §13 above.
-2. **Executable source-quality scoring** — provider-rich planner tools now expose source summaries, route/map status, route geometry, route comparison refresh, and an explicit source-quality `not_available` seam. The scoring engine itself remains a separate design commitment. See §13 above.
+2. **Executable source-quality scoring** — the deterministic `SourceQualityScorer` is now implemented in `trip_planner/sources/quality.py` with the `SourceConfidenceSummary` bounded output shape and a `build_source_confidence_explanation` builder in `trip_planner/ranking/explanations.py`. The remaining gap is wiring the planner tool `read_source_quality_summary` and the leisure/business engines to consume resolved `SourceRecord`/`ProvenanceReference` instances per bundle.
 3. **Live TPP transport verification** — `live-tpp-execution-reoptimization-epic.md`. All seams exist but no live HTTP round-trip is required by the default test matrix. See §15 above.
-4. **Source quality model implementation** — `source-quality-model.md` + `source-channel-strategy.md`. Design defined; no engine code.
+4. **Source quality model implementation** — `source-quality-model.md` + `source-channel-strategy.md`. Engine landed in `trip_planner/sources/quality.py` with `SourceConfidenceSummary` and a ranking-explanation builder. Remaining gap is per-bundle wiring once inventory carries resolved source records.
 5. **Provider-rich timeline/map depth** — workspace timeline and map surfaces now share route/segment focus and per-leg timing/confidence, but still need live provider distance/geometry verification and richer source-backed option details. See §16 above.
 6. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
 

--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -5,8 +5,8 @@ It distinguishes docs-only claims from tested implementations so weekly reviews 
 without re-reading every design doc.
 
 **Last updated:** 2026-05-11
-**Test suite baseline:** 524 passed, 1 xfailed (was 3; two resolved by issue #1046 audit — see `tests/planner/MIGRATIONS.md`)  
-**Source baseline:** 159 Python modules (~21.5 K LOC), 84 test modules (~18 K LOC), 38 TypeScript/React files
+**Test suite baseline:** 976 passed, 1 xfailed (issue #1163 added 24 source-quality and explanation-builder tests)  
+**Source baseline:** 161 Python modules (~22 K LOC), 86 test modules (~18.5 K LOC), 38 TypeScript/React files
 
 ---
 
@@ -134,7 +134,7 @@ Design ref: [`docs/ranking-route-search-epic.md`](ranking-route-search-epic.md)
 |------------|--------|-------|--------|
 | Leisure ranking | `trip_planner/ranking/leisure.py` | `tests/ranking/` | ✅ Implemented |
 | Business ranking | `trip_planner/ranking/business.py` | `tests/ranking/` | ✅ Implemented |
-| Ranking explanations | `trip_planner/ranking/explanations.py` | `tests/ranking/test_source_confidence_explanation.py` | 🟡 Partial |
+| Ranking explanations | `trip_planner/ranking/explanations.py` | `tests/ranking/test_source_confidence_explanation.py` | ✅ Implemented |
 | Source quality model | `trip_planner/sources/quality.py` + `docs/source-quality-model.md` | `tests/sources/test_source_quality.py` | ✅ Implemented |
 | Source channel strategy | `docs/source-channel-strategy.md` | — | 📄 Docs-only |
 
@@ -325,11 +325,10 @@ From [`docs/product-architecture-brief.md`](product-architecture-brief.md) and [
 These design commitments are still missing, partial, or not yet verified in a live provider environment. Each is a candidate for a follow-up issue:
 
 1. **Semantic planner memory and reorientation** — planner checkpoints and notebook state exist, but there is no semantic recall/reorientation layer for scattered traveler notes and "I was working on..." context shifts. See §13 above.
-2. **Executable source-quality scoring** — the deterministic `SourceQualityScorer` is now implemented in `trip_planner/sources/quality.py` with the `SourceConfidenceSummary` bounded output shape and a `build_source_confidence_explanation` builder in `trip_planner/ranking/explanations.py`. The remaining gap is wiring the planner tool `read_source_quality_summary` and the leisure/business engines to consume resolved `SourceRecord`/`ProvenanceReference` instances per bundle.
+2. **Per-bundle source-quality wiring** — `SourceQualityScorer`, `SourceConfidenceSummary`, and `build_source_confidence_explanation` are fully implemented and tested (issue #1163). The remaining gap is attaching resolved `SourceRecord`/`ProvenanceReference` instances to `InventoryBundle` so the `read_source_quality_summary` planner tool and the leisure/business ranking engines can consume the engine end-to-end.
 3. **Live TPP transport verification** — `live-tpp-execution-reoptimization-epic.md`. All seams exist but no live HTTP round-trip is required by the default test matrix. See §15 above.
-4. **Source quality model implementation** — `source-quality-model.md` + `source-channel-strategy.md`. Engine landed in `trip_planner/sources/quality.py` with `SourceConfidenceSummary` and a ranking-explanation builder. Remaining gap is per-bundle wiring once inventory carries resolved source records.
-5. **Provider-rich timeline/map depth** — workspace timeline and map surfaces now share route/segment focus and per-leg timing/confidence, but still need live provider distance/geometry verification and richer source-backed option details. See §16 above.
-6. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
+4. **Provider-rich timeline/map depth** — workspace timeline and map surfaces now share route/segment focus and per-leg timing/confidence, but still need live provider distance/geometry verification and richer source-backed option details. See §16 above.
+5. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
 
 ---
 

--- a/docs/next-issue-set.md
+++ b/docs/next-issue-set.md
@@ -123,6 +123,8 @@ This note captures the remaining gaps after the recent readiness, planner-runtim
 - Stale or conflicting inputs reduce confidence without deleting useful options.
 - Source-quality behavior is deterministic and covered by tests.
 
+**Status (2026-05-11):** The deterministic engine, conflict detection, and traveler-facing summary shape are implemented in `trip_planner/sources/quality.py` with `tests/sources/test_source_quality.py` and a ranking-explanation builder in `trip_planner/ranking/explanations.py` (`tests/ranking/test_source_confidence_explanation.py`). The remaining downstream work is to attach resolved `SourceRecord`/`ProvenanceReference` instances onto bundles so the `read_source_quality_summary` planner tool and the leisure/business engines can consume the engine end-to-end.
+
 ## 7. Finish Product UX Cleanup For Traveler Comfort
 
 **Goal:** Remove remaining developer-shaped copy and make the workspace feel like a planning product rather than an implementation surface.

--- a/docs/source-quality-model.md
+++ b/docs/source-quality-model.md
@@ -231,3 +231,40 @@ Before heavy ingestion work begins, the repo should lock:
 5. business-approval and policy compatibility fields
 
 The current `source-channel-strategy.md` can remain the shortlist of seed channels. This document should be treated as the behavioral model for how those channels are used.
+
+## Implementation Status
+
+The deterministic scoring engine described above is implemented in
+[`trip_planner/sources/quality.py`](../trip_planner/sources/quality.py) and is
+covered by [`tests/sources/test_source_quality.py`](../tests/sources/test_source_quality.py).
+
+What landed:
+
+- `SourceQualityScorer.score_source` and `.score_provenance` produce a typed
+  `SourceQualityScore` (freshness, channel fit, provenance strength, traveler
+  relevance, confidence label, tags, traveler-facing explanation fragment) from
+  a `SourceRecord` or `ProvenanceReference`.
+- `SourceQualityScorer.summarize` (and the module-level `summarize_sources`
+  helper) fuses multiple contributions into a bounded `SourceConfidenceSummary`
+  with explicit conflict detection, freshness span, per-category counts, and
+  traveler-facing language. The summary is `mutates_state=False` so it is safe
+  for read-only planner tools to embed.
+- `build_source_confidence_explanation` in
+  [`trip_planner/ranking/explanations.py`](../trip_planner/ranking/explanations.py)
+  turns a `SourceConfidenceSummary` into an `ExplanationRecord` of type
+  `confidence`, so ranking and route-search outputs can attach source-confidence
+  language alongside the existing ranking-confidence record without disrupting
+  the existing engines.
+- Stale, conflicting, and sparse inputs are reflected in `confidence_label`,
+  `tags`, and `explanation_fragments`; useful-but-uncertain options remain
+  visible rather than being deleted.
+
+What still depends on later ingestion/scoring work:
+
+- The bundle-level planner tool `read_source_quality_summary` keeps its
+  bounded `not_available` shape until inventory carries fully resolved
+  `SourceRecord`/`ProvenanceReference` instances per option (see
+  [`docs/next-issue-set.md`](next-issue-set.md) item 6 for downstream work).
+- Live commerciality and review_consistency calibration across providers, and
+  the full live source-fusion pipeline described in §Fusion Logic, are not part
+  of this scoring engine; they remain ingestion-side commitments.

--- a/tests/ranking/test_source_confidence_explanation.py
+++ b/tests/ranking/test_source_confidence_explanation.py
@@ -1,0 +1,219 @@
+"""Tests for the source-confidence ExplanationRecord builder."""
+
+from __future__ import annotations
+
+import pytest
+
+# Importing trip_planner.itinerary.feasibility first breaks a pre-existing
+# circular import between trip_planner.ranking and trip_planner.itinerary.search;
+# mirrors the import order in tests/ranking/test_leisure_ranking.py.
+from trip_planner.itinerary.feasibility import FeasibilityAssessment  # noqa: F401
+from trip_planner.ranking.explanations import (
+    EXPLANATION_RECORD_TYPES,
+    ExplanationRecord,
+    build_source_confidence_explanation,
+)
+from trip_planner.sources import (
+    ProvenanceReference,
+    QualityValueFitSummary,
+    SourceConfidenceSummary,
+    SourceRecord,
+    SourceTrustSignals,
+    summarize_sources,
+)
+
+
+def _strong_summary() -> SourceConfidenceSummary:
+    return summarize_sources(
+        [
+            SourceRecord(
+                source_id="amtrak-service-alerts",
+                provider_name="Amtrak",
+                display_name="Amtrak Service Alerts",
+                category="official_operational",
+                coverage_scope="national",
+                supported_option_kinds=["rail"],
+                trust_signals=SourceTrustSignals(
+                    freshness_days=0,
+                    freshness_confidence=0.95,
+                    commerciality=0.3,
+                    editorial_independence=0.4,
+                    operational_reliability=0.92,
+                    review_consistency=0.55,
+                ),
+                quality_summary=QualityValueFitSummary(
+                    quality_signal=0.85,
+                    value_signal=0.7,
+                    fit_signal=0.8,
+                    confidence=0.85,
+                ),
+            ),
+            SourceRecord(
+                source_id="booking-dot-com",
+                provider_name="Booking",
+                display_name="Booking.com",
+                category="commercial_inventory",
+                coverage_scope="global",
+                supported_option_kinds=["lodging"],
+                trust_signals=SourceTrustSignals(
+                    freshness_days=2,
+                    freshness_confidence=0.9,
+                    commerciality=0.85,
+                    editorial_independence=0.1,
+                    operational_reliability=0.75,
+                    review_consistency=0.6,
+                ),
+                quality_summary=QualityValueFitSummary(
+                    quality_signal=0.75,
+                    value_signal=0.8,
+                    fit_signal=0.65,
+                    confidence=0.75,
+                ),
+            ),
+        ]
+    )
+
+
+def _sparse_summary() -> SourceConfidenceSummary:
+    return summarize_sources([])
+
+
+def test_builder_produces_confidence_record_for_strong_coverage() -> None:
+    summary = _strong_summary()
+
+    record = build_source_confidence_explanation(
+        target_id="option:rail-1",
+        target_kind="item",
+        summary=summary,
+        source_refs=["external:rail-leg-1"],
+    )
+
+    assert isinstance(record, ExplanationRecord)
+    assert record.record_type == "confidence"
+    assert record.record_type in EXPLANATION_RECORD_TYPES
+    assert record.target_kind == "item"
+    assert record.target_id == "option:rail-1"
+    assert record.machine_context["source_confidence_label"] == summary.confidence_label
+    assert record.machine_context["contributing_source_count"] == str(
+        summary.contributing_source_count
+    )
+    assert "external:rail-leg-1" in record.source_refs
+    # source_ids from the per-source scores should also be present.
+    assert any(ref.startswith("amtrak") or ref.startswith("booking") for ref in record.source_refs)
+
+
+def test_builder_handles_sparse_summary_with_uncertain_language() -> None:
+    summary = _sparse_summary()
+
+    record = build_source_confidence_explanation(
+        target_id="option:sparse-1",
+        summary=summary,
+    )
+
+    assert record.record_type == "confidence"
+    assert record.machine_context["source_confidence_label"] == "sparse"
+    assert record.machine_context["contributing_source_count"] == "0"
+    assert record.headline == "Sparse source coverage"
+    assert "sparse" in record.summary.lower() or "uncertainty" in record.summary.lower()
+
+
+def test_builder_flags_conflict_in_machine_context() -> None:
+    summary = summarize_sources(
+        [
+            SourceRecord(
+                source_id="enthusiast-blog",
+                provider_name="Enthusiast Blog",
+                display_name="Enthusiast Travel Blog",
+                category="specialist_non_commercial",
+                coverage_scope="regional",
+                supported_option_kinds=["lodging"],
+                trust_signals=SourceTrustSignals(
+                    freshness_days=14,
+                    freshness_confidence=0.7,
+                    commerciality=0.15,
+                    editorial_independence=0.85,
+                    operational_reliability=0.6,
+                    review_consistency=0.55,
+                ),
+                quality_summary=QualityValueFitSummary(
+                    quality_signal=0.9, value_signal=0.8, fit_signal=0.7, confidence=0.8
+                ),
+            ),
+            SourceRecord(
+                source_id="ratings-platform",
+                provider_name="Ratings Platform",
+                display_name="Cheap Ratings Platform",
+                category="ratings_reviews",
+                coverage_scope="global",
+                supported_option_kinds=["lodging"],
+                trust_signals=SourceTrustSignals(
+                    freshness_days=10,
+                    freshness_confidence=0.6,
+                    commerciality=0.7,
+                    editorial_independence=0.3,
+                    operational_reliability=0.5,
+                    review_consistency=0.5,
+                ),
+                quality_summary=QualityValueFitSummary(
+                    quality_signal=0.25, value_signal=0.3, fit_signal=0.3, confidence=0.45
+                ),
+            ),
+        ]
+    )
+
+    record = build_source_confidence_explanation(
+        target_id="option:lodging-conflict-1",
+        summary=summary,
+    )
+
+    assert record.machine_context["conflict_detected"] == "true"
+    # The traveler-facing summary should mention disagreement somewhere.
+    assert any("disagree" in fragment.lower() for fragment in record.human_summary)
+
+
+def test_builder_rejects_non_summary_input() -> None:
+    with pytest.raises(ValueError, match="SourceConfidenceSummary"):
+        build_source_confidence_explanation(
+            target_id="option:bad",
+            summary="not a summary",  # type: ignore[arg-type]
+        )
+
+
+def test_builder_rejects_invalid_target_kind() -> None:
+    summary = _strong_summary()
+    with pytest.raises(ValueError, match="target_kind"):
+        build_source_confidence_explanation(
+            target_id="option:bad-kind",
+            target_kind="city",  # not in EXPLANATION_TARGET_KINDS
+            summary=summary,
+        )
+
+
+def test_builder_works_with_provenance_only_summary() -> None:
+    reference = ProvenanceReference(
+        provenance_id="prov-rail-1",
+        source_id="official-rail",
+        source_category="official_operational",
+        subject_kind="option",
+        subject_id="rail-option-1",
+        contribution_kind="operational",
+        summary="Service alert for the rail option.",
+        freshness_days_at_capture=0,
+        trust_snapshot=SourceTrustSignals(
+            freshness_days=0,
+            freshness_confidence=0.95,
+            commerciality=0.3,
+            operational_reliability=0.9,
+            review_consistency=0.55,
+        ),
+    )
+    summary = summarize_sources([reference])
+
+    record = build_source_confidence_explanation(
+        target_id="option:rail-prov-only",
+        summary=summary,
+    )
+
+    assert record.record_type == "confidence"
+    assert record.machine_context["contributing_source_count"] == "1"
+    assert "official-rail" in record.source_refs

--- a/tests/sources/test_source_quality.py
+++ b/tests/sources/test_source_quality.py
@@ -1,0 +1,430 @@
+"""Tests for the deterministic source-quality scoring engine."""
+
+from __future__ import annotations
+
+import pytest
+
+from trip_planner.sources import (
+    CONFIDENCE_LABELS,
+    ProvenanceReference,
+    QualityValueFitSummary,
+    SourceConfidenceSummary,
+    SourceQualityScore,
+    SourceQualityScorer,
+    SourceRecord,
+    SourceTrustSignals,
+    summarize_sources,
+)
+
+
+def _official_amtrak_source() -> SourceRecord:
+    return SourceRecord(
+        source_id="amtrak-service-alerts",
+        provider_name="Amtrak",
+        display_name="Amtrak Service Alerts",
+        category="official_operational",
+        coverage_scope="national",
+        supported_option_kinds=["rail"],
+        trust_signals=SourceTrustSignals(
+            freshness_days=0,
+            freshness_confidence=0.95,
+            commerciality=0.3,
+            editorial_independence=0.4,
+            operational_reliability=0.92,
+            review_consistency=0.55,
+        ),
+        quality_summary=QualityValueFitSummary(
+            quality_signal=0.85,
+            value_signal=0.7,
+            fit_signal=0.8,
+            confidence=0.85,
+        ),
+    )
+
+
+def _commercial_booking_source() -> SourceRecord:
+    return SourceRecord(
+        source_id="booking-dot-com",
+        provider_name="Booking",
+        display_name="Booking.com",
+        category="commercial_inventory",
+        coverage_scope="global",
+        supported_option_kinds=["lodging"],
+        trust_signals=SourceTrustSignals(
+            freshness_days=2,
+            freshness_confidence=0.9,
+            commerciality=0.85,
+            editorial_independence=0.1,
+            operational_reliability=0.75,
+            review_consistency=0.6,
+        ),
+        quality_summary=QualityValueFitSummary(
+            quality_signal=0.75,
+            value_signal=0.8,
+            fit_signal=0.65,
+            confidence=0.75,
+        ),
+    )
+
+
+def _crowd_review_source() -> SourceRecord:
+    return SourceRecord(
+        source_id="tripadvisor-reviews",
+        provider_name="TripAdvisor",
+        display_name="TripAdvisor Reviews",
+        category="ratings_reviews",
+        coverage_scope="global",
+        supported_option_kinds=["lodging", "activity"],
+        trust_signals=SourceTrustSignals(
+            freshness_days=20,
+            freshness_confidence=0.7,
+            commerciality=0.55,
+            editorial_independence=0.45,
+            operational_reliability=0.5,
+            review_consistency=0.55,
+        ),
+        quality_summary=QualityValueFitSummary(
+            quality_signal=0.6,
+            value_signal=0.55,
+            fit_signal=0.55,
+            confidence=0.55,
+        ),
+    )
+
+
+def _stale_editorial_source() -> SourceRecord:
+    return SourceRecord(
+        source_id="stale-city-guide",
+        provider_name="Old Guide",
+        display_name="Old City Guide",
+        category="editorial",
+        coverage_scope="regional",
+        supported_option_kinds=["activity", "route"],
+        trust_signals=SourceTrustSignals(
+            freshness_days=540,  # ~18 months
+            freshness_confidence=0.3,
+            commerciality=0.2,
+            editorial_independence=0.75,
+            operational_reliability=0.45,
+            review_consistency=0.4,
+        ),
+        quality_summary=QualityValueFitSummary(
+            quality_signal=0.5,
+            value_signal=0.5,
+            fit_signal=0.5,
+            confidence=0.4,
+        ),
+    )
+
+
+def _conflicting_strong_review_source() -> SourceRecord:
+    return SourceRecord(
+        source_id="enthusiast-blog",
+        provider_name="Enthusiast Blog",
+        display_name="Enthusiast Travel Blog",
+        category="specialist_non_commercial",
+        coverage_scope="regional",
+        supported_option_kinds=["lodging"],
+        trust_signals=SourceTrustSignals(
+            freshness_days=14,
+            freshness_confidence=0.7,
+            commerciality=0.15,
+            editorial_independence=0.85,
+            operational_reliability=0.6,
+            review_consistency=0.55,
+        ),
+        quality_summary=QualityValueFitSummary(
+            quality_signal=0.9,
+            value_signal=0.8,
+            fit_signal=0.7,
+            confidence=0.8,
+        ),
+    )
+
+
+def _conflicting_weak_review_source() -> SourceRecord:
+    return SourceRecord(
+        source_id="ratings-platform",
+        provider_name="Ratings Platform",
+        display_name="Cheap Ratings Platform",
+        category="ratings_reviews",
+        coverage_scope="global",
+        supported_option_kinds=["lodging"],
+        trust_signals=SourceTrustSignals(
+            freshness_days=10,
+            freshness_confidence=0.6,
+            commerciality=0.7,
+            editorial_independence=0.3,
+            operational_reliability=0.5,
+            review_consistency=0.5,
+        ),
+        quality_summary=QualityValueFitSummary(
+            quality_signal=0.25,
+            value_signal=0.3,
+            fit_signal=0.3,
+            confidence=0.45,
+        ),
+    )
+
+
+def _sparse_unknown_source() -> SourceRecord:
+    return SourceRecord(
+        source_id="sparse-local-blog",
+        provider_name="Local Blog",
+        display_name="Local Blog",
+        category="specialist_non_commercial",
+        coverage_scope="local",
+        supported_option_kinds=[],
+        trust_signals=SourceTrustSignals(),
+        quality_summary=QualityValueFitSummary(),
+    )
+
+
+def test_official_operational_source_scores_very_high() -> None:
+    scorer = SourceQualityScorer()
+    score = scorer.score_source(
+        _official_amtrak_source(),
+        intended_option_kind="rail",
+    )
+
+    assert isinstance(score, SourceQualityScore)
+    assert score.confidence_label == "very_high"
+    assert score.confidence >= 0.80
+    assert "official" in score.tags
+    assert "fresh" in score.tags
+    assert "stale" not in score.tags
+    assert "stranske" not in score.explanation_fragment  # sanity check on copy
+
+
+def test_commercial_inventory_source_scores_high() -> None:
+    scorer = SourceQualityScorer()
+    score = scorer.score_source(
+        _commercial_booking_source(),
+        intended_option_kind="lodging",
+    )
+
+    assert score.confidence_label in {"high", "very_high"}
+    assert score.confidence >= 0.65
+    assert "commercial" in score.tags
+
+
+def test_crowd_review_source_scores_moderate() -> None:
+    scorer = SourceQualityScorer()
+    score = scorer.score_source(
+        _crowd_review_source(),
+        intended_option_kind="lodging",
+    )
+
+    # Crowd reviews should be moderate-confidence: useful but not authoritative.
+    assert score.confidence_label in {"moderate", "high"}
+    assert 0.45 <= score.confidence < 0.85
+    assert "crowd-review" in score.tags
+    assert "stale" not in score.tags
+
+
+def test_stale_editorial_source_is_flagged_and_uncertain() -> None:
+    scorer = SourceQualityScorer()
+    score = scorer.score_source(_stale_editorial_source(), intended_option_kind="activity")
+
+    assert score.confidence_label in {"uncertain", "sparse", "moderate"}
+    assert "stale" in score.tags
+    assert score.freshness_score < 0.35
+    # Stale options should still be visible, not zero-confidence.
+    assert score.confidence > 0.0
+
+
+def test_sparse_unknown_source_does_not_crash_and_is_low_confidence() -> None:
+    scorer = SourceQualityScorer()
+    score = scorer.score_source(_sparse_unknown_source())
+
+    assert score.confidence_label in {"uncertain", "sparse", "moderate"}
+    # No trust signals at all should still produce a bounded score.
+    assert 0.0 <= score.confidence <= 1.0
+
+
+def test_summarize_handles_empty_input_with_sparse_label() -> None:
+    summary = summarize_sources([])
+
+    assert isinstance(summary, SourceConfidenceSummary)
+    assert summary.confidence == 0.0
+    assert summary.confidence_label == "sparse"
+    assert summary.contributing_source_count == 0
+    assert summary.tags == ["sparse"]
+    assert summary.conflict_detected is False
+    assert summary.mutates_state is False
+    assert summary.freshness_summary == "no source records"
+
+
+def test_summarize_mixes_official_commercial_editorial_into_high_confidence() -> None:
+    summary = summarize_sources(
+        [
+            _official_amtrak_source(),
+            _commercial_booking_source(),
+            _stale_editorial_source(),
+        ],
+        subject_kind="option",
+    )
+
+    assert summary.confidence_label in {"high", "very_high", "moderate"}
+    assert summary.contributing_source_count == 3
+    assert summary.category_counts["official_operational"] == 1
+    assert summary.category_counts["commercial_inventory"] == 1
+    assert summary.category_counts["editorial"] == 1
+    # The stale editorial source must still contribute and be visible via tags.
+    assert "stale" in summary.tags
+    assert "official" in summary.tags
+    assert summary.freshness_summary.startswith("freshness span")
+
+
+def test_summarize_detects_conflict_between_strong_and_weak_signals() -> None:
+    summary = summarize_sources(
+        [
+            _conflicting_strong_review_source(),
+            _conflicting_weak_review_source(),
+        ]
+    )
+
+    assert summary.conflict_detected is True
+    assert "quality" in summary.conflict_summary
+    assert "conflict" in summary.tags
+    assert summary.contributing_source_count == 2
+    # Sources disagreeing should depress fused confidence but not zero it.
+    assert 0.0 < summary.confidence < 0.85
+    assert any("disagree" in fragment.lower() for fragment in summary.explanation_fragments)
+
+
+def test_summarize_single_source_marks_sparse() -> None:
+    summary = summarize_sources([_commercial_booking_source()])
+
+    assert summary.contributing_source_count == 1
+    assert "sparse" in summary.tags
+    # Single-source summaries still produce non-empty fragments.
+    assert summary.explanation_fragments
+    assert all(isinstance(fragment, str) and fragment for fragment in summary.explanation_fragments)
+
+
+def test_summary_explanation_fragments_are_traveler_facing() -> None:
+    summary = summarize_sources(
+        [
+            _official_amtrak_source(),
+            _commercial_booking_source(),
+        ]
+    )
+
+    joined = " ".join(summary.explanation_fragments).lower()
+    # Should avoid raw IDs, internal field names, or developer terminology.
+    assert "freshness_days" not in joined
+    assert "operational_reliability" not in joined
+    assert "source_id" not in joined
+
+
+def test_summarize_is_deterministic_across_reorderings() -> None:
+    records = [
+        _official_amtrak_source(),
+        _commercial_booking_source(),
+        _crowd_review_source(),
+    ]
+
+    forward = summarize_sources(records)
+    reverse = summarize_sources(list(reversed(records)))
+
+    assert forward.confidence == reverse.confidence
+    assert forward.confidence_label == reverse.confidence_label
+    assert forward.tags == reverse.tags
+    assert [s.source_id for s in forward.per_source_scores] == [
+        s.source_id for s in reverse.per_source_scores
+    ]
+
+
+def test_scorer_accepts_provenance_reference_with_trust_snapshot() -> None:
+    reference = ProvenanceReference(
+        provenance_id="prov-1",
+        source_id="booking-com",
+        source_category="commercial_inventory",
+        subject_kind="option",
+        subject_id="lodging-option-1",
+        contribution_kind="pricing",
+        summary="Provided the working nightly rate and cancellation terms.",
+        freshness_days_at_capture=1,
+        trust_snapshot=SourceTrustSignals(
+            freshness_days=1,
+            freshness_confidence=0.9,
+            commerciality=0.8,
+            editorial_independence=0.1,
+            operational_reliability=0.7,
+            review_consistency=0.6,
+        ),
+        quality_value_fit=QualityValueFitSummary(
+            quality_signal=0.7,
+            value_signal=0.8,
+            fit_signal=0.6,
+            confidence=0.7,
+        ),
+    )
+
+    scorer = SourceQualityScorer()
+    score = scorer.score_provenance(reference, intended_option_kind="lodging")
+
+    assert isinstance(score, SourceQualityScore)
+    assert score.source_id == "booking-com"
+    assert score.confidence_label in {"moderate", "high", "very_high"}
+
+
+def test_summarize_accepts_mixed_record_and_provenance_inputs() -> None:
+    reference = ProvenanceReference(
+        provenance_id="prov-mixed",
+        source_id="official-rail",
+        source_category="official_operational",
+        subject_kind="option",
+        subject_id="rail-option-1",
+        contribution_kind="operational",
+        summary="Real-time service alerts on the candidate rail leg.",
+        freshness_days_at_capture=0,
+        trust_snapshot=SourceTrustSignals(
+            freshness_days=0,
+            freshness_confidence=0.95,
+            commerciality=0.3,
+            operational_reliability=0.9,
+            review_consistency=0.55,
+        ),
+    )
+
+    summary = summarize_sources([_commercial_booking_source(), reference])
+
+    assert summary.contributing_source_count == 2
+    # Mixed inputs should still produce a single bounded summary.
+    assert summary.confidence_label in CONFIDENCE_LABELS
+    assert summary.category_counts["commercial_inventory"] == 1
+    assert summary.category_counts["official_operational"] == 1
+
+
+def test_scorer_rejects_invalid_intended_option_kind() -> None:
+    scorer = SourceQualityScorer()
+    with pytest.raises(ValueError, match="intended_option_kind"):
+        scorer.score_source(_commercial_booking_source(), intended_option_kind="spaceship")
+
+
+def test_scorer_rejects_invalid_traveler_relevance_hint() -> None:
+    scorer = SourceQualityScorer()
+    with pytest.raises(ValueError, match="traveler_relevance_hint"):
+        scorer.score_source(_commercial_booking_source(), traveler_relevance_hint=2.0)
+
+
+def test_summary_rejects_invalid_subject_kind() -> None:
+    with pytest.raises(ValueError, match="subject_kind"):
+        summarize_sources([_commercial_booking_source()], subject_kind="city_vibe")
+
+
+def test_summary_rejects_non_source_inputs() -> None:
+    with pytest.raises(ValueError, match="SourceRecord or ProvenanceReference"):
+        summarize_sources(["not a source"])  # type: ignore[list-item]
+
+
+def test_summary_round_trip_to_dict_preserves_fields() -> None:
+    summary = summarize_sources([_official_amtrak_source()])
+    payload = summary.to_dict()
+
+    assert payload["subject_kind"] == "option"
+    assert payload["confidence_label"] == summary.confidence_label
+    assert payload["per_source_scores"][0]["source_id"] == "amtrak-service-alerts"
+    assert payload["mutates_state"] is False

--- a/trip_planner/ranking/__init__.py
+++ b/trip_planner/ranking/__init__.py
@@ -4,6 +4,7 @@ from .explanations import (
     EXPLANATION_RECORD_TYPES,
     EXPLANATION_TARGET_KINDS,
     ExplanationRecord,
+    build_source_confidence_explanation,
 )
 from .business import BusinessRankingEngine
 from .leisure import LeisureRankingEngine
@@ -38,4 +39,5 @@ __all__ = [
     "ScoreBreakdown",
     "ScoreConfidenceSummary",
     "ScoreContribution",
+    "build_source_confidence_explanation",
 ]

--- a/trip_planner/ranking/explanations.py
+++ b/trip_planner/ranking/explanations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 
 from trip_planner._validators import require_non_empty, require_strings
+from trip_planner.sources.quality import SourceConfidenceSummary
 
 EXPLANATION_RECORD_TYPES: tuple[str, ...] = (
     "summary",
@@ -54,3 +55,72 @@ class ExplanationRecord:
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
+
+
+def build_source_confidence_explanation(
+    *,
+    target_id: str,
+    target_kind: str = "item",
+    summary: SourceConfidenceSummary,
+    source_refs: list[str] | None = None,
+) -> ExplanationRecord:
+    """Build a ``confidence`` ExplanationRecord from a fused source summary.
+
+    Ranking engines and planner-tool consumers can call this when a candidate
+    or option carries a :class:`SourceConfidenceSummary` so that traveler-facing
+    explanations include source-confidence language alongside the existing
+    ranking-confidence record.
+    """
+
+    if not isinstance(summary, SourceConfidenceSummary):
+        raise ValueError("summary must be a SourceConfidenceSummary")
+    if target_kind not in EXPLANATION_TARGET_KINDS:
+        raise ValueError(f"target_kind must be one of {EXPLANATION_TARGET_KINDS}")
+
+    machine_context: dict[str, str] = {
+        "source_confidence": f"{summary.confidence:.2f}",
+        "source_confidence_label": summary.confidence_label,
+        "contributing_source_count": str(summary.contributing_source_count),
+        "freshness": summary.freshness_summary,
+        "conflict_detected": "true" if summary.conflict_detected else "false",
+    }
+
+    refs: list[str] = []
+    seen: set[str] = set()
+    for entry in source_refs or []:
+        if entry and entry not in seen:
+            refs.append(entry)
+            seen.add(entry)
+    for score in summary.per_source_scores:
+        if score.source_id not in seen:
+            refs.append(score.source_id)
+            seen.add(score.source_id)
+    refs = refs[:6]
+
+    factor_keys = ["source_confidence", *summary.tags[:4]]
+
+    headline_map = {
+        "very_high": "Strong source coverage",
+        "high": "Solid source coverage",
+        "moderate": "Mixed source coverage",
+        "uncertain": "Uncertain source coverage",
+        "sparse": "Sparse source coverage",
+    }
+    headline = headline_map.get(summary.confidence_label, "Source confidence")
+
+    summary_text = " ".join(summary.explanation_fragments) or (
+        "Source confidence is summarized from the contributing source records."
+    )
+
+    return ExplanationRecord(
+        explanation_id=f"source-confidence:{target_id}",
+        record_type="confidence",
+        target_kind=target_kind,
+        target_id=target_id,
+        headline=headline,
+        summary=summary_text,
+        factor_keys=factor_keys,
+        machine_context=machine_context,
+        human_summary=list(summary.explanation_fragments),
+        source_refs=refs,
+    )

--- a/trip_planner/sources/__init__.py
+++ b/trip_planner/sources/__init__.py
@@ -4,6 +4,13 @@ from .adapters import SourceAdapter
 from .dedup import DeduplicationDecision
 from .models import QualityValueFitSummary, SourceRecord, SourceTrustSignals
 from .provenance import ProvenanceReference
+from .quality import (
+    CONFIDENCE_LABELS,
+    SourceConfidenceSummary,
+    SourceQualityScore,
+    SourceQualityScorer,
+    summarize_sources,
+)
 from .resolution import (
     AttributeConflict,
     EntityResolution,
@@ -21,6 +28,7 @@ from .snapshots import (
 __all__ = [
     "AdapterIssue",
     "AttributeConflict",
+    "CONFIDENCE_LABELS",
     "DeduplicationDecision",
     "EntityResolution",
     "MatchCandidate",
@@ -31,7 +39,11 @@ __all__ = [
     "RawSnapshot",
     "RawSourceRecord",
     "SourceAdapter",
+    "SourceConfidenceSummary",
+    "SourceQualityScore",
+    "SourceQualityScorer",
     "SourceRecord",
     "SourceQuery",
     "SourceTrustSignals",
+    "summarize_sources",
 ]

--- a/trip_planner/sources/quality.py
+++ b/trip_planner/sources/quality.py
@@ -1,0 +1,653 @@
+"""Deterministic source-quality scoring and explanation engine.
+
+Implements the behavioral model from ``docs/source-quality-model.md``: freshness,
+channel fit, provenance strength, conflict state, and traveler relevance are scored
+independently and fused into a bounded confidence summary that ranking explanations
+and planner tools can consume.
+
+The scorer accepts :class:`SourceRecord` and :class:`ProvenanceReference` inputs in
+the same call to support fused summaries across multiple contributions for one
+subject.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass, field
+from statistics import fmean, median
+from typing import Any
+
+from trip_planner._validators import (
+    require_non_empty,
+    require_non_negative,
+    require_probability,
+    require_strings,
+)
+
+from . import schema
+from .models import QualityValueFitSummary, SourceRecord, SourceTrustSignals
+from .provenance import ProvenanceReference
+
+CONFIDENCE_LABELS: tuple[str, ...] = (
+    "very_high",
+    "high",
+    "moderate",
+    "uncertain",
+    "sparse",
+)
+
+
+SourceLike = SourceRecord | ProvenanceReference
+
+
+_CATEGORY_OPERATIONAL_PRIOR: dict[str, float] = {
+    "official_operational": 0.90,
+    "managed_travel_policy": 0.85,
+    "commercial_inventory": 0.75,
+    "editorial": 0.65,
+    "specialist_non_commercial": 0.55,
+    "ratings_reviews": 0.55,
+}
+
+
+_CATEGORY_TRAVELER_RELEVANCE_PRIOR: dict[str, float] = {
+    "editorial": 0.80,
+    "specialist_non_commercial": 0.75,
+    "ratings_reviews": 0.70,
+    "commercial_inventory": 0.65,
+    "official_operational": 0.60,
+    "managed_travel_policy": 0.55,
+}
+
+
+_CATEGORY_TAGS: dict[str, str] = {
+    "official_operational": "official",
+    "managed_travel_policy": "managed-channel",
+    "commercial_inventory": "commercial",
+    "ratings_reviews": "crowd-review",
+    "editorial": "editorial",
+    "specialist_non_commercial": "specialist",
+}
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, value))
+
+
+def _round(value: float) -> float:
+    return round(value, 4)
+
+
+def _confidence_label(score: float) -> str:
+    if score >= 0.80:
+        return "very_high"
+    if score >= 0.65:
+        return "high"
+    if score >= 0.45:
+        return "moderate"
+    if score >= 0.25:
+        return "uncertain"
+    return "sparse"
+
+
+@dataclass(slots=True)
+class SourceQualityScore:
+    """Typed score for a single source contribution.
+
+    All numeric fields are in ``[0.0, 1.0]``. ``confidence_label`` is one of
+    :data:`CONFIDENCE_LABELS`.
+    """
+
+    source_id: str
+    source_category: str
+    confidence: float
+    confidence_label: str
+    freshness_score: float
+    channel_fit_score: float
+    provenance_strength: float
+    traveler_relevance: float
+    explanation_fragment: str
+    tags: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.source_id, "source_id")
+        if self.source_category not in schema.SOURCE_CATEGORIES:
+            raise ValueError(f"source_category must be one of {schema.SOURCE_CATEGORIES}")
+        if self.confidence_label not in CONFIDENCE_LABELS:
+            raise ValueError(f"confidence_label must be one of {CONFIDENCE_LABELS}")
+        for field_name in (
+            "confidence",
+            "freshness_score",
+            "channel_fit_score",
+            "provenance_strength",
+            "traveler_relevance",
+        ):
+            require_probability(getattr(self, field_name), field_name)
+        require_non_empty(self.explanation_fragment, "explanation_fragment")
+        require_strings(self.tags, "tags")
+        require_strings(self.notes, "notes")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class SourceConfidenceSummary:
+    """Bounded fused summary over one or more source contributions.
+
+    ``conflict_detected`` is ``True`` when the contributing sources disagree
+    materially on quality/value/fit signals; ``conflict_summary`` describes the
+    disagreement in traveler-facing language. ``mutates_state`` is always
+    ``False`` so this shape is safe for read-only planner tools.
+    """
+
+    subject_kind: str
+    confidence: float
+    confidence_label: str
+    contributing_source_count: int
+    category_counts: dict[str, int]
+    freshness_summary: str
+    conflict_detected: bool
+    conflict_summary: str
+    explanation_fragments: list[str]
+    tags: list[str]
+    per_source_scores: list[SourceQualityScore] = field(default_factory=list)
+    mutates_state: bool = False
+    notes: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.subject_kind not in schema.PROVENANCE_SUBJECT_KINDS:
+            raise ValueError(f"subject_kind must be one of {schema.PROVENANCE_SUBJECT_KINDS}")
+        require_probability(self.confidence, "confidence")
+        if self.confidence_label not in CONFIDENCE_LABELS:
+            raise ValueError(f"confidence_label must be one of {CONFIDENCE_LABELS}")
+        require_non_negative(self.contributing_source_count, "contributing_source_count")
+        for key, value in self.category_counts.items():
+            if not isinstance(key, str) or not key:
+                raise ValueError("category_counts keys must be non-empty strings")
+            if key not in schema.SOURCE_CATEGORIES:
+                raise ValueError(f"category_counts keys must be from {schema.SOURCE_CATEGORIES}")
+            require_non_negative(value, f"category_counts[{key}]")
+        require_strings(self.explanation_fragments, "explanation_fragments")
+        require_strings(self.tags, "tags")
+        require_strings(self.notes, "notes")
+        if self.mutates_state:
+            raise ValueError("SourceConfidenceSummary is read-only; mutates_state must be False")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class SourceQualityScorer:
+    """Deterministic source-quality scoring engine.
+
+    All scoring is pure-function on the input contracts so identical inputs
+    always produce identical outputs regardless of iteration order. The engine
+    keeps stale, conflicting, or sparse sources visible rather than deleting
+    them; their confidence_label and tags surface the uncertainty.
+    """
+
+    FRESHNESS_HALF_LIFE_DAYS: float = 45.0
+    CONFLICT_SIGNAL_GAP: float = 0.35
+
+    def score_source(
+        self,
+        record: SourceRecord,
+        *,
+        traveler_relevance_hint: float | None = None,
+        intended_option_kind: str | None = None,
+    ) -> SourceQualityScore:
+        if not isinstance(record, SourceRecord):
+            raise ValueError("record must be a SourceRecord")
+        return self._score(
+            source_id=record.source_id,
+            source_category=record.category,
+            supported_option_kinds=tuple(record.supported_option_kinds),
+            trust_signals=record.trust_signals,
+            quality_summary=record.quality_summary,
+            traveler_relevance_hint=traveler_relevance_hint,
+            intended_option_kind=intended_option_kind,
+            display_label=record.display_name or record.provider_name,
+        )
+
+    def score_provenance(
+        self,
+        reference: ProvenanceReference,
+        *,
+        traveler_relevance_hint: float | None = None,
+        intended_option_kind: str | None = None,
+    ) -> SourceQualityScore:
+        if not isinstance(reference, ProvenanceReference):
+            raise ValueError("reference must be a ProvenanceReference")
+        trust = reference.trust_snapshot or SourceTrustSignals(
+            freshness_days=reference.freshness_days_at_capture
+        )
+        quality = reference.quality_value_fit or QualityValueFitSummary()
+        return self._score(
+            source_id=reference.source_id,
+            source_category=reference.source_category,
+            supported_option_kinds=(),
+            trust_signals=trust,
+            quality_summary=quality,
+            traveler_relevance_hint=traveler_relevance_hint,
+            intended_option_kind=intended_option_kind,
+            display_label=reference.source_id,
+        )
+
+    def summarize(
+        self,
+        records: Iterable[SourceLike],
+        *,
+        subject_kind: str = "option",
+        traveler_relevance_hint: float | None = None,
+        intended_option_kind: str | None = None,
+    ) -> SourceConfidenceSummary:
+        if subject_kind not in schema.PROVENANCE_SUBJECT_KINDS:
+            raise ValueError(f"subject_kind must be one of {schema.PROVENANCE_SUBJECT_KINDS}")
+        record_list = list(records)
+        for entry in record_list:
+            if not isinstance(entry, (SourceRecord, ProvenanceReference)):
+                raise ValueError(
+                    "summarize() inputs must be SourceRecord or ProvenanceReference instances"
+                )
+
+        if not record_list:
+            return SourceConfidenceSummary(
+                subject_kind=subject_kind,
+                confidence=0.0,
+                confidence_label="sparse",
+                contributing_source_count=0,
+                category_counts={},
+                freshness_summary="no source records",
+                conflict_detected=False,
+                conflict_summary="",
+                explanation_fragments=[
+                    "No supporting sources were attached, so this option carries uncertainty.",
+                ],
+                tags=["sparse"],
+                per_source_scores=[],
+                notes=["empty input"],
+            )
+
+        per_source: list[SourceQualityScore] = []
+        for entry in record_list:
+            if isinstance(entry, SourceRecord):
+                per_source.append(
+                    self.score_source(
+                        entry,
+                        traveler_relevance_hint=traveler_relevance_hint,
+                        intended_option_kind=intended_option_kind,
+                    )
+                )
+            else:
+                per_source.append(
+                    self.score_provenance(
+                        entry,
+                        traveler_relevance_hint=traveler_relevance_hint,
+                        intended_option_kind=intended_option_kind,
+                    )
+                )
+
+        per_source.sort(key=lambda item: (-item.confidence, item.source_category, item.source_id))
+
+        category_counts: dict[str, int] = {}
+        for score in per_source:
+            category_counts[score.source_category] = (
+                category_counts.get(score.source_category, 0) + 1
+            )
+
+        freshness_days = self._collect_freshness_days(record_list)
+        freshness_summary = self._summarize_freshness(freshness_days)
+
+        conflict_detected, conflict_summary = self._detect_conflicts(record_list)
+
+        base_confidence = fmean(score.confidence for score in per_source)
+        coverage_bonus = min(0.08, 0.025 * max(0, len(per_source) - 1))
+        diversity_bonus = min(0.06, 0.02 * (len(category_counts) - 1))
+        conflict_penalty = 0.18 if conflict_detected else 0.0
+        sparse_penalty = 0.10 if len(per_source) == 1 else 0.0
+
+        confidence = _round(
+            _clamp(
+                base_confidence
+                + coverage_bonus
+                + diversity_bonus
+                - conflict_penalty
+                - sparse_penalty
+            )
+        )
+        label = _confidence_label(confidence)
+
+        tags = self._summary_tags(per_source, conflict_detected, len(per_source))
+        fragments = self._summary_fragments(
+            per_source=per_source,
+            confidence=confidence,
+            label=label,
+            conflict_detected=conflict_detected,
+            conflict_summary=conflict_summary,
+        )
+
+        return SourceConfidenceSummary(
+            subject_kind=subject_kind,
+            confidence=confidence,
+            confidence_label=label,
+            contributing_source_count=len(per_source),
+            category_counts=category_counts,
+            freshness_summary=freshness_summary,
+            conflict_detected=conflict_detected,
+            conflict_summary=conflict_summary,
+            explanation_fragments=fragments,
+            tags=tags,
+            per_source_scores=per_source,
+        )
+
+    def _score(
+        self,
+        *,
+        source_id: str,
+        source_category: str,
+        supported_option_kinds: tuple[str, ...],
+        trust_signals: SourceTrustSignals,
+        quality_summary: QualityValueFitSummary,
+        traveler_relevance_hint: float | None,
+        intended_option_kind: str | None,
+        display_label: str,
+    ) -> SourceQualityScore:
+        if traveler_relevance_hint is not None:
+            require_probability(traveler_relevance_hint, "traveler_relevance_hint")
+        if (
+            intended_option_kind is not None
+            and intended_option_kind not in schema.SOURCE_OPTION_KINDS
+        ):
+            raise ValueError(f"intended_option_kind must be one of {schema.SOURCE_OPTION_KINDS!r}")
+
+        freshness_score = self._freshness_score(trust_signals)
+        channel_fit_score = self._channel_fit_score(
+            source_category, supported_option_kinds, intended_option_kind
+        )
+        provenance_strength = self._provenance_strength(source_category, trust_signals)
+        traveler_relevance = self._traveler_relevance(
+            source_category, traveler_relevance_hint, quality_summary
+        )
+
+        weighted = (
+            freshness_score * 0.25
+            + channel_fit_score * 0.20
+            + provenance_strength * 0.30
+            + traveler_relevance * 0.25
+        )
+        # quality_summary.confidence (when present) is a small final adjustment toward the
+        # source's own self-reported certainty, but never overrides the structural signals.
+        if quality_summary.confidence is not None:
+            weighted = 0.85 * weighted + 0.15 * quality_summary.confidence
+
+        confidence = _round(_clamp(weighted))
+        label = _confidence_label(confidence)
+        tags = self._per_source_tags(
+            source_category=source_category,
+            freshness_score=freshness_score,
+            confidence_label=label,
+            channel_fit_score=channel_fit_score,
+            provenance_strength=provenance_strength,
+        )
+        fragment = self._per_source_fragment(
+            display_label=display_label,
+            source_category=source_category,
+            label=label,
+            freshness_score=freshness_score,
+        )
+
+        return SourceQualityScore(
+            source_id=source_id,
+            source_category=source_category,
+            confidence=confidence,
+            confidence_label=label,
+            freshness_score=_round(freshness_score),
+            channel_fit_score=_round(channel_fit_score),
+            provenance_strength=_round(provenance_strength),
+            traveler_relevance=_round(traveler_relevance),
+            explanation_fragment=fragment,
+            tags=tags,
+        )
+
+    def _freshness_score(self, trust: SourceTrustSignals) -> float:
+        days = trust.freshness_days
+        if days is None:
+            base = 0.40
+        else:
+            # exponential-style decay anchored at FRESHNESS_HALF_LIFE_DAYS so a
+            # one-week-old source still scores high while a 6-month-old source
+            # falls below 0.25.
+            base = self.FRESHNESS_HALF_LIFE_DAYS / (self.FRESHNESS_HALF_LIFE_DAYS + max(0, days))
+        confidence_modifier = trust.freshness_confidence
+        if confidence_modifier is None:
+            return _clamp(base)
+        return _clamp(0.7 * base + 0.3 * confidence_modifier)
+
+    def _channel_fit_score(
+        self,
+        category: str,
+        supported_kinds: tuple[str, ...],
+        intended_option_kind: str | None,
+    ) -> float:
+        category_prior = _CATEGORY_OPERATIONAL_PRIOR.get(category, 0.55)
+        if intended_option_kind is None:
+            return category_prior
+        if not supported_kinds:
+            # unknown coverage — keep the category prior but apply a small penalty
+            return _clamp(category_prior - 0.10)
+        if intended_option_kind in supported_kinds:
+            return _clamp(category_prior + 0.10)
+        return _clamp(category_prior - 0.20)
+
+    def _provenance_strength(self, category: str, trust: SourceTrustSignals) -> float:
+        components: list[float] = []
+        if trust.operational_reliability is not None:
+            components.append(trust.operational_reliability)
+        if trust.review_consistency is not None:
+            components.append(trust.review_consistency)
+        if trust.editorial_independence is not None:
+            # editorial independence reduces commercial-bias risk; we treat it as
+            # additive on top of the other reliability signals.
+            components.append(trust.editorial_independence)
+        if trust.commerciality is not None:
+            # commerciality is informative but does not penalize: commercial-inventory
+            # sources are expected to be commercial. We scale it lightly toward 0.5.
+            components.append(0.4 + 0.2 * trust.commerciality)
+        if not components:
+            return _CATEGORY_OPERATIONAL_PRIOR.get(category, 0.55) * 0.7
+        return _clamp(fmean(components))
+
+    def _traveler_relevance(
+        self,
+        category: str,
+        hint: float | None,
+        quality_summary: QualityValueFitSummary,
+    ) -> float:
+        prior = _CATEGORY_TRAVELER_RELEVANCE_PRIOR.get(category, 0.55)
+        fit_signal = quality_summary.fit_signal
+        if hint is not None and fit_signal is not None:
+            blended = 0.4 * prior + 0.3 * hint + 0.3 * fit_signal
+        elif hint is not None:
+            blended = 0.5 * prior + 0.5 * hint
+        elif fit_signal is not None:
+            blended = 0.5 * prior + 0.5 * fit_signal
+        else:
+            blended = prior
+        return _clamp(blended)
+
+    def _per_source_tags(
+        self,
+        *,
+        source_category: str,
+        freshness_score: float,
+        confidence_label: str,
+        channel_fit_score: float,
+        provenance_strength: float,
+    ) -> list[str]:
+        tags: list[str] = []
+        category_tag = _CATEGORY_TAGS.get(source_category)
+        if category_tag:
+            tags.append(category_tag)
+        if freshness_score < 0.35:
+            tags.append("stale")
+        elif freshness_score >= 0.85:
+            tags.append("fresh")
+        if provenance_strength < 0.40:
+            tags.append("weak-provenance")
+        if channel_fit_score < 0.40:
+            tags.append("off-channel")
+        if confidence_label == "sparse":
+            tags.append("sparse")
+        return list(dict.fromkeys(tags))
+
+    def _per_source_fragment(
+        self,
+        *,
+        display_label: str,
+        source_category: str,
+        label: str,
+        freshness_score: float,
+    ) -> str:
+        readable_category = source_category.replace("_", " ")
+        if label == "very_high":
+            tone = "Strong"
+        elif label == "high":
+            tone = "Solid"
+        elif label == "moderate":
+            tone = "Mixed"
+        elif label == "uncertain":
+            tone = "Uncertain"
+        else:
+            tone = "Sparse"
+        freshness_note = ""
+        if freshness_score < 0.35:
+            freshness_note = " (stale)"
+        elif freshness_score >= 0.85:
+            freshness_note = " (recent)"
+        return f"{tone} {readable_category} signal from {display_label}{freshness_note}."
+
+    def _summary_tags(
+        self,
+        per_source: Sequence[SourceQualityScore],
+        conflict_detected: bool,
+        count: int,
+    ) -> list[str]:
+        tags: list[str] = []
+        for score in per_source:
+            for tag in score.tags:
+                if tag not in tags:
+                    tags.append(tag)
+        if conflict_detected and "conflict" not in tags:
+            tags.append("conflict")
+        if count == 1 and "sparse" not in tags:
+            tags.append("sparse")
+        return tags
+
+    def _summary_fragments(
+        self,
+        *,
+        per_source: Sequence[SourceQualityScore],
+        confidence: float,
+        label: str,
+        conflict_detected: bool,
+        conflict_summary: str,
+    ) -> list[str]:
+        fragments: list[str] = []
+        if label == "very_high":
+            fragments.append(
+                "Multiple consistent sources support this option, so confidence is very high."
+            )
+        elif label == "high":
+            fragments.append("Source coverage is solid and the available signals agree.")
+        elif label == "moderate":
+            fragments.append(
+                "Source coverage is mixed; weigh the available signals against your own priorities."
+            )
+        elif label == "uncertain":
+            fragments.append(
+                "Source coverage is thin or aging, so this option carries notable uncertainty."
+            )
+        else:
+            fragments.append(
+                "Source coverage is sparse; the option remains visible but with low confidence."
+            )
+        if conflict_detected and conflict_summary:
+            fragments.append(conflict_summary)
+        elif conflict_detected:
+            fragments.append(
+                "Sources disagree materially on this option; review tradeoffs carefully."
+            )
+        return fragments
+
+    def _detect_conflicts(self, records: Sequence[SourceLike]) -> tuple[bool, str]:
+        per_axis: dict[str, list[float]] = {"quality": [], "value": [], "fit": []}
+        for entry in records:
+            if isinstance(entry, SourceRecord):
+                quality_summary = entry.quality_summary
+            else:
+                quality_summary = entry.quality_value_fit or QualityValueFitSummary()
+            if quality_summary.quality_signal is not None:
+                per_axis["quality"].append(quality_summary.quality_signal)
+            if quality_summary.value_signal is not None:
+                per_axis["value"].append(quality_summary.value_signal)
+            if quality_summary.fit_signal is not None:
+                per_axis["fit"].append(quality_summary.fit_signal)
+
+        disagreements: list[str] = []
+        for axis_name in ("quality", "value", "fit"):
+            values = per_axis[axis_name]
+            if len(values) < 2:
+                continue
+            gap = max(values) - min(values)
+            if gap >= self.CONFLICT_SIGNAL_GAP:
+                disagreements.append(
+                    f"{axis_name} signal spans {min(values):.2f}–{max(values):.2f} across sources"
+                )
+
+        if not disagreements:
+            return False, ""
+        return True, "Sources disagree: " + "; ".join(disagreements) + "."
+
+    def _collect_freshness_days(self, records: Sequence[SourceLike]) -> list[int]:
+        days: list[int] = []
+        for entry in records:
+            if isinstance(entry, SourceRecord):
+                value = entry.trust_signals.freshness_days
+            else:
+                value = entry.freshness_days_at_capture
+                if value is None and entry.trust_snapshot is not None:
+                    value = entry.trust_snapshot.freshness_days
+            if value is not None:
+                days.append(value)
+        return days
+
+    def _summarize_freshness(self, days: list[int]) -> str:
+        if not days:
+            return "freshness unknown"
+        if len(days) == 1:
+            return f"freshness {days[0]} days"
+        return f"freshness span {min(days)}–{max(days)} days (median {int(median(days))})"
+
+
+def summarize_sources(
+    records: Iterable[SourceLike],
+    *,
+    subject_kind: str = "option",
+    traveler_relevance_hint: float | None = None,
+    intended_option_kind: str | None = None,
+) -> SourceConfidenceSummary:
+    """Module-level convenience wrapper around :class:`SourceQualityScorer`.
+
+    Planner tools and ranking explanation builders should call this helper rather
+    than instantiating the scorer themselves so future tuning of the scoring
+    weights stays in one place.
+    """
+
+    return SourceQualityScorer().summarize(
+        records,
+        subject_kind=subject_kind,
+        traveler_relevance_hint=traveler_relevance_hint,
+        intended_option_kind=intended_option_kind,
+    )

--- a/trip_planner/sources/quality.py
+++ b/trip_planner/sources/quality.py
@@ -321,8 +321,6 @@ class SourceQualityScorer:
 
         tags = self._summary_tags(per_source, conflict_detected, len(per_source))
         fragments = self._summary_fragments(
-            per_source=per_source,
-            confidence=confidence,
             label=label,
             conflict_detected=conflict_detected,
             conflict_summary=conflict_summary,
@@ -448,8 +446,8 @@ class SourceQualityScorer:
         if trust.review_consistency is not None:
             components.append(trust.review_consistency)
         if trust.editorial_independence is not None:
-            # editorial independence reduces commercial-bias risk; we treat it as
-            # additive on top of the other reliability signals.
+            # editorial independence reduces commercial-bias risk and is blended
+            # with the other reliability signals.
             components.append(trust.editorial_independence)
         if trust.commerciality is not None:
             # commerciality is informative but does not penalize: commercial-inventory
@@ -548,8 +546,6 @@ class SourceQualityScorer:
     def _summary_fragments(
         self,
         *,
-        per_source: Sequence[SourceQualityScore],
-        confidence: float,
         label: str,
         conflict_detected: bool,
         conflict_summary: str,


### PR DESCRIPTION
Closes #1163.

## Summary
- Adds `trip_planner/sources/quality.py` with `SourceQualityScorer`, `SourceQualityScore`, and `SourceConfidenceSummary`. Deterministic scoring covers freshness, channel fit, provenance strength, and traveler relevance, fuses contributions with explicit conflict detection, and emits a bounded summary shape with `mutates_state=False` so read-only planner tools can embed it.
- Adds `build_source_confidence_explanation` in `trip_planner/ranking/explanations.py` so candidate / route outputs can attach `confidence` `ExplanationRecord` entries built from a `SourceConfidenceSummary` without disrupting the existing leisure/business ranking engines.
- Documents the new status in `docs/source-quality-model.md`, `docs/design-coverage-map.md` (§7 row + cross-cutting gap rows), and `docs/next-issue-set.md` item 6.

## Behavior
- Stale, sparse, and conflicting inputs remain visible: their `confidence_label` (`uncertain`/`sparse`) and `tags` (`stale`, `weak-provenance`, `conflict`) surface the uncertainty rather than dropping the option.
- Conflict detection fires when quality / value / fit signals span >= 0.35 across the contributing sources and produces traveler-facing disagreement language in both the summary and the resulting `ExplanationRecord`.
- Module-level `summarize_sources` keeps weights in one place so future tuning is centralized.

## Tests
- `python -m pytest tests/sources/test_source_quality.py tests/ranking/test_source_confidence_explanation.py --no-cov` -> 24 passed.
- `python -m pytest tests/sources/ tests/ranking/ tests/contracts/ --no-cov` -> 130 passed.
- `ruff check`, `black --check`, and `mypy` all clean on touched files.

## Out of scope
- Per-bundle planner-tool wiring (`read_source_quality_summary` keeps its bounded `not_available` shape until inventory carries resolved `SourceRecord`/`ProvenanceReference` instances).
- Live commerciality and review_consistency calibration across providers and the full source-fusion pipeline (ingestion-side commitments).