### PR TITLE
Issue #1263: gate live planner integrations by data zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ Use these env vars only when you are intentionally exercising an integration sea
 - `VITE_GOOGLE_MAPS_BROWSER_API_KEY`: primary key for enabling the Google Maps JavaScript adapter path in the workspace.
 - `VITE_GOOGLE_MAPS_EMBED_API_KEY`: legacy key name still accepted as a compatibility fallback when `VITE_GOOGLE_MAPS_BROWSER_API_KEY` is not set.
 - `VITE_GOOGLE_MAPS_PROVIDER_STATE`: optional local/test override for the map adapter load state (`ready`, `loading`, or `error`).
-- `TPP_BASE_URL`, `TPP_ACCESS_TOKEN`, `TPP_OIDC_PROVIDER`: enable the live `Travel-Plan-Permission` transport client. If they are unset, the repo should continue to present stored-policy and passive/local TPP seams rather than implying a real remote policy round-trip.
+- `TRIP_PLANNER_DATA_ZONE`: explicit data-zone switch for integration seams. Use `synthetic` for local/demo data (the default) or `proprietary` for real traveler/company data inside the perimeter.
+- `TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT`: marker for an approved no-train OpenAI endpoint. In `TRIP_PLANNER_DATA_ZONE=proprietary`, the planner refuses the OpenAI path and stays in deterministic fallback unless this marker is set. The outbound planner prompt redaction hook still runs before model invocation when the OpenAI path is enabled.
+- `TPP_BASE_URL`, `TPP_ACCESS_TOKEN`, `TPP_OIDC_PROVIDER`: enable the live `Travel-Plan-Permission` transport client. If they are unset, the repo should continue to present stored-policy and passive/local TPP seams rather than implying a real remote policy round-trip. In `TRIP_PLANNER_DATA_ZONE=proprietary`, `TPP_BASE_URL` must point only at an in-perimeter service.
 - `TPP_REPO_PATH`: optional sibling checkout path used by `make full-product-check` when it needs to start a local Travel-Plan-Permission service instead of using `TPP_BASE_URL`.
 
 TPP transport policy env overrides (used only when live TPP transport is enabled):

--- a/docs/live-tpp-execution-reoptimization-epic.md
+++ b/docs/live-tpp-execution-reoptimization-epic.md
@@ -127,6 +127,8 @@ The `make full-product-check` lane is the live-verification surface for this epi
 
 Both modes also require `TPP_ACCESS_TOKEN` and `TPP_OIDC_PROVIDER`. Missing values are reported as `SKIPPED` or `BLOCKED` (depending on whether a transport target is configured), each with a `remediation` hint that names the next concrete env var or command.
 
+`TRIP_PLANNER_DATA_ZONE` is the shared privacy boundary for the live TPP and planner LLM seams. The default `synthetic` zone is suitable for demo and fixture data. In `proprietary`, live TPP must target an in-perimeter `TPP_BASE_URL` or sibling service, and the OpenAI planner path remains `BLOCKED` unless `TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT` marks an approved no-train endpoint. When that marker is present, the planner still applies the outbound prompt redaction hook before invoking the model.
+
 For the full result-state matrix, env-var matrix, and example invocations, see [`docs/local-testing-plan.md` → "Live TPP Verification Setup"](local-testing-plan.md#live-tpp-verification-setup). Keep that section as the operator-facing source of truth; this epic doc records the design intent behind the seam, not the runbook.
 
 ### Default Local Behavior

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -42,7 +42,12 @@ async function fetchWithTimeout(
 ): Promise<Response> {
   // Without AbortController support (or an already-supplied signal) fall back
   // to a plain fetch so non-browser callers keep working.
-  if (!timeoutMs || typeof AbortController === "undefined" || init.signal) {
+  if (
+    !timeoutMs ||
+    typeof AbortController === "undefined" ||
+    init.signal ||
+    (typeof window !== "undefined" && fetch !== window.fetch)
+  ) {
     return fetch(requestUrl, init);
   }
 
@@ -52,6 +57,14 @@ async function fetchWithTimeout(
   }, timeoutMs);
   try {
     return await fetch(requestUrl, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (
+      error instanceof TypeError &&
+      String(error.message).includes("instance of AbortSignal")
+    ) {
+      return fetch(requestUrl, init);
+    }
+    throw error;
   } finally {
     window.clearTimeout(timer);
   }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -42,12 +42,7 @@ async function fetchWithTimeout(
 ): Promise<Response> {
   // Without AbortController support (or an already-supplied signal) fall back
   // to a plain fetch so non-browser callers keep working.
-  if (
-    !timeoutMs ||
-    typeof AbortController === "undefined" ||
-    init.signal ||
-    (typeof window !== "undefined" && fetch !== window.fetch)
-  ) {
+  if (!timeoutMs || typeof AbortController === "undefined" || init.signal) {
     return fetch(requestUrl, init);
   }
 
@@ -57,14 +52,6 @@ async function fetchWithTimeout(
   }, timeoutMs);
   try {
     return await fetch(requestUrl, { ...init, signal: controller.signal });
-  } catch (error) {
-    if (
-      error instanceof TypeError &&
-      String(error.message).includes("instance of AbortSignal")
-    ) {
-      return fetch(requestUrl, init);
-    }
-    throw error;
   } finally {
     window.clearTimeout(timer);
   }

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -29,6 +29,9 @@ if str(REPO_ROOT) not in sys.path:
 from fastapi.testclient import TestClient  # noqa: E402
 
 from trip_planner.app.main import create_app  # noqa: E402
+from trip_planner.app.services.planner_runtime_config import (  # noqa: E402
+    build_planner_runtime_config,
+)
 from trip_planner.persistence.db import ensure_database_ready, reset_database_state  # noqa: E402
 
 DEFAULT_TPP_REPO_PATH = REPO_ROOT.parent / "Travel-Plan-Permission"
@@ -347,6 +350,28 @@ def classify_map_prerequisite(env: Mapping[str, str] | None = None) -> CheckResu
         "FAIL",
         {"provider_state": provider_state, "message": "Configured map provider reported an error."},
     )
+
+
+def classify_planner_llm_prerequisite(env: Mapping[str, str] | None = None) -> CheckResult:
+    runtime = build_planner_runtime_config(os.environ if env is None else env)
+    details = {
+        "data_zone": runtime.data_zone,
+        "mode": runtime.mode,
+        "provider": runtime.provider,
+        "model": runtime.model,
+        "llm_status": runtime.llm_status,
+        "fallback_reason": runtime.fallback_reason,
+    }
+    if runtime.llm_status == "blocked":
+        details["remediation"] = (
+            "Set TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT only for an approved no-train "
+            "OpenAI endpoint with the outbound prompt redaction hook enabled, or leave the "
+            "planner in deterministic fallback mode."
+        )
+        return CheckResult("planner-llm", "BLOCKED", details)
+    if runtime.mode == "model":
+        return CheckResult("planner-llm", "READY", details)
+    return CheckResult("planner-llm", "SKIPPED", details)
 
 
 _REMEDIATION_OFF = (
@@ -960,6 +985,8 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
             results.append(map_result)
             if map_result.status == "FAIL":
                 raise VerificationFailure(json.dumps(map_result.details, sort_keys=True))
+
+            results.append(classify_planner_llm_prerequisite())
 
             tpp_status = tpp_prerequisite_status(live_tpp=live_tpp)
             if tpp_status.status == "READY":

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -759,6 +759,7 @@ def _force_planner_fallback_runtime() -> Iterator[None]:
 
 
 def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
+    planner_llm_env = dict(os.environ)
     with (
         tempfile.TemporaryDirectory(prefix="trip-planner-full-product.") as tmpdir,
         _temporary_database_url(f"sqlite:///{Path(tmpdir) / 'full_product.db'}"),
@@ -986,7 +987,7 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
             if map_result.status == "FAIL":
                 raise VerificationFailure(json.dumps(map_result.details, sort_keys=True))
 
-            results.append(classify_planner_llm_prerequisite())
+            results.append(classify_planner_llm_prerequisite(env=planner_llm_env))
 
             tpp_status = tpp_prerequisite_status(live_tpp=live_tpp)
             if tpp_status.status == "READY":

--- a/tests/app/test_full_product_verification.py
+++ b/tests/app/test_full_product_verification.py
@@ -5,6 +5,7 @@ from scripts import check_full_product_verification as verifier
 from scripts.check_full_product_verification import (
     CheckResult,
     classify_map_prerequisite,
+    classify_planner_llm_prerequisite,
     run_product_journeys,
     run_frontend_runtime_smoke,
     tpp_prerequisite_status,
@@ -17,6 +18,11 @@ def test_full_product_local_journeys_cover_runtime_identifiers(monkeypatch) -> N
         "TPP_ACCESS_TOKEN",
         "TPP_OIDC_PROVIDER",
         "TPP_REPO_PATH",
+        "TRIP_PLANNER_DATA_ZONE",
+        "TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT",
+        "TRIP_PLANNER_PLANNER_MODEL_PROVIDER",
+        "TRIP_PLANNER_PLANNER_MODEL",
+        "OPENAI_API_KEY",
         "VITE_GOOGLE_MAPS_PROVIDER_STATE",
         "VITE_GOOGLE_MAPS_BROWSER_API_KEY",
         "VITE_GOOGLE_MAPS_EMBED_API_KEY",
@@ -72,6 +78,38 @@ def test_map_provider_check_fails_when_configured_provider_errors(monkeypatch) -
 
     assert check.status == "FAIL"
     assert check.details["provider_state"] == "error"
+
+
+def test_planner_llm_check_blocks_openai_in_proprietary_zone_without_marker() -> None:
+    check = classify_planner_llm_prerequisite(
+        env={
+            "TRIP_PLANNER_DATA_ZONE": "proprietary",
+            "TRIP_PLANNER_PLANNER_MODEL_PROVIDER": "openai",
+            "TRIP_PLANNER_PLANNER_MODEL": "gpt-test",
+            "OPENAI_API_KEY": "fake-key",
+        }
+    )
+
+    assert check.status == "BLOCKED"
+    assert check.details["data_zone"] == "proprietary"
+    assert check.details["llm_status"] == "blocked"
+    assert check.details["fallback_reason"] == "proprietary_zone_llm_blocked"
+
+
+def test_planner_llm_check_reports_authorized_openai_ready() -> None:
+    check = classify_planner_llm_prerequisite(
+        env={
+            "TRIP_PLANNER_DATA_ZONE": "proprietary",
+            "TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT": "1",
+            "TRIP_PLANNER_PLANNER_MODEL_PROVIDER": "openai",
+            "TRIP_PLANNER_PLANNER_MODEL": "gpt-test",
+            "OPENAI_API_KEY": "fake-key",
+        }
+    )
+
+    assert check.status == "READY"
+    assert check.details["data_zone"] == "proprietary"
+    assert check.details["llm_status"] == "authorized"
 
 
 def test_live_tpp_auto_reports_missing_config_as_skipped(monkeypatch, tmp_path) -> None:

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -37,6 +37,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
         "TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'planner.db'}"
     )
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_PLANNER_PROVIDER", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_DATA_ZONE", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT", raising=False)

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -214,6 +214,13 @@ def test_proprietary_zone_blocks_openai_without_authorized_endpoint(
     assert runtime["llm_status"] == "blocked"
     assert runtime["fallback_reason"] == "proprietary_zone_llm_blocked"
 
+    monkeypatch.setenv("TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT", "0")
+    still_blocked_response = client.get(f"/api/planner/{trip_id}/session")
+    assert still_blocked_response.status_code == 200
+    still_blocked_runtime = still_blocked_response.json()["runtime"]
+    assert still_blocked_runtime["mode"] == "fallback"
+    assert still_blocked_runtime["llm_status"] == "blocked"
+
     monkeypatch.setenv("TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT", "1")
     authorized_response = client.get(f"/api/planner/{trip_id}/session")
 

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -9,7 +9,10 @@ from sqlalchemy import delete, select
 
 from trip_planner.app.main import create_app
 from trip_planner.app.services.auth import AuthenticatedUser
-from trip_planner.app.services.planner import set_planner_chat_model_factory_for_tests
+from trip_planner.app.services.planner import (
+    set_planner_chat_model_factory_for_tests,
+    set_planner_prompt_redactor_for_tests,
+)
 from trip_planner.app.services.planner_tools import (
     execute_planner_tool_call,
     list_planner_tools,
@@ -35,6 +38,8 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     )
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_DATA_ZONE", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
     monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
@@ -43,6 +48,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_LANGSMITH_FLEET_PATH", raising=False)
     set_planner_chat_model_factory_for_tests(None)
+    set_planner_prompt_redactor_for_tests(None)
     reset_database_state()
     app = create_app()
 
@@ -59,6 +65,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
         yield test_client
 
     set_planner_chat_model_factory_for_tests(None)
+    set_planner_prompt_redactor_for_tests(None)
     reset_database_state()
 
 
@@ -186,6 +193,71 @@ def test_planner_session_reports_model_runtime_when_configured(
     assert runtime["mode"] == "model"
     assert runtime["provider"] == "openai"
     assert runtime["model"] == "fake-planner-model"
+
+
+def test_proprietary_zone_blocks_openai_without_authorized_endpoint(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    monkeypatch.setenv("TRIP_PLANNER_DATA_ZONE", "proprietary")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+
+    response = client.get(f"/api/planner/{trip_id}/session")
+
+    assert response.status_code == 200
+    runtime = response.json()["runtime"]
+    assert runtime["mode"] == "fallback"
+    assert runtime["data_zone"] == "proprietary"
+    assert runtime["llm_status"] == "blocked"
+    assert runtime["fallback_reason"] == "proprietary_zone_llm_blocked"
+
+    monkeypatch.setenv("TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT", "1")
+    authorized_response = client.get(f"/api/planner/{trip_id}/session")
+
+    assert authorized_response.status_code == 200
+    authorized_runtime = authorized_response.json()["runtime"]
+    assert authorized_runtime["mode"] == "model"
+    assert authorized_runtime["provider"] == "openai"
+    assert authorized_runtime["llm_status"] == "authorized"
+
+
+def test_openai_planner_payload_uses_redaction_hook(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    fake_model = FakePlannerChatModel(
+        {"content": "The redacted prompt is safe to send.", "tool_calls": []}
+    )
+    redacted_payloads: list[dict[str, Any]] = []
+
+    def redactor(payload: dict[str, Any]) -> dict[str, Any]:
+        redacted = dict(payload)
+        redacted["message"] = "[redacted traveler prompt]"
+        redacted_payloads.append(redacted)
+        return redacted
+
+    monkeypatch.setenv("TRIP_PLANNER_DATA_ZONE", "proprietary")
+    monkeypatch.setenv("TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT", "1")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+    set_planner_chat_model_factory_for_tests(lambda _: fake_model)
+    set_planner_prompt_redactor_for_tests(redactor)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "My traveler note contains sensitive account context."},
+    )
+
+    assert response.status_code == 200
+    assert redacted_payloads
+    assert fake_model.requests[0]["message"] == "[redacted traveler prompt]"
+    assert fake_model.requests[0]["data_zone"] == "proprietary"
+    assert "sensitive account context" not in json.dumps(fake_model.requests[0])
 
 
 def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> None:

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -84,8 +84,10 @@ class PlannerChatModel(Protocol):
 
 
 PlannerChatModelFactory = Callable[[PlannerRuntimeConfig], PlannerChatModel]
+PlannerPromptRedactor = Callable[[dict[str, Any]], dict[str, Any]]
 
 _PLANNER_CHAT_MODEL_FACTORY: PlannerChatModelFactory | None = None
+_PLANNER_PROMPT_REDACTOR: PlannerPromptRedactor | None = None
 _GROUNDING_TOOL_NAMES: tuple[str, ...] = (
     "read_workspace_state",
     "refresh_inventory",
@@ -1059,6 +1061,18 @@ def set_planner_chat_model_factory_for_tests(
     _PLANNER_CHAT_MODEL_FACTORY = factory
 
 
+def set_planner_prompt_redactor_for_tests(
+    redactor: PlannerPromptRedactor | None,
+) -> None:
+    global _PLANNER_PROMPT_REDACTOR
+    _PLANNER_PROMPT_REDACTOR = redactor
+
+
+def _redact_openai_planner_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    redactor = _PLANNER_PROMPT_REDACTOR or (lambda item: item)
+    return redactor(payload)
+
+
 class PlannerConversationRunnable(Protocol):
     """LangChain-style runnable abstraction for planner conversation turns."""
 
@@ -1220,17 +1234,19 @@ class ModelBackedPlannerConversationRunnable:
         self._chat_model = chat_model
 
     def invoke(self, request: PlannerConversationRequest) -> PlannerConversationReply:
-        raw = self._chat_model.invoke(
-            {
-                "message": request.message,
-                "trip_id": request.trip_id,
-                "available_tools": list_planner_tools(),
-                "runtime_context": request.runtime_context,
-                "provider": self._config.provider,
-                "model": self._config.model,
-                "langsmith_run_config": request.langsmith_run_config,
-            }
-        )
+        model_payload = {
+            "message": request.message,
+            "trip_id": request.trip_id,
+            "available_tools": list_planner_tools(),
+            "runtime_context": request.runtime_context,
+            "provider": self._config.provider,
+            "model": self._config.model,
+            "langsmith_run_config": request.langsmith_run_config,
+            "data_zone": self._config.data_zone,
+        }
+        if self._config.provider == "openai":
+            model_payload = _redact_openai_planner_payload(model_payload)
+        raw = self._chat_model.invoke(model_payload)
         content = str(raw.get("content") or "").strip()
         if not content:
             content = "Planner model returned an empty response after reading the current trip context."

--- a/trip_planner/app/services/planner_runtime_config.py
+++ b/trip_planner/app/services/planner_runtime_config.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 PROPRIETARY_DATA_ZONE = "proprietary"
 SYNTHETIC_DATA_ZONE = "synthetic"
 AUTHORIZED_OPENAI_ENDPOINT_ENV = "TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT"
+AUTHORIZED_MARKERS = frozenset({"1", "true", "yes", "authorized"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -60,7 +61,7 @@ def build_planner_runtime_config(env: Mapping[str, str]) -> PlannerRuntimeConfig
     data_zone = (env.get("TRIP_PLANNER_DATA_ZONE") or SYNTHETIC_DATA_ZONE).strip().lower()
     if data_zone not in {PROPRIETARY_DATA_ZONE, SYNTHETIC_DATA_ZONE}:
         data_zone = SYNTHETIC_DATA_ZONE
-    authorized_openai_endpoint = env.get(AUTHORIZED_OPENAI_ENDPOINT_ENV, "").strip()
+    authorized_openai_endpoint = _has_explicit_openai_authorization(env)
     fake_enabled = provider == "fake"
     openai_requested = provider == "openai" and bool(model) and bool(openai_api_key)
     openai_blocked_by_zone = (
@@ -104,3 +105,8 @@ def build_planner_runtime_config(env: Mapping[str, str]) -> PlannerRuntimeConfig
         data_zone=data_zone,
         llm_status="blocked" if openai_blocked_by_zone else "deterministic",
     )
+
+
+def _has_explicit_openai_authorization(env: Mapping[str, str]) -> bool:
+    marker = env.get(AUTHORIZED_OPENAI_ENDPOINT_ENV, "").strip().lower()
+    return marker in AUTHORIZED_MARKERS

--- a/trip_planner/app/services/planner_runtime_config.py
+++ b/trip_planner/app/services/planner_runtime_config.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
+
+PROPRIETARY_DATA_ZONE = "proprietary"
+SYNTHETIC_DATA_ZONE = "synthetic"
+AUTHORIZED_OPENAI_ENDPOINT_ENV = "TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT"
 
 
 @dataclass(frozen=True, slots=True)
@@ -15,6 +20,8 @@ class PlannerRuntimeConfig:
     title: str
     summary: str
     fallback_reason: str | None = None
+    data_zone: str = SYNTHETIC_DATA_ZONE
+    llm_status: str = "deterministic"
 
     @property
     def model_configured(self) -> bool:
@@ -29,23 +36,39 @@ class PlannerRuntimeConfig:
             "title": self.title,
             "summary": self.summary,
             "fallback_reason": self.fallback_reason,
+            "data_zone": self.data_zone,
+            "llm_status": self.llm_status,
         }
 
 
 def get_planner_runtime_config() -> PlannerRuntimeConfig:
+    return build_planner_runtime_config(os.environ)
+
+
+def build_planner_runtime_config(env: Mapping[str, str]) -> PlannerRuntimeConfig:
     provider = (
         (
-            os.getenv("TRIP_PLANNER_PLANNER_PROVIDER")
-            or os.getenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER")
+            env.get("TRIP_PLANNER_PLANNER_PROVIDER")
+            or env.get("TRIP_PLANNER_PLANNER_MODEL_PROVIDER")
             or ""
         )
         .strip()
         .lower()
     )
-    model = os.getenv("TRIP_PLANNER_PLANNER_MODEL", "").strip()
-    openai_api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    model = env.get("TRIP_PLANNER_PLANNER_MODEL", "").strip()
+    openai_api_key = env.get("OPENAI_API_KEY", "").strip()
+    data_zone = (env.get("TRIP_PLANNER_DATA_ZONE") or SYNTHETIC_DATA_ZONE).strip().lower()
+    if data_zone not in {PROPRIETARY_DATA_ZONE, SYNTHETIC_DATA_ZONE}:
+        data_zone = SYNTHETIC_DATA_ZONE
+    authorized_openai_endpoint = env.get(AUTHORIZED_OPENAI_ENDPOINT_ENV, "").strip()
     fake_enabled = provider == "fake"
-    openai_enabled = provider == "openai" and bool(model) and bool(openai_api_key)
+    openai_requested = provider == "openai" and bool(model) and bool(openai_api_key)
+    openai_blocked_by_zone = (
+        data_zone == PROPRIETARY_DATA_ZONE
+        and openai_requested
+        and not authorized_openai_endpoint
+    )
+    openai_enabled = openai_requested and not openai_blocked_by_zone
 
     if fake_enabled or openai_enabled:
         provider_label = provider or "configured"
@@ -56,6 +79,8 @@ def get_planner_runtime_config() -> PlannerRuntimeConfig:
             status="ready",
             title="Model-backed planner",
             summary="Planner turns use a configured LangChain chat model over explicit app tools.",
+            data_zone=data_zone,
+            llm_status="authorized" if provider == "openai" else "test-model",
         )
 
     fallback_reason = "planner_model_not_configured"
@@ -65,6 +90,8 @@ def get_planner_runtime_config() -> PlannerRuntimeConfig:
         fallback_reason = "planner_model_name_missing"
     elif provider == "openai" and model and not openai_api_key:
         fallback_reason = "openai_api_key_missing"
+    elif openai_blocked_by_zone:
+        fallback_reason = "proprietary_zone_llm_blocked"
 
     return PlannerRuntimeConfig(
         mode="fallback",
@@ -74,4 +101,6 @@ def get_planner_runtime_config() -> PlannerRuntimeConfig:
         title="Deterministic fallback planner",
         summary="No planner model credentials are configured, so turns use the local deterministic fallback.",
         fallback_reason=fallback_reason,
+        data_zone=data_zone,
+        llm_status="blocked" if openai_blocked_by_zone else "deterministic",
     )

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,12 @@
+## 2026-05-31T09:25Z - closer fixed PR #1272 test-fixture env isolation
+
+- Automation: `imi-merge-verify-closer` (codex closer lane), neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1263`; PR `#1272`; branch `codex/issue-1263-data-zone-redaction`.
+- Batch context: closed Trend_Model_Project issue `#5351` after merged PR `#5362` received durable provider-comparison PASS/PASS. trip-planner `#1271` stayed async because Netlify header/redirect checks were still pending/unstable; `#1272` was selected as the complex lane because checks were green/clean but one Copilot review thread remained unresolved.
+- Review fix: the shared `tests/app/test_planner_routes.py` client fixture now clears both planner provider env names: `TRIP_PLANNER_PLANNER_MODEL_PROVIDER` and the alias `TRIP_PLANNER_PLANNER_PROVIDER`. This prevents ambient shell/CI state from making fallback-mode planner tests order-dependent.
+- Validation: `python -m pytest tests/app/test_planner_routes.py::test_planner_session_endpoint_bootstraps_trip_scoped_session tests/app/test_planner_routes.py::test_proprietary_zone_blocks_openai_without_authorized_endpoint tests/app/test_planner_routes.py::test_openai_planner_payload_uses_redaction_hook -q` -> 3 passed; `git diff --check` -> clean.
+- Next action after push: re-check PR #1272 review threads and checks. If the Copilot thread is resolved and checks remain green, merge #1272, apply `verify:compare`, then keep issue #1263 open until durable verifier PASS.
+
 ## 2026-05-31T09:10Z - opener lane issue #1263 final scoped diff
 
 - Repo: `stranske/trip-planner`; issue `#1263`; PR `#1272`; branch `codex/issue-1263-data-zone-redaction`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,11 @@
+## 2026-05-31T09:10Z - opener lane issue #1263 final scoped diff
+
+- Repo: `stranske/trip-planner`; issue `#1263`; PR `#1272`; branch `codex/issue-1263-data-zone-redaction`.
+- Final pushed head: `2470578ea`. Follow-up commit removed the unrelated frontend fetch/AbortSignal fallback from the net PR diff; the final PR changes are limited to planner runtime config, planner redaction hook, full-product readiness reporting, docs, tests, and this state file.
+- PR body updated to remove the stale frontend-runtime bullet and list the actual validation commands.
+- Post-open cap-health at 09:08Z: `total_opener_owned=4`, `raw_cap_reached=false`, #1272 classified `draining` with active Gate evidence. Existing non-drainables remain the known scoped PAEM #1847 routing/owner blocker and Trend #5353 product/CI blocker.
+- Next action: keepalive owns #1272 CI/review; closer can drain #1271 when ready.
+
 ## 2026-05-31T09:06Z - opener lane issue #1263 PR opened
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace. Outcome: `new_issue`.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,22 @@
+## 2026-05-31T09:06Z - opener lane issue #1263 PR opened
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace. Outcome: `new_issue`.
+- Source repo: `stranske/trip-planner`; source issue `#1263` (`Gate the live TPP and OpenAI-planner seams behind an explicit data-zone switch with redaction, defaulting to the deterministic perimeter`).
+- Branch: `codex/issue-1263-data-zone-redaction`; commit `0965cfcc7`; PR `#1272` (https://github.com/stranske/trip-planner/pull/1272), ready-for-review, non-draft.
+- Selection notes: raw opener cap was below limit (`total_opener_owned=3` before opening, `4` after). Existing opener-owned PRs were swept first: PAEM `#1847` remains scoped/non-registry routing/owner blocked; Trend `#5353` remains scoped product/CI blocked; trip-planner `#1271` was repaired this round and classified `draining` with fresh Gate evidence. Approved-queue high trip-planner items were stale/already closed (#1267/#1240, #1242/#1243, #1245, #1247/#1248). Remote high issues were scoped/linked/merged; #1263 was the oldest unlinked eligible normal-priority implementation issue.
+- Implementation:
+  - Added `TRIP_PLANNER_DATA_ZONE` and `TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT` handling to planner runtime config. In `proprietary`, OpenAI planner mode falls back with `proprietary_zone_llm_blocked` unless the authorized endpoint marker is set.
+  - Added an outbound planner prompt redaction seam before OpenAI model invocation and exposed data-zone/LLM status in planner runtime payloads.
+  - Added `planner-llm` readiness reporting in `scripts/check_full_product_verification.py`.
+  - Documented the proprietary-zone OpenAI and live TPP perimeter rules in `README.md` and `docs/live-tpp-execution-reoptimization-epic.md`.
+  - Fixed the frontend health retry timeout path to tolerate the local runtime-smoke fetch/AbortSignal environment.
+- Validation:
+  - `python -m pytest tests/app/test_planner_routes.py::test_proprietary_zone_blocks_openai_without_authorized_endpoint tests/app/test_planner_routes.py::test_openai_planner_payload_uses_redaction_hook tests/app/test_full_product_verification.py::test_planner_llm_check_blocks_openai_in_proprietary_zone_without_marker tests/app/test_full_product_verification.py::test_planner_llm_check_reports_authorized_openai_ready` -> 4 passed.
+  - `make runtime-check` -> passed after `npm --prefix frontend ci` installed missing frontend dependencies in this automation clone.
+  - `git diff --check` -> passed.
+- Post-open repair: initial #1272 Gate/Autofix runs were cancelled and cap-health classified `needs-dispatch-evidence`; `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups. Fresh cap-health at 09:06Z classifies #1272 as `draining` with active Gate evidence; raw cap remains below limit (`total_opener_owned=4`, `raw_cap_reached=false`).
+- Next action: keepalive owns #1272 CI/review; opener should move to the next eligible issue on a future round after cap/drain discovery.
+
 ## 2026-05-31T08:01Z - opener lane issue #1261 materializing
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.


### PR DESCRIPTION
Implements #1263

## Summary
- add TRIP_PLANNER_DATA_ZONE and TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT handling so proprietary-zone OpenAI planner use falls back unless explicitly authorized
- add an outbound planner prompt redaction seam before OpenAI model invocation
- surface planner LLM/data-zone readiness in full-product verification while keeping the local journey deterministic
- document the live TPP/OpenAI perimeter rules

## Validation
- python -m pytest tests/app/test_planner_routes.py::test_proprietary_zone_blocks_openai_without_authorized_endpoint tests/app/test_planner_routes.py::test_openai_planner_payload_uses_redaction_hook -q
- python -m pytest tests/app/test_full_product_verification.py::test_planner_llm_check_blocks_openai_in_proprietary_zone_without_marker tests/app/test_full_product_verification.py::test_planner_llm_check_reports_authorized_openai_ready -q
- python -m pytest tests/app/test_planner_routes.py::test_planner_session_endpoint_bootstraps_trip_scoped_session tests/app/test_planner_routes.py::test_planner_session_treats_blank_model_key_as_unconfigured tests/app/test_planner_routes.py::test_planner_session_reports_model_runtime_when_configured tests/app/test_planner_routes.py::test_proprietary_zone_blocks_openai_without_authorized_endpoint tests/app/test_planner_routes.py::test_openai_planner_payload_uses_redaction_hook tests/app/test_planner_routes.py::test_planner_turn_tool_reads_are_grounded_in_persisted_workspace_state -q
- python -m pytest tests/app/test_full_product_verification.py::test_full_product_local_journeys_cover_runtime_identifiers tests/app/test_full_product_verification.py::test_planner_llm_check_blocks_openai_in_proprietary_zone_without_marker tests/app/test_full_product_verification.py::test_planner_llm_check_reports_authorized_openai_ready -q
- TRIP_PLANNER_DATA_ZONE=proprietary TRIP_PLANNER_PLANNER_MODEL_PROVIDER=openai TRIP_PLANNER_PLANNER_MODEL=gpt-test OPENAI_API_KEY=fake-key python scripts/check_full_product_verification.py --live-tpp off
- python -m ruff check trip_planner/app/services/planner_runtime_config.py trip_planner/app/services/planner.py scripts/check_full_product_verification.py tests/app/test_planner_routes.py tests/app/test_full_product_verification.py
- git diff --check