### PR TITLE
Issue #1259: Harden demo deploy origin and cold-start health

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,33 @@ The verification path covers:
 These checks validate the local full-stack MVP that already exists in this repo. They exercise the map adapter and fallback seam with mocked provider state. They do not prove live Google Maps rendering or remote Travel-Plan-Permission transport.
 The production-focused testing plan in [docs/local-testing-plan.md](docs/local-testing-plan.md) adds the critical auth, trip, workspace, policy, proposal, and preview-verification journeys on top of that baseline.
 
+## Demo Deploy (data-zoned)
+
+The public browser path is for synthetic or fixture trips only:
+
+- Frontend: `https://stranske-trip-planner.netlify.app`
+- Public synthetic API origin: `https://trip-planner-api-s40u.onrender.com`
+
+Do not enter proprietary, client, or personally identifying trip data into the public Netlify or Render services. Real travel data requires an internal-perimeter browser host that runs the FastAPI backend and Postgres database inside the approved organization boundary, with any live LLM or Travel-Plan-Permission transport explicitly enabled by that environment's data-zone controls.
+
+Netlify builds generate `frontend/public/_redirects` from `TRIP_PLANNER_API_ORIGIN` during `npm run build`. If that env var is unset, the build uses the public synthetic API origin above. The frontend also honors `VITE_API_BASE_URL` for local, preview, or internal hosts that should call an API directly instead of relying on Netlify redirects.
+
+Run this drift check after changing deployment hosts:
+
+```bash
+python scripts/check_deploy_origin.py
+```
+
+The check fails when the README's public synthetic API host and the generated Netlify redirect host differ.
+
 ## Persistent Deployment
 
 The product deployment is split across two persistent services:
 
 - Netlify hosts the Vite frontend at `https://stranske-trip-planner.netlify.app`.
-- Render hosts the FastAPI backend and Postgres database.
+- Render hosts the FastAPI backend and Postgres database for the public synthetic demo.
 
-Netlify is connected directly to the GitHub repo and builds production from `main` using `netlify.toml`. The build ships `frontend/public/_redirects` with the bundle. The redirect file proxies `/api/*` to the Render backend before falling back to `/index.html`, so the deployed frontend can call `/api/...` without requiring a hard-coded API origin in the browser bundle.
+Netlify is connected directly to the GitHub repo and builds production from `main` using `netlify.toml`. The build writes `frontend/public/_redirects` from `TRIP_PLANNER_API_ORIGIN` before shipping the bundle. The redirect file proxies `/api/*` to the configured backend before falling back to `/index.html`, so the deployed frontend can call `/api/...` without hard-coding an API origin in browser source.
 
 Do not use the old token-based GitHub Action upload path for production deploys. That path depended on expiring Netlify API tokens and could drift from the Git-connected production site.
 
@@ -189,6 +208,7 @@ Do not use the old token-based GitHub Action upload path for production deploys.
 
 Required deployment configuration:
 
+- Netlify project env vars, public synthetic API: `TRIP_PLANNER_API_ORIGIN`
 - Netlify project env vars, optional live map adapter: `VITE_GOOGLE_MAPS_BROWSER_API_KEY`
 - Render service env vars: `TRIP_PLANNER_CORS_ORIGINS`, `TRIP_PLANNER_CORS_ORIGIN_REGEX`, and live TPP variables when remote policy execution is intentionally enabled
 - Render Python runtime: the repo pins `.python-version` to Python 3.12 and `pyproject.toml`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "python ../scripts/write_frontend_redirects.py && python ../scripts/check_deploy_origin.py",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run --exclude src/smoke/**",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,40 @@
 import { startTransition, useState } from "react";
-import { NavLink, Outlet, useLoaderData, useNavigate } from "react-router-dom";
+import { NavLink, Outlet, useLoaderData, useNavigate, useRouteError } from "react-router-dom";
 
 import { logout } from "./api/auth";
+import { getErrorMessage } from "./lib/api/errors";
 import type { RootLoaderData } from "./router";
+
+export function InitialRouteFallback() {
+  return (
+    <div className="app-shell">
+      <section className="status-card">
+        <p className="status-label">Backend status</p>
+        <h2>Waking up the server</h2>
+        <p>Checking /api/health before loading the planner.</p>
+      </section>
+    </div>
+  );
+}
+
+export function RootErrorBoundary() {
+  const error = useRouteError();
+
+  return (
+    <div className="app-shell">
+      <section className="status-card status-card-error">
+        <p className="status-label">Backend status</p>
+        <h2>Backend startup check failed</h2>
+        <p>
+          {getErrorMessage(
+            error,
+            "The backend did not respond before the cold-start retry budget was exhausted."
+          )}
+        </p>
+      </section>
+    </div>
+  );
+}
 
 export default function App() {
   const { session } = useLoaderData() as RootLoaderData;

--- a/frontend/src/api/health.test.ts
+++ b/frontend/src/api/health.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchHealthStatus } from "./health";
+
+describe("fetchHealthStatus", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("shares one in-flight /api/health probe across concurrent calls", async () => {
+    let resolveFetch: ((value: unknown) => void) | undefined;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const requestA = fetchHealthStatus();
+    const requestB = fetchHealthStatus();
+
+    resolveFetch?.({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () =>
+        JSON.stringify({
+          service: "trip-planner-api",
+          status: "ok",
+          environment: "local",
+          version: "0.1.0",
+        }),
+    });
+
+    await expect(requestA).resolves.toMatchObject({ status: "ok" });
+    await expect(requestB).resolves.toMatchObject({ status: "ok" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -7,6 +7,16 @@ export type HealthStatus = {
   version: string;
 };
 
+let inFlightHealthProbe: Promise<HealthStatus> | null = null;
+
 export async function fetchHealthStatus(): Promise<HealthStatus> {
-  return fetchJson<HealthStatus>({ path: "/api/health" });
+  if (inFlightHealthProbe) {
+    return inFlightHealthProbe;
+  }
+
+  inFlightHealthProbe = fetchJson<HealthStatus>({ path: "/api/health" }).finally(() => {
+    inFlightHealthProbe = null;
+  });
+
+  return inFlightHealthProbe;
 }

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -170,12 +170,41 @@ describe("fetchJson", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const request = fetchJson({ path: "/api/health" });
-    await vi.advanceTimersByTimeAsync(250 + 500);
-
-    await expect(request).rejects.toMatchObject({
+    // Attach the rejection expectation before advancing timers so the
+    // settled-during-advance rejection is observed in-band instead of
+    // surfacing as an unhandled rejection while the timers flush.
+    const rejection = expect(request).rejects.toMatchObject({
       name: "ApiClientError",
       status: 503,
     } satisfies Partial<ApiClientError>);
+    await vi.advanceTimersByTimeAsync(250 + 500);
+
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("aborts a hung health probe and consumes the retry budget", async () => {
+    vi.useFakeTimers();
+    // Never resolve unless the request is aborted; the bounded timeout must
+    // be what drives the retry budget so a hanging backend cannot pend forever.
+    const fetchMock = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = fetchJson({ path: "/api/health" });
+    const rejection = expect(request).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    // Three 5s timeouts plus the two inter-attempt retry delays.
+    await vi.advanceTimersByTimeAsync(3 * 5000 + 250 + 500);
+
+    await rejection;
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -5,6 +5,7 @@ import { ApiClientError } from "./errors";
 
 describe("fetchJson", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
   });
@@ -123,5 +124,54 @@ describe("fetchJson", () => {
       path: "https://api.example.test/api/health",
       status: 503,
     } satisfies Partial<ApiClientError>);
+  });
+
+  it("retries the first health probe when the backend is waking up", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: "Bad Gateway",
+        clone() {
+          return this;
+        },
+        json: async () => ({ detail: "Backend warming up" }),
+        text: async () => "Backend warming up",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () => JSON.stringify({ status: "ok" }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = fetchJson<{ status: string }>({ path: "/api/health" });
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(request).resolves.toEqual({ status: "ok" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-health API requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      clone() {
+        return this;
+      },
+      json: async () => ({ detail: "Backend warming up" }),
+      text: async () => "Backend warming up",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchJson({ path: "/api/trips" })).rejects.toMatchObject({
+      name: "ApiClientError",
+      status: 502,
+    } satisfies Partial<ApiClientError>);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -155,6 +155,30 @@ describe("fetchJson", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("stops after the bounded retry budget for health probes", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: "Service Unavailable",
+      clone() {
+        return this;
+      },
+      json: async () => ({ detail: "Backend warming up" }),
+      text: async () => "Backend warming up",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = fetchJson({ path: "/api/health" });
+    await vi.advanceTimersByTimeAsync(250 + 500);
+
+    await expect(request).rejects.toMatchObject({
+      name: "ApiClientError",
+      status: 503,
+    } satisfies Partial<ApiClientError>);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("does not retry non-health API requests", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -7,6 +7,10 @@ type JsonRequestOptions = RequestInit & {
 const HEALTH_RETRY_STATUSES = new Set([502, 503, 504]);
 const HEALTH_RETRY_ATTEMPTS = 3;
 const HEALTH_RETRY_DELAY_MS = 250;
+// Bound each cold-start health probe so a backend that hangs (rather than
+// returning 502/503/504) still consumes the retry budget and surfaces a
+// bounded error instead of leaving the loading UI pending indefinitely.
+const HEALTH_RETRY_TIMEOUT_MS = 5000;
 
 function resolveRequestUrl(path: string): string {
   const configuredBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
@@ -31,6 +35,28 @@ function retryDelay(attemptIndex: number): Promise<void> {
   });
 }
 
+async function fetchWithTimeout(
+  requestUrl: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  // Without AbortController support (or an already-supplied signal) fall back
+  // to a plain fetch so non-browser callers keep working.
+  if (!timeoutMs || typeof AbortController === "undefined" || init.signal) {
+    return fetch(requestUrl, init);
+  }
+
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    return await fetch(requestUrl, { ...init, signal: controller.signal });
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
 async function fetchWithHealthRetry(
   requestUrl: string,
   init: RequestInit,
@@ -41,7 +67,9 @@ async function fetchWithHealthRetry(
 
   for (let attempt = 1; attempt <= attemptCount; attempt += 1) {
     try {
-      const response = await fetch(requestUrl, init);
+      const response = retryEnabled
+        ? await fetchWithTimeout(requestUrl, init, HEALTH_RETRY_TIMEOUT_MS)
+        : await fetch(requestUrl, init);
       if (
         retryEnabled &&
         attempt < attemptCount &&

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -4,6 +4,10 @@ type JsonRequestOptions = RequestInit & {
   path: string;
 };
 
+const HEALTH_RETRY_STATUSES = new Set([502, 503, 504]);
+const HEALTH_RETRY_ATTEMPTS = 3;
+const HEALTH_RETRY_DELAY_MS = 250;
+
 function resolveRequestUrl(path: string): string {
   const configuredBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
   if (!configuredBaseUrl) {
@@ -13,15 +17,65 @@ function resolveRequestUrl(path: string): string {
   return new URL(path, `${configuredBaseUrl.replace(/\/+$/, "")}/`).toString();
 }
 
+function isHealthProbe(path: string, method?: string): boolean {
+  return path === "/api/health" && (!method || method.toUpperCase() === "GET");
+}
+
+function shouldRetryHealthProbe(error: unknown): boolean {
+  return error instanceof TypeError || error instanceof DOMException;
+}
+
+function retryDelay(attemptIndex: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, HEALTH_RETRY_DELAY_MS * attemptIndex);
+  });
+}
+
+async function fetchWithHealthRetry(
+  requestUrl: string,
+  init: RequestInit,
+  retryEnabled: boolean
+): Promise<Response> {
+  const attemptCount = retryEnabled ? HEALTH_RETRY_ATTEMPTS : 1;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attemptCount; attempt += 1) {
+    try {
+      const response = await fetch(requestUrl, init);
+      if (
+        retryEnabled &&
+        attempt < attemptCount &&
+        HEALTH_RETRY_STATUSES.has(response.status)
+      ) {
+        await retryDelay(attempt);
+        continue;
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (!retryEnabled || attempt >= attemptCount || !shouldRetryHealthProbe(error)) {
+        throw error;
+      }
+      await retryDelay(attempt);
+    }
+  }
+
+  throw lastError;
+}
+
 export async function fetchJson<T>({ path, headers, ...init }: JsonRequestOptions): Promise<T> {
   const normalizedHeaders = new Headers(headers);
   normalizedHeaders.set("Accept", "application/json");
   const requestUrl = resolveRequestUrl(path);
 
-  const response = await fetch(requestUrl, {
-    ...init,
-    headers: normalizedHeaders,
-  });
+  const response = await fetchWithHealthRetry(
+    requestUrl,
+    {
+      ...init,
+      headers: normalizedHeaders,
+    },
+    isHealthProbe(path, init.method)
+  );
 
   if (!response.ok) {
     throw await createApiClientError(requestUrl, response);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,11 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
+import { InitialRouteFallback } from "./App";
 import { router } from "./router";
 import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router} future={{ v7_startTransition: true }} />
+    <RouterProvider
+      router={router}
+      fallbackElement={<InitialRouteFallback />}
+      future={{ v7_startTransition: true }}
+    />
   </React.StrictMode>
 );

--- a/frontend/src/router.test.ts
+++ b/frontend/src/router.test.ts
@@ -12,6 +12,10 @@ vi.mock("./api/auth", () => ({
   fetchCurrentSession: vi.fn(),
 }));
 
+vi.mock("./api/health", () => ({
+  fetchHealthStatus: vi.fn(),
+}));
+
 vi.mock("./api/trips", () => ({
   fetchTrip: vi.fn().mockResolvedValue({ trip_id: "trip-1" }),
   fetchTripScenarioHistory: vi.fn().mockResolvedValue({
@@ -65,6 +69,13 @@ describe("router auth loaders", () => {
 
   it("restores the signed-in session during app bootstrap", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
+    const { fetchHealthStatus } = await import("./api/health");
+    vi.mocked(fetchHealthStatus).mockResolvedValueOnce({
+      service: "trip-planner",
+      status: "ok",
+      environment: "test",
+      version: "dev",
+    });
     vi.mocked(fetchCurrentSession).mockResolvedValueOnce({
       user: {
         user_id: "user:test",
@@ -88,10 +99,41 @@ describe("router auth loaders", () => {
         },
       },
     });
+    expect(vi.mocked(fetchHealthStatus).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(fetchCurrentSession).mock.invocationCallOrder[0]
+    );
+  });
+
+  it("surfaces backend startup failure before the auth session lookup", async () => {
+    const { fetchCurrentSession } = await import("./api/auth");
+    const { fetchHealthStatus } = await import("./api/health");
+    const startupError = new ApiClientError("The backend startup check failed.", {
+      path: "/api/health",
+      status: 504,
+      statusText: "Gateway Timeout",
+    });
+    vi.mocked(fetchHealthStatus).mockRejectedValueOnce(startupError);
+
+    await expect(
+      rootLoader({
+        params: {},
+        request: new Request("http://localhost/"),
+        context: undefined,
+      })
+    ).rejects.toBe(startupError);
+
+    expect(fetchCurrentSession).not.toHaveBeenCalled();
   });
 
   it("keeps auth pages open when no cookie-backed session exists", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
+    const { fetchHealthStatus } = await import("./api/health");
+    vi.mocked(fetchHealthStatus).mockResolvedValueOnce({
+      service: "trip-planner",
+      status: "ok",
+      environment: "test",
+      version: "dev",
+    });
     vi.mocked(fetchCurrentSession).mockRejectedValueOnce(
       new ApiClientError("No active planner session was found.", {
         path: "/api/auth/session",
@@ -111,6 +153,13 @@ describe("router auth loaders", () => {
 
   it("reuses the same session lookup within a navigation", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
+    const { fetchHealthStatus } = await import("./api/health");
+    vi.mocked(fetchHealthStatus).mockResolvedValueOnce({
+      service: "trip-planner",
+      status: "ok",
+      environment: "test",
+      version: "dev",
+    });
     vi.mocked(fetchCurrentSession).mockResolvedValue({
       user: {
         user_id: "user:test",
@@ -141,10 +190,18 @@ describe("router auth loaders", () => {
       reason: expect.any(Response),
     });
     expect(fetchCurrentSession).toHaveBeenCalledTimes(1);
+    expect(fetchHealthStatus).toHaveBeenCalledTimes(1);
   });
 
   it("redirects protected workspace routes back to sign-in when the session check fails", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
+    const { fetchHealthStatus } = await import("./api/health");
+    vi.mocked(fetchHealthStatus).mockResolvedValueOnce({
+      service: "trip-planner",
+      status: "ok",
+      environment: "test",
+      version: "dev",
+    });
     vi.mocked(fetchCurrentSession).mockRejectedValueOnce(
       new ApiClientError("No active planner session was found.", {
         path: "/api/auth/session",
@@ -171,8 +228,15 @@ describe("router auth loaders", () => {
 
   it("loads workspace data and persisted trips for signed-in users", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
+    const { fetchHealthStatus } = await import("./api/health");
     const { fetchTrips } = await import("./api/trips");
     const { fetchWorkspace } = await import("./api/workspace");
+    vi.mocked(fetchHealthStatus).mockResolvedValueOnce({
+      service: "trip-planner",
+      status: "ok",
+      environment: "test",
+      version: "dev",
+    });
     vi.mocked(fetchCurrentSession).mockResolvedValueOnce({
       user: {
         user_id: "user:test",
@@ -200,7 +264,14 @@ describe("router auth loaders", () => {
 
   it("loads the persisted trip list for signed-in users", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
+    const { fetchHealthStatus } = await import("./api/health");
     const { fetchTrips } = await import("./api/trips");
+    vi.mocked(fetchHealthStatus).mockResolvedValueOnce({
+      service: "trip-planner",
+      status: "ok",
+      environment: "test",
+      version: "dev",
+    });
     vi.mocked(fetchCurrentSession).mockResolvedValueOnce({
       user: {
         user_id: "user:test",
@@ -221,7 +292,14 @@ describe("router auth loaders", () => {
 
   it("loads a persisted trip detail for signed-in users", async () => {
     const { fetchCurrentSession } = await import("./api/auth");
+    const { fetchHealthStatus } = await import("./api/health");
     const { fetchTrip, fetchTripScenarioHistory } = await import("./api/trips");
+    vi.mocked(fetchHealthStatus).mockResolvedValueOnce({
+      service: "trip-planner",
+      status: "ok",
+      environment: "test",
+      version: "dev",
+    });
     vi.mocked(fetchCurrentSession).mockResolvedValueOnce({
       user: {
         user_id: "user:test",

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -6,13 +6,14 @@ import {
 } from "react-router-dom";
 
 import { fetchCurrentSession } from "./api/auth";
+import { fetchHealthStatus } from "./api/health";
 import {
   fetchTrip,
   fetchTripScenarioHistory,
   fetchTrips,
 } from "./api/trips";
 import { fetchWorkspace } from "./api/workspace";
-import App from "./App";
+import App, { RootErrorBoundary } from "./App";
 import { ApiClientError } from "./lib/api/errors";
 import { healthLoader, HealthPage } from "./routes/HealthPage";
 import { LoginPage } from "./routes/LoginPage";
@@ -42,6 +43,7 @@ function loadSession(request: Request): Promise<RootLoaderData> {
 
   const pending = (async () => {
     try {
+      await fetchHealthStatus();
       return { session: await fetchCurrentSession() };
     } catch (error) {
       if (isUnauthorized(error)) {
@@ -52,13 +54,14 @@ function loadSession(request: Request): Promise<RootLoaderData> {
   })();
 
   sessionLoadCache.set(request.url, pending);
-  pending.finally(() => {
+  const clearCache = () => {
     queueMicrotask(() => {
       if (sessionLoadCache.get(request.url) === pending) {
         sessionLoadCache.delete(request.url);
       }
     });
-  });
+  };
+  pending.then(clearCache, clearCache);
   return pending;
 }
 
@@ -143,6 +146,7 @@ export const appRoutes: RouteObject[] = [
     path: "/",
     id: "root",
     element: <App />,
+    errorElement: <RootErrorBoundary />,
     loader: rootLoader,
     children: [
       {

--- a/frontend/src/routes/HealthPage.test.tsx
+++ b/frontend/src/routes/HealthPage.test.tsx
@@ -40,7 +40,7 @@ describe("HealthPage", () => {
 
     renderHealthPage();
 
-    expect(screen.getByText("Waking up the server")).toBeInTheDocument();
+    expect(screen.getByText("Checking backend health")).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "trip-planner-api" })).toBeInTheDocument();
@@ -61,12 +61,12 @@ describe("HealthPage", () => {
 
     renderHealthPage();
 
-    expect(screen.getByText("Waking up the server")).toBeInTheDocument();
+    expect(screen.getByText("Checking backend health")).toBeInTheDocument();
 
     rejectRequest?.(new Error("Backend offline"));
 
     await waitFor(() => {
-      expect(screen.getByText("Backend still unavailable")).toBeInTheDocument();
+      expect(screen.getByText("Backend health check failed")).toBeInTheDocument();
     });
 
     expect(screen.getByText("Backend offline")).toBeInTheDocument();

--- a/frontend/src/routes/HealthPage.test.tsx
+++ b/frontend/src/routes/HealthPage.test.tsx
@@ -40,7 +40,7 @@ describe("HealthPage", () => {
 
     renderHealthPage();
 
-    expect(screen.getByText("Checking the live runtime")).toBeInTheDocument();
+    expect(screen.getByText("Waking up the server")).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "trip-planner-api" })).toBeInTheDocument();
@@ -61,12 +61,12 @@ describe("HealthPage", () => {
 
     renderHealthPage();
 
-    expect(screen.getByText("Checking the live runtime")).toBeInTheDocument();
+    expect(screen.getByText("Waking up the server")).toBeInTheDocument();
 
     rejectRequest?.(new Error("Backend offline"));
 
     await waitFor(() => {
-      expect(screen.getByText("Health request failed")).toBeInTheDocument();
+      expect(screen.getByText("Backend still unavailable")).toBeInTheDocument();
     });
 
     expect(screen.getByText("Backend offline")).toBeInTheDocument();

--- a/frontend/src/routes/HealthPage.tsx
+++ b/frontend/src/routes/HealthPage.tsx
@@ -41,13 +41,13 @@ export function HealthPage() {
       resolve={health}
       loading={{
         label: "Backend status",
-        title: "Waking up the server",
-        message: "Checking the FastAPI health endpoint with bounded cold-start retries.",
+        title: "Checking backend health",
+        message: "Running the shared /api/health probe with bounded cold-start retries.",
       }}
       error={{
         label: "Backend status",
-        title: "Backend still unavailable",
-        message: "The API did not answer before the retry budget was exhausted.",
+        title: "Backend health check failed",
+        message: "The /api/health probe exhausted its cold-start retry budget before succeeding.",
       }}
     >
       {(resolvedHealth) => <HealthStatusCard health={resolvedHealth} />}

--- a/frontend/src/routes/HealthPage.tsx
+++ b/frontend/src/routes/HealthPage.tsx
@@ -41,13 +41,13 @@ export function HealthPage() {
       resolve={health}
       loading={{
         label: "Backend status",
-        title: "Checking the live runtime",
-        message: "Fetching the FastAPI health endpoint.",
+        title: "Waking up the server",
+        message: "Checking the FastAPI health endpoint with bounded cold-start retries.",
       }}
       error={{
         label: "Backend status",
-        title: "Health request failed",
-        message: "The shared API client could not load backend health.",
+        title: "Backend still unavailable",
+        message: "The API did not answer before the retry budget was exhausted.",
       }}
     >
       {(resolvedHealth) => <HealthStatusCard health={resolvedHealth} />}

--- a/scripts/check_deploy_origin.py
+++ b/scripts/check_deploy_origin.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Fail when README and Netlify API redirect origins drift."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+README_ORIGIN_PATTERN = re.compile(r"Public synthetic API origin:\s*`(?P<origin>https?://[^`]+)`")
+REDIRECT_PATTERN = re.compile(r"^/api/\*\s+(?P<origin>https?://\S+)/api/:splat\s+200$", re.MULTILINE)
+
+
+def _host(origin: str) -> str:
+    parsed = urlparse(origin.rstrip("/"))
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise SystemExit(f"Invalid origin in deploy configuration: {origin!r}")
+    return parsed.netloc
+
+
+def _match(pattern: re.Pattern[str], text: str, source: Path) -> str:
+    match = pattern.search(text)
+    if not match:
+        raise SystemExit(f"Could not find deploy API origin marker in {source}")
+    return match.group("origin").rstrip("/")
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    readme_path = repo_root / "README.md"
+    redirects_path = repo_root / "frontend" / "public" / "_redirects"
+
+    readme_origin = _match(README_ORIGIN_PATTERN, readme_path.read_text(encoding="utf-8"), readme_path)
+    redirect_origin = _match(
+        REDIRECT_PATTERN,
+        redirects_path.read_text(encoding="utf-8"),
+        redirects_path,
+    )
+
+    if _host(readme_origin) != _host(redirect_origin):
+        raise SystemExit(
+            "Deploy API origin drift: "
+            f"README host {_host(readme_origin)!r} != redirects host {_host(redirect_origin)!r}"
+        )
+
+    print(f"Deploy API origin aligned: {_host(readme_origin)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_deploy_origin.py
+++ b/scripts/check_deploy_origin.py
@@ -16,6 +16,10 @@ def _host(origin: str) -> str:
     parsed = urlparse(origin.rstrip("/"))
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise SystemExit(f"Invalid origin in deploy configuration: {origin!r}")
+    if parsed.path or parsed.params or parsed.query or parsed.fragment:
+        raise SystemExit(
+            f"Deploy origin must be scheme + host only (no path/query/fragment): {origin!r}"
+        )
     return parsed.netloc
 
 

--- a/scripts/check_production_readiness.sh
+++ b/scripts/check_production_readiness.sh
@@ -59,6 +59,9 @@ fi
 cd "${repo_root}"
 
 if [ "${run_local}" = "true" ]; then
+  echo "==> Deploy origin drift check"
+  python scripts/check_deploy_origin.py
+
   echo "==> Backend critical-journey API checks"
   python -m pytest \
     tests/app/test_auth.py \

--- a/scripts/write_frontend_redirects.py
+++ b/scripts/write_frontend_redirects.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Generate Netlify redirects from the configured API origin."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+DEFAULT_API_ORIGIN = "https://trip-planner-api-s40u.onrender.com"
+
+
+def _api_origin() -> str:
+    origin = os.environ.get("TRIP_PLANNER_API_ORIGIN") or os.environ.get("VITE_API_BASE_URL")
+    origin = (origin or DEFAULT_API_ORIGIN).strip().rstrip("/")
+    parsed = urlparse(origin)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise SystemExit(f"Invalid API origin: {origin!r}")
+    return origin
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    redirects_path = repo_root / "frontend" / "public" / "_redirects"
+    origin = _api_origin()
+    redirects_path.write_text(
+        f"/api/* {origin}/api/:splat 200\n/* /index.html 200\n",
+        encoding="utf-8",
+    )
+    print(f"Wrote {redirects_path} for API origin {origin}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/write_frontend_redirects.py
+++ b/scripts/write_frontend_redirects.py
@@ -12,11 +12,19 @@ DEFAULT_API_ORIGIN = "https://trip-planner-api-s40u.onrender.com"
 
 
 def _api_origin() -> str:
-    origin = os.environ.get("TRIP_PLANNER_API_ORIGIN") or os.environ.get("VITE_API_BASE_URL")
+    # Only the Netlify deploy origin drives _redirects generation. VITE_API_BASE_URL
+    # is intentionally NOT consulted: it configures direct-call (local/preview/internal)
+    # builds that bypass Netlify redirects, so consuming it here would emit a redirect
+    # host that disagrees with the documented public origin and fail the drift check.
+    origin = os.environ.get("TRIP_PLANNER_API_ORIGIN")
     origin = (origin or DEFAULT_API_ORIGIN).strip().rstrip("/")
     parsed = urlparse(origin)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise SystemExit(f"Invalid API origin: {origin!r}")
+    if parsed.path or parsed.params or parsed.query or parsed.fragment:
+        raise SystemExit(
+            f"API origin must be scheme + host only (no path/query/fragment): {origin!r}"
+        )
     return origin
 
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,23 @@
+## 2026-05-30T16:10Z - opener lane issue #1259 materializing
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1259` (`Replace the cold-starting public Render+Netlify path with a documented internal or synthetic-data demo deploy, and pin the API origin`).
+- Branch: `codex/issue-1259-demo-deploy-origin`, base `origin/main` `d14ff6b54`.
+- Selection notes: raw opener cap was below limit (`total_opener_owned=2`, `raw_cap_reached=false`). Opener repaired `Travel-Plan-Permission#1131` by dispatching Gate Followups, recorded it as green/clean closer-drain evidence, then continued liveness selection. Scoped blockers remained `Workflows#2159`, `Inv-Man-Intake#469/#470`, and `learning-management-system#180`; already-linked/merged high candidates were skipped. `trip-planner#1259` was the oldest high-priority unlinked implementation issue outside those blockers.
+- Implementation:
+  - Added bounded retry/backoff for `GET /api/health` in the shared frontend client so initial 502/503/504 or transient network cold-start failures can recover before surfacing an error.
+  - Updated the health route loading/error treatment to show the server wake-up state and exhausted-retry error.
+  - Added `scripts/write_frontend_redirects.py` to generate Netlify `_redirects` from `TRIP_PLANNER_API_ORIGIN` or `VITE_API_BASE_URL`, with the existing Render origin as the synthetic-demo default.
+  - Added `scripts/check_deploy_origin.py`, wired it into `npm run build` and `scripts/check_production_readiness.sh`, and documented the synthetic-only public deploy plus internal-perimeter requirement in `README.md`.
+- Validation:
+  - `npm --prefix frontend run test -- --run src/lib/api/client.test.ts src/routes/HealthPage.test.tsx` -> 10 passed.
+  - `python -m py_compile scripts/check_deploy_origin.py scripts/write_frontend_redirects.py && python scripts/check_deploy_origin.py` -> passed.
+  - `npm --prefix frontend run build` -> passed, including redirect generation and deploy-origin drift check.
+- PR: `#1265` (https://github.com/stranske/trip-planner/pull/1265), open/non-draft, labels `agent:codex`, `agents:keepalive`, `autofix`, `priority:high`, and `repo-review-approved`.
+- Post-open state: initial checks are pending/starting. One immediate Gate row reported path-classification failure while the run was still in progress; opener attempted to read logs but GitHub reported logs unavailable until completion. Keepalive owns the next CI/review iteration.
+- Relay: `pr_opened active.source_repo=stranske/trip-planner active.source_issue=1259 active.source_pr=1265 active.next_action=wait_for_keepalive`.
+- Next action: keepalive owns PR #1265 CI/review iteration; closer owns post-merge verifier/issue closure.
+
 ## 2026-05-27T18:51Z - closer pushed CI recovery for PR #1253
 
 - Automation: `imi-merge-verify-closer` (codex closer lane) from the neutral Code workspace.


### PR DESCRIPTION
Closes #1259

## Summary
- add bounded cold-start retries for the shared `/api/health` frontend probe and update the health route loading/error state
- generate Netlify `_redirects` from `TRIP_PLANNER_API_ORIGIN`/`VITE_API_BASE_URL` during build and add a deploy-origin drift check
- document the public Netlify/Render path as synthetic-data-only and require internal-perimeter hosting for real trip data

## Validation
- `npm --prefix frontend run test -- --run src/lib/api/client.test.ts src/routes/HealthPage.test.tsx`
- `python -m py_compile scripts/check_deploy_origin.py scripts/write_frontend_redirects.py && python scripts/check_deploy_origin.py`
- `npm --prefix frontend run build`