### PR TITLE
Add app behavior baseline kit (transport-option deterministic baselines)

### DIFF
--- a/.github/workflows/baseline-report.yml
+++ b/.github/workflows/baseline-report.yml
@@ -1,0 +1,56 @@
+# Keeps docs/reports/baseline-coverage.md fresh for the weekly repo-review
+# evaluator (which reads committed reports under docs/reports/). Runs the
+# baseline suite (regenerating the report) and commits it if it changed.
+#
+# Scheduled weekly, ahead of the evaluator; also runnable on demand. Does NOT
+# gate PRs.
+#
+# baseline_kit lives in the (private) stranske/Workflows repo under
+# packages/app-baseline-kit; installing it pulls pytest-regressions transitively.
+# Uses AGENTS_AUTOMATION_PAT for the install and a bot PAT to push the report.
+name: baseline-report
+
+on:
+  schedule:
+    - cron: "10 6 * * 1" # Mondays 06:10 UTC, before the weekly review
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: baseline-report-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ACTIONS_BOT_PAT || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install "app-baseline-kit @ git+https://x-access-token:${{ secrets.AGENTS_AUTOMATION_PAT }}@github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit"
+
+      - name: Run baseline suite (regenerates the coverage report)
+        run: pytest tests/baseline/ -q
+
+      - name: Commit refreshed report if changed
+        run: |
+          if ! git diff --quiet -- docs/reports/baseline-coverage.md; then
+            git config user.name "stranske-bot"
+            git config user.email "bot@stranskemo.com"
+            git add docs/reports/baseline-coverage.md
+            git commit -m "chore(baseline): refresh coverage report [skip ci]"
+            git push
+          else
+            echo "Coverage report already current."
+          fi

--- a/.project_modules.txt
+++ b/.project_modules.txt
@@ -1,0 +1,5 @@
+# Modules imported by tests that the dep-sync check should treat as known.
+# baseline_kit is provided by the declared `app-baseline-kit` dependency;
+# conftest is the local test-fixtures module imported via `from .conftest import`.
+baseline_kit
+conftest

--- a/docs/reports/baseline-coverage.md
+++ b/docs/reports/baseline-coverage.md
@@ -1,0 +1,11 @@
+# Trip-planner baseline coverage manifest
+
+- Input parameters: **14**
+- Exercised by a scenario: **3** (21.4%)
+- Observed read at runtime: **0**
+
+## Priority parameters
+
+- [x] `cost_total`
+- [x] `transfer_count`
+- [x] `overall_signal`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ dev = [
     "PyYAML==6.0.3",
     "types-PyYAML==6.0.12.20260510",
     "pytest-httpserver==1.1.5",
+    # Required by pytest-regressions' num_regression fixture (used by the baseline
+    # golden tests). It is an *optional* dep of pytest-regressions, so a non-numeric
+    # app like trip-planner must declare it explicitly or the fixture errors with
+    # "Numpy library is an optional dependency and must be installed explicitly".
+    "numpy==2.4.6",
     # Shared app behavior baseline harness (pulls pytest-regressions). Pinned to
     # the Workflows default branch; move to a tagged ref once the package is versioned.
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
@@ -88,5 +93,9 @@ module = [
     "langchain_openai",
     "langchain_core.*",
     "tomlkit",
+    # Shared baseline kit ships without a py.typed marker yet; ignore until the
+    # package is published with type information.
+    "baseline_kit",
+    "baseline_kit.*",
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dev = [
     "PyYAML==6.0.3",
     "types-PyYAML==6.0.12.20260510",
     "pytest-httpserver==1.1.5",
+    # Shared app behavior baseline harness (pulls pytest-regressions). Pinned to
+    # the Workflows default branch; move to a tagged ref once the package is versioned.
+    "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",
 ]
 [build-system]
 requires = ["setuptools>=82.0.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     # app like trip-planner must declare it explicitly or the fixture errors with
     # "Numpy library is an optional dependency and must be installed explicitly".
     "numpy==2.4.6",
+    "pandas==3.0.3",
     # Shared app behavior baseline harness (pulls pytest-regressions). Pinned to
     # the Workflows default branch; move to a tagged ref once the package is versioned.
     "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit",

--- a/requirements.lock
+++ b/requirements.lock
@@ -102,6 +102,10 @@ packaging==26.2
     #   langchain-core
     #   langsmith
     #   pytest
+pandas==3.0.3
+    # via
+    #   trip-planner (pyproject.toml)
+    #   pytest-regressions
 pathspec==1.1.1
     # via
     #   black

--- a/requirements.lock
+++ b/requirements.lock
@@ -88,6 +88,10 @@ mypy-extensions==1.1.0
     # via
     #   black
     #   mypy
+numpy==2.4.6
+    # via
+    #   trip-planner (pyproject.toml)
+    #   pytest-regressions
 openai==2.33.0
     # via langchain-openai
 orjson==3.11.8 ; platform_python_implementation != 'PyPy'

--- a/tests/baseline/README.md
+++ b/tests/baseline/README.md
@@ -5,8 +5,12 @@ Scenario-driven wiring/sensibility/regression tests built on the shared
 
 ## Requires
 
-`baseline_kit` must be importable (pilot: `pip install -e ../app-baseline-kit`
-into the same environment). It is not yet published.
+`baseline_kit` (the shared core) must be importable. It lives in
+`stranske/Workflows` under `packages/app-baseline-kit`:
+
+```bash
+pip install "app-baseline-kit @ git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit"
+```
 
 ## Target surface
 

--- a/tests/baseline/README.md
+++ b/tests/baseline/README.md
@@ -1,0 +1,48 @@
+# Trip-planner app behavior baseline kit
+
+Scenario-driven wiring/sensibility/regression tests built on the shared
+**`baseline_kit`** package. Only the app-specific pieces live here.
+
+## Requires
+
+`baseline_kit` must be importable (pilot: `pip install -e ../app-baseline-kit`
+into the same environment). It is not yet published.
+
+## Target surface
+
+The **deterministic compute** — transport-option evaluation
+(`trip_planner.options.TransportOption`), which takes a fixture and produces
+scoreable scalars with no DB/network/LLM. (Preference resolution and planner
+routing are the natural next surfaces.)
+
+## Layout
+
+```
+adapter.py                # fixture -> flat metrics dict  (the only app-specific glue)
+catalog.yaml              # fixtures + cross-option orderings + priority metrics
+invariants.py             # economic/structural bounds -> baseline_kit.InvariantResult
+test_golden.py            # golden master each fixture's metrics
+test_directional.py       # cross-option orderings (cheaper, fewer transfers, better fit)
+test_invariants.py        # invariants per fixture
+test_coverage_manifest.py # metric-dimension coverage -> docs/reports/baseline-coverage.md
+```
+
+## Running
+
+```bash
+pytest tests/baseline/                       # full suite
+pytest tests/baseline/test_golden.py --force-regen   # re-bless after intended change
+```
+
+## Calibration notes (first run)
+
+Three invariants were initially too strict for this domain and were fixed (not
+trip-planner bugs): optional cost fields (`base_fare`, `taxes_and_fees`) can be
+absent (`NaN` = allowed), and structural integrity is **idempotent**
+serialization, not byte-equality with the raw fixture.
+
+## Next surfaces
+
+- Preference resolution (`resolve_dimension_evidence`) — directional confidence/
+  salience checks.
+- Planner routing (`route_planner_turn`) — message → task/effort classification.

--- a/tests/baseline/__init__.py
+++ b/tests/baseline/__init__.py
@@ -1,0 +1,7 @@
+"""Trip-planner app behavior baseline kit.
+
+Built on the shared ``baseline_kit`` package -- this directory contains only the
+app-specific pieces (adapter, catalog, invariant bounds). The generic harness
+(directional engine, invariant assertion, golden glue, coverage manifest) is
+imported from ``baseline_kit``, the same core the TMP pilot uses.
+"""

--- a/tests/baseline/adapter.py
+++ b/tests/baseline/adapter.py
@@ -1,0 +1,91 @@
+"""App-specific adapter for trip-planner.
+
+This is the ONLY app-specific piece the shared ``baseline_kit`` needs: a way to
+turn an input (here, a transport-option fixture) into a flat dict of named
+scalar metrics. Everything else -- directional checks, invariants, golden
+masters, the coverage manifest -- is generic and lives in ``baseline_kit``.
+
+The deterministic compute surface is ``TransportOption.from_dict`` (no DB, no
+network, no LLM), so baselines here are stable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "options" / "transport"
+
+# The metric dimensions this adapter exposes (the kit's "input parameter" space
+# for coverage purposes).
+METRIC_KEYS = [
+    "cost_total",
+    "cost_base_fare",
+    "cost_taxes_and_fees",
+    "transfer_count",
+    "minimum_connection_minutes",
+    "overall_signal",
+    "schedule_fit_signal",
+    "friction_fit_signal",
+    "experiential_fit_signal",
+    "policy_fit_signal",
+    "self_navigation_burden_signal",
+    "baggage_complexity_signal",
+    "schedule_protection_signal",
+    "connection_risk_signal",
+]
+
+_SIGNAL_KEYS = [k for k in METRIC_KEYS if k.endswith("_signal")]
+
+
+def load_option(fixture_name: str):
+    from trip_planner.options import TransportOption
+
+    payload = json.loads((FIXTURES_DIR / fixture_name).read_text(encoding="utf-8"))
+    return TransportOption.from_dict(payload)
+
+
+def _amount(money) -> float:
+    return float(getattr(money, "typical_amount", float("nan"))) if money is not None else float("nan")
+
+
+def metrics_for(fixture_name: str) -> dict[str, float]:
+    """Reduce one transport option to a flat metrics dict."""
+    o = load_option(fixture_name)
+    c, f, t = o.cost_summary, o.fit_summary, o.transfer_burden
+    return {
+        "cost_total": _amount(c.total),
+        "cost_base_fare": _amount(c.base_fare),
+        "cost_taxes_and_fees": _amount(c.taxes_and_fees),
+        "transfer_count": float(t.transfer_count),
+        "minimum_connection_minutes": float(t.minimum_connection_minutes or 0.0),
+        "overall_signal": float(f.overall_signal),
+        "schedule_fit_signal": float(f.schedule_fit_signal),
+        "friction_fit_signal": float(f.friction_fit_signal),
+        "experiential_fit_signal": float(f.experiential_fit_signal),
+        "policy_fit_signal": float(f.policy_fit_signal),
+        "self_navigation_burden_signal": float(t.self_navigation_burden_signal),
+        "baggage_complexity_signal": float(t.baggage_complexity_signal),
+        "schedule_protection_signal": float(t.schedule_protection_signal),
+        "connection_risk_signal": float(t.connection_risk_signal),
+    }
+
+
+def signal_keys() -> list[str]:
+    return list(_SIGNAL_KEYS)
+
+
+def roundtrip_is_stable(fixture_name: str) -> bool:
+    """Structural integrity: from_dict/to_dict is idempotent.
+
+    The first parse may normalize (fill defaults, canonicalize legacy keys), so
+    we don't require equality with the raw fixture. We require that re-parsing
+    the serialized form yields the *same* serialization -- i.e. the model has a
+    stable canonical representation.
+    """
+    from trip_planner.options import TransportOption
+
+    once = load_option(fixture_name).to_dict()
+    twice = TransportOption.from_dict(once).to_dict()
+    return once == twice

--- a/tests/baseline/catalog.yaml
+++ b/tests/baseline/catalog.yaml
@@ -1,0 +1,47 @@
+# Trip-planner scenario catalog -- transport-option deterministic compute.
+#
+# Same shape as the TMP catalog, but the "directional" checks here are
+# cross-entity ORDERINGS (one option vs another) rather than control-vs-variant.
+# The shared baseline_kit engine treats both identically (compare two numbers).
+
+fixtures:
+  - coastal_flight.json
+  - scenic_rail.json
+  - island_ferry.json
+  - regional_rental_car.json
+  - downtown_local_ground.json
+
+# Directional orderings -- each compares `left` vs `right` on a metric.
+# Confirmed against existing tests/options/test_transport.py assertions.
+orderings:
+  - id: car_cheaper_than_flight
+    left: regional_rental_car.json
+    right: coastal_flight.json
+    metric: cost_total
+    direction: less_than
+    enforce: true
+  - id: flight_fewer_transfers_than_rail
+    left: coastal_flight.json
+    right: scenic_rail.json
+    metric: transfer_count
+    direction: less_than
+    enforce: true
+  - id: rail_better_fit_than_flight
+    left: scenic_rail.json
+    right: coastal_flight.json
+    metric: overall_signal
+    direction: greater_than
+    enforce: true
+  - id: ferry_cheaper_than_rail
+    left: island_ferry.json
+    right: scenic_rail.json
+    metric: cost_total
+    direction: less_than
+    enforce: true
+
+# The must-cover metric dimensions (coverage manifest asserts these appear in
+# at least one ordering).
+priority_metrics:
+  - cost_total
+  - transfer_count
+  - overall_signal

--- a/tests/baseline/conftest.py
+++ b/tests/baseline/conftest.py
@@ -1,0 +1,29 @@
+"""Fixtures and catalog loading for the trip-planner baseline kit."""
+
+from __future__ import annotations
+
+import functools
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+CATALOG_PATH = HERE / "catalog.yaml"
+
+# Ensure the repo root is importable (so `trip_planner` resolves under pytest).
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@functools.lru_cache(maxsize=1)
+def load_catalog_cached():
+    from baseline_kit import load_catalog
+
+    return load_catalog(CATALOG_PATH)
+
+
+@pytest.fixture(scope="session")
+def catalog():
+    return load_catalog_cached()

--- a/tests/baseline/invariants.py
+++ b/tests/baseline/invariants.py
@@ -1,0 +1,61 @@
+"""Trip-planner economic/structural invariants (always true for any option).
+
+Bounds are app-specific; the result type and assertion helper are shared
+(``baseline_kit.InvariantResult`` / ``assert_invariants``).
+"""
+
+from __future__ import annotations
+
+import math
+
+from baseline_kit import InvariantResult
+
+from . import adapter
+
+
+def check_option(fixture_name: str) -> list[InvariantResult]:
+    m = adapter.metrics_for(fixture_name)
+    results: list[InvariantResult] = []
+
+    def add(name, ok, detail, severity="error"):
+        results.append(InvariantResult(name, bool(ok), severity, detail))
+
+    # Costs non-negative where present. NaN means "field absent" (e.g. a rental
+    # with no separate taxes line) and is allowed -- only finite values are bounded.
+    for key in ("cost_total", "cost_base_fare", "cost_taxes_and_fees"):
+        add(f"{key}_non_negative", math.isnan(m[key]) or m[key] >= 0, f"{key}={m[key]}")
+
+    # total >= base fare (total includes taxes/fees on top of base), when both present.
+    both_present = math.isfinite(m["cost_total"]) and math.isfinite(m["cost_base_fare"])
+    add(
+        "total_ge_base_fare",
+        (not both_present) or m["cost_total"] >= m["cost_base_fare"] - 1e-9,
+        f"total={m['cost_total']} base={m['cost_base_fare']}",
+    )
+
+    # Transfer count is a non-negative integer.
+    add(
+        "transfer_count_non_negative_int",
+        m["transfer_count"] >= 0 and float(m["transfer_count"]).is_integer(),
+        f"transfer_count={m['transfer_count']}",
+    )
+
+    # All fit/burden signals are probabilities in [0, 1].
+    for key in adapter.signal_keys():
+        add(f"{key}_in_unit_interval", 0.0 <= m[key] <= 1.0, f"{key}={m[key]}")
+
+    # Connection minutes non-negative.
+    add(
+        "min_connection_minutes_non_negative",
+        m["minimum_connection_minutes"] >= 0,
+        f"min_connection_minutes={m['minimum_connection_minutes']}",
+    )
+
+    # Structural integrity: serialization is idempotent (stable canonical form).
+    add(
+        "roundtrip_stable",
+        adapter.roundtrip_is_stable(fixture_name),
+        "from_dict/to_dict is not idempotent",
+    )
+
+    return results

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -1,0 +1,48 @@
+"""Coverage manifest -- which metric dimensions are exercised; emit report.
+
+Uses the generic ``baseline_kit.CoverageManifest``. The app supplies the input
+space (the transport metric dimensions) and the touched set (metrics referenced
+by an ordering).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from baseline_kit import CoverageManifest, load_catalog
+
+from . import adapter
+from .conftest import CATALOG_PATH, REPO_ROOT
+
+REPORT_PATH = REPO_ROOT / "docs" / "reports" / "baseline-coverage.md"
+
+
+def _build_manifest() -> CoverageManifest:
+    catalog = load_catalog(CATALOG_PATH)
+    touched = {o["metric"] for o in catalog.get("orderings", [])}
+    return CoverageManifest(
+        all_keys=set(adapter.METRIC_KEYS),
+        touched_keys=touched,
+        priority_params=list(catalog.get("priority_metrics", [])),
+        title="Trip-planner baseline coverage manifest",
+    )
+
+
+def test_ordering_metrics_exist():
+    m = _build_manifest()
+    assert not m.unknown_catalog_keys, (
+        "Catalog references metrics not produced by the adapter: "
+        f"{sorted(m.unknown_catalog_keys)}"
+    )
+
+
+def test_priority_metrics_covered():
+    m = _build_manifest()
+    assert not m.priority_gaps, "Priority metrics with no ordering: " + ", ".join(m.priority_gaps)
+
+
+def test_emit_coverage_report():
+    m = _build_manifest()
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(m.to_markdown())
+    assert REPORT_PATH.exists()

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -7,7 +7,6 @@ by an ordering).
 
 from __future__ import annotations
 
-from pathlib import Path
 
 from baseline_kit import CoverageManifest, load_catalog
 

--- a/tests/baseline/test_coverage_manifest.py
+++ b/tests/baseline/test_coverage_manifest.py
@@ -7,7 +7,6 @@ by an ordering).
 
 from __future__ import annotations
 
-
 from baseline_kit import CoverageManifest, load_catalog
 
 from . import adapter

--- a/tests/baseline/test_directional.py
+++ b/tests/baseline/test_directional.py
@@ -1,0 +1,25 @@
+"""Tier 1 directional checks: cross-option orderings (cheaper, fewer transfers...)."""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import evaluate_direction, load_catalog
+
+from . import adapter
+from .conftest import CATALOG_PATH
+
+_ORDERINGS = load_catalog(CATALOG_PATH)["orderings"]
+
+
+@pytest.mark.parametrize("scen", _ORDERINGS, ids=[s["id"] for s in _ORDERINGS])
+def test_ordering(scen, record_property):
+    metric = scen["metric"]
+    left = adapter.metrics_for(scen["left"])[metric]
+    right = adapter.metrics_for(scen["right"])[metric]
+    holds = evaluate_direction(scen["direction"], left, right)
+    msg = f"{scen['id']}: {metric} left={left:.4g} {scen['direction']} right={right:.4g} -> {holds}"
+    record_property("ordering", msg)
+    if scen.get("enforce"):
+        assert holds, "Economically wrong ordering -- " + msg
+    elif not holds:
+        pytest.skip("[report-only] " + msg)

--- a/tests/baseline/test_golden.py
+++ b/tests/baseline/test_golden.py
@@ -1,0 +1,21 @@
+"""Tier 0/1 golden masters of each transport fixture's derived metrics.
+
+Re-bless after an intended change:
+    pytest tests/baseline/test_golden.py --force-regen
+then review and commit the updated baseline files.
+"""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import check_metrics, load_catalog
+
+from . import adapter
+from .conftest import CATALOG_PATH
+
+_FIXTURES = load_catalog(CATALOG_PATH)["fixtures"]
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES, ids=[f.replace(".json", "") for f in _FIXTURES])
+def test_transport_metrics_golden(fixture, num_regression):
+    check_metrics(num_regression, adapter.metrics_for(fixture))

--- a/tests/baseline/test_golden/test_transport_metrics_golden_coastal_flight_.csv
+++ b/tests/baseline/test_golden/test_transport_metrics_golden_coastal_flight_.csv
@@ -1,0 +1,2 @@
+,cost_total,cost_base_fare,cost_taxes_and_fees,transfer_count,minimum_connection_minutes,overall_signal,schedule_fit_signal,friction_fit_signal,experiential_fit_signal,policy_fit_signal,self_navigation_burden_signal,baggage_complexity_signal,schedule_protection_signal,connection_risk_signal
+0,248,214,34,0,0,0.72999999999999998,0.88,0.90000000000000002,0.44,0.93999999999999995,0.22,0.28000000000000003,0.79000000000000004,0.14000000000000001

--- a/tests/baseline/test_golden/test_transport_metrics_golden_downtown_local_ground_.csv
+++ b/tests/baseline/test_golden/test_transport_metrics_golden_downtown_local_ground_.csv
@@ -1,0 +1,2 @@
+,cost_total,cost_base_fare,cost_taxes_and_fees,transfer_count,minimum_connection_minutes,overall_signal,schedule_fit_signal,friction_fit_signal,experiential_fit_signal,policy_fit_signal,self_navigation_burden_signal,baggage_complexity_signal,schedule_protection_signal,connection_risk_signal
+0,4.5,,,1,5,0.82999999999999996,0.85999999999999999,0.73999999999999999,0.32000000000000001,0.94999999999999996,0.41999999999999998,0.10000000000000001,0.76000000000000001,0.20000000000000001

--- a/tests/baseline/test_golden/test_transport_metrics_golden_island_ferry_.csv
+++ b/tests/baseline/test_golden/test_transport_metrics_golden_island_ferry_.csv
@@ -1,0 +1,2 @@
+,cost_total,cost_base_fare,cost_taxes_and_fees,transfer_count,minimum_connection_minutes,overall_signal,schedule_fit_signal,friction_fit_signal,experiential_fit_signal,policy_fit_signal,self_navigation_burden_signal,baggage_complexity_signal,schedule_protection_signal,connection_risk_signal
+0,46,,,0,0,0.78000000000000003,0.73999999999999999,0.69999999999999996,0.92000000000000004,0.57999999999999996,0.38,0.40999999999999998,0.67000000000000004,0.20999999999999999

--- a/tests/baseline/test_golden/test_transport_metrics_golden_regional_rental_car_.csv
+++ b/tests/baseline/test_golden/test_transport_metrics_golden_regional_rental_car_.csv
@@ -1,0 +1,2 @@
+,cost_total,cost_base_fare,cost_taxes_and_fees,transfer_count,minimum_connection_minutes,overall_signal,schedule_fit_signal,friction_fit_signal,experiential_fit_signal,policy_fit_signal,self_navigation_burden_signal,baggage_complexity_signal,schedule_protection_signal,connection_risk_signal
+0,118,86,,0,0,0.68999999999999995,0.71999999999999997,0.40999999999999998,0.83999999999999997,0.64000000000000001,0.73999999999999999,0.17999999999999999,0.52000000000000002,0.12

--- a/tests/baseline/test_golden/test_transport_metrics_golden_scenic_rail_.csv
+++ b/tests/baseline/test_golden/test_transport_metrics_golden_scenic_rail_.csv
@@ -1,0 +1,2 @@
+,cost_total,cost_base_fare,cost_taxes_and_fees,transfer_count,minimum_connection_minutes,overall_signal,schedule_fit_signal,friction_fit_signal,experiential_fit_signal,policy_fit_signal,self_navigation_burden_signal,baggage_complexity_signal,schedule_protection_signal,connection_risk_signal
+0,138,122,16,1,16,0.91000000000000003,0.79000000000000004,0.70999999999999996,0.97999999999999998,0.85999999999999999,0.33000000000000002,0.26000000000000001,0.76000000000000001,0.32000000000000001

--- a/tests/baseline/test_invariants.py
+++ b/tests/baseline/test_invariants.py
@@ -1,0 +1,16 @@
+"""Tier 3 invariants on every transport fixture."""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import assert_invariants, load_catalog
+
+from . import invariants
+from .conftest import CATALOG_PATH
+
+_FIXTURES = load_catalog(CATALOG_PATH)["fixtures"]
+
+
+@pytest.mark.parametrize("fixture", _FIXTURES, ids=[f.replace(".json", "") for f in _FIXTURES])
+def test_option_invariants(fixture):
+    assert_invariants(invariants.check_option(fixture), context=fixture)

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -19,6 +19,16 @@ def _split_spec(raw: str) -> str:
     return entry.strip().split("[")[0]
 
 
+def _is_direct_reference(entry: str) -> bool:
+    """True for PEP 508 direct references (e.g. ``pkg @ git+https://...``).
+
+    Such dependencies are pinned by URL (and optionally a commit), not by a
+    ``==`` version in requirements.lock, so they are exempt from the lock
+    version-presence check below.
+    """
+    return " @ " in entry
+
+
 def _load_lock_versions(path: Path) -> Dict[str, str]:
     versions: Dict[str, str] = {}
     for line in path.read_text(encoding="utf-8").splitlines():
@@ -40,10 +50,14 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
 
     declared = set()
     for entry in project.get("dependencies", []):
+        if _is_direct_reference(entry):
+            continue
         declared.add(_split_spec(entry).lower())
 
     for group in project.get("optional-dependencies", {}).values():
         for entry in group:
+            if _is_direct_reference(entry):
+                continue
             declared.add(_split_spec(entry).lower())
 
     lock_versions = _load_lock_versions(Path("requirements.lock"))


### PR DESCRIPTION
Supersedes #1273 (closed; its head was stuck on a stale commit). This branch is rebased clean on `main` with only the baseline-kit commits.

## Why
Adds the shared app behavior baseline kit over the deterministic transport-option compute (`TransportOption.from_dict`), built on `baseline_kit` (proven on TMP, PAEM).

## Tasks
- [x] tests/baseline kit on baseline_kit
- [x] Declare app-baseline-kit dev dependency + .project_modules.txt (dep-sync)

## Acceptance Criteria
- [ ] Gate green; `pytest tests/baseline/` passes with baseline_kit installed
- [ ] docs/reports/baseline-coverage.md present

🤖 Generated with [Claude Code](https://claude.com/claude-code)