### PR TITLE
Issue #1191: expose provider-rich route depth metadata

### DIFF
--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -275,7 +275,7 @@ Design ref: [`docs/live-tpp-execution-reoptimization-epic.md`](live-tpp-executio
 Design refs: [`docs/google-maps-platform-hardening-epic.md`](google-maps-platform-hardening-epic.md), [`docs/maps-timeline-comparison-epic.md`](maps-timeline-comparison-epic.md)  
 Issues: `#679` (epic), `#698`–`#700`
 
-> **Partial.** The map adapter boundary, bounded fallback rendering, Google Maps JavaScript provider path, global/regional/segment map-scope controls, workspace timeline rendering, shared route/segment focus, source-quality summaries, and scenario comparison surfaces now exist. Remaining work is mostly product depth: live provider verification in configured environments, deeper option-marker detail, and real provider distance geometry beyond the current duration-first runtime segment payload.
+> **Partial.** The map adapter boundary, bounded fallback rendering, Google Maps JavaScript provider path, global/regional/segment map-scope controls, workspace timeline rendering, shared route/segment focus, source-quality summaries, and scenario comparison surfaces now exist. Issue `#1191` adds deterministic route-depth metadata for source-backed markers and per-segment distance-verification state without requiring live Google Maps credentials. Remaining work is mostly release/live-provider confidence, not default local behavior.
 
 | Commitment | Source | Tests | Status |
 |------------|--------|-------|--------|
@@ -283,12 +283,12 @@ Issues: `#679` (epic), `#698`–`#700`
 | Route-context map contract (`docs/contracts/route-context-map-target.md`) | `docs/contracts/route-context-map-target.md`, `frontend/src/components/maps/mapSurface.ts`, `frontend/src/components/maps/TripMap.tsx` | `tests/contracts/test_route_context_map_target.py`, frontend map tests | ✅ Implemented |
 | Global/regional/segment map scope switching | `frontend/src/components/maps/mapSurface.ts`, `frontend/src/components/maps/TripMap.tsx` | `frontend/src/components/maps/mapSurface.test.ts`, `frontend/src/components/maps/TripMap.test.tsx`, `frontend/src/routes/WorkspacePage.test.tsx` | ✅ Implemented |
 | Timeline view for trip structure + day sequencing (`#698`) | `frontend/src/routes/WorkspacePage.tsx` (`buildTimelineStops`, timeline section, segment focus notes) | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (segment timing/confidence shipped; source-backed per-stop timing still pending) |
-| Dedicated map surface for route + option context (`#699`) | `frontend/src/components/maps/TripMap.tsx`, `frontend/src/components/maps/mapSurface.ts` | frontend map/workspace tests | ✅ Implemented |
+| Dedicated map surface for route + option context (`#699`, `#1191`) | `frontend/src/components/maps/TripMap.tsx`, `frontend/src/components/maps/mapSurface.ts`, `trip_planner/app/services/workspace.py`, `docs/reports/provider-rich-route-depth.md` | frontend map/workspace tests, `tests/app/test_planner_routes.py`, `tests/app/test_workspace.py` | ✅ Implemented |
 | Saved-scenario + trip comparison views (`#700`) | `frontend/src/components/workspace/ScenarioComparison.tsx`, `components/trips/TripComparison.tsx`, `frontend/src/routes/WorkspacePage.tsx` | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial (workspace-tested; targeted component tests still thin) |
 | Traveler-facing workspace polish and hidden diagnostics (`#1164`) | `frontend/src/routes/WorkspacePage.tsx`, `frontend/src/components/workspace/RouteOptionWorkbench.tsx`, `frontend/src/components/maps/TripMap.tsx`, `frontend/src/components/planner/PlanningModeSelector.tsx` | `frontend/src/routes/WorkspacePage.test.tsx`, `frontend/src/components/workspace/RouteOptionWorkbench.test.tsx`, `frontend/src/components/maps/TripMap.test.tsx`, `frontend/src/components/planner/PlanningModeSelector.test.tsx` | ✅ Implemented |
 | Workspace timeline contract | `docs/workspace_timeline_contract.md`, `frontend/src/routes/WorkspacePage.tsx` | `frontend/src/routes/WorkspacePage.test.tsx` | 🟡 Partial |
 
-**Gap detail (follow-up issue candidate):** The shipped timeline and map surfaces now let a traveler move between whole-trip outline, regional comparison, and precise segment review without losing selected route context, and issue `#1164` keeps raw runtime/provider/debug details behind diagnostics while improving planner reply and route-option presentation. The next gap is deeper provider richness: live distance/geometry verification and more inspectable option-marker detail.
+**Gap detail:** The shipped timeline and map surfaces now let a traveler move between whole-trip outline, regional comparison, and precise segment review without losing selected route context, and issue `#1164` keeps raw runtime/provider/debug details behind diagnostics while improving planner reply and route-option presentation. Issue `#1191` resolves the default-runtime depth gap by exposing source-backed marker descriptions, segment source refs, and an explicit `distance_verification_state` through the workspace and planner-tool payloads. Live Google Maps distance/geometry verification remains an opt-in release verification concern.
 
 ---
 
@@ -326,7 +326,7 @@ From [`docs/product-architecture-brief.md`](product-architecture-brief.md) and [
 These design commitments are still missing, partial, or not yet verified in a live provider environment. Each is a candidate for a follow-up issue:
 
 1. **Semantic planner memory and reorientation** — planner checkpoints and notebook state exist, but there is no semantic recall/reorientation layer for scattered traveler notes and "I was working on..." context shifts. See §13 above.
-2. **Provider-rich timeline/map depth** — workspace timeline and map surfaces now share route/segment focus and per-leg timing/confidence, but still need live provider distance/geometry verification and richer source-backed option details. See §16 above.
+2. **Provider-rich timeline/map depth** — default workspace and planner-tool payloads now expose source-backed marker detail and per-segment distance-verification state. Remaining work is live provider verification in configured release environments. See §16 above.
 3. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
 
 ---

--- a/docs/reports/provider-rich-route-depth.md
+++ b/docs/reports/provider-rich-route-depth.md
@@ -1,0 +1,31 @@
+# Provider-Rich Route/Map Depth Audit
+
+Issue: #1191
+
+## Classification
+
+The provider-rich route/map follow-up is implemented for the default deterministic runtime path and intentionally deferred for live Google Maps distance verification.
+
+## Evidence
+
+- `trip_planner/app/services/workspace.py` builds route markers and rough geometry for each runtime route option from ranked scenario data.
+- `trip_planner/app/services/planner_tools.py` exposes that payload through `read_map_provider_status` and `read_route_geometry`.
+- `frontend/src/components/maps/mapSurface.ts` prefers `map_view.place_markers` and `map_view.rough_route_geometry` when the runtime payload supplies them.
+- `frontend/src/components/maps/TripMap.tsx` keeps provider diagnostics out of the default traveler view while still showing segment timing, confidence, and unavailable-state copy.
+
+## Decision
+
+The default local and CI path must not require live Google Maps credentials. Instead, the runtime now makes the route-depth state inspectable with bounded metadata:
+
+- Route stop markers include a traveler-safe description and source references back to ranked scenario evidence.
+- Route segments include duration, confidence, source references, and an explicit `distance_verification_state`.
+- When provider distance is absent, segments report `duration_estimate_only` and keep the existing unavailable reason instead of fabricating distance.
+- Missing route scenarios still return `not_available` from `read_map_provider_status` and `read_route_geometry`.
+
+Live provider distance/geometry verification remains opt-in through the Google Maps adapter path and explicit local or release verification, not the default test path.
+
+## Validation
+
+- `tests/app/test_planner_routes.py` asserts planner tools expose source-backed markers, segment verification state, and preserved missing-route `not_available` behavior.
+- `tests/app/test_workspace.py` asserts workspace route comparison payloads carry source-backed marker and segment metadata.
+- `frontend/src/components/maps/mapSurface.test.ts` asserts provider-supplied marker descriptions and source refs flow into the map surface model.

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -273,6 +273,8 @@ export type RuntimeScenarioComparison = {
         id: string;
         source_id: string;
         label: string;
+        description?: string;
+        source_refs?: string[];
         route_index: number;
         x: number;
         y: number;
@@ -291,6 +293,10 @@ export type RuntimeScenarioComparison = {
         duration_minutes?: number | null;
         distance_km?: number | null;
         confidence?: "high" | "medium" | "low" | null;
+        provider_distance_available?: boolean;
+        distance_verification_state?: "scenario_distance_available" | "duration_estimate_only";
+        distance_source?: string | null;
+        source_refs?: string[];
         unavailable_reason?: string | null;
       }>;
       confidence: {

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -242,7 +242,16 @@ describe("mapSurface", () => {
           active_route_option_id: "route-option:provider",
           selected_segment_id: "segment:uji-nara",
           place_markers: [
-            { id: "marker:kyoto", source_id: "kyoto", label: "Kyoto", route_index: 0, x: 0.1, y: 0.5 },
+            {
+              id: "marker:kyoto",
+              source_id: "kyoto",
+              label: "Kyoto",
+              description: "Source-backed route origin.",
+              source_refs: ["source:provider-route"],
+              route_index: 0,
+              x: 0.1,
+              y: 0.5,
+            },
             { id: "marker:uji", source_id: "uji", label: "Uji", route_index: 1, x: 0.45, y: 0.3 },
             { id: "marker:nara", source_id: "nara", label: "Nara", route_index: 2, x: 0.85, y: 0.6 },
           ],
@@ -301,6 +310,10 @@ describe("mapSurface", () => {
     });
 
     expect(model.workspaceView.activeRouteOptionId).toBe("route-option:provider");
+    expect(model.routeStops[0]).toMatchObject({
+      description: "Source-backed route origin.",
+      sourceRefs: ["source:provider-route"],
+    });
     expect(model.visibleRouteStops.map((stop) => stop.label)).toEqual(["Uji", "Nara"]);
     expect(model.visibleRouteSegments[0]).toMatchObject({
       id: "segment:uji-nara",

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -31,6 +31,7 @@ export type RouteStop = {
   sourceId: string;
   label: string;
   description: string;
+  sourceRefs: string[];
   x: number;
   y: number;
 };
@@ -296,7 +297,8 @@ function buildRouteStops(activeScenario: TripMapScenario): RouteStop[] {
       id: marker.id,
       sourceId: marker.source_id,
       label: marker.label,
-      description: describeStop(index, providerMarkers.length),
+      description: marker.description ?? describeStop(index, providerMarkers.length),
+      sourceRefs: marker.source_refs ?? [],
       x: marker.x * 100,
       y: marker.y * 100,
     }));
@@ -309,6 +311,7 @@ function buildRouteStops(activeScenario: TripMapScenario): RouteStop[] {
       sourceId: stop,
       label: humanizeStop(stop),
       description: describeStop(index, activeScenario.route_sequence.length),
+      sourceRefs: [],
       x: coordinate.x,
       y: coordinate.y,
     };

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -688,7 +688,17 @@ def test_planner_turn_executes_provider_rich_read_only_tools(client: TestClient)
     }
     assert tool_outputs["read_map_provider_status"]["output"]["route_state"] == "ready"
     assert tool_outputs["read_route_geometry"]["status"] == "completed"
-    assert tool_outputs["read_route_geometry"]["output"]["rough_route_geometry"]
+    geometry_output = tool_outputs["read_route_geometry"]["output"]
+    assert geometry_output["rough_route_geometry"]
+    assert geometry_output["place_markers"]
+    assert geometry_output["place_markers"][0]["description"].startswith("Route stop 1")
+    assert geometry_output["place_markers"][0]["source_refs"]
+    first_segment = geometry_output["rough_route_geometry"][0]
+    assert first_segment["duration_minutes"] is not None
+    assert first_segment["provider_distance_available"] is False
+    assert first_segment["distance_verification_state"] == "duration_estimate_only"
+    assert first_segment["unavailable_reason"]
+    assert first_segment["source_refs"] == geometry_output["place_markers"][0]["source_refs"]
     assert tool_outputs["refresh_route_comparison"]["output"]["scenarios"]
     assert (
         tool_outputs["refresh_route_comparison"]["output"]["lead_scenario_id"]

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -2515,6 +2515,14 @@ def test_workspace_route_option_actions_update_comparison_and_ledger(
     else:
         assert route_options[0]["open_question"] is None
     assert route_options[0]["available_action"] == route_options[0]["available_actions"][0]
+    marker = route_options[0]["map_view"]["place_markers"][0]
+    assert marker["description"].startswith("Route stop 1")
+    assert marker["source_refs"]
+    segment = route_options[0]["map_view"]["rough_route_geometry"][0]
+    assert segment["source_refs"] == marker["source_refs"]
+    assert segment["provider_distance_available"] is False
+    assert segment["distance_verification_state"] == "duration_estimate_only"
+    assert segment["unavailable_reason"]
 
     candidate = route_options[min(1, len(route_options) - 1)]
     candidate_id = candidate["route_option_id"]

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -889,12 +889,22 @@ def _map_coordinate_for_route_index(index: int, route_length: int) -> dict[str, 
     }
 
 
-def _build_runtime_map_place_markers(route_sequence: list[str]) -> list[dict[str, Any]]:
+def _build_runtime_map_place_markers(
+    route_sequence: list[str],
+    *,
+    source_refs: list[str],
+) -> list[dict[str, Any]]:
+    stop_count = len([stop for stop in route_sequence if stop])
     return [
         {
             "id": f"route-stop:{index + 1}",
             "source_id": stop,
             "label": _humanize_route_stop(stop),
+            "description": (
+                f"Route stop {index + 1} of {stop_count}, sourced from the ranked scenario "
+                "route sequence."
+            ),
+            "source_refs": list(source_refs),
             "route_index": index,
             **_map_coordinate_for_route_index(index, len(route_sequence)),
         }
@@ -909,6 +919,7 @@ def _build_runtime_map_route_geometry(
     route_warning: str | None,
     total_travel_minutes: int,
     feasible: bool,
+    source_refs: list[str],
     total_distance_km: float | None = None,
 ) -> list[dict[str, Any]]:
     segments: list[dict[str, Any]] = []
@@ -919,6 +930,7 @@ def _build_runtime_map_route_geometry(
         if total_distance_km is not None and total_distance_km > 0
         else None
     )
+    distance_available = per_segment_distance_km is not None
     for index, marker in enumerate(place_markers[:-1]):
         next_marker = place_markers[index + 1]
         segments.append(
@@ -936,9 +948,17 @@ def _build_runtime_map_route_geometry(
                 "duration_minutes": per_segment_minutes,
                 "distance_km": per_segment_distance_km,
                 "confidence": "medium" if feasible else "low",
+                "provider_distance_available": distance_available,
+                "distance_verification_state": (
+                    "scenario_distance_available"
+                    if distance_available
+                    else "duration_estimate_only"
+                ),
+                "distance_source": "scenario_summary" if distance_available else None,
+                "source_refs": list(source_refs),
                 "unavailable_reason": (
                     None
-                    if per_segment_distance_km is not None
+                    if distance_available
                     else "Provider distance is not available; duration is estimated from ranked scenario timing."
                 ),
             }
@@ -954,13 +974,22 @@ def _build_runtime_map_view_payload(
 ) -> dict[str, Any]:
     confidence_level = "high" if summary.get("feasible", False) else "medium"
     route_warning = None if summary.get("feasible", False) else "Scenario feasibility needs review."
-    place_markers = _build_runtime_map_place_markers(route_sequence)
+    source_refs = [
+        ref
+        for ref in [
+            scenario.get("source_result_id"),
+            *list(scenario.get("objective_refs") or []),
+        ]
+        if ref
+    ]
+    place_markers = _build_runtime_map_place_markers(route_sequence, source_refs=source_refs)
     rough_route_geometry = _build_runtime_map_route_geometry(
         place_markers,
         route_warning=route_warning,
         total_travel_minutes=int(summary.get("total_travel_minutes") or 0),
         total_distance_km=summary.get("total_distance_km"),
         feasible=bool(summary.get("feasible", False)),
+        source_refs=source_refs,
     )
     return {
         "active_scope": "regional",


### PR DESCRIPTION
Closes #1191

## Summary
- Add source-backed route marker descriptions and source refs to runtime workspace map payloads.
- Add per-segment distance verification metadata so planner tools expose whether route depth is scenario-backed or still duration-estimate-only.
- Document the #1191 audit decision and update the design coverage map to distinguish default deterministic route-depth metadata from opt-in live Google Maps verification.

## Validation
- `pytest tests/app/test_planner_routes.py::test_planner_turn_executes_provider_rich_read_only_tools tests/app/test_planner_routes.py::test_planner_turn_reports_sparse_provider_tool_state tests/app/test_workspace.py::test_workspace_route_option_actions_update_comparison_and_ledger -q`
- `git diff --check HEAD~1..HEAD`
- `npm test -- src/components/maps/mapSurface.test.ts` (after `npm ci --ignore-scripts --prefer-offline` in the isolated frontend worktree)

## Acceptance Criteria
- [x] Exact provider-rich route/map behavior is classified in `docs/reports/provider-rich-route-depth.md`.
- [x] `read_map_provider_status` and `read_route_geometry` still report `not_available` for missing route scenarios.
- [x] Tests prove source-backed marker metadata and distance-verification state without live Google Maps credentials.
- [x] `docs/design-coverage-map.md` is updated to mark the default-runtime follow-up claim as addressed and keep live provider verification as opt-in release work.

