### PR TITLE
Fix production deployment wiring

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -3,6 +3,7 @@ name: CI + Netlify Deploy
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   test-and-deploy:
@@ -15,44 +16,37 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Cache pip
-        uses: actions/cache@v5
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            
-      - name: Install deps
-        run: pip install -r requirements.txt
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
-      - name: Generate AI segments
-        continue-on-error: false   # skip or ignore failures while quota is exhausted
+      - name: Install backend dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Install frontend dependencies
+        run: npm --prefix frontend ci
+
+      - name: Verify production readiness
+        run: make runtime-production-check
+
+      - name: Build frontend for deploy
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          pip install "openai<1.0.0"
-          python scripts/generate_segments.py
-
-      - name: Validate request
-        run: python scripts/validate_request.py
-
-      - name: Run unit tests
-        run: pytest tests
-
-      - name: Generate itineraries
-        run: python scripts/generate_itins.py
-
-      - name: Build HTML
-        run: python scripts/build_html.py
+          VITE_GOOGLE_MAPS_BROWSER_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_BROWSER_API_KEY }}
+          VITE_GOOGLE_MAPS_EMBED_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_EMBED_API_KEY }}
+          VITE_GOOGLE_MAPS_PROVIDER_STATE: ${{ vars.VITE_GOOGLE_MAPS_PROVIDER_STATE }}
+        run: npm --prefix frontend run build
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3
         with:
-          publish-dir: ./bundle
+          publish-dir: ./frontend/dist
           production-branch: main
+          production-deploy: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Automated deployment from GitHub Actions"
         env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN || secrets.NETLIFY_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,17 @@ __pycache__/
 .mypy_cache/
 .venv/
 
+# Local environment files can contain API keys and other secrets.
+.env
+.env.local
+.env.*.local
+frontend/.env
+frontend/.env.local
+frontend/.env.*.local
+
+# macOS filesystem metadata.
+.DS_Store
+
 # JavaScript dependencies — never track node_modules; use npm ci to install.
 node_modules/
 dist/

--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ The verification path covers:
 These checks validate the local full-stack MVP that already exists in this repo. They exercise the map adapter and fallback seam with mocked provider state. They do not prove live Google Maps rendering or remote Travel-Plan-Permission transport.
 The production-focused testing plan in [docs/local-testing-plan.md](docs/local-testing-plan.md) adds the critical auth, trip, workspace, policy, proposal, and preview-verification journeys on top of that baseline.
 
+## Persistent Deployment
+
+The product deployment is split across two persistent services:
+
+- Netlify hosts the Vite frontend at `https://stranske-trip-planner.netlify.app`.
+- Render hosts the FastAPI backend and Postgres database.
+
+The Netlify deploy workflow builds `frontend/dist` from `main`, deploys that directory to Netlify production, and ships `frontend/public/_redirects` with the bundle. The redirect file proxies `/api/*` to the Render backend before falling back to `/index.html`, so the deployed frontend can call `/api/...` without requiring a hard-coded API origin in the browser bundle.
+
+`render.yaml` is the Render Blueprint source for the backend service and database. Render should track `main` for this file; stale topic branches will leave the live backend pinned to old commits even when GitHub `main` has advanced.
+
+Required deployment secrets:
+
+- GitHub Actions: `NETLIFY_SITE_ID` and either `NETLIFY_AUTH_TOKEN` or the legacy `NETLIFY_TOKEN`
+- GitHub Actions, optional live map adapter: `VITE_GOOGLE_MAPS_BROWSER_API_KEY`
+- Render service env vars: `TRIP_PLANNER_CORS_ORIGINS`, `TRIP_PLANNER_CORS_ORIGIN_REGEX`, and live TPP variables when remote policy execution is intentionally enabled
+
 ## Python Unit Tests
 
 After installing the backend dev extras (`python -m pip install -e ".[dev]"`), run the unit test suite from the repo root:

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,0 +1,2 @@
+/api/* https://trip-planner-api-s40u.onrender.com/api/:splat 200
+/* /index.html 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+base = "frontend"
+command = "npm run build"
+publish = "dist"
+
+[build.environment]
+NODE_VERSION = "20"

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,30 @@
+services:
+  - type: web
+    name: trip-planner-api
+    runtime: python
+    plan: free
+    buildCommand: python -m pip install --upgrade pip && python -m pip install -e .
+    startCommand: uvicorn trip_planner.app.main:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /api/health
+    envVars:
+      - key: TRIP_PLANNER_ENV
+        value: staging
+      - key: TRIP_PLANNER_DATABASE_URL
+        fromDatabase:
+          name: trip-planner-db
+          property: connectionString
+      - key: TRIP_PLANNER_CORS_ORIGINS
+        sync: false
+      - key: TRIP_PLANNER_CORS_ORIGIN_REGEX
+        sync: false
+      - key: TPP_BASE_URL
+        sync: false
+      - key: TPP_ACCESS_TOKEN
+        sync: false
+      - key: TPP_OIDC_PROVIDER
+        sync: false
+
+databases:
+  - name: trip-planner-db
+    plan: free
+    databaseName: trip_planner


### PR DESCRIPTION
## Summary
- build and deploy the Vite frontend from frontend/dist instead of the old bundle output
- add Netlify build config, SPA/API redirects, and Render Blueprint config to main
- document the persistent Netlify + Render deployment relationship and required secrets

## Validation
- git diff --check
- YAML parse check for .github/workflows/netlify.yml and render.yaml
- make runtime-production-check