### PR TITLE
Issue #1261: Label workspace map as schematic preview

### DIFF
--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -156,6 +156,7 @@ const planningLedger: WorkspaceData["planning_ledger"] = {
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllEnvs();
 });
 
 function renderTripMap(
@@ -229,9 +230,23 @@ describe("TripMap", () => {
     expect(screen.getByLabelText("Map view confidence")).toHaveTextContent(
       "Regional route review"
     );
+    expect(screen.getByText("Schematic preview — not a live map")).toBeInTheDocument();
     expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Provider misconfigured/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Provider error/i)).not.toBeInTheDocument();
+  });
+
+  it("labels the keyed provider surface as a schematic preview", () => {
+    vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "test-key");
+    vi.stubEnv("VITE_GOOGLE_MAPS_PROVIDER_STATE", "ready");
+
+    renderTripMap();
+
+    expect(screen.getByText("Schematic preview — not a live map")).toBeInTheDocument();
+    expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass(
+      "map-route-google-maps-js"
+    );
+    expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
   });
 
   it("surfaces linked planning ledger entries as map focus cues", () => {

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -10,6 +10,7 @@ import {
 
 type InventoryBundle = WorkspaceData["inventory_summary"]["bundles"][number];
 type TripMapScenario = RuntimeScenarioComparison["scenarios"][number];
+const SCHEMATIC_PREVIEW_BADGE_TEXT = "Schematic preview — not a live map";
 
 export function TripMap({
   comparison,
@@ -243,7 +244,9 @@ function ActiveTripMap({
         >
           <div className="map-provider-toolbar">
             <span className="map-provider-name">{mapSurface.scope.label}</span>
-            <span className="map-preview-badge">Schematic preview — not a live map</span>
+            <span className="map-preview-badge" aria-label={SCHEMATIC_PREVIEW_BADGE_TEXT}>
+              {SCHEMATIC_PREVIEW_BADGE_TEXT}
+            </span>
             <span>{mapSurface.visibleRouteSegments.length} shown segment(s)</span>
             <span>{mapSurface.visibleMarkers.length} shown marker(s)</span>
             {mapSurface.visibleFocusCues.length > 0 ? (

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -243,6 +243,7 @@ function ActiveTripMap({
         >
           <div className="map-provider-toolbar">
             <span className="map-provider-name">{mapSurface.scope.label}</span>
+            <span className="map-preview-badge">Schematic preview — not a live map</span>
             <span>{mapSurface.visibleRouteSegments.length} shown segment(s)</span>
             <span>{mapSurface.visibleMarkers.length} shown marker(s)</span>
             {mapSurface.visibleFocusCues.length > 0 ? (

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1697,6 +1697,10 @@ describe("WorkspacePage", () => {
     expect(container.querySelector("iframe")).toBeNull();
     expect(screen.queryByTitle(/google maps/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Fallback option markers")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Schematic preview — not a live map")).toBeInTheDocument();
+    expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass(
+      "map-route-google-maps-js"
+    );
     expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
     expect(
       screen.getAllByText("High confidence: the route has enough map detail for close review.")

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1052,6 +1052,15 @@ a {
   font-weight: 800;
 }
 
+.map-preview-badge {
+  border: 1px solid rgba(19, 33, 44, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #13212c;
+  font-weight: 700;
+  padding: 0.18rem 0.55rem;
+}
+
 .map-provider-canvas {
   position: relative;
   min-height: 340px;

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,18 @@
+## 2026-05-31T08:01Z - opener lane issue #1261 materializing
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1261` (`Label the workspace map as a non-interactive schematic preview in both provider and fallback modes`).
+- Branch: `codex/issue-1261-schematic-preview-label`, base `origin/main`.
+- Selection notes: cap-health after opener infra repair showed raw cap below limit (`total_opener_owned=4`, `raw_cap_reached=false`, `normal_cap_reached=false`). Existing opener-owned PRs were classified as: PAEM #1847 scoped/non-registry routing blocker; Trend #5353 scoped product/CI decision; Trend #5362 draining; LMS #212 draining with active Gate. High-priority #5344 was scoped this round because it explicitly depends on/cross-links the unresolved #5343 demo-mode guard branch. Older normal candidates were merged, linked, or scoped (#2159 merged #2161, #479 scoped, #5351 linked #5362, #2182 merged #2196, #182 linked #212). `trip-planner#1261` was the oldest unlinked eligible normal-priority implementation issue.
+- Implementation:
+  - Added an always-visible `Schematic preview — not a live map` badge in the `TripMap` map-provider toolbar, shared by the provider-backed and fallback rendering branches.
+  - Added styling for the preview badge without changing provider selection or route rendering behavior.
+  - Extended `TripMap.test.tsx` to assert the preview badge in normal rendering and when `VITE_GOOGLE_MAPS_BROWSER_API_KEY` selects the `google-maps-js` provider branch, while keeping provider diagnostics hidden.
+- Validation:
+  - `npm --prefix frontend test -- src/components/maps/TripMap.test.tsx src/routes/WorkspacePage.test.tsx` -> 53 passed.
+  - `npm --prefix frontend test` -> 103 passed.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
+
 ## 2026-05-30T16:10Z - opener lane issue #1259 materializing
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.


### PR DESCRIPTION
Implements #1261

## Summary
- add an always-visible `Schematic preview — not a live map` badge to the trip map toolbar
- keep the badge shared across provider-backed and fallback schematic branches
- cover the keyed `google-maps-js` branch with a Vitest assertion while keeping provider diagnostics hidden

## Validation
- `npm --prefix frontend test -- src/components/maps/TripMap.test.tsx src/routes/WorkspacePage.test.tsx`
- `npm --prefix frontend test`
