### PR TITLE
Issue #1243: Add preference explanation contract tests

### DIFF
--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -59,7 +59,7 @@ Issues: `#506` (epic), `#507`–`#512`
 | Preference resolution engine (`#510`) | `trip_planner/preferences/resolution.py` | `tests/preferences/test_resolution.py` | ✅ Implemented |
 | Autonomy + revealed-preference updates (`#511`) | `trip_planner/preferences/autonomy.py`, `revealed_preference.py` | `tests/preferences/test_autonomy.py`, `test_revealed_preference.py` | ✅ Implemented |
 | Interaction tracking | `trip_planner/preferences/interactions.py` | `tests/preferences/test_interactions.py` | ✅ Implemented |
-| Explanation generation | `trip_planner/preferences/explanations.py` | — | 🟡 Partial (no dedicated test) |
+| Explanation generation | `trip_planner/preferences/explanations.py` | `tests/preferences/test_explanations.py` | ✅ Implemented |
 | Legacy request adapter | `trip_planner/preferences/legacy_request_adapter.py` | — | 🟡 Partial (no dedicated test) |
 | Preference roadmap items (collaborative, in-trip, revealed-preference modes) | `docs/preference-roadmap.md` | — | 📄 Docs-only |
 
@@ -328,8 +328,6 @@ These design commitments are still missing, partial, or not yet verified in a li
 
 1. **Semantic planner memory and reorientation** — ✅ Addressed by the `read_notebook_context` tool, which synthesizes trip-scoped notebook context across categories and fires on session-resume phrases. Remaining work is deeper embedding-based recall over free-text notes (explicitly out of scope for the deterministic layer). See §13 above.
 2. **Provider-rich timeline/map depth** — default workspace and planner-tool payloads now expose source-backed marker detail and per-segment distance-verification state. Remaining work is live provider verification in configured release environments. See §16 above.
-3. **Preference explanation generation tests** — `trip_planner/preferences/explanations.py` exists; no `tests/preferences/test_explanations.py`.
-
 ---
 
 ## How to Use This Map in Weekly Reviews

--- a/tests/preferences/test_explanations.py
+++ b/tests/preferences/test_explanations.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+
+from trip_planner.preferences.explanations import (
+    DimensionResolutionExplanation,
+    HybridFactorExplanation,
+    InteractionActivation,
+    MaterialInfluence,
+    ResolutionExplanation,
+    ResolvedLeisureProfile,
+)
+
+
+def test_material_influence_to_dict_round_trip() -> None:
+    influence = MaterialInfluence(
+        source_kind="evidence",
+        source_id="ev-001",
+        weight=0.8,
+        summary="Traveler prefers rail travel",
+    )
+
+    assert influence.to_dict() == {
+        "source_kind": "evidence",
+        "source_id": "ev-001",
+        "weight": 0.8,
+        "summary": "Traveler prefers rail travel",
+    }
+
+
+def test_dimension_resolution_explanation_to_dict_with_influences() -> None:
+    influence = MaterialInfluence(
+        source_kind="evidence",
+        source_id="ev-scenic-rail",
+        weight=0.72,
+        summary="Scenic rail segments are preferred over short-haul flights.",
+    )
+    explanation = DimensionResolutionExplanation(
+        dimension_key="movement_vs_friction",
+        initial_value=0.2,
+        resolved_value=0.65,
+        confidence=0.8,
+        salience=0.7,
+        stability=0.6,
+        value_delta=0.45,
+        influences=[influence],
+        interaction_rule_ids=["rail-comfort-rule"],
+        tension_flag_ids=["transfer-fatigue-conflict"],
+        notes=["Explicit rail preference outweighed transfer friction."],
+        explanation_code="explicit_override",
+        explanation_text="Rail preference pushed the movement score higher.",
+        contributing_evidence_ids=["ev-scenic-rail"],
+    )
+
+    assert explanation.to_dict() == {
+        "dimension_key": "movement_vs_friction",
+        "initial_value": 0.2,
+        "resolved_value": 0.65,
+        "confidence": 0.8,
+        "salience": 0.7,
+        "stability": 0.6,
+        "value_delta": 0.45,
+        "influences": [influence.to_dict()],
+        "interaction_rule_ids": ["rail-comfort-rule"],
+        "tension_flag_ids": ["transfer-fatigue-conflict"],
+        "notes": ["Explicit rail preference outweighed transfer friction."],
+        "explanation_code": "explicit_override",
+        "explanation_text": "Rail preference pushed the movement score higher.",
+        "contributing_evidence_ids": ["ev-scenic-rail"],
+    }
+
+
+def test_resolution_explanation_empty_and_populated() -> None:
+    assert ResolutionExplanation().to_dict() == {
+        "dimension_explanations": {},
+        "hybrid_factor_explanations": {},
+        "activated_interactions": [],
+        "tension_explanations": {},
+    }
+
+    dimension = DimensionResolutionExplanation(
+        dimension_key="iconic_vs_discovery",
+        initial_value=0.0,
+        resolved_value=-0.4,
+        confidence=0.55,
+        salience=0.7,
+        stability=0.5,
+    )
+    hybrid = HybridFactorExplanation(
+        hybrid_factor_key="local_texture",
+        mode="weighted",
+        salience=0.6,
+        anchor_strength=0.3,
+        influences=[
+            MaterialInfluence(
+                source_kind="anchor",
+                source_id="anchor-local-markets",
+                weight=0.3,
+                summary="Local market anchor informs discovery weighting.",
+            )
+        ],
+    )
+    interaction = InteractionActivation(
+        rule_id="discovery-depth-bias",
+        dimensions=["iconic_vs_discovery"],
+        planning_biases={"neighborhood_depth": 0.4},
+        triggered_tension_ids=["breadth-recovery-conflict"],
+        notes=["Bias activated for slower local exploration."],
+    )
+    tension_influence = MaterialInfluence(
+        source_kind="tension",
+        source_id="breadth-recovery-conflict",
+        weight=0.4,
+        summary="Breadth is capped by recovery needs.",
+    )
+
+    populated = ResolutionExplanation(
+        dimension_explanations={"iconic_vs_discovery": dimension},
+        hybrid_factor_explanations={"local_texture": hybrid},
+        activated_interactions=[interaction],
+        tension_explanations={"breadth-recovery-conflict": [tension_influence]},
+    ).to_dict()
+
+    assert populated == {
+        "dimension_explanations": {"iconic_vs_discovery": dimension.to_dict()},
+        "hybrid_factor_explanations": {"local_texture": hybrid.to_dict()},
+        "activated_interactions": [interaction.to_dict()],
+        "tension_explanations": {
+            "breadth-recovery-conflict": [tension_influence.to_dict()],
+        },
+    }
+
+
+def test_explanation_code_default_is_default_seed() -> None:
+    explanation = DimensionResolutionExplanation(
+        dimension_key="recovery_vs_intensity",
+        initial_value=0.1,
+        resolved_value=0.1,
+        confidence=0.2,
+        salience=0.3,
+        stability=0.4,
+    )
+
+    assert explanation.explanation_code == "default_seed"
+
+
+def test_resolved_leisure_profile_to_dict_delegates_profile_and_explanation() -> None:
+    @dataclass
+    class ProfileStub:
+        profile_id: str
+
+        def to_dict(self) -> dict[str, str]:
+            return {"profile_id": self.profile_id}
+
+    explanation = ResolutionExplanation(
+        dimension_explanations={
+            "movement_vs_friction": DimensionResolutionExplanation(
+                dimension_key="movement_vs_friction",
+                initial_value=0.2,
+                resolved_value=0.5,
+                confidence=0.7,
+                salience=0.6,
+                stability=0.5,
+            )
+        }
+    )
+    resolved = ResolvedLeisureProfile(
+        profile=ProfileStub(profile_id="profile-scenic-rail"),
+        explanation=explanation,
+    )
+
+    assert resolved.to_dict() == {
+        "profile": {"profile_id": "profile-scenic-rail"},
+        "explanation": explanation.to_dict(),
+    }

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -19,6 +19,16 @@
 - Validation (`.venv`): `pytest tests/app/test_planner_routes.py tests/app/test_workspace.py` -> 100 passed; planner suite `test_planner_routes.py + test_planner_turn_e2e.py + test_planner_routing.py` -> 75 passed; `ruff check` + `ruff format --check` clean on changed files; `mypy` clean on `planner_tools.py`/`planner.py`.
 - Next action: keepalive owns CI/review on the opened PR (`agent:claude`); closer owns post-merge verification. Unrelated local `.gitignore` change left unstaged.
 
+## 2026-05-27T14:08Z - opener cap hygiene for PR #1241
+
+- Repo: `stranske/trip-planner`
+- PR: `#1241` (`Issue #1240: Add read_notebook_context tool for session-resume recall`)
+- Branch: `claude/issue-1240-notebook-context`
+- Lane: opener / codex cap-drain sweep
+- Evidence: final cap-health after opening PR `#1244` showed `#1241` as `needs-dispatch-evidence` after Gate completed successfully; labels were otherwise plausible and the PR was non-draft.
+- Action: added `agent:retry` and dispatched `agents-81-gate-followups.yml` with `pr_number=1241`, `force_retry=true`.
+- Next action: wait for Gate Followups/keepalive evidence; keepalive/closer owns subsequent PR drain.
+
 ## 2026-05-27T14:06Z - opener lane issue #1243 materializing
 
 - Repo: `stranske/trip-planner`

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,12 @@
+## 2026-05-27T15:08Z - closer conflict recovery for PR #1244
+
+- Automation: `imi-merge-verify-closer` (codex closer lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1243`; PR `#1244`; branch `codex/issue-1243-preference-explanation-tests`.
+- Blocker: PR #1244 became `DIRTY` / `CONFLICTING` after PR #1241 merged into `main`.
+- Fix: rebased the branch onto `origin/main` at `683b9552` and resolved the `workloop-state.md` history conflict by preserving both PR #1241 and PR #1244 lane entries.
+- Validation: `python -m pytest tests/preferences/test_explanations.py tests/preferences/test_resolution.py -q` -> 18 passed; `python -m ruff check tests/preferences/test_explanations.py` -> passed; `python -m ruff format --check tests/preferences/test_explanations.py` -> passed; `git diff --check` -> clean.
+- Next action: push the rebased branch, then let fresh Gate/CI run before merge.
+
 ## 2026-05-27T14:25Z - closer review-thread recovery for PR #1241
 
 - Automation: `imi-merge-verify-closer` (codex closer lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -25,7 +25,8 @@
 - Issue: `#1243` (`Add dedicated tests for preference explanation generation module`)
 - Branch: `codex/issue-1243-preference-explanation-tests`
 - Lane: opener / codex
-- Status: implementation complete locally; preparing push and ready-for-review PR.
+- PR: `#1244` (https://github.com/stranske/trip-planner/pull/1244)
+- Status: ready-for-review PR opened, non-draft, closing issue `#1243`.
 - Selection notes:
   - Cap-health after opener infra repair reported `total_opener_owned=2`, `raw_cap_reached=false`, `non_drainable_count=0`.
   - Existing opener PRs were classified as draining: LMS `#173` with green Gate evidence and trip-planner `#1241` with current Gate/CI in progress.
@@ -42,7 +43,8 @@
   - `python -m ruff check tests/preferences/test_explanations.py` -> passed.
   - `python -m ruff format --check tests/preferences/test_explanations.py` -> passed.
   - `git diff --check` -> passed.
-- Next action: commit, push, open ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+- Labels verified on PR: `agent:codex`, `agents:keepalive`, `autofix`, `repo-review-approved`, `priority:high`.
+- Next action: keepalive owns PR `#1244`; opener should move to the next eligible issue on a future round after cap checks.
 
 ## 2026-05-27T02:42Z - opener lane issue #1235 PR opened
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -19,6 +19,31 @@
 - Validation (`.venv`): `pytest tests/app/test_planner_routes.py tests/app/test_workspace.py` -> 100 passed; planner suite `test_planner_routes.py + test_planner_turn_e2e.py + test_planner_routing.py` -> 75 passed; `ruff check` + `ruff format --check` clean on changed files; `mypy` clean on `planner_tools.py`/`planner.py`.
 - Next action: keepalive owns CI/review on the opened PR (`agent:claude`); closer owns post-merge verification. Unrelated local `.gitignore` change left unstaged.
 
+## 2026-05-27T14:06Z - opener lane issue #1243 materializing
+
+- Repo: `stranske/trip-planner`
+- Issue: `#1243` (`Add dedicated tests for preference explanation generation module`)
+- Branch: `codex/issue-1243-preference-explanation-tests`
+- Lane: opener / codex
+- Status: implementation complete locally; preparing push and ready-for-review PR.
+- Selection notes:
+  - Cap-health after opener infra repair reported `total_opener_owned=2`, `raw_cap_reached=false`, `non_drainable_count=0`.
+  - Existing opener PRs were classified as draining: LMS `#173` with green Gate evidence and trip-planner `#1241` with current Gate/CI in progress.
+  - Priority discovery found trip-planner `#1240` and LMS `#121`, both already linked to open opener PRs; Workflows `#2159` remains scoped-blocked for closer/workflow-health disposition.
+  - Approved queue candidate_index 2 was the highest-priority unmaterialized implementation item; no matching open issue/PR existed, so opener materialized issue `#1243`.
+- Implementation:
+  - Added `tests/preferences/test_explanations.py` with direct `to_dict()` contract coverage for `MaterialInfluence`, `DimensionResolutionExplanation`, `HybridFactorExplanation`, `InteractionActivation`, `ResolutionExplanation`, and `ResolvedLeisureProfile`.
+  - Added a sentinel test for `DimensionResolutionExplanation.explanation_code == "default_seed"`.
+  - Updated `docs/design-coverage-map.md` to mark explanation generation implemented with the new dedicated test file and removed the stale remaining-follow-up claim.
+- Validation:
+  - `python -m pytest tests/preferences/test_explanations.py -q` -> 5 passed.
+  - `python -m pytest tests/preferences/test_explanations.py tests/preferences/test_resolution.py -q` -> 18 passed.
+  - `python -m pytest tests/preferences -q` -> 185 passed.
+  - `python -m ruff check tests/preferences/test_explanations.py` -> passed.
+  - `python -m ruff format --check tests/preferences/test_explanations.py` -> passed.
+  - `git diff --check` -> passed.
+- Next action: commit, push, open ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-05-27T02:42Z - opener lane issue #1235 PR opened
 
 - Repo: `stranske/trip-planner`


### PR DESCRIPTION
Closes #1243

## Summary
- add direct contract tests for preference explanation dataclasses and nested `to_dict()` payloads
- assert the `DimensionResolutionExplanation.explanation_code` default sentinel stays `default_seed`
- update the design coverage map to mark preference explanation generation as covered by the new dedicated test file

## Validation
- `python -m pytest tests/preferences/test_explanations.py -q`
- `python -m pytest tests/preferences/test_explanations.py tests/preferences/test_resolution.py -q`
- `python -m pytest tests/preferences -q`
- `python -m ruff check tests/preferences/test_explanations.py`
- `python -m ruff format --check tests/preferences/test_explanations.py`
- `git diff --check`
