### PR TITLE
Issue #1262: raise CI coverage floor from 8 to measured baseline 88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,10 @@ jobs:
       format_check: false
       typecheck: true
       coverage: true
-      # Floor set to measured backend baseline (89% on 2026-05-31), rounded down
-      # to 88 for cross-version (3.12/3.13) headroom. See docs/CI_SYSTEM_GUIDE.md.
-      coverage-min: '88'
+      # Floor set from the measured reusable CI coverage baseline (about 84% on
+      # 2026-05-31), rounded down to 83 for cross-environment headroom.
+      # See docs/CI_SYSTEM_GUIDE.md.
+      coverage-min: '83'
     secrets: inherit
 
   runtime:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
       format_check: false
       typecheck: true
       coverage: true
-      coverage-min: '8'
+      # Floor set to measured backend baseline (89% on 2026-05-31), rounded down
+      # to 88 for cross-version (3.12/3.13) headroom. See docs/CI_SYSTEM_GUIDE.md.
+      coverage-min: '88'
     secrets: inherit
 
   runtime:

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -67,7 +67,10 @@ jobs:
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main
     with:
       python-versions: '["3.12", "3.13"]'
-      coverage-min: "8"
+      # Keep in lockstep with ci.yml: the Gate is the branch-protection-enforced
+      # check, so its coverage floor must match ci.yml's measured baseline (83),
+      # not the old placeholder 8. See docs/CI_SYSTEM_GUIDE.md.
+      coverage-min: "83"
       format_check: false  # Using ruff for formatting
       working-directory: "."
       artifact-prefix: "gate-"

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -55,11 +55,12 @@ provides:
 | `reusable-12-ci-docker.yml` | Docker build + smoke test | Projects with Dockerfile |
 | `reusable-18-autofix.yml` | Automated code formatting fixes | All projects (via autofix label) |
 
-> **Coverage floor baseline.** `.github/workflows/ci.yml` passes `coverage-min: '88'`
-> to `reusable-10-ci-python.yml`. This reflects the measured backend baseline of
-> **89%** (`python -m pytest --cov=trip_planner`, 1021 passed / 1 skipped on
-> 2026-05-31), rounded down to **88** to absorb minor cross-version (3.12/3.13)
-> variation. The previous placeholder floor of `8` was too low to catch real
+> **Coverage floor baseline.** `.github/workflows/ci.yml` passes `coverage-min: '83'`
+> to `reusable-10-ci-python.yml`. This reflects the reusable workflow's measured
+> fallback coverage baseline of about **84%** (84.10% in CI on Python 3.12/3.13,
+> 83.98% in local fallback validation on 2026-05-31), rounded down to **83** to
+> absorb minor cross-environment variation. The previous placeholder floor of `8`
+> was too low to catch real
 > regressions. Re-measure and raise this floor (never below the current measured
 > value) when the suite grows; change only the literal in this repo's `ci.yml`,
 > not the reusable workflow.

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -55,6 +55,15 @@ provides:
 | `reusable-12-ci-docker.yml` | Docker build + smoke test | Projects with Dockerfile |
 | `reusable-18-autofix.yml` | Automated code formatting fixes | All projects (via autofix label) |
 
+> **Coverage floor baseline.** `.github/workflows/ci.yml` passes `coverage-min: '88'`
+> to `reusable-10-ci-python.yml`. This reflects the measured backend baseline of
+> **89%** (`python -m pytest --cov=trip_planner`, 1021 passed / 1 skipped on
+> 2026-05-31), rounded down to **88** to absorb minor cross-version (3.12/3.13)
+> variation. The previous placeholder floor of `8` was too low to catch real
+> regressions. Re-measure and raise this floor (never below the current measured
+> value) when the suite grows; change only the literal in this repo's `ci.yml`,
+> not the reusable workflow.
+
 ### Agent Automation System
 
 The Workflows repo includes a sophisticated agent automation system:

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -55,15 +55,18 @@ provides:
 | `reusable-12-ci-docker.yml` | Docker build + smoke test | Projects with Dockerfile |
 | `reusable-18-autofix.yml` | Automated code formatting fixes | All projects (via autofix label) |
 
-> **Coverage floor baseline.** `.github/workflows/ci.yml` passes `coverage-min: '83'`
-> to `reusable-10-ci-python.yml`. This reflects the reusable workflow's measured
-> fallback coverage baseline of about **84%** (84.10% in CI on Python 3.12/3.13,
-> 83.98% in local fallback validation on 2026-05-31), rounded down to **83** to
-> absorb minor cross-environment variation. The previous placeholder floor of `8`
-> was too low to catch real
-> regressions. Re-measure and raise this floor (never below the current measured
-> value) when the suite grows; change only the literal in this repo's `ci.yml`,
-> not the reusable workflow.
+> **Coverage floor baseline.** Both `.github/workflows/ci.yml` and the
+> branch-protection-enforced `.github/workflows/pr-00-gate.yml` pass
+> `coverage-min: '83'` to `reusable-10-ci-python.yml`. This reflects the reusable
+> workflow's measured fallback coverage baseline of about **84%** (84.10% in CI on
+> Python 3.12/3.13, 83.98% in local fallback validation on 2026-05-31), set
+> **at or slightly below** the measured baseline (rounded down to **83**) so minor
+> cross-environment variation does not flake the gate while still ratcheting far
+> above the previous placeholder floor of `8`, which was too low to catch real
+> regressions. When the suite grows, re-measure and raise this floor toward the
+> new measured baseline (keeping the small headroom margin); update the literal in
+> **both** this repo's `ci.yml` and `pr-00-gate.yml` so the standalone Python CI
+> and the enforced Gate stay in lockstep, and do not edit the reusable workflow.
 
 ### Agent Automation System
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -34,6 +34,20 @@
 - Post-open repair: initial #1272 Gate/Autofix runs were cancelled and cap-health classified `needs-dispatch-evidence`; `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups. Fresh cap-health at 09:06Z classifies #1272 as `draining` with active Gate evidence; raw cap remains below limit (`total_opener_owned=4`, `raw_cap_reached=false`).
 - Next action: keepalive owns #1272 CI/review; opener should move to the next eligible issue on a future round after cap/drain discovery.
 
+## 2026-05-31T09:03Z - closer lane PR #1271 CI coverage-floor recovery
+
+- Automation: `imi-merge-verify-closer` (codex closer lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1262`; PR `#1271`; branch `claude/issue-1262-coverage-floor`.
+- Blocker: CI run `26708187914` failed only `Python CI / python 3.12` and `Python CI / python 3.13`; both test jobs passed pytest, then failed the coverage minimum because the branch set `coverage-min: '88'` while the reusable CI fallback measured coverage at `84.10%`.
+- Keepalive state: fresh Claude keepalive run `26708248540` completed successfully with no commit and confirmed the PR tasks were already implemented, so closer took the deterministic CI threshold repair.
+- Fix: changed `.github/workflows/ci.yml` to `coverage-min: '83'` and updated `docs/CI_SYSTEM_GUIDE.md` to document the reusable CI/local fallback coverage baseline and why the floor is rounded down for cross-environment headroom.
+- Validation:
+  - `python -m pytest --cov=src --cov-report=xml:/tmp/trip-planner-1271-coverage.xml --cov-report=term-missing` -> 1021 passed / 1 skipped; local literal `--cov=src` collected no data because this repo has no `src/` directory, matching why reusable CI falls back to `.`.
+  - `python -m pytest --cov=. --cov-report=xml:/tmp/trip-planner-1271-coverage-dot.xml --cov-report=term-missing` -> 1021 passed / 1 skipped, coverage `83.98%`.
+  - Parsed `/tmp/trip-planner-1271-coverage-dot.xml` and confirmed `83.98 >= 83`.
+  - `git diff --check` -> clean.
+- Next action: re-check fresh CI/Gate on the pushed head. If checks are green and review threads remain clear, merge PR #1271, apply `verify:compare`, emit `pr_merged` and `verify_label_applied`, and keep issue #1262 open until durable verifier PASS.
+
 ## 2026-05-31T08:01Z - opener lane issue #1261 materializing
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,13 @@
+## 2026-05-31T10:08Z - closer rebased PR #1271 after #1272 main merge
+
+- Automation: `imi-merge-verify-closer` (codex closer lane), neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1262`; PR `#1271`; branch `claude/issue-1262-coverage-floor`.
+- Batch context: closed issue `#1263` after merged PR `#1272` received durable provider-comparison PASS/PASS; emitted `issue_closed` and reset the closer chain once after the sweep.
+- Blocker: PR `#1271` was `DIRTY`/`CONFLICTING` after `#1272` merged to `main`. The only rebase conflict was concurrent prepend history in `workloop-state.md`; the coverage-floor workflow/doc changes themselves applied cleanly.
+- Action: rebased detached automation worktree `~/.codex/automations/imi-merge-verify-closer/worktrees/tp-1271-gatefloor` onto `origin/main` `64de0e715` and kept both workloop entries. The rebased head preserves `.github/workflows/ci.yml` coverage-min `83`, `.github/workflows/pr-00-gate.yml` coverage-min `"83"`, and the CI guide update.
+- Validation: `python` YAML parse for `.github/workflows/ci.yml` and `.github/workflows/pr-00-gate.yml` -> ok; `git diff --check` -> clean.
+- Next action: after push, re-check PR #1271 checks and review threads. If fresh checks are green and threads remain resolved, merge #1271, apply `verify:compare`, and keep issue #1262 open until durable verifier PASS.
+
 ## 2026-05-31T09:25Z - closer fixed PR #1272 test-fixture env isolation
 
 - Automation: `imi-merge-verify-closer` (codex closer lane), neutral Code workspace.


### PR DESCRIPTION
Implements #1262.

## Why
The Python CI coverage gate passed `coverage-min: '8'` to `reusable-10-ci-python.yml` (`.github/workflows/ci.yml:34`). For a backend this size with a large passing suite, an 8% floor cannot catch real regressions — large swaths of code could break without failing CI.

## What
- **Measured** current backend coverage: `python -m pytest --cov=trip_planner` → **89%** (exact 89.33%, 1021 passed / 1 skipped, on 2026-05-31), honoring the existing `[tool.coverage.run] omit` list.
- **`.github/workflows/ci.yml`**: `coverage-min` `'8'` → `'88'` — the measured baseline rounded down to absorb minor cross-version (3.12/3.13) variation. Only the literal in this repo's caller changed; the reusable workflow in `stranske/Workflows` is untouched (per repo CLAUDE.md).
- **`docs/CI_SYSTEM_GUIDE.md`**: recorded the measured baseline (89%), date (2026-05-31), the new floor (88), and the rationale near the reusable-10 row.

## Verifiable gate (Acceptance Criteria)
Both outcomes captured locally:

| Scenario | Command | Result |
|----------|---------|--------|
| Current suite | `pytest --cov=trip_planner --cov-fail-under=88` | **exit 0** — "Required test coverage of 88% reached. Total coverage: 89.33%" |
| Coverage artificially dropped (single test file) | `pytest tests/test_complexity.py --cov=trip_planner --cov-fail-under=88` | **exit 1** — "FAIL Required test coverage of 88% not reached. Total coverage: 19.56%" |

The floor is reproducibly passable on the current `main` suite and fires non-zero when coverage regresses below it.

## Non-Goals (respected)
- No new tests written to chase a target; no `[tool.coverage]` omit-rule changes; the reusable workflow was not edited; the floor is tied to a measured run, not guessed.