### PR TITLE
Issue #1208: Add planner LangSmith fleet traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ frontend/.env.*.local
 node_modules/
 dist/
 *.tsbuildinfo
+
+# Runtime LangSmith fleet artifacts are regenerated and can contain local trace IDs.
+artifacts/langsmith/

--- a/docs/runbooks/langsmith-planner-traces.md
+++ b/docs/runbooks/langsmith-planner-traces.md
@@ -1,0 +1,42 @@
+# LangSmith Planner Trace Artifacts
+
+Trip-scoped planner turns emit dashboard-safe `langsmith-fleet/v1` records for
+the shared Workflows fleet dashboard contract owned by `stranske/Workflows#2150`.
+
+## Runtime Behavior
+
+- The planner service sets LangSmith project defaults only when
+  `LANGSMITH_API_KEY` is present.
+- Missing LangSmith credentials never block planner turns; records use
+  `status=no_secret` and the normal deterministic fallback/model behavior
+  continues.
+- Local records are appended to `artifacts/langsmith/langsmith-fleet.ndjson` by
+  default. Set `TRIP_PLANNER_LANGSMITH_FLEET_PATH` to redirect the file in tests
+  or local debugging.
+- Planner response actions persist a `langsmith_fleet` payload with the artifact
+  path, local run ID, trace ID, and record count.
+
+## Recorded Fields
+
+Every record includes shared fields such as schema version, repo, surface,
+operation, run ID, status, provider, model, and trace ID when available.
+
+The trip-planner domain payload includes bounded metadata only:
+
+- hashed session and trip identifiers
+- planning mode, planner action, itinerary phase, and provider/fallback state
+- tool-call counts, failed call counts, and mutating call counts
+- inventory, budget, and itinerary-coherence status
+- context-readiness status and missing context section names
+
+Records must not contain raw traveler messages, full prompts, private trip IDs,
+or full itinerary payloads.
+
+## Validation
+
+Focused checks:
+
+```bash
+python -m pytest tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py -q
+python -m ruff check trip_planner/observability/langsmith_fleet.py trip_planner/app/services/planner.py tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py
+```

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -2805,15 +2805,12 @@ describe("WorkspacePage", () => {
     });
 
     const user = userEvent.setup();
-    fireEvent.change(screen.getByLabelText("Budget title"), {
-      target: { value: "Kyoto spring guardrails" },
-    });
-    fireEvent.change(screen.getByLabelText("Lodging cap"), {
-      target: { value: "600" },
-    });
-    fireEvent.change(screen.getByLabelText("Food cap"), {
-      target: { value: "180" },
-    });
+    await user.clear(screen.getByLabelText("Budget title"));
+    await user.type(screen.getByLabelText("Budget title"), "Kyoto spring guardrails");
+    await user.clear(screen.getByLabelText("Lodging cap"));
+    await user.type(screen.getByLabelText("Lodging cap"), "600");
+    await user.clear(screen.getByLabelText("Food cap"));
+    await user.type(screen.getByLabelText("Food cap"), "180");
     await user.click(screen.getByRole("button", { name: "Save budget plan" }));
 
     await waitFor(() => {

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,12 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
+    monkeypatch.delenv("LANGSMITH_PROJECT", raising=False)
+    monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_LANGSMITH_FLEET_PATH", raising=False)
     set_planner_chat_model_factory_for_tests(None)
     reset_database_state()
     app = create_app()
@@ -549,6 +556,97 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
         assert checkpoint is not None
         assert checkpoint.metadata_payload["tool_call_count"] == 6
         assert checkpoint.metadata_payload["selected_planning_mode"] == "collaborative"
+
+
+def test_planner_turn_emits_no_secret_langsmith_fleet_artifact(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    trip_id = _create_trip(client)
+    artifact_path = tmp_path / "langsmith-fleet.ndjson"
+    monkeypatch.setenv("TRIP_PLANNER_LANGSMITH_FLEET_PATH", str(artifact_path))
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={
+            "message": "Compare Chicago food options without storing my exact traveler note.",
+            "tool_calls": [{"tool_name": "read_budget_state"}],
+        },
+    )
+
+    assert response.status_code == 200
+    records = [json.loads(line) for line in artifact_path.read_text().splitlines()]
+    assert len(records) == 1
+    record = records[0]
+    assert record["schema_version"] == "langsmith-fleet/v1"
+    assert record["repo"] == "stranske/trip-planner"
+    assert record["surface"] == "planner-conversation"
+    assert record["operation"] == "planner-turn"
+    assert record["status"] == "no_secret"
+    assert record["github_issue"] == "stranske/trip-planner#1208"
+    domain = record["domain"]
+    assert domain["planning_mode"] == "collaborative"
+    assert domain["tool_call_count"] == 1
+    assert domain["budget_constraint_status"] == "used"
+    assert "trip_id_hash" in domain
+    serialized = json.dumps(record)
+    assert trip_id not in serialized
+    assert "Compare Chicago food options" not in serialized
+
+    with get_session_factory()() as db_session:
+        stored = db_session.scalars(
+            select(PersistedPlannerAction)
+            .where(PersistedPlannerAction.trip_id == trip_id)
+            .order_by(PersistedPlannerAction.occurred_at.asc())
+        ).all()
+        fleet_payload = stored[-1].payload["langsmith_fleet"]
+        assert fleet_payload["artifact_path"] == str(artifact_path)
+        assert fleet_payload["record_count"] == 1
+        assert fleet_payload["run_id"].startswith("planner-turn:")
+
+
+def test_configured_planner_model_receives_langsmith_trace_config(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    trip_id = _create_trip(client)
+    artifact_path = tmp_path / "langsmith-fleet.ndjson"
+    fake_model = FakePlannerChatModel(
+        {
+            "content": "I read the current workspace before recommending next steps.",
+            "tool_calls": [{"tool_name": "read_workspace_state", "arguments": {}}],
+        }
+    )
+    monkeypatch.setenv("TRIP_PLANNER_LANGSMITH_FLEET_PATH", str(artifact_path))
+    monkeypatch.setenv("LANGSMITH_API_KEY", "fake-langsmith-key")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-openai-key")
+    set_planner_chat_model_factory_for_tests(lambda _: fake_model)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Use the configured model path with trace metadata."},
+    )
+
+    assert response.status_code == 200
+    langsmith_config = fake_model.requests[0]["langsmith_run_config"]
+    assert langsmith_config["run_name"] == "trip-planner.planner-conversation"
+    assert "repo:trip-planner" in langsmith_config["tags"]
+    assert langsmith_config["metadata"]["repo"] == "stranske/trip-planner"
+    assert langsmith_config["metadata"]["trip_id_hash"]
+    assert langsmith_config["metadata"]["trip_id_hash"] != trip_id
+    assert langsmith_config["metadata"]["provider"] == "openai"
+    assert langsmith_config["metadata"]["model"] == "fake-planner-model"
+    assert fake_model.requests[0]["runtime_context"]["langsmith_run_config"] == langsmith_config
+    records = [json.loads(line) for line in artifact_path.read_text().splitlines()]
+    assert records
+    assert records[0]["status"] == "success"
+    assert records[0]["provider"] == "openai"
+    assert records[0]["model"] == "fake-planner-model"
+    assert records[0]["domain"]["provider_state"] == "model"
 
 
 def test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state(

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -640,7 +640,7 @@ def test_configured_planner_model_receives_langsmith_trace_config(
     assert langsmith_config["metadata"]["trip_id_hash"] != trip_id
     assert langsmith_config["metadata"]["provider"] == "openai"
     assert langsmith_config["metadata"]["model"] == "fake-planner-model"
-    assert fake_model.requests[0]["runtime_context"]["langsmith_run_config"] == langsmith_config
+    assert "langsmith_run_config" not in fake_model.requests[0]["runtime_context"]
     records = [json.loads(line) for line in artifact_path.read_text().splitlines()]
     assert records
     assert records[0]["status"] == "success"

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -96,6 +96,7 @@ def test_planner_fleet_record_summarizes_domain_metadata_without_raw_payload(mon
     serialized = json.dumps(record)
     assert "trip-private" not in serialized
     assert "session-private" not in serialized
+    assert record["domain"]["fallback_state"] == "missing_model_config"
 
 
 def test_write_fleet_records_uses_deterministic_ndjson(tmp_path):

--- a/tests/observability/test_langsmith_fleet.py
+++ b/tests/observability/test_langsmith_fleet.py
@@ -1,0 +1,117 @@
+import json
+import os
+
+from trip_planner.observability.langsmith_fleet import (
+    PlannerFleetContext,
+    build_langsmith_run_config,
+    build_planner_fleet_records,
+    ensure_langsmith_project_defaults,
+    write_fleet_records,
+)
+
+
+def test_langsmith_defaults_are_noop_without_secret(monkeypatch):
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+    monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+
+    assert ensure_langsmith_project_defaults() is False
+    assert "LANGCHAIN_TRACING_V2" not in os.environ
+    assert (
+        build_langsmith_run_config(
+            context=PlannerFleetContext(run_id="run-1", session_id="session-1", trip_id="trip-1"),
+            metadata={"task_class": "first_turn_triage"},
+        )
+        is None
+    )
+
+
+def test_langsmith_config_hashes_trip_id_and_sets_project_defaults(monkeypatch):
+    monkeypatch.setenv("LANGSMITH_API_KEY", "secret-test-key")
+    monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+    monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+
+    config = build_langsmith_run_config(
+        context=PlannerFleetContext(
+            run_id="run-1",
+            session_id="session-1",
+            trip_id="trip-private",
+            planning_mode="collaborative",
+            provider="openai",
+            model="gpt-test",
+        ),
+        metadata={"task_class": "route_comparison", "plan_maturity": "coherent_plan"},
+    )
+
+    assert config is not None
+    assert config["metadata"]["trip_id_hash"] != "trip-private"
+    assert config["metadata"]["provider"] == "openai"
+    assert config["metadata"]["model"] == "gpt-test"
+    assert "planning_mode:collaborative" in config["tags"]
+    assert os.environ["LANGCHAIN_TRACING_V2"] == "true"
+    assert os.environ["LANGCHAIN_PROJECT"] == "trip-planner"
+    assert os.environ["LANGCHAIN_API_KEY"] == "secret-test-key"
+
+
+def test_planner_fleet_record_summarizes_domain_metadata_without_raw_payload(monkeypatch):
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    context = PlannerFleetContext(
+        run_id="run-2",
+        session_id="session-private",
+        trip_id="trip-private",
+        planning_mode="delegated",
+        provider="openai",
+        model="gpt-test",
+        trace_id="trace-1",
+    )
+
+    records = build_planner_fleet_records(
+        context=context,
+        runtime_mode="fallback",
+        turn_metadata={
+            "task_class": "planning_synthesis",
+            "plan_maturity": "coherent_plan",
+            "provider_state": "fallback",
+            "fallback_reason": "missing_model_config",
+        },
+        tool_calls=[
+            {"tool_name": "refresh_inventory", "status": "completed", "mutates_state": False},
+            {"tool_name": "update_budget_plan", "status": "completed", "mutates_state": True},
+        ],
+        context_readiness={"status": "partial", "missing_sections": ["policy"]},
+        artifact_ref="artifacts/langsmith/langsmith-fleet.ndjson",
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["status"] == "no_secret"
+    assert record["trace_id"] == "trace-1"
+    assert record["domain"]["planner_action"] == "planning_synthesis"
+    assert record["domain"]["inventory_usage"] == "used"
+    assert record["domain"]["budget_constraint_status"] == "used"
+    assert record["domain"]["mutating_tool_call_count"] == 1
+    assert record["domain"]["context_readiness_status"] == "partial"
+    serialized = json.dumps(record)
+    assert "trip-private" not in serialized
+    assert "session-private" not in serialized
+
+
+def test_write_fleet_records_uses_deterministic_ndjson(tmp_path):
+    path = tmp_path / "langsmith-fleet.ndjson"
+    write_fleet_records(
+        path,
+        [
+            {
+                "schema_version": "langsmith-fleet/v1",
+                "repo": "stranske/trip-planner",
+                "status": "no_secret",
+            }
+        ],
+    )
+
+    assert path.read_text(encoding="utf-8") == (
+        '{"repo":"stranske/trip-planner","schema_version":"langsmith-fleet/v1",'
+        '"status":"no_secret"}\n'
+    )

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import re
 import secrets
-from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Callable, Protocol
@@ -66,6 +65,7 @@ class PlannerConversationRequest:
     planner_panel_state: dict[str, Any]
     session: PlanningSessionState
     runtime_context: dict[str, Any]
+    langsmith_run_config: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1035,7 +1035,7 @@ class ModelBackedPlannerConversationRunnable:
                 "runtime_context": request.runtime_context,
                 "provider": self._config.provider,
                 "model": self._config.model,
-                "langsmith_run_config": request.runtime_context.get("langsmith_run_config"),
+                "langsmith_run_config": request.langsmith_run_config,
             }
         )
         content = str(raw.get("content") or "").strip()
@@ -1448,7 +1448,7 @@ def submit_planner_turn(
         planner_memory=planner_memory,
         activity_log=activity_log,
     )
-    runtime_context["langsmith_run_config"] = build_langsmith_run_config(
+    langsmith_run_config = build_langsmith_run_config(
         context=fleet_context,
         metadata=_planner_turn_metadata(
             message=normalized_message,
@@ -1465,6 +1465,7 @@ def submit_planner_turn(
                 planner_panel_state=workspace_payload["planner_panel_state"],
                 session=session,
                 runtime_context=runtime_context,
+                langsmith_run_config=langsmith_run_config,
             )
         )
     except Exception as error:
@@ -1569,8 +1570,15 @@ def submit_planner_turn(
         context_readiness=runtime_context["context_readiness"],
         artifact_ref=str(fleet_artifact_path),
     )
-    with suppress(Exception):
+    fleet_write_status = "failed"
+    fleet_write_error: str | None = None
+    fleet_record_count = 0
+    try:
         append_fleet_records(fleet_artifact_path, fleet_records)
+        fleet_write_status = "written"
+        fleet_record_count = len(fleet_records)
+    except Exception as error:  # pragma: no cover - defensive metadata path
+        fleet_write_error = type(error).__name__
     _record_planner_action(
         db_session,
         trip_id=trip_id,
@@ -1594,10 +1602,14 @@ def submit_planner_turn(
             "runtime_mode": runtime_config.mode,
             "context_readiness": runtime_context["context_readiness"],
             "langsmith_fleet": {
-                "artifact_path": str(fleet_artifact_path),
+                "artifact_path": (
+                    str(fleet_artifact_path) if fleet_write_status == "written" else ""
+                ),
                 "run_id": fleet_context.run_id,
                 "trace_id": fleet_context.trace_id,
-                "record_count": len(fleet_records),
+                "record_count": fleet_record_count,
+                "write_status": fleet_write_status,
+                "write_error": fleet_write_error,
             },
         },
     )

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 import secrets
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Callable, Protocol
@@ -39,6 +40,13 @@ from trip_planner.app.services.workspace import (
     _record_planner_action,
     _serialize_activity_record,
     _serialize_session_record,
+)
+from trip_planner.observability.langsmith_fleet import (
+    PlannerFleetContext,
+    append_fleet_records,
+    build_langsmith_run_config,
+    build_planner_fleet_records,
+    default_fleet_artifact_path,
 )
 from trip_planner.persistence.models.activity import (
     PersistedActivityLogEvent,
@@ -977,6 +985,10 @@ class _OpenAIPlannerChatModel:
             for tool in payload["available_tools"]
         ]
         model = self._model.bind_tools(tools)
+        invoke_kwargs: dict[str, Any] = {}
+        langsmith_run_config = payload.get("langsmith_run_config")
+        if isinstance(langsmith_run_config, dict):
+            invoke_kwargs["config"] = langsmith_run_config
         response = model.invoke(
             [
                 (
@@ -995,7 +1007,8 @@ class _OpenAIPlannerChatModel:
                         default=str,
                     ),
                 ),
-            ]
+            ],
+            **invoke_kwargs,
         )
         tool_calls: list[dict[str, Any]] = []
         for call in getattr(response, "tool_calls", []) or []:
@@ -1022,6 +1035,7 @@ class ModelBackedPlannerConversationRunnable:
                 "runtime_context": request.runtime_context,
                 "provider": self._config.provider,
                 "model": self._config.model,
+                "langsmith_run_config": request.runtime_context.get("langsmith_run_config"),
             }
         )
         content = str(raw.get("content") or "").strip()
@@ -1418,11 +1432,30 @@ def submit_planner_turn(
     activity_log = _activity_log(db_session, trip_id=trip_id)
     runtime_config = get_planner_runtime_config()
     runnable = _planner_runnable(runtime_config)
+    fleet_context = PlannerFleetContext(
+        run_id=f"planner-turn:{secrets.token_hex(8)}",
+        session_id=session.session_state_id,
+        trip_id=trip_id,
+        planning_mode=session.selected_planning_mode,
+        provider=runtime_config.provider,
+        model=runtime_config.model,
+        trace_id=f"planner-trace:{secrets.token_hex(8)}",
+        recorded_at=occurred_at,
+    )
     runtime_context = _planner_runtime_context(
         workspace_payload,
         session=session,
         planner_memory=planner_memory,
         activity_log=activity_log,
+    )
+    runtime_context["langsmith_run_config"] = build_langsmith_run_config(
+        context=fleet_context,
+        metadata=_planner_turn_metadata(
+            message=normalized_message,
+            runtime_config=runtime_config,
+            turn_index=len(activity_log),
+            planning_mode=session.selected_planning_mode,
+        ),
     )
     try:
         reply = runnable.invoke(
@@ -1527,6 +1560,17 @@ def submit_planner_turn(
         actor="planner",
         metadata={"ref_count": str(len(reply.refs))},
     )
+    fleet_artifact_path = default_fleet_artifact_path()
+    fleet_records = build_planner_fleet_records(
+        context=fleet_context,
+        runtime_mode=runtime_config.mode,
+        turn_metadata=reply.turn_metadata or {},
+        tool_calls=reply.tool_calls,
+        context_readiness=runtime_context["context_readiness"],
+        artifact_ref=str(fleet_artifact_path),
+    )
+    with suppress(Exception):
+        append_fleet_records(fleet_artifact_path, fleet_records)
     _record_planner_action(
         db_session,
         trip_id=trip_id,
@@ -1549,6 +1593,12 @@ def submit_planner_turn(
             ),
             "runtime_mode": runtime_config.mode,
             "context_readiness": runtime_context["context_readiness"],
+            "langsmith_fleet": {
+                "artifact_path": str(fleet_artifact_path),
+                "run_id": fleet_context.run_id,
+                "trace_id": fleet_context.trace_id,
+                "record_count": len(fleet_records),
+            },
         },
     )
     refresh_planner_memory(

--- a/trip_planner/observability/__init__.py
+++ b/trip_planner/observability/__init__.py
@@ -1,0 +1,2 @@
+"""Observability helpers for trip planner runtime surfaces."""
+

--- a/trip_planner/observability/langsmith_fleet.py
+++ b/trip_planner/observability/langsmith_fleet.py
@@ -1,0 +1,286 @@
+"""Build dashboard-safe LangSmith fleet records for planner turns.
+
+The shared schema is owned by `stranske/Workflows#2150`; this module emits the
+trip-planner-specific `langsmith-fleet/v1` records for trip-scoped planner
+conversation runs. Records deliberately avoid raw traveler messages, prompt
+text, and itinerary payloads. They keep only stable IDs, counts, statuses, and
+bounded domain metadata useful for fleet dashboards.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Iterable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Final, Literal
+
+SCHEMA_VERSION: Final = "langsmith-fleet/v1"
+REPO: Final = "stranske/trip-planner"
+SURFACE: Final = "planner-conversation"
+GITHUB_ISSUE: Final = "stranske/trip-planner#1208"
+ARTIFACT_NAME: Final = "langsmith-fleet.ndjson"
+DEFAULT_PROJECT: Final = "trip-planner"
+ENV_LANGSMITH_KEY: Final = "LANGSMITH_API_KEY"
+ENV_LANGCHAIN_PROJECT: Final = "LANGCHAIN_PROJECT"
+ENV_LANGSMITH_PROJECT: Final = "LANGSMITH_PROJECT"
+ENV_LANGCHAIN_TRACING_V2: Final = "LANGCHAIN_TRACING_V2"
+ENV_LANGCHAIN_API_KEY: Final = "LANGCHAIN_API_KEY"
+ENV_FLEET_PATH: Final = "TRIP_PLANNER_LANGSMITH_FLEET_PATH"
+
+Status = Literal["success", "error", "fallback", "no_secret", "skipped"]
+
+
+@dataclass(frozen=True, slots=True)
+class PlannerFleetContext:
+    """Shared trace context for one planner conversation turn."""
+
+    run_id: str
+    session_id: str
+    trip_id: str
+    planning_mode: str | None = None
+    provider: str | None = None
+    model: str | None = None
+    trace_id: str | None = None
+    trace_url: str | None = None
+    recorded_at: str | None = None
+    github_pr: str | None = None
+
+
+def ensure_langsmith_project_defaults() -> bool:
+    """Apply trip-planner LangSmith defaults when a key is present."""
+
+    api_key = os.environ.get(ENV_LANGSMITH_KEY, "").strip()
+    if not api_key:
+        return False
+    os.environ.setdefault(ENV_LANGCHAIN_TRACING_V2, "true")
+    os.environ.setdefault(ENV_LANGCHAIN_PROJECT, DEFAULT_PROJECT)
+    os.environ.setdefault(ENV_LANGSMITH_PROJECT, DEFAULT_PROJECT)
+    os.environ.setdefault(ENV_LANGCHAIN_API_KEY, api_key)
+    return True
+
+
+def build_langsmith_run_config(
+    *,
+    context: PlannerFleetContext,
+    metadata: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Return LangChain config metadata when LangSmith is enabled."""
+
+    if not ensure_langsmith_project_defaults():
+        return None
+    return {
+        "run_name": "trip-planner.planner-conversation",
+        "tags": [
+            "repo:trip-planner",
+            "surface:planner-conversation",
+            f"planning_mode:{context.planning_mode or 'unknown'}",
+        ],
+        "metadata": {
+            "schema_version": SCHEMA_VERSION,
+            "repo": REPO,
+            "surface": SURFACE,
+            "github_issue": GITHUB_ISSUE,
+            "run_id": context.run_id,
+            "session_id": context.session_id,
+            "trip_id_hash": _hash_identifier(context.trip_id),
+            "planning_mode": context.planning_mode,
+            "provider": context.provider,
+            "model": context.model,
+            "task_class": metadata.get("task_class"),
+            "plan_maturity": metadata.get("plan_maturity"),
+        },
+    }
+
+
+def build_planner_fleet_records(
+    *,
+    context: PlannerFleetContext,
+    runtime_mode: str,
+    turn_metadata: Mapping[str, Any],
+    tool_calls: Iterable[Mapping[str, Any]],
+    context_readiness: Mapping[str, Any],
+    artifact_ref: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return one Workflows-compatible fleet record for a planner run."""
+
+    tracing_enabled = ensure_langsmith_project_defaults()
+    calls = [dict(item) for item in tool_calls]
+    failed_calls = [item for item in calls if str(item.get("status") or "") == "error"]
+    fallback_reason = turn_metadata.get("fallback_reason")
+    if failed_calls:
+        status: Status = "error"
+    elif runtime_mode == "fallback" or fallback_reason:
+        status = "fallback"
+    elif tracing_enabled:
+        status = "success"
+    elif not os.environ.get(ENV_LANGSMITH_KEY, "").strip():
+        status = "no_secret"
+    else:
+        status = "no_secret"
+
+    domain = {
+        "session_id_hash": _hash_identifier(context.session_id),
+        "trip_id_hash": _hash_identifier(context.trip_id),
+        "planning_mode": context.planning_mode or "unknown",
+        "planner_action": turn_metadata.get("task_class") or "unknown",
+        "itinerary_phase": turn_metadata.get("plan_maturity") or "unknown",
+        "provider_state": turn_metadata.get("provider_state") or runtime_mode,
+        "fallback_state": fallback_reason or "none",
+        "error_state": "tool_error" if failed_calls else "none",
+        "tool_call_count": len(calls),
+        "failed_tool_call_count": len(failed_calls),
+        "mutating_tool_call_count": sum(1 for item in calls if bool(item.get("mutates_state"))),
+        "inventory_usage": _tool_state(calls, {"refresh_inventory"}),
+        "budget_constraint_status": _tool_state(calls, {"read_budget_state", "update_budget_plan"}),
+        "itinerary_coherence_status": _tool_state(
+            calls,
+            {"refresh_scenarios", "refresh_route_comparison", "read_route_geometry"},
+        ),
+        "persisted_workspace_result": "available",
+        "context_readiness_status": context_readiness.get("status") or "unknown",
+        "missing_context_sections": list(context_readiness.get("missing_sections") or []),
+    }
+    return [
+        _record(
+            context=context,
+            status=status,
+            recorded_at=context.recorded_at or _utc_timestamp(),
+            domain=domain,
+            error_code=_first_error_category(failed_calls),
+            artifact_ref=artifact_ref,
+        )
+    ]
+
+
+def default_fleet_artifact_path() -> Path:
+    """Return the default NDJSON path used by the planner surface."""
+
+    override = os.environ.get(ENV_FLEET_PATH, "").strip()
+    if override:
+        return Path(override).expanduser()
+    root = _project_root(Path(__file__).resolve())
+    return root / "artifacts" / "langsmith" / ARTIFACT_NAME
+
+
+def write_fleet_records(path: Path, records: Iterable[Mapping[str, Any]]) -> Path:
+    """Write fleet records as deterministic NDJSON and return the path."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [json.dumps(dict(record), sort_keys=True, separators=(",", ":")) for record in records]
+    payload = "\n".join(lines)
+    if lines:
+        payload += "\n"
+    path.write_text(payload, encoding="utf-8")
+    return path
+
+
+def append_fleet_records(
+    path: Path,
+    records: Iterable[Mapping[str, Any]],
+    *,
+    retention_limit: int = 2_000,
+) -> Path:
+    """Append fleet records as NDJSON with bounded local retention."""
+
+    if retention_limit < 1:
+        raise ValueError("retention_limit must be >= 1")
+    materialized = [dict(record) for record in records]
+    if not materialized:
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl_module: ModuleType | None = None
+        with suppress(ImportError):
+            import fcntl as fcntl_module
+        if fcntl_module is not None:
+            with suppress(OSError):
+                fcntl_module.flock(handle.fileno(), fcntl_module.LOCK_EX)
+        for record in materialized:
+            handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+        handle.flush()
+        handle.seek(0)
+        lines = handle.read().splitlines()
+        if len(lines) > retention_limit:
+            trimmed = lines[-retention_limit:]
+            temp_path = path.with_suffix(path.suffix + ".tmp")
+            temp_path.write_text("\n".join(trimmed) + "\n", encoding="utf-8")
+            temp_path.replace(path)
+        if fcntl_module is not None:
+            with suppress(Exception):
+                fcntl_module.flock(handle.fileno(), fcntl_module.LOCK_UN)
+    return path
+
+
+def _record(
+    *,
+    context: PlannerFleetContext,
+    status: Status,
+    recorded_at: str,
+    domain: Mapping[str, Any],
+    error_code: str | None,
+    artifact_ref: str | None,
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "repo": REPO,
+        "surface": SURFACE,
+        "operation": "planner-turn",
+        "run_id": context.run_id,
+        "status": status,
+        "github_issue": GITHUB_ISSUE,
+        "recorded_at": recorded_at,
+        "domain": dict(domain),
+    }
+    if context.github_pr:
+        record["github_pr"] = context.github_pr
+    if context.provider:
+        record["provider"] = context.provider
+    if context.model:
+        record["model"] = context.model
+    if context.trace_id:
+        record["trace_id"] = context.trace_id
+    if context.trace_url:
+        record["trace_url"] = context.trace_url
+    if artifact_ref:
+        record["artifact_ref"] = artifact_ref
+    if error_code:
+        record["error_category"] = error_code
+    return record
+
+
+def _tool_state(calls: list[dict[str, Any]], names: set[str]) -> str:
+    matched = [item for item in calls if str(item.get("tool_name") or "") in names]
+    if not matched:
+        return "not_requested"
+    if any(str(item.get("status") or "") == "error" for item in matched):
+        return "error"
+    if any(str(item.get("status") or "") in {"completed", "partial"} for item in matched):
+        return "used"
+    return "unavailable"
+
+
+def _first_error_category(failed_calls: list[dict[str, Any]]) -> str | None:
+    if not failed_calls:
+        return None
+    return str(failed_calls[0].get("tool_name") or "planner_tool_error")
+
+
+def _hash_identifier(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _project_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").exists():
+            return candidate
+    return Path.cwd()
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/trip_planner/observability/langsmith_fleet.py
+++ b/trip_planner/observability/langsmith_fleet.py
@@ -115,12 +115,12 @@ def build_planner_fleet_records(
     fallback_reason = turn_metadata.get("fallback_reason")
     if failed_calls:
         status: Status = "error"
+    elif not os.environ.get(ENV_LANGSMITH_KEY, "").strip():
+        status = "no_secret"
     elif runtime_mode == "fallback" or fallback_reason:
         status = "fallback"
     elif tracing_enabled:
         status = "success"
-    elif not os.environ.get(ENV_LANGSMITH_KEY, "").strip():
-        status = "no_secret"
     else:
         status = "no_secret"
 

--- a/trip_planner/observability/langsmith_fleet.py
+++ b/trip_planner/observability/langsmith_fleet.py
@@ -33,7 +33,7 @@ ENV_LANGCHAIN_TRACING_V2: Final = "LANGCHAIN_TRACING_V2"
 ENV_LANGCHAIN_API_KEY: Final = "LANGCHAIN_API_KEY"
 ENV_FLEET_PATH: Final = "TRIP_PLANNER_LANGSMITH_FLEET_PATH"
 
-Status = Literal["success", "error", "fallback", "no_secret", "skipped"]
+Status = Literal["success", "error", "fallback", "no_secret"]
 
 
 @dataclass(frozen=True, slots=True)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,0 +1,19 @@
+## 2026-05-24T05:20Z - opener lane issue #1208 PR materializing
+
+- Repo: `stranske/trip-planner`
+- Issue: `#1208` (`Add LangSmith tracing for planner conversations and tool calls`)
+- Branch: `codex/issue-1208-langsmith-planner-traces`
+- Lane: opener / codex
+- PR: `#1226` (https://github.com/stranske/trip-planner/pull/1226)
+- Status: PR opened, non-draft, labeled `agent:codex`, `agents:keepalive`, and `autofix`
+- Notes:
+  - Selected from supported-repo existing LangSmith child issues after priority searches returned no eligible implementation issues and cap-health reported raw opener cap below 5.
+  - Reused the existing mid-materialization worktree for this issue; no open PR existed for the branch at selection time.
+  - Local main worktree had an unrelated `.gitignore` edit, so all issue work is isolated in this worktree.
+- Validation:
+  - `python -m pytest tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py -q --no-cov` -> 37 passed, 33 warnings.
+  - `python -m ruff check trip_planner/observability trip_planner/app/services/planner.py tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py` -> passed.
+  - `python -m mypy trip_planner/observability trip_planner/app/services/planner.py` -> passed.
+  - `git diff --check` -> passed.
+- Relay: emitted `issue_created` for source issue `#1208` and `pr_opened` for source PR `#1226`.
+- Next action: keepalive owns PR `#1226`; opener should move to the next eligible issue on a future round after cap checks.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,21 @@
+## 2026-05-24T05:28Z - opener lane issue #1208 PR opened
+
+- Repo: `stranske/trip-planner`
+- Issue: `#1208` (`Add LangSmith tracing for planner conversations and tool calls`)
+- PR: `#1226` (`Issue #1208: Add planner LangSmith fleet traces`)
+- Branch: `codex/issue-1208-langsmith-planner-traces`
+- Lane: opener / codex
+- Status: PR opened and handed to keepalive
+- Labels verified on PR: `agent:codex`, `agents:keepalive`, `autofix`
+- Head: `2fa0718eda6f515b6d99b539839ce75972cf63d1`
+- Validation:
+  - `python -m pytest tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py -q --no-cov` -> passed, 37 tests.
+  - `python -m ruff check trip_planner/observability/langsmith_fleet.py trip_planner/app/services/planner.py tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py` -> passed.
+  - `python -m mypy trip_planner/observability/langsmith_fleet.py trip_planner/app/services/planner.py` -> passed.
+  - `git diff --check` -> passed.
+- Relay: `pr_opened active.source_repo=stranske/trip-planner active.source_issue=1208 active.source_pr=1226 active.next_action=wait_for_keepalive`.
+- Next action: keepalive owns PR `#1226`; do not wait for CI inside opener.
+
 ## 2026-05-24T05:20Z - opener lane issue #1208 PR materializing
 
 - Repo: `stranske/trip-planner`

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -7,7 +7,7 @@
 - Lane: opener / codex
 - Status: PR opened and handed to keepalive
 - Labels verified on PR: `agent:codex`, `agents:keepalive`, `autofix`
-- Head: `359dbf4bfda03443bc5ba57f44bfc9adc7c00fb2`
+- Branch state: pushed after PR handoff state update.
 - Validation:
   - `python -m pytest tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py -q --no-cov` -> passed, 37 tests.
   - `python -m ruff check trip_planner/observability/langsmith_fleet.py trip_planner/app/services/planner.py tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py` -> passed.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -7,7 +7,7 @@
 - Lane: opener / codex
 - Status: PR opened and handed to keepalive
 - Labels verified on PR: `agent:codex`, `agents:keepalive`, `autofix`
-- Head: `2fa0718eda6f515b6d99b539839ce75972cf63d1`
+- Head: `359dbf4bfda03443bc5ba57f44bfc9adc7c00fb2`
 - Validation:
   - `python -m pytest tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py -q --no-cov` -> passed, 37 tests.
   - `python -m ruff check trip_planner/observability/langsmith_fleet.py trip_planner/app/services/planner.py tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py` -> passed.


### PR DESCRIPTION
Implements #1208

## Summary
- add dashboard-safe `langsmith-fleet/v1` records for planner conversation turns
- pass LangSmith/LangChain trace config into configured model-backed planner calls
- persist local trace artifact metadata without raw traveler text, trip IDs, prompts, or itinerary payloads
- document the planner trace artifact and ignore regenerated runtime outputs

## Validation
- `python -m pytest tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py -q --no-cov`
- `python -m ruff check trip_planner/observability trip_planner/app/services/planner.py tests/observability/test_langsmith_fleet.py tests/app/test_planner_routes.py`
- `python -m mypy trip_planner/observability trip_planner/app/services/planner.py`
- `git diff --check`