### PR TITLE
Issue #1184: Wire source quality summaries to inventory bundles

### DIFF
--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -18,6 +18,7 @@ from trip_planner.persistence.models.planner_memory import (
     PersistedPlannerMemoryArtifact,
 )
 from trip_planner.persistence.models.session import PersistedPlanningSessionState
+from trip_planner.sources import CONFIDENCE_LABELS
 
 
 @pytest.fixture
@@ -693,8 +694,18 @@ def test_planner_turn_executes_provider_rich_read_only_tools(client: TestClient)
         tool_outputs["refresh_route_comparison"]["output"]["lead_scenario_id"]
         == response.json()["planner_panel_state"]["option_set"]["options"][0]["option_id"]
     )
-    assert tool_outputs["read_source_quality_summary"]["status"] == "not_available"
-    assert tool_outputs["read_source_quality_summary"]["output"]["quality_state"] == "not_available"
+    quality_tool_output = tool_outputs["read_source_quality_summary"]
+    assert quality_tool_output["status"] in {"completed", "partial"}
+    assert quality_tool_output["output"]["quality_state"] != "not_available"
+    quality_rows = quality_tool_output["output"]["rows"]
+    assert quality_rows
+    assert any(
+        row["status"] == "completed"
+        and row["score"] is not None
+        and row["confidence_label"] in CONFIDENCE_LABELS
+        and row["contributing_source_count"] > 0
+        for row in quality_rows
+    )
 
     with get_session_factory()() as db_session:
         stored = db_session.scalars(

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -16,11 +16,13 @@ from trip_planner.sources import (
     AdapterIssue,
     NormalizationHandoff,
     ProvenanceReference,
+    QualityValueFitSummary,
     RawSnapshot,
     RawSourceRecord,
     SourceAdapter,
     SourceQuery,
     SourceRecord,
+    SourceTrustSignals,
 )
 
 _BUNDLE_RESOURCE_PACKAGE = "trip_planner.resources.options.bundles"
@@ -155,6 +157,19 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
             category="commercial_inventory",
             coverage_scope="global",
             supported_option_kinds=["mixed", "lodging"],
+            trust_signals=SourceTrustSignals(
+                freshness_days=0,
+                freshness_confidence=0.7,
+                commerciality=0.5,
+                operational_reliability=0.65,
+                notes=["Fixture source freshness is pinned to the bundled fixture capture date."],
+            ),
+            quality_summary=QualityValueFitSummary(
+                quality_signal=0.68,
+                value_signal=0.62,
+                fit_signal=0.7,
+                confidence=0.66,
+            ),
             notes=[
                 "Provides a bounded adapter seam until live provider-backed inventory is available."
             ],
@@ -231,6 +246,7 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
         records: list[RawSourceRecord] = []
         for index, fixture_name in enumerate(fixture_names, start=1):
             mixed_option = _load_mixed_option_fixture(fixture_name)
+            source_record_payload = self.source_record.to_dict()
             records.append(
                 RawSourceRecord(
                     record_id=f"{query.query_id}:{index}",
@@ -240,7 +256,13 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
                     payload={
                         "fixture_name": fixture_name,
                         "trip_id": self.trip_id,
-                        "bundle_payloads": [bundle.to_dict() for bundle in mixed_option.bundles],
+                        "bundle_payloads": [
+                            {
+                                **bundle.to_dict(),
+                                "source_records": [source_record_payload],
+                            }
+                            for bundle in mixed_option.bundles
+                        ],
                     },
                     captured_at="2026-04-11T00:00:00Z",
                     metadata={
@@ -338,6 +360,23 @@ class PersistedTripSourceInventoryAdapter(SourceAdapter):
             category="commercial_inventory",
             coverage_scope="global",
             supported_option_kinds=["mixed", "lodging", "activity", "rail"],
+            coverage_regions=list(self.primary_regions),
+            trust_signals=SourceTrustSignals(
+                freshness_days=0,
+                freshness_confidence=0.85,
+                commerciality=0.7,
+                operational_reliability=0.76,
+                notes=[
+                    "Runtime inventory is generated from current persisted trip context.",
+                    f"Primary region count: {len(self.primary_regions)}.",
+                ],
+            ),
+            quality_summary=QualityValueFitSummary(
+                quality_signal=0.78 if trip_mode == "business" else 0.74,
+                value_signal=0.72 if trip_mode == "business" else 0.69,
+                fit_signal=0.8 if primary_regions else 0.55,
+                confidence=0.76 if primary_regions else 0.5,
+            ),
             notes=["Derives normalized inventory seeds directly from persisted trip context."],
         )
         self.supported_entity_scopes = ("mixed",)
@@ -612,6 +651,7 @@ class PersistedTripSourceInventoryAdapter(SourceAdapter):
                 "value_signal": baseline_signal - 0.05,
                 "fit_signal": baseline_signal,
             },
+            "source_records": [self.source_record.to_dict()],
             "feasibility": {"available": True, "internally_consistent": True},
             "explanation": {
                 "headline": "Runtime inventory assembled from persisted trip context.",
@@ -1003,6 +1043,7 @@ def build_inventory_summary_payload(
                 "option_count": len(bundle.option_ids),
                 "strengths": list(bundle.explanation.strengths[:2]),
                 "tradeoffs": list(bundle.explanation.tradeoffs[:2]),
+                "source_records": [record.to_dict() for record in bundle.source_records],
             }
             for bundle in bundles
         ],

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -19,6 +19,8 @@ from trip_planner.app.services.workspace import (
     set_planning_notebook_focus,
     submit_workspace_option_feedback,
 )
+from trip_planner.sources import QualityValueFitSummary, SourceQualityScorer, SourceRecord
+from trip_planner.sources import SourceTrustSignals
 
 
 @dataclass(frozen=True, slots=True)
@@ -70,7 +72,7 @@ _TOOL_DEFINITIONS: tuple[PlannerToolDefinition, ...] = (
     ),
     PlannerToolDefinition(
         tool_name="read_source_quality_summary",
-        description="Read source quality scoring status when available, otherwise return a bounded not_available result.",
+        description="Read source quality scoring state for attached workspace source records.",
     ),
     PlannerToolDefinition(
         tool_name="read_map_provider_status",
@@ -184,6 +186,25 @@ def _ref_list(*refs: str | None) -> list[str]:
 
 def _bounded_items(items: list[Any], limit: int) -> list[Any]:
     return items[: max(0, min(limit, 20))]
+
+
+def _source_record_from_payload(payload: Any) -> SourceRecord | None:
+    if isinstance(payload, SourceRecord):
+        return payload
+    if not isinstance(payload, dict):
+        return None
+    trust_payload = payload.get("trust_signals") or {}
+    quality_payload = payload.get("quality_summary") or {}
+    try:
+        return SourceRecord(
+            **{
+                **payload,
+                "trust_signals": SourceTrustSignals(**trust_payload),
+                "quality_summary": QualityValueFitSummary(**quality_payload),
+            }
+        )
+    except (TypeError, ValueError):
+        return None
 
 
 def _route_scenarios(payload: dict[str, Any]) -> list[dict[str, Any]]:
@@ -394,28 +415,49 @@ def _read_source_quality_summary(
     payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
     inventory = payload["inventory_summary"]
     runtime_state = inventory.get("runtime_state") or {}
+    scorer = SourceQualityScorer()
     quality_rows = []
     for bundle in _bounded_items(list(inventory.get("bundles") or []), 5):
+        source_records = [
+            record
+            for record in (
+                _source_record_from_payload(item) for item in bundle.get("source_records", [])
+            )
+            if record is not None
+        ]
+        summary = scorer.summarize(
+            source_records,
+            subject_kind="option",
+            intended_option_kind=str(bundle.get("bundle_context") or "mixed"),
+        )
+        row_status = "completed" if summary.contributing_source_count else "missing_source_records"
         quality_rows.append(
             {
                 "target_id": bundle.get("bundle_id"),
                 "target_title": bundle.get("title"),
-                "status": "not_available",
-                "score": None,
-                "summary": "Source quality scoring service is not implemented for this target yet.",
+                "status": row_status,
+                "score": summary.confidence if summary.contributing_source_count else None,
+                "confidence_label": summary.confidence_label,
+                "contributing_source_count": summary.contributing_source_count,
+                "category_counts": dict(summary.category_counts),
+                "summary": " ".join(summary.explanation_fragments[:2]),
+                "tags": list(summary.tags),
             }
         )
+    completed_rows = [row for row in quality_rows if row["status"] == "completed"]
+    tool_status = "completed" if completed_rows else "missing_source_records"
     return PlannerToolResult(
         tool_name="read_source_quality_summary",
-        status="not_available",
+        status=tool_status,
         summary=(
-            "Source quality scoring is not implemented yet; returned bounded placeholder rows "
-            "for current workspace targets."
+            f"Scored source quality for {len(completed_rows)} workspace bundle(s)."
+            if completed_rows
+            else "No source records are attached to the current workspace targets yet."
         ),
         mutates_state=False,
         refs=_ref_list(payload["session"]["session_state_id"]),
         output={
-            "quality_state": "not_available",
+            "quality_state": tool_status,
             "runtime_inventory_status": runtime_state.get("status", "unknown"),
             "rows": quality_rows,
             "next_service": "source_quality_scoring",

--- a/trip_planner/options/bundles.py
+++ b/trip_planner/options/bundles.py
@@ -19,6 +19,7 @@ from trip_planner._option_contracts import (
     OptionCostSummary,
     OptionQualitySummary,
 )
+from trip_planner.sources.models import QualityValueFitSummary, SourceRecord, SourceTrustSignals
 
 from .activities import ActivityOption
 from .destinations import Destination
@@ -68,6 +69,18 @@ def _parse_money_range(payload: dict[str, Any] | None, field_name: str) -> Money
 
 def _dedupe_strings(values: list[str]) -> list[str]:
     return list(dict.fromkeys(values))
+
+
+def _parse_source_record(payload: dict[str, Any]) -> SourceRecord:
+    trust_payload = payload.get("trust_signals") or {}
+    quality_payload = payload.get("quality_summary") or {}
+    return SourceRecord(
+        **{
+            **payload,
+            "trust_signals": SourceTrustSignals(**trust_payload),
+            "quality_summary": QualityValueFitSummary(**quality_payload),
+        }
+    )
 
 
 @dataclass(slots=True)
@@ -268,6 +281,7 @@ class InventoryBundle:
     quality_value_fit: BundleQualityValueFitSummary = field(
         default_factory=BundleQualityValueFitSummary
     )
+    source_records: list[SourceRecord] = field(default_factory=list)
     feasibility: BundleFeasibility = field(default_factory=BundleFeasibility)
     explanation: BundleExplanation = field(default_factory=BundleExplanation)
     summary: str = ""
@@ -296,6 +310,8 @@ class InventoryBundle:
             raise ValueError("provenance_summary must be a BundleProvenanceSummary")
         if not isinstance(self.quality_value_fit, BundleQualityValueFitSummary):
             raise ValueError("quality_value_fit must be a BundleQualityValueFitSummary")
+        if any(not isinstance(item, SourceRecord) for item in self.source_records):
+            raise ValueError("source_records must contain SourceRecord instances")
         if not isinstance(self.feasibility, BundleFeasibility):
             raise ValueError("feasibility must be a BundleFeasibility")
         if not isinstance(self.explanation, BundleExplanation):
@@ -430,6 +446,10 @@ class InventoryBundle:
             quality_value_fit=BundleQualityValueFitSummary(
                 **_optional_mapping_field(payload, "quality_value_fit")
             ),
+            source_records=[
+                _parse_source_record(item)
+                for item in _optional_list_field(payload, "source_records")
+            ],
             feasibility=BundleFeasibility(**_optional_mapping_field(payload, "feasibility")),
             explanation=BundleExplanation(**_optional_mapping_field(payload, "explanation")),
             summary=payload.get("summary", ""),


### PR DESCRIPTION
Closes #1184

## Summary
- attach serialized SourceRecord payloads to fixture and runtime InventoryBundle contracts
- route read_source_quality_summary through SourceQualityScorer instead of placeholder rows
- update planner route coverage to require scored quality rows and valid confidence labels

## Validation
- pytest tests/sources/test_source_quality.py tests/app/test_planner_routes.py -x

Design refs: docs/source-quality-model.md, docs/design-coverage-map.md