### PR TITLE
fix: handle all skip/success combinations in Gate summarize

### DIFF
--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -147,6 +147,13 @@ jobs:
           state="success"
           description="All checks passed"
 
+          is_terminal_ok() {
+            case "$1" in
+              success|skipped) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
           if [ "$python_result" = "failure" ]; then
             state="failure"
             description="Python CI failed"
@@ -159,18 +166,43 @@ jobs:
           elif [ "$python_result" = "cancelled" ] || [ "$runtime_result" = "cancelled" ] || [ "$cross_repo_result" = "cancelled" ]; then
             state="error"
             description="Checks were cancelled"
-          elif [ "$python_result" = "success" ] && [ "$runtime_result" = "success" ] && [ "$cross_repo_result" = "success" ]; then
+          elif is_terminal_ok "$python_result" && is_terminal_ok "$runtime_result" && is_terminal_ok "$cross_repo_result"; then
             state="success"
-            description="Python, runtime, and cross-repo CI passed"
-          elif [ "$python_result" = "success" ] && [ "$runtime_result" = "skipped" ] && [ "$cross_repo_result" = "skipped" ]; then
-            state="success"
-            description="Python CI passed; runtime and cross-repo CI skipped"
-          elif [ "$python_result" = "skipped" ] && [ "$runtime_result" = "success" ] && [ "$cross_repo_result" = "skipped" ]; then
-            state="success"
-            description="Runtime CI passed; Python and cross-repo CI skipped"
-          elif [ "$python_result" = "skipped" ] && [ "$runtime_result" = "skipped" ] && [ "$cross_repo_result" = "skipped" ]; then
-            state="success"
-            description="Checks skipped (no relevant changes)"
+            ran=()
+            skipped=()
+            for pair in "Python CI:$python_result" "runtime CI:$runtime_result" "cross-repo smoke:$cross_repo_result"; do
+              name="${pair%%:*}"
+              result="${pair#*:}"
+              if [ "$result" = "success" ]; then
+                ran+=("$name")
+              else
+                skipped+=("$name")
+              fi
+            done
+            join_csv() {
+              local sep=', '
+              local first=1
+              local out=''
+              local item
+              for item in "$@"; do
+                if [ "$first" -eq 1 ]; then
+                  out="$item"
+                  first=0
+                else
+                  out="$out$sep$item"
+                fi
+              done
+              printf '%s' "$out"
+            }
+            if [ "${#ran[@]}" -eq 0 ]; then
+              description="Checks skipped (no relevant changes)"
+            elif [ "${#skipped[@]}" -eq 0 ]; then
+              description="Python, runtime, and cross-repo CI passed"
+            else
+              ran_csv=$(join_csv "${ran[@]}")
+              skipped_csv=$(join_csv "${skipped[@]}")
+              description="${ran_csv} passed; ${skipped_csv} skipped"
+            fi
           else
             state="pending"
             description="Checks still running"


### PR DESCRIPTION
## Summary

The Summarize results bash script in `.github/workflows/pr-00-gate.yml` enumerates four success cases for the (python_result, runtime_result, cross_repo_result) tuple but misses the `(skipped, success, success)` combination produced by frontend-only PRs that skip Python CI yet run runtime and cross-repo smoke. Such PRs fall through to the `else` branch and emit the `Gate / gate` commit status as `pending - Checks still running`, leaving the PR-level merge state UNSTABLE even though every individual sub-check is green.

This PR replaces the enumeration with a single `is_terminal_ok` predicate plus a `join_csv` helper for the description. After failure/cancellation are handled, any of the eight `{success, skipped}` combinations across the three results now correctly resolves to `state=success`, with a description that names which checks ran versus skipped. Pending and in-progress states remain pending as before.

## Observed failure

PR #1170 (head `b1e901a3`): files were docs/frontend only. The job log shows:
- `PYTHON_RESULT: skipped`
- `RUNTIME_RESULT: success`
- `CROSS_REPO_RESULT: success`
- `[Gate] State: pending, Description: Checks still running`
- `Created commit status: pending - Checks still running`

Result: `Gate / gate` stuck pending, `mergeStateStatus=UNSTABLE`, merge blocked despite every sub-check being green and the Gate workflow itself finishing with conclusion `success`.

## Test plan

Local matrix test against the new bash:

| python | runtime | cross-repo | state    | description (excerpt)                                  |
|--------|---------|------------|----------|--------------------------------------------------------|
| success | success | success  | success  | Python, runtime, and cross-repo CI passed              |
| skipped | success | success  | success  | runtime CI, cross-repo smoke passed; Python CI skipped |
| success | skipped | success  | success  | Python CI, cross-repo smoke passed; runtime CI skipped |
| skipped | skipped | success  | success  | cross-repo smoke passed; Python CI, runtime CI skipped |
| skipped | skipped | skipped  | success  | Checks skipped (no relevant changes)                   |
| failure | success | success  | failure  | Python CI failed                                        |
| success | cancelled | success | error   | Checks were cancelled                                   |
| skipped | success | in_progress | pending | Checks still running                                  |

- [ ] Gate workflow runs on this PR and emits `Gate / gate` success.
- [ ] After merge, re-running Gate on PR #1170 (or pushing a no-op there) emits `Gate / gate` success and clears the UNSTABLE state.