### PR TITLE
Fix trip deletion and visible UI actions

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,16 +25,16 @@ export default function App() {
     <div className="app-shell">
       <header className="app-header">
         <div>
-          <p className="eyebrow">Trip Planner Runtime</p>
-          <h1>Persisted planner workspace</h1>
+          <p className="eyebrow">Trip Planner</p>
+          <h1>Plan trips with a saved workspace</h1>
           <p className="lede">
             {session
-              ? `Signed in as ${session.user.display_name}. Saved trips are now the persisted planning container for later workspace issues.`
-              : "The React shell now bootstraps through cookie-backed sessions before protected planner routes load."}
+              ? `Signed in as ${session.user.display_name}. Open a trip to keep decisions, notes, budgets, and route options together.`
+              : "Sign in to continue planning trips, compare routes, and keep notes in one place."}
           </p>
         </div>
         <nav aria-label="Primary">
-          <NavLink to="/health">Health</NavLink>
+          <NavLink to="/health">Status</NavLink>
           {session ? (
             <>
               <NavLink to="/trips">Trips</NavLink>

--- a/frontend/src/api/trips.ts
+++ b/frontend/src/api/trips.ts
@@ -133,3 +133,11 @@ export async function createTrip(payload: CreateTripPayload): Promise<TripRecord
   });
   return response.trip;
 }
+
+export async function deleteTrip(tripId: string): Promise<void> {
+  await fetchJson<unknown>({
+    path: `/api/trips/${tripId}`,
+    method: "DELETE",
+    credentials: "include",
+  });
+}

--- a/frontend/src/components/workspace/PlanningNotebookPanel.tsx
+++ b/frontend/src/components/workspace/PlanningNotebookPanel.tsx
@@ -107,6 +107,7 @@ function NotebookItemCard({
 export function PlanningNotebookPanel({
   notebookState,
   busyLabel,
+  successMessage,
   errorMessage,
   onCreateItem,
   onCompleteItem,
@@ -116,6 +117,7 @@ export function PlanningNotebookPanel({
 }: {
   notebookState: PlanningNotebookState;
   busyLabel: string | null;
+  successMessage?: string | null;
   errorMessage: string | null;
   onCreateItem: (payload: { title: string; category: NotebookCategory; note?: string; priority?: NotebookPriority }) => Promise<void>;
   onCompleteItem: (notebookItemId: string) => Promise<void>;
@@ -235,6 +237,11 @@ export function PlanningNotebookPanel({
       ) : null}
 
       {busyLabel ? <p className="muted-copy">{busyLabel}</p> : null}
+      {successMessage ? (
+        <p className="planner-inline-success" role="status">
+          {successMessage}
+        </p>
+      ) : null}
       {errorMessage ? <p className="planner-inline-error">{errorMessage}</p> : null}
       {validationMessage ? <p className="planner-inline-error">{validationMessage}</p> : null}
 

--- a/frontend/src/components/workspace/RouteOptionWorkbench.tsx
+++ b/frontend/src/components/workspace/RouteOptionWorkbench.tsx
@@ -159,6 +159,7 @@ export function RouteOptionWorkbench({
   comparison,
   selectedScenarioId,
   busyLabel,
+  successMessage,
   errorMessage,
   onSelectScenario,
   onRouteOptionAction,
@@ -166,6 +167,7 @@ export function RouteOptionWorkbench({
   comparison: RuntimeScenarioComparison;
   selectedScenarioId: string | null;
   busyLabel: string | null;
+  successMessage?: string | null;
   errorMessage: string | null;
   onSelectScenario: (scenarioId: string) => void;
   onRouteOptionAction: (optionId: string, actionType: RouteOptionActionType) => void;
@@ -200,6 +202,11 @@ export function RouteOptionWorkbench({
         </span>
       </div>
       {busyLabel ? <p className="muted-copy">{busyLabel}</p> : null}
+      {successMessage ? (
+        <p className="planner-inline-success" role="status">
+          {successMessage}
+        </p>
+      ) : null}
       {errorMessage ? <p className="planner-inline-error">{errorMessage}</p> : null}
       <div className="route-option-grid" aria-label="Route option comparison workbench">
         {scenarios.map((scenario) => {

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -14,7 +14,7 @@ describe("fetchJson", () => {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({ service: "trip-planner-api" }),
+      text: async () => JSON.stringify({ service: "trip-planner-api" }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -34,7 +34,7 @@ describe("fetchJson", () => {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({ ok: true }),
+      text: async () => JSON.stringify({ ok: true }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -72,13 +72,27 @@ describe("fetchJson", () => {
     } satisfies Partial<ApiClientError>);
   });
 
+  it("allows successful no-content responses for mutation endpoints", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+        text: async () => "",
+      })
+    );
+
+    await expect(fetchJson<void>({ path: "/api/trips/trip-1", method: "DELETE" })).resolves.toBeUndefined();
+  });
+
   it("resolves request URLs against VITE_API_BASE_URL when configured", async () => {
     vi.stubEnv("VITE_API_BASE_URL", "https://api.example.test/base/");
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({ ok: true }),
+      text: async () => JSON.stringify({ ok: true }),
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -27,8 +27,17 @@ export async function fetchJson<T>({ path, headers, ...init }: JsonRequestOption
     throw await createApiClientError(requestUrl, response);
   }
 
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  const responseText = await response.text();
+  if (!responseText) {
+    return undefined as T;
+  }
+
   try {
-    return (await response.json()) as T;
+    return JSON.parse(responseText) as T;
   } catch (error) {
     throw new ApiClientError(`Response from ${requestUrl} was not valid JSON.`, {
       path: requestUrl,

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -44,11 +44,10 @@ export function LoginPage() {
   return (
     <section className="auth-layout">
       <article className="status-card auth-card">
-        <p className="status-label">Account access</p>
+        <p className="status-label">Welcome back</p>
         <h2>Sign in to resume planning</h2>
         <p className="lede">
-          Use the small-business account foundation to restore your saved trip workspace and
-          session state.
+          Continue working with your saved trips, route comparisons, notes, and planning history.
         </p>
         <form className="auth-form" onSubmit={handleSubmit}>
           <label>

--- a/frontend/src/routes/NewTripPage.tsx
+++ b/frontend/src/routes/NewTripPage.tsx
@@ -49,10 +49,10 @@ export function NewTripPage() {
   return (
     <section className="auth-layout">
       <article className="status-card auth-card">
-        <p className="status-label">Trip creation</p>
-        <h2>Create a persisted trip</h2>
+        <p className="status-label">New trip</p>
+        <h2>Create a trip</h2>
         <p className="lede">
-          Capture the durable planning container now so later scenario and policy issues can attach to it.
+          Add the basics now. You can refine routes, notes, budget, and decisions in the planner.
         </p>
         <form className="auth-form" onSubmit={handleSubmit}>
           <label>

--- a/frontend/src/routes/SignupPage.tsx
+++ b/frontend/src/routes/SignupPage.tsx
@@ -35,11 +35,10 @@ export function SignupPage() {
   return (
     <section className="auth-layout">
       <article className="status-card auth-card">
-        <p className="status-label">Account foundation</p>
+        <p className="status-label">New account</p>
         <h2>Create your planner account</h2>
         <p className="lede">
-          This first pass keeps auth intentionally small-business sized: email, password, and a
-          durable session cookie.
+          Save trips, compare options, and return to planning work without losing the thread.
         </p>
         <form className="auth-form" onSubmit={handleSubmit}>
           <label>

--- a/frontend/src/routes/TripsPage.test.tsx
+++ b/frontend/src/routes/TripsPage.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useLoaderData } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { deleteTrip } from "../api/trips";
 import { TripsPage } from "./TripsPage";
 import { TestMemoryRouter } from "../test/router";
 
@@ -13,43 +15,49 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+vi.mock("../api/trips", () => ({
+  deleteTrip: vi.fn(),
+}));
+
 const mockedUseLoaderData = vi.mocked(useLoaderData);
+const mockedDeleteTrip = vi.mocked(deleteTrip);
+
+const kyotoTrip = {
+  trip_id: "trip-kyoto-123abc",
+  user_id: "user:test",
+  title: "Kyoto Spring",
+  summary: "Food and gardens",
+  mode: "leisure",
+  status: "draft",
+  trip_frame: {
+    start_date: "2026-04-20",
+    end_date: "2026-04-26",
+    duration_days: 7,
+    primary_regions: ["Kyoto", "Osaka"],
+    traveler_party: { kind: "solo", traveler_count: 1, notes: "" },
+  },
+  profile_refs: {
+    leisure_profile_id: "profile:trip-kyoto-123abc:leisure",
+    business_profile_id: null,
+  },
+  artifacts: {
+    objective_id: null,
+    option_set_ids: [],
+    itinerary_state_id: null,
+    budget_state_id: null,
+    policy_state_id: null,
+  },
+};
 
 describe("TripsPage", () => {
   afterEach(() => {
+    cleanup();
     vi.clearAllMocks();
   });
 
   it("renders saved trip cards from the loader payload", async () => {
     mockedUseLoaderData.mockReturnValue({
-      trips: Promise.resolve([
-        {
-          trip_id: "trip-kyoto-123abc",
-          user_id: "user:test",
-          title: "Kyoto Spring",
-          summary: "Food and gardens",
-          mode: "leisure",
-          status: "draft",
-          trip_frame: {
-            start_date: "2026-04-20",
-            end_date: "2026-04-26",
-            duration_days: 7,
-            primary_regions: ["Kyoto", "Osaka"],
-            traveler_party: { kind: "solo", traveler_count: 1, notes: "" },
-          },
-          profile_refs: {
-            leisure_profile_id: "profile:trip-kyoto-123abc:leisure",
-            business_profile_id: null,
-          },
-          artifacts: {
-            objective_id: null,
-            option_set_ids: [],
-            itinerary_state_id: null,
-            budget_state_id: null,
-            policy_state_id: null,
-          },
-        },
-      ]),
+      trips: Promise.resolve([kyotoTrip]),
     });
 
     render(
@@ -63,9 +71,42 @@ describe("TripsPage", () => {
     });
 
     expect(screen.getByText("Food and gardens")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Open trip detail" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Open planner" })).toHaveAttribute(
+      "href",
+      "/workspace/trip-kyoto-123abc"
+    );
+    expect(screen.getByRole("link", { name: "Details" })).toHaveAttribute(
       "href",
       "/trips/trip-kyoto-123abc"
     );
+  });
+
+  it("deletes a trip after inline confirmation", async () => {
+    const user = userEvent.setup();
+    mockedDeleteTrip.mockResolvedValue(undefined);
+    mockedUseLoaderData.mockReturnValue({
+      trips: Promise.resolve([kyotoTrip]),
+    });
+
+    render(
+      <TestMemoryRouter>
+        <TripsPage />
+      </TestMemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Kyoto Spring" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.getByText("Delete this trip and its saved planning work? This cannot be undone.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Yes, delete trip" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Kyoto Spring" })).not.toBeInTheDocument();
+    });
+    expect(mockedDeleteTrip).toHaveBeenCalledWith("trip-kyoto-123abc");
+    expect(screen.getByRole("heading", { name: "Start your first trip" })).toBeInTheDocument();
   });
 });

--- a/frontend/src/routes/TripsPage.tsx
+++ b/frontend/src/routes/TripsPage.tsx
@@ -1,6 +1,7 @@
+import { startTransition, useEffect, useState } from "react";
 import { Link, useLoaderData } from "react-router-dom";
 
-import type { TripRecord } from "../api/trips";
+import { deleteTrip, type TripRecord } from "../api/trips";
 import { AsyncRouteContent } from "../lib/routes/AsyncRouteContent";
 
 type LoaderData = {
@@ -37,28 +38,63 @@ export function TripsPage() {
 }
 
 function TripsPageContent({ trips }: { trips: TripRecord[] }) {
+  const [visibleTrips, setVisibleTrips] = useState(trips);
+  const [confirmingTripId, setConfirmingTripId] = useState<string | null>(null);
+  const [deletingTripId, setDeletingTripId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setVisibleTrips(trips);
+  }, [trips]);
+
+  async function handleDeleteTrip(trip: TripRecord) {
+    setDeleteError(null);
+    setDeletingTripId(trip.trip_id);
+    try {
+      await deleteTrip(trip.trip_id);
+      startTransition(() => {
+        setVisibleTrips((current) =>
+          current.filter((candidate) => candidate.trip_id !== trip.trip_id)
+        );
+        setConfirmingTripId(null);
+      });
+    } catch (error) {
+      setDeleteError(
+        error instanceof Error ? error.message : `Could not delete ${trip.title}.`
+      );
+    } finally {
+      setDeletingTripId(null);
+    }
+  }
+
   return (
     <section className="workspace-layout">
       <article className="status-card">
         <p className="status-label">Saved trips</p>
-        <h2>Persisted planning containers</h2>
+        <h2>Your trips</h2>
         <p className="lede">
-          Each trip record is now the durable root object for later scenario, budget, and policy work.
+          Open a trip to keep planning, or remove a trip you no longer need.
         </p>
         <Link className="cta-link" to="/trips/new">
           Create a trip
         </Link>
       </article>
 
-      {trips.length === 0 ? (
+      {deleteError ? (
+        <p className="planner-inline-error" role="alert">
+          {deleteError}
+        </p>
+      ) : null}
+
+      {visibleTrips.length === 0 ? (
         <article className="status-card">
           <p className="status-label">No trips yet</p>
-          <h2>Start the first saved itinerary container</h2>
-          <p className="muted-copy">Create a trip to persist title, timing, traveler party, and ownership.</p>
+          <h2>Start your first trip</h2>
+          <p className="muted-copy">Create a trip to save dates, places, travelers, and planning notes.</p>
         </article>
       ) : (
         <section className="trip-grid">
-          {trips.map((trip) => (
+          {visibleTrips.map((trip) => (
             <article key={trip.trip_id} className="status-card trip-card">
               <p className="status-label">{trip.mode}</p>
               <h2>{trip.title}</h2>
@@ -77,9 +113,49 @@ function TripsPageContent({ trips }: { trips: TripRecord[] }) {
                   <dd>{summarizeRegions(trip.trip_frame.primary_regions)}</dd>
                 </div>
               </dl>
-              <Link className="cta-link" to={`/trips/${trip.trip_id}`}>
-                Open trip detail
-              </Link>
+              <div className="trip-card-actions">
+                <Link className="cta-link" to={`/workspace/${trip.trip_id}`}>
+                  Open planner
+                </Link>
+                <Link className="secondary-link" to={`/trips/${trip.trip_id}`}>
+                  Details
+                </Link>
+                <button
+                  type="button"
+                  className="secondary-button danger-button"
+                  disabled={deletingTripId === trip.trip_id}
+                  onClick={() =>
+                    setConfirmingTripId((current) =>
+                      current === trip.trip_id ? null : trip.trip_id
+                    )
+                  }
+                >
+                  Delete
+                </button>
+              </div>
+              {confirmingTripId === trip.trip_id ? (
+                <div className="trip-delete-confirmation" role="group" aria-label={`Confirm delete ${trip.title}`}>
+                  <p>
+                    Delete this trip and its saved planning work? This cannot be undone.
+                  </p>
+                  <button
+                    type="button"
+                    className="danger-button"
+                    disabled={deletingTripId === trip.trip_id}
+                    onClick={() => handleDeleteTrip(trip)}
+                  >
+                    {deletingTripId === trip.trip_id ? "Deleting..." : "Yes, delete trip"}
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    disabled={deletingTripId === trip.trip_id}
+                    onClick={() => setConfirmingTripId(null)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : null}
             </article>
           ))}
         </section>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -156,6 +156,14 @@ const PLANNER_BLOCK_PRESENTATION: Record<string, { label: string; order: number 
   traveler_input_summary: { label: "What I heard", order: 90 },
 };
 
+const ROUTE_OPTION_ACTION_SUCCESS: Record<RouteOptionActionType, string> = {
+  make_baseline: "Route saved as the working baseline.",
+  keep: "Route kept for later comparison.",
+  reject: "Route moved out of the active comparison.",
+  reopen: "Route returned to the active comparison.",
+  revise: "Revision request saved for the planner.",
+};
+
 function formatTravelerToken(value: string | null | undefined, fallback = "Not set yet"): string {
   if (!value) {
     return fallback;
@@ -995,6 +1003,7 @@ function WorkspacePageContent({
   );
   const [plannerSession, setPlannerSession] = useState<PlannerSessionResponse | null>(null);
   const [plannerConversationDraft, setPlannerConversationDraft] = useState("");
+  const [plannerConversationNotice, setPlannerConversationNotice] = useState<string | null>(null);
   const [plannerConversationError, setPlannerConversationError] = useState<string | null>(null);
   const [plannerConversationBusyLabel, setPlannerConversationBusyLabel] = useState<string | null>(
     null
@@ -1009,17 +1018,23 @@ function WorkspacePageContent({
   const [budgetBusyLabel, setBudgetBusyLabel] = useState<string | null>(null);
   const [notebookError, setNotebookError] = useState<string | null>(null);
   const [notebookBusyLabel, setNotebookBusyLabel] = useState<string | null>(null);
+  const [notebookSuccess, setNotebookSuccess] = useState<string | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
   const [proposalBusyLabel, setProposalBusyLabel] = useState<string | null>(null);
   const [routeOptionError, setRouteOptionError] = useState<string | null>(null);
   const [routeOptionBusyLabel, setRouteOptionBusyLabel] = useState<string | null>(null);
+  const [routeOptionSuccess, setRouteOptionSuccess] = useState<string | null>(null);
   const plannerSessionLoadVersion = useRef(0);
+  const plannerConversationTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const isCompactLayout = useCompactWorkspaceLayout();
   useEffect(() => {
     setCurrentWorkspace(workspace);
     setSelectedScenarioId(resolveMapScenarioId(workspace));
     setSelectedMapScope("regional");
     setSelectedSegmentId(null);
+    setPlannerConversationNotice(null);
+    setRouteOptionSuccess(null);
+    setNotebookSuccess(null);
     setShowWorkspaceDebugDetails(false);
   }, [workspace]);
 
@@ -1191,6 +1206,7 @@ function WorkspacePageContent({
 
   async function handleRouteOptionAction(optionId: string, actionType: RouteOptionActionType) {
     setRouteOptionError(null);
+    setRouteOptionSuccess(null);
     setRouteOptionBusyLabel("Saving route option...");
     plannerSessionLoadVersion.current += 1;
     try {
@@ -1198,6 +1214,7 @@ function WorkspacePageContent({
       startTransition(() => {
         setCurrentWorkspace(nextWorkspace);
         setSelectedScenarioId(resolveMapScenarioId(nextWorkspace));
+        setRouteOptionSuccess(ROUTE_OPTION_ACTION_SUCCESS[actionType]);
       });
     } catch (error) {
       setRouteOptionError(error instanceof Error ? error.message : "Route option update failed.");
@@ -1214,6 +1231,7 @@ function WorkspacePageContent({
       return;
     }
 
+    setPlannerConversationNotice(null);
     setPlannerConversationError(null);
     setPlannerConversationBusyLabel("Sending planner turn...");
     plannerSessionLoadVersion.current += 1;
@@ -1235,7 +1253,9 @@ function WorkspacePageContent({
 
   function handlePlannerPromptSuggestion(draft: string) {
     setPlannerConversationDraft(draft);
+    setPlannerConversationNotice("Draft added. Edit it if needed, then send it to the planner.");
     setPlannerConversationError(null);
+    plannerConversationTextareaRef.current?.focus();
   }
 
   async function handleBudgetSave(payload: BudgetPlanUpsertPayload) {
@@ -1326,11 +1346,13 @@ function WorkspacePageContent({
     priority?: NotebookPriority;
   }) {
     setNotebookError(null);
+    setNotebookSuccess(null);
     setNotebookBusyLabel("Adding notebook item...");
     try {
       const newItem = await createNotebookItem(trip.trip_id, payload);
       startTransition(() => {
         setCurrentWorkspace((current) => mergeNotebookItem(current, newItem));
+        setNotebookSuccess("Notebook item added.");
       });
     } catch (error) {
       setNotebookError(error instanceof Error ? error.message : "Notebook item creation failed.");
@@ -1341,12 +1363,14 @@ function WorkspacePageContent({
 
   async function handleNotebookComplete(notebookItemId: string) {
     setNotebookError(null);
+    setNotebookSuccess(null);
     try {
       const updatedItem = await updateNotebookItem(trip.trip_id, notebookItemId, {
         status: "completed",
       });
       startTransition(() => {
         setCurrentWorkspace((current) => mergeNotebookItem(current, updatedItem));
+        setNotebookSuccess("Notebook item marked complete.");
       });
     } catch (error) {
       setNotebookError(error instanceof Error ? error.message : "Notebook item update failed.");
@@ -1355,12 +1379,14 @@ function WorkspacePageContent({
 
   async function handleNotebookReopen(notebookItemId: string) {
     setNotebookError(null);
+    setNotebookSuccess(null);
     try {
       const updatedItem = await updateNotebookItem(trip.trip_id, notebookItemId, {
         status: "active",
       });
       startTransition(() => {
         setCurrentWorkspace((current) => mergeNotebookItem(current, updatedItem));
+        setNotebookSuccess("Notebook item reopened.");
       });
     } catch (error) {
       setNotebookError(error instanceof Error ? error.message : "Notebook item reopen failed.");
@@ -1369,10 +1395,12 @@ function WorkspacePageContent({
 
   async function handleNotebookDelete(notebookItemId: string) {
     setNotebookError(null);
+    setNotebookSuccess(null);
     try {
       await deleteNotebookItem(trip.trip_id, notebookItemId);
       startTransition(() => {
         setCurrentWorkspace((current) => mergeNotebookItemDeleted(current, notebookItemId));
+        setNotebookSuccess("Notebook item deleted.");
       });
     } catch (error) {
       setNotebookError(error instanceof Error ? error.message : "Notebook item deletion failed.");
@@ -1384,10 +1412,14 @@ function WorkspacePageContent({
     notebook_item_id?: string | null;
   }) {
     setNotebookError(null);
+    setNotebookSuccess(null);
     try {
       const nextFocus = await setNotebookFocus(trip.trip_id, focus);
       startTransition(() => {
         setCurrentWorkspace((current) => mergeNotebookFocus(current, nextFocus));
+        setNotebookSuccess(
+          focus.category || focus.notebook_item_id ? "Notebook focus updated." : "Notebook focus cleared."
+        );
       });
     } catch (error) {
       setNotebookError(error instanceof Error ? error.message : "Notebook focus update failed.");
@@ -1622,6 +1654,11 @@ function WorkspacePageContent({
             {plannerConversationBusyLabel ? (
               <p className="muted-copy">{plannerConversationBusyLabel}</p>
             ) : null}
+            {plannerConversationNotice ? (
+              <p className="planner-inline-success" role="status">
+                {plannerConversationNotice}
+              </p>
+            ) : null}
             {plannerConversationError ? (
               <p className="planner-inline-error">{plannerConversationError}</p>
             ) : null}
@@ -1657,6 +1694,7 @@ function WorkspacePageContent({
               <label>
                 Message the planner
                 <textarea
+                  ref={plannerConversationTextareaRef}
                   value={plannerConversationDraft}
                   onChange={(event) => setPlannerConversationDraft(event.target.value)}
                   placeholder="Ask what to compare, what to remember, or what decision comes next."
@@ -1711,6 +1749,7 @@ function WorkspacePageContent({
           comparison={routeComparison}
           selectedScenarioId={selectedScenarioId}
           busyLabel={routeOptionBusyLabel}
+          successMessage={routeOptionSuccess}
           errorMessage={routeOptionError}
           onSelectScenario={handleScenarioSelection}
           onRouteOptionAction={handleRouteOptionAction}
@@ -1722,6 +1761,7 @@ function WorkspacePageContent({
           <PlanningNotebookPanel
             notebookState={currentWorkspace.planning_notebook}
             busyLabel={notebookBusyLabel}
+            successMessage={notebookSuccess}
             errorMessage={notebookError}
             onCreateItem={handleNotebookCreate}
             onCompleteItem={handleNotebookComplete}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -624,6 +624,10 @@ a {
   color: #912c22;
 }
 
+.planner-inline-success {
+  color: #25633f;
+}
+
 .planner-panel-host .planner-panel {
   min-height: 100%;
 }
@@ -1561,6 +1565,27 @@ a {
   gap: 1rem;
 }
 
+.trip-card-actions,
+.trip-delete-confirmation {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.trip-delete-confirmation {
+  padding: 0.85rem;
+  border: 1px solid rgba(145, 44, 34, 0.22);
+  border-radius: 12px;
+  background: rgba(145, 44, 34, 0.07);
+}
+
+.trip-delete-confirmation p {
+  flex-basis: 100%;
+  margin: 0;
+  color: #5a2a24;
+}
+
 .cta-link {
   display: inline-flex;
   width: fit-content;
@@ -1571,6 +1596,35 @@ a {
   background: #13212c;
   color: #f7f1e5;
   font-weight: 600;
+}
+
+.secondary-link,
+.secondary-button,
+.danger-button {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.7rem 0.95rem;
+  border: 1px solid rgba(19, 33, 44, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #13212c;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.danger-button {
+  border-color: rgba(145, 44, 34, 0.36);
+  color: #912c22;
+}
+
+.secondary-button:disabled,
+.danger-button:disabled {
+  cursor: progress;
+  opacity: 0.58;
 }
 
 .status-grid {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,12 +8,13 @@ function fileUrlToFsPath(relativePath: string): string {
 }
 
 const bundleDirectory = fileUrlToFsPath("../bundle");
+const frontendDirectory = fileUrlToFsPath(".");
 
 export default defineConfig({
   plugins: [react()],
   server: {
     fs: {
-      allow: [bundleDirectory],
+      allow: [frontendDirectory, bundleDirectory],
     },
     port: 5173,
     proxy: {

--- a/tests/app/test_trip_routes.py
+++ b/tests/app/test_trip_routes.py
@@ -78,6 +78,40 @@ def test_trip_create_list_and_detail_flow(client: TestClient) -> None:
     assert detail.json()["trip"]["trip_frame"]["traveler_party"]["notes"] == "Window seat preferred"
 
 
+def test_trip_delete_removes_owned_trip_and_workspace_state(client: TestClient) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+
+    create = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "Food and gardens",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+    assert create.status_code == 201
+    trip_id = create.json()["trip"]["trip_id"]
+
+    workspace = client.get(f"/api/workspace/{trip_id}")
+    assert workspace.status_code == 200
+    notebook = client.post(
+        f"/api/workspace/{trip_id}/planning-notebook",
+        json={"title": "Remember museum tickets", "category": "activities"},
+    )
+    assert notebook.status_code == 200
+
+    delete = client.delete(f"/api/trips/{trip_id}")
+    assert delete.status_code == 200
+    assert delete.json() == {"deleted": True}
+
+    listing = client.get("/api/trips")
+    assert listing.status_code == 200
+    assert listing.json()["trips"] == []
+    assert client.get(f"/api/trips/{trip_id}").status_code == 404
+    assert client.get(f"/api/workspace/{trip_id}").status_code == 404
+
+
 def test_trip_routes_require_authentication(client: TestClient) -> None:
     assert client.get("/api/trips").status_code == 401
     assert (
@@ -112,6 +146,33 @@ def test_trip_detail_hides_other_users_records(client: TestClient) -> None:
 
     detail = client.get(f"/api/trips/{trip_id}")
     assert detail.status_code == 404
+
+
+def test_trip_delete_hides_other_users_records(client: TestClient) -> None:
+    signup(client, email="owner@example.com", display_name="Owner")
+    create = client.post(
+        "/api/trips",
+        json={
+            "title": "Kyoto Spring",
+            "summary": "Food and gardens",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 7},
+        },
+    )
+    trip_id = create.json()["trip"]["trip_id"]
+
+    client.post("/api/auth/logout")
+    signup(client, email="other@example.com", display_name="Other")
+
+    delete = client.delete(f"/api/trips/{trip_id}")
+    assert delete.status_code == 404
+
+    client.post("/api/auth/logout")
+    client.post(
+        "/api/auth/login",
+        json={"email": "owner@example.com", "password": "password123"},
+    )
+    assert client.get(f"/api/trips/{trip_id}").status_code == 200
 
 
 def test_trip_create_rejects_invalid_mode(client: TestClient) -> None:

--- a/trip_planner/app/routes/trips.py
+++ b/trip_planner/app/routes/trips.py
@@ -1,9 +1,14 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from trip_planner.app.schemas.trips import CreateTripRequest, TripListResponse, TripResponse
+from trip_planner.app.schemas.trips import (
+    CreateTripRequest,
+    DeleteTripResponse,
+    TripListResponse,
+    TripResponse,
+)
 from trip_planner.app.services.auth import AuthenticatedUser, require_authenticated_user
-from trip_planner.app.services.trips import create_trip, get_trip, list_trips
+from trip_planner.app.services.trips import create_trip, delete_trip, get_trip, list_trips
 from trip_planner.persistence.db import get_db_session
 
 router = APIRouter(tags=["trips"])
@@ -50,3 +55,15 @@ def read_trip_detail(
     if trip is None:
         raise HTTPException(status_code=404, detail=f"Trip '{trip_id}' was not found.")
     return TripResponse(trip=trip)
+
+
+@router.delete("/trips/{trip_id}", response_model=DeleteTripResponse)
+def delete_trip_record(
+    trip_id: str,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> DeleteTripResponse:
+    deleted = delete_trip(db_session, user=user, trip_id=trip_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Trip '{trip_id}' was not found.")
+    return DeleteTripResponse()

--- a/trip_planner/app/schemas/trips.py
+++ b/trip_planner/app/schemas/trips.py
@@ -38,3 +38,7 @@ class TripResponse(BaseModel):
 
 class TripListResponse(BaseModel):
     trips: list[dict]
+
+
+class DeleteTripResponse(BaseModel):
+    deleted: bool = True

--- a/trip_planner/app/services/trips.py
+++ b/trip_planner/app/services/trips.py
@@ -6,7 +6,7 @@ import re
 import secrets
 
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from trip_planner.app.services.auth import AuthenticatedUser
@@ -17,6 +17,25 @@ from trip_planner.contracts.trip import (
     TripArtifactRefs,
     TripFrameSummary,
 )
+from trip_planner.persistence.models.activity import (
+    PersistedActivityLogEvent,
+    PersistedPlannerAction,
+)
+from trip_planner.persistence.models.budget import (
+    PersistedActualSpendEvent,
+    PersistedBudgetPlan,
+    PersistedBudgetPlanVersion,
+)
+from trip_planner.persistence.models.planner_memory import (
+    PersistedPlannerCheckpoint,
+    PersistedPlannerMemoryArtifact,
+)
+from trip_planner.persistence.models.planning_ledger import PersistedPlanningLedgerEntry
+from trip_planner.persistence.models.planning_notebook import PersistedPlanningNotebookItem
+from trip_planner.persistence.models.policy import PersistedPolicyState
+from trip_planner.persistence.models.proposal import PersistedProposalState
+from trip_planner.persistence.models.scenario import PersistedSavedScenario
+from trip_planner.persistence.models.session import PersistedPlanningSessionState
 from trip_planner.persistence.models.trip import PersistedTrip
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
@@ -177,3 +196,36 @@ def get_trip(db_session: Session, *, user: AuthenticatedUser, trip_id: str) -> d
     if record is None:
         return None
     return serialize_trip(record)
+
+
+def delete_trip(db_session: Session, *, user: AuthenticatedUser, trip_id: str) -> bool:
+    record = db_session.scalar(
+        select(PersistedTrip)
+        .where(PersistedTrip.trip_id == trip_id)
+        .where(PersistedTrip.user_id == user.user_id)
+    )
+    if record is None:
+        return False
+
+    # Keep deletion deterministic in SQLite test databases, where foreign-key
+    # cascade enforcement is not guaranteed unless PRAGMA foreign_keys is on.
+    for model in (
+        PersistedActualSpendEvent,
+        PersistedBudgetPlanVersion,
+        PersistedBudgetPlan,
+        PersistedPlannerAction,
+        PersistedActivityLogEvent,
+        PersistedPlannerMemoryArtifact,
+        PersistedPlannerCheckpoint,
+        PersistedPlanningLedgerEntry,
+        PersistedPlanningNotebookItem,
+        PersistedPolicyState,
+        PersistedProposalState,
+        PersistedSavedScenario,
+        PersistedPlanningSessionState,
+    ):
+        db_session.execute(delete(model).where(model.trip_id == trip_id))
+
+    db_session.delete(record)
+    db_session.commit()
+    return True


### PR DESCRIPTION
## Summary\n- add owned-trip deletion across API, frontend trip cards, and persisted workspace child state\n- allow successful no-content mutation responses so delete-style interactions do not surface false JSON errors\n- add visible success feedback for planner prompt drafts, route option actions, and notebook actions\n- replace several developer-facing labels on the app shell/auth/new-trip/trips pages\n- fix Vite local dev direct-route serving by allowing the frontend root alongside bundle\n\n## Validation\n- uv run pytest tests/app/test_trip_routes.py tests/app/test_workspace.py::test_workspace_planning_notebook_api_persists_items_and_focus_across_reload tests/app/test_workspace.py::test_workspace_route_option_actions_update_comparison_and_ledger\n- npm test -- --run src/lib/api/client.test.ts src/routes/TripsPage.test.tsx src/components/workspace/RouteOptionWorkbench.test.tsx src/routes/WorkspacePage.test.tsx\n- npm run build\n- rendered local audit with disposable account: trip list delete confirmation, planner prompt draft feedback, notebook add/delete feedback, final trip deletion