### PR TITLE
Issue #1260: Add opt-in synthetic demo seed + guided first-trip path

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,28 @@ python scripts/check_deploy_origin.py
 
 The check fails when the README's public synthetic API host and the generated Netlify redirect host differ.
 
+### Try the demo (synthetic data)
+
+For a non-production checkout, you can seed a synthetic demo user plus two
+ready-to-explore trips so a tester sees a populated workspace immediately. The
+seed is **opt-in** (it no-ops unless `TRIP_PLANNER_SEED_DEMO=1`) and uses only
+synthetic data; the planner runs in its deterministic `fallback` mode, so **no
+proprietary data and no external LLM** are involved.
+
+```bash
+TRIP_PLANNER_SEED_DEMO=1 python scripts/seed_demo_data.py
+```
+
+Then sign in at `/login` with the documented demo credentials and open either
+seeded workspace (the script prints the exact `/workspace/<trip_id>` URLs):
+
+- email: `demo@trip-planner.local`
+- password: `demo-trip-planner-2026`
+
+Each `/workspace/<trip_id>` immediately shows ranked scenarios and the
+(schematic) map card. Do **not** run this seed against a production deployment;
+it exists for local and non-production evaluation only.
+
 ## Persistent Deployment
 
 The product deployment is split across two persistent services:

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -1,0 +1,225 @@
+"""Opt-in synthetic demo seed + guided "first trip" path.
+
+A fresh tester sees nothing today: every surface is gated behind self-service
+sign-up and trip creation, so a non-developer cannot evaluate the workspace,
+planner, scenario comparison, or map. This script provisions one synthetic demo
+user plus one leisure and one business trip using the existing service layer, so
+that an authenticated ``GET /api/workspace/{trip_id}`` immediately returns ranked
+scenarios and inventory bundles.
+
+Safety/data-zone guarantees:
+
+* **Opt-in only.** The seed runs only when ``TRIP_PLANNER_SEED_DEMO`` is truthy.
+  With the flag unset it no-ops (and logs) so it can never seed by default --
+  including in production.
+* **Synthetic only.** Titles/summaries/regions are obviously synthetic.
+* **No external LLM.** The seeded trips carry full trip-frame context, so the
+  workspace renders via the planner's deterministic ``fallback`` mode (the
+  default). The seed never sets ``provider=openai`` / model / ``OPENAI_API_KEY``.
+
+Run it for a non-production checkout with::
+
+    TRIP_PLANNER_SEED_DEMO=1 python scripts/seed_demo_data.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from fastapi import HTTPException
+
+from trip_planner.app.services.auth import (
+    AuthenticatedUser,
+    authenticate_user,
+    create_account,
+)
+from trip_planner.app.services.trips import create_trip, list_trips
+from trip_planner.persistence.db import ensure_database_ready, get_session_factory
+
+logger = logging.getLogger(__name__)
+
+#: Environment flag that must be truthy for the seed to run.
+SEED_ENV_FLAG = "TRIP_PLANNER_SEED_DEMO"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+#: Documented synthetic demo credentials (non-production only).
+DEMO_EMAIL = "demo@trip-planner.local"
+DEMO_PASSWORD = "demo-trip-planner-2026"  # synthetic; >= 8 chars
+DEMO_DISPLAY_NAME = "Demo Tester"
+
+#: Stable titles let the seed stay idempotent across re-runs.
+DEMO_LEISURE_TITLE = "Demo leisure getaway (synthetic)"
+DEMO_BUSINESS_TITLE = "Demo business summit (synthetic)"
+
+
+@dataclass(frozen=True)
+class DemoSeedResult:
+    """Identifiers a caller (or the README) needs to reach the seeded demo."""
+
+    email: str
+    password: str
+    leisure_trip_id: str
+    business_trip_id: str
+
+    def workspace_urls(self) -> list[str]:
+        return [
+            f"/workspace/{self.leisure_trip_id}",
+            f"/workspace/{self.business_trip_id}",
+        ]
+
+
+def seed_enabled() -> bool:
+    """Return True only when the opt-in flag is explicitly truthy."""
+
+    return os.environ.get(SEED_ENV_FLAG, "").strip().lower() in _TRUTHY
+
+
+def _ensure_demo_user(db_session) -> AuthenticatedUser:
+    """Create the demo account if absent; otherwise reuse it (idempotent)."""
+
+    try:
+        user = create_account(
+            db_session,
+            email=DEMO_EMAIL,
+            password=DEMO_PASSWORD,
+            display_name=DEMO_DISPLAY_NAME,
+        )
+    except HTTPException as error:
+        if error.status_code != 409:
+            raise
+        # Account already exists from a prior seed run -- reuse it.
+        user = authenticate_user(db_session, email=DEMO_EMAIL, password=DEMO_PASSWORD)
+    return AuthenticatedUser(
+        user_id=user.user_id,
+        email=user.email,
+        display_name=user.display_name,
+    )
+
+
+def _ensure_trip(
+    db_session,
+    *,
+    user: AuthenticatedUser,
+    existing_by_title: dict[str, str],
+    title: str,
+    summary: str,
+    mode: str,
+    primary_regions: list[str],
+    traveler_kind: str,
+    traveler_count: int,
+) -> str:
+    """Create the demo trip if absent; otherwise reuse it (idempotent).
+
+    The trip frame carries destination + dates + duration so the workspace
+    renders ranked scenarios via the deterministic fallback planner rather than a
+    ``missing_destination`` / ``missing_dates`` partial.
+    """
+
+    if title in existing_by_title:
+        return existing_by_title[title]
+
+    # Future, deterministic-relative dates keep the demo trip "upcoming".
+    start = date.today() + timedelta(days=45)
+    end = start + timedelta(days=3)
+    created = create_trip(
+        db_session,
+        user=user,
+        title=title,
+        summary=summary,
+        mode=mode,
+        start_date=start.isoformat(),
+        end_date=end.isoformat(),
+        duration_days=(end - start).days,
+        primary_regions=primary_regions,
+        traveler_kind=traveler_kind,
+        traveler_count=traveler_count,
+        traveler_notes="Synthetic demo data -- safe to delete.",
+    )
+    return created["trip_id"]
+
+
+def seed_demo_data(*, force: bool = False) -> DemoSeedResult | None:
+    """Provision the synthetic demo user + two trips.
+
+    Returns the :class:`DemoSeedResult` when seeding ran, or ``None`` when the
+    opt-in flag was unset (and ``force`` was not passed), having made no writes.
+    """
+
+    if not (force or seed_enabled()):
+        logger.info(
+            "Demo seed skipped: set %s=1 to provision synthetic demo data.",
+            SEED_ENV_FLAG,
+        )
+        return None
+
+    ensure_database_ready()
+    session = get_session_factory()()
+    try:
+        user = _ensure_demo_user(session)
+        existing_by_title = {trip["title"]: trip["trip_id"] for trip in list_trips(session, user=user)}
+
+        leisure_trip_id = _ensure_trip(
+            session,
+            user=user,
+            existing_by_title=existing_by_title,
+            title=DEMO_LEISURE_TITLE,
+            summary="A relaxed multi-day city break to explore the workspace.",
+            mode="leisure",
+            primary_regions=["Chicago"],
+            traveler_kind="solo",
+            traveler_count=1,
+        )
+        business_trip_id = _ensure_trip(
+            session,
+            user=user,
+            existing_by_title=existing_by_title,
+            title=DEMO_BUSINESS_TITLE,
+            summary="A short business summit with a small travelling team.",
+            mode="business",
+            primary_regions=["Chicago"],
+            traveler_kind="team",
+            traveler_count=3,
+        )
+    finally:
+        session.close()
+
+    result = DemoSeedResult(
+        email=DEMO_EMAIL,
+        password=DEMO_PASSWORD,
+        leisure_trip_id=leisure_trip_id,
+        business_trip_id=business_trip_id,
+    )
+    logger.info(
+        "Seeded synthetic demo data: user=%s leisure=%s business=%s",
+        result.email,
+        result.leisure_trip_id,
+        result.business_trip_id,
+    )
+    return result
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    result = seed_demo_data()
+    if result is None:
+        print(
+            f"Demo seed is opt-in. Re-run with {SEED_ENV_FLAG}=1 to provision "
+            "synthetic demo data (non-production only)."
+        )
+        return 0
+
+    print("Synthetic demo data seeded (deterministic fallback planner, no external LLM).")
+    print("  Sign in at /login with:")
+    print(f"    email:    {result.email}")
+    print(f"    password: {result.password}")
+    print("  Then open a populated workspace:")
+    for url in result.workspace_urls():
+        print(f"    {url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -159,7 +159,9 @@ def seed_demo_data(*, force: bool = False) -> DemoSeedResult | None:
     session = get_session_factory()()
     try:
         user = _ensure_demo_user(session)
-        existing_by_title = {trip["title"]: trip["trip_id"] for trip in list_trips(session, user=user)}
+        existing_by_title = {
+            trip["title"]: trip["trip_id"] for trip in list_trips(session, user=user)
+        }
 
         leisure_trip_id = _ensure_trip(
             session,

--- a/tests/app/test_demo_seed.py
+++ b/tests/app/test_demo_seed.py
@@ -21,6 +21,8 @@ from scripts.seed_demo_data import (
     DEMO_EMAIL,
     DEMO_PASSWORD,
     SEED_ENV_FLAG,
+    _ensure_demo_user,
+    main,
     seed_demo_data,
 )
 
@@ -34,9 +36,7 @@ def temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     reset_database_state()
 
 
-def test_demo_seed_populates_workspace(
-    temp_db: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_demo_seed_populates_workspace(temp_db: None, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(SEED_ENV_FLAG, "1")
 
     result = seed_demo_data()
@@ -68,9 +68,7 @@ def test_demo_seed_populates_workspace(
         assert payload["runtime_state"]["status"] == "ready"
 
 
-def test_demo_seed_is_noop_when_flag_unset(
-    temp_db: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_demo_seed_is_noop_when_flag_unset(temp_db: None, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(SEED_ENV_FLAG, raising=False)
 
     result = seed_demo_data()
@@ -79,3 +77,67 @@ def test_demo_seed_is_noop_when_flag_unset(
     with get_session_factory()() as db_session:
         users = db_session.scalars(select(UserAccount)).all()
     assert users == [], "seed must not create any account when the flag is unset"
+
+
+def test_demo_seed_is_idempotent(temp_db: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-running the seed reuses the existing account and trips (no duplicates)."""
+    monkeypatch.setenv(SEED_ENV_FLAG, "1")
+
+    first = seed_demo_data()
+    assert first is not None
+
+    second = seed_demo_data()
+    assert second is not None
+
+    # Same trip IDs on re-run — idempotent.
+    assert second.leisure_trip_id == first.leisure_trip_id
+    assert second.business_trip_id == first.business_trip_id
+
+    # Still only one account.
+    with get_session_factory()() as db_session:
+        users = db_session.scalars(select(UserAccount)).all()
+    assert len(users) == 1
+
+
+def test_workspace_urls(temp_db: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(SEED_ENV_FLAG, "1")
+    result = seed_demo_data()
+    assert result is not None
+
+    urls = result.workspace_urls()
+    assert len(urls) == 2
+    assert urls[0] == f"/workspace/{result.leisure_trip_id}"
+    assert urls[1] == f"/workspace/{result.business_trip_id}"
+
+
+def test_main_without_flag(
+    temp_db: None, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.delenv(SEED_ENV_FLAG, raising=False)
+
+    exit_code = main()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert SEED_ENV_FLAG in out
+
+
+def test_main_with_flag(
+    temp_db: None, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    monkeypatch.setenv(SEED_ENV_FLAG, "1")
+
+    exit_code = main()
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert DEMO_EMAIL in out
+    assert DEMO_PASSWORD in out
+    assert "/workspace/" in out
+
+
+def test_ensure_demo_user_reuses_existing_account(temp_db: None) -> None:
+    """_ensure_demo_user returns the same user on second call via the 409 path."""
+    with get_session_factory()() as session:
+        first = _ensure_demo_user(session)
+        second = _ensure_demo_user(session)
+    assert first.user_id == second.user_id
+    assert first.email == second.email

--- a/tests/app/test_demo_seed.py
+++ b/tests/app/test_demo_seed.py
@@ -1,0 +1,81 @@
+"""Acceptance tests for the opt-in synthetic demo seed (issue #1260)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from trip_planner.app.main import create_app
+from trip_planner.persistence.db import (
+    ensure_database_ready,
+    get_session_factory,
+    reset_database_state,
+)
+from trip_planner.persistence.models.account import UserAccount
+
+from scripts.seed_demo_data import (
+    DEMO_EMAIL,
+    DEMO_PASSWORD,
+    SEED_ENV_FLAG,
+    seed_demo_data,
+)
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'seed.db'}")
+    reset_database_state()
+    ensure_database_ready()
+    yield
+    reset_database_state()
+
+
+def test_demo_seed_populates_workspace(
+    temp_db: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(SEED_ENV_FLAG, "1")
+
+    result = seed_demo_data()
+    assert result is not None
+    assert result.leisure_trip_id and result.business_trip_id
+
+    app = create_app()
+    with TestClient(app) as client:
+        login = client.post(
+            "/api/auth/login",
+            json={"email": DEMO_EMAIL, "password": DEMO_PASSWORD},
+        )
+        assert login.status_code == 200, login.text
+
+        response = client.get(f"/api/workspace/{result.leisure_trip_id}")
+        assert response.status_code == 200, response.text
+        payload = response.json()
+
+        # Ranked scenario comparison must be populated, not a missing-* partial.
+        comparison = payload["runtime_scenario_comparison"]
+        assert comparison["scenarios"], "expected ranked scenarios, got empty comparison"
+        assert comparison["lead_scenario_id"] == comparison["scenarios"][0]["scenario_id"]
+
+        # At least one inventory bundle must be assembled.
+        assert payload["inventory_summary"]["bundle_count"] >= 1
+        assert payload["inventory_summary"]["bundles"]
+
+        # Deterministic fallback planner -- no external LLM was invoked.
+        assert payload["runtime_state"]["status"] == "ready"
+
+
+def test_demo_seed_is_noop_when_flag_unset(
+    temp_db: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(SEED_ENV_FLAG, raising=False)
+
+    result = seed_demo_data()
+    assert result is None
+
+    with get_session_factory()() as db_session:
+        users = db_session.scalars(select(UserAccount)).all()
+    assert users == [], "seed must not create any account when the flag is unset"


### PR DESCRIPTION
Closes #1260.

## Summary
A fresh tester sees nothing today — every surface is gated behind self-service sign-up + trip creation, and the two hard-coded fixture IDs in `workspace.py` are not provisioned for a new user. This adds an **opt-in, synthetic-only** seed so a tester reaches a populated workspace immediately.

- **`scripts/seed_demo_data.py`** — gated behind `TRIP_PLANNER_SEED_DEMO=1`; no-ops (and logs) when the flag is unset so it can never seed by default (incl. production). Provisions one demo user + one leisure and one business trip via the existing `create_account`/`create_trip` services. Seeded trips carry full trip-frame context (destination + dates + duration) so an authenticated `GET /api/workspace/{trip_id}` returns ranked scenarios and inventory bundles via the deterministic **fallback** planner — no external LLM, no proprietary data. Idempotent: reuses the demo account on `409` and matches existing demo trips by title on re-run.
- **README** — new "Try the demo (synthetic data)" subsection documenting the demo credentials, the printed `/workspace/<trip_id>` URLs, and the synthetic/deterministic guarantees (non-production only).
- **`tests/app/test_demo_seed.py`** — failing-first acceptance test: seeds a temp SQLite DB, logs in as the demo user, and asserts `GET /api/workspace/{leisure_trip_id}` returns `200` with a non-empty ranked `runtime_scenario_comparison` and `>=1` inventory bundle; plus a test asserting the seed creates no `UserAccount` when the flag is unset.

## Privacy / data-zone
Synthetic data only. The planner runs in its default deterministic `fallback` mode; the seed never sets `provider=openai` / model / `OPENAI_API_KEY`. README warns against running it on production.

## Validation
- `pytest tests/app/test_demo_seed.py` → 2 passed
- `pytest tests/test_repo_hygiene.py` + demo seed → 17 passed, 1 skipped (pre-existing)
- `ruff check` clean; `mypy scripts/seed_demo_data.py` clean
- CLI end-to-end (both modes) verified; idempotent re-run reuses the same trip IDs

## Non-Goals
No production auto-seeding (flag-gated off by default). No auth/password-hashing bypass. No live external provider during seeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)