### PR TITLE
Issue #1268 follow-up: add preference-resolution and planner-routing baseline scenarios

### DIFF
--- a/tests/baseline/test_planner_routing_baseline.py
+++ b/tests/baseline/test_planner_routing_baseline.py
@@ -1,0 +1,157 @@
+"""Baseline scenarios for planner routing (``route_planner_turn``).
+
+Issue #1268 acceptance criteria require at least one planner-routing baseline
+scenario with directional and/or invariant checks. ``route_planner_turn`` is a
+deterministic pure function over the message text and planning mode (no DB,
+network, or LLM), so its task-class -> effort-class routing is a stable baseline
+surface.
+
+The routing decision lives in a small discrete space (three effort classes),
+so it is expressed as cross-scenario *orderings* and structural *invariants*
+using the shared ``baseline_kit`` primitives rather than frozen golden scalars.
+"""
+
+from __future__ import annotations
+
+import pytest
+from baseline_kit import InvariantResult, assert_invariants, evaluate_direction
+
+from trip_planner.app.services.planner_routing import (
+    EFFORT_CLASSES,
+    EFFORT_DEEP,
+    EFFORT_FAST,
+    TASK_CLASSES,
+    TASK_FIRST_TURN_TRIAGE,
+    route_planner_turn,
+)
+
+# Effort classes form an ordinal scale: fast < standard < deep.
+_EFFORT_RANK = {cls: rank for rank, cls in enumerate(("fast", "standard", "deep"))}
+
+
+def _route(
+    message: str, *, mode: str = "collaborative", base: str = TASK_FIRST_TURN_TRIAGE
+):
+    return route_planner_turn(
+        message=message,
+        base_task_class=base,
+        planning_mode=mode,
+        provider_state="model",
+        fallback_reason=None,
+    )
+
+
+# Each message deterministically lands on a single task class (verified against
+# ``classify_task_class`` lexical markers).
+_SCENARIOS: dict[str, str] = {
+    "quick_ack": "thanks",
+    "note_capture": "remember this: passport renewal is due in March",
+    "focus_switch": "let's switch to lodging",
+    "final_summary": "let's wrap the trip up",
+    "major_revision": "let's start over",
+    "policy_prep": "prepare the policy packet",
+    "research_pass": "research flights for the route",
+    # deep-request marker on a first-turn-triage base -> planning_synthesis
+    "planning_synthesis": "let's think this through carefully",
+    "clarifying": "could you clarify what you mean",
+}
+
+# Directional orderings on effort rank (planning mode held at collaborative).
+# A planning/synthesis/summary turn must receive at least as much effort as a
+# quick acknowledgement / note / focus-switch turn.
+_ORDERINGS = [
+    ("final_summary_deeper_than_ack", "final_summary", "quick_ack", "greater_than"),
+    ("research_deeper_than_note", "research_pass", "note_capture", "greater_than"),
+    (
+        "major_revision_deeper_than_clarify",
+        "major_revision",
+        "clarifying",
+        "greater_than",
+    ),
+    (
+        "synthesis_deeper_than_focus_switch",
+        "planning_synthesis",
+        "focus_switch",
+        "greater_than",
+    ),
+]
+
+
+@pytest.mark.parametrize("scen", _ORDERINGS, ids=[s[0] for s in _ORDERINGS])
+def test_routing_effort_orderings(scen):
+    name, left_key, right_key, direction = scen
+    left = _EFFORT_RANK[_route(_SCENARIOS[left_key]).effort_class]
+    right = _EFFORT_RANK[_route(_SCENARIOS[right_key]).effort_class]
+    assert evaluate_direction(direction, left, right), (
+        f"{name}: rank({left_key})={left} !{direction} rank({right_key})={right}"
+    )
+
+
+def test_planning_mode_biases_standard_band_only():
+    # A clarifying question carries a base ``standard`` effort. Delegated mode
+    # lifts the standard band to deep (autonomous synthesis); in-trip mode drops
+    # it to fast (quick response). The two must straddle the standard baseline.
+    delegated = _EFFORT_RANK[
+        _route(_SCENARIOS["clarifying"], mode="delegated").effort_class
+    ]
+    in_trip = _EFFORT_RANK[
+        _route(_SCENARIOS["clarifying"], mode="in-trip").effort_class
+    ]
+    assert evaluate_direction("greater_than", delegated, in_trip), (
+        f"delegated rank={delegated} should exceed in-trip rank={in_trip}"
+    )
+
+
+def test_routing_invariants():
+    results: list[InvariantResult] = []
+    for key, msg in _SCENARIOS.items():
+        d = _route(msg)
+        results.append(
+            InvariantResult(
+                f"{key}_task_class_known",
+                d.task_class in TASK_CLASSES,
+                detail=d.task_class,
+            )
+        )
+        results.append(
+            InvariantResult(
+                f"{key}_effort_class_known",
+                d.effort_class in EFFORT_CLASSES,
+                detail=d.effort_class,
+            )
+        )
+        results.append(
+            InvariantResult(
+                f"{key}_base_effort_known",
+                d.base_effort_class in EFFORT_CLASSES,
+                detail=d.base_effort_class,
+            )
+        )
+        # Planning mode never downgrades an explicit deep task nor upgrades an
+        # explicit fast task; only the standard band is adjusted.
+        if d.base_effort_class == EFFORT_DEEP:
+            results.append(
+                InvariantResult(
+                    f"{key}_deep_preserved",
+                    d.effort_class == EFFORT_DEEP,
+                    detail=d.effort_class,
+                )
+            )
+        if d.base_effort_class == EFFORT_FAST:
+            results.append(
+                InvariantResult(
+                    f"{key}_fast_preserved",
+                    d.effort_class == EFFORT_FAST,
+                    detail=d.effort_class,
+                )
+            )
+        # Routing is deterministic: re-running the same turn yields the same payload.
+        again = _route(msg)
+        results.append(
+            InvariantResult(
+                f"{key}_deterministic",
+                again.to_payload() == d.to_payload(),
+                detail="non-deterministic routing decision",
+            )
+        )
+    assert_invariants(results, context="planner_routing_baseline")

--- a/tests/baseline/test_preference_resolution_baseline.py
+++ b/tests/baseline/test_preference_resolution_baseline.py
@@ -1,0 +1,129 @@
+"""Baseline scenarios for preference resolution (``resolve_dimension_evidence``).
+
+Issue #1268 acceptance criteria require at least one preference-resolution
+baseline scenario with directional and/or invariant checks.
+``resolve_dimension_evidence`` is deterministic given a dimension key, a seed
+value, and a list of evidence records (no DB, network, or LLM), so its resolved
+value / confidence is a stable baseline surface.
+
+Inputs are drawn from the existing deterministic leisure-traveler fixture
+corpus; checks use the shared ``baseline_kit`` directional/invariant primitives.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from baseline_kit import InvariantResult, assert_invariants, evaluate_direction
+
+from tests.preferences.fixture_corpus import load_fixture_corpus
+from trip_planner.preferences.resolution import resolve_dimension_evidence
+
+_CORPUS = {f.id: f for f in load_fixture_corpus()}
+
+# A dimension key no fixture's evidence affects -> the resolver retains the seed
+# value at zero confidence. Used as the "no signal" control for directional checks.
+_NO_EVIDENCE_DIM = "__no_such_dimension__"
+
+# Fixtures whose dominant dimensions carry strong explicit/behavioral evidence.
+_SCENARIO_IDS = [
+    "scenic-rail-nomad",
+    "urban-historian",
+    "discovery-wanderer",
+    "food-splurger",
+]
+
+
+def _resolve_dominant(fixture):
+    dimension_key = fixture.intended_interpretation.dominant_dimensions[0]
+    seed = fixture.profile.tradeoff_dimensions[dimension_key].value
+    resolved = resolve_dimension_evidence(dimension_key, seed, fixture.evidence)
+    return dimension_key, seed, resolved
+
+
+@pytest.mark.parametrize("fid", _SCENARIO_IDS)
+def test_evidence_raises_confidence_over_no_evidence(fid):
+    """Directional: a dominant dimension backed by applicable evidence resolves
+    with higher confidence than a dimension with no applicable evidence."""
+    fixture = _CORPUS[fid]
+    _, _, resolved = _resolve_dominant(fixture)
+    no_evidence = resolve_dimension_evidence(_NO_EVIDENCE_DIM, 0.4, fixture.evidence)
+    assert evaluate_direction(
+        "greater_than", resolved.confidence, no_evidence.confidence
+    ), (
+        f"{fid}: evidence-backed confidence {resolved.confidence:.4f} should exceed "
+        f"no-evidence confidence {no_evidence.confidence:.4f}"
+    )
+
+
+@pytest.mark.parametrize("fid", _SCENARIO_IDS)
+def test_resolution_invariants(fid):
+    fixture = _CORPUS[fid]
+    dimension_key, seed, r = _resolve_dominant(fixture)
+    evidence_ids = {e.id for e in fixture.evidence}
+    results = [
+        InvariantResult(
+            f"{fid}_final_value_in_axis",
+            -1.0 <= r.final_value <= 1.0,
+            detail=f"final_value={r.final_value}",
+        ),
+        InvariantResult(
+            f"{fid}_confidence_unit_interval",
+            0.0 <= r.confidence <= 1.0,
+            detail=f"confidence={r.confidence}",
+        ),
+        InvariantResult(
+            f"{fid}_behavior_support_finite",
+            math.isfinite(r.recent_behavior_support)
+            and math.isfinite(r.older_behavior_support),
+            detail=f"recent={r.recent_behavior_support} older={r.older_behavior_support}",
+        ),
+        InvariantResult(
+            f"{fid}_contrib_ids_subset",
+            set(r.contributing_evidence_ids) <= evidence_ids,
+            detail=str(r.contributing_evidence_ids),
+        ),
+        InvariantResult(
+            f"{fid}_contrib_ids_bounded",
+            len(r.contributing_evidence_ids) <= 5,
+            detail=str(len(r.contributing_evidence_ids)),
+        ),
+    ]
+    # Resolution is deterministic for the same inputs.
+    again = resolve_dimension_evidence(dimension_key, seed, fixture.evidence)
+    results.append(
+        InvariantResult(
+            f"{fid}_deterministic",
+            (again.final_value, again.confidence, again.explanation_code)
+            == (r.final_value, r.confidence, r.explanation_code),
+            detail="non-deterministic resolution",
+        )
+    )
+    assert_invariants(results, context=f"preference_resolution_baseline[{fid}]")
+
+
+def test_no_evidence_retains_seed_at_zero_confidence():
+    """Invariant: with no applicable evidence the resolver returns the seed value
+    unchanged, at zero confidence, with the ``default_seed`` explanation code."""
+    fixture = _CORPUS["scenic-rail-nomad"]
+    seed = 0.37
+    r = resolve_dimension_evidence(_NO_EVIDENCE_DIM, seed, fixture.evidence)
+    results = [
+        InvariantResult(
+            "no_evidence_retains_seed",
+            r.final_value == seed,
+            detail=f"final={r.final_value} seed={seed}",
+        ),
+        InvariantResult(
+            "no_evidence_zero_confidence",
+            r.confidence == 0.0,
+            detail=f"confidence={r.confidence}",
+        ),
+        InvariantResult(
+            "no_evidence_default_code",
+            r.explanation_code == "default_seed",
+            detail=r.explanation_code,
+        ),
+    ]
+    assert_invariants(results, context="preference_resolution_no_evidence")


### PR DESCRIPTION
## Why

Bounded closer follow-up completing the remaining acceptance criteria of #1268. The merged baseline-kit PR #1274 landed the transport-option baselines, but the `verify:compare` provider comparison correctly flagged that two explicit AC items were unmet (Anthropic CONCERNS, accurate on audit):

- [ ] *Add baseline scenarios for preference resolution (`resolve_dimension_evidence`) with directional confidence/salience checks*
- [ ] *Add baseline scenarios for planner routing (`route_planner_turn`) covering message -> task/effort classification*

Verified against the merged `tests/baseline/`: it covered only `TransportOption` compute — neither `resolve_dimension_evidence` nor `route_planner_turn` had any scenario.

## What

Two self-contained baseline modules under `tests/baseline/`, built on the shared `baseline_kit` directional/invariant primitives:

- **`test_preference_resolution_baseline.py`** — `resolve_dimension_evidence` over the deterministic leisure-traveler fixture corpus. Directional: evidence-backed dominant dimensions resolve at higher confidence than a no-evidence control. Invariants: `final_value ∈ [-1,1]`, `confidence ∈ [0,1]`, finite behavior support, contributing-id subset/bound, determinism, and the no-evidence → seed-retained-at-zero-confidence contract.
- **`test_planner_routing_baseline.py`** — `route_planner_turn` effort-class routing. Directional: planning/synthesis/summary turns receive ≥ effort of acknowledgement/note/focus turns; planning-mode bias straddles the standard band. Invariants: known task/effort classes, deep-never-downgraded / fast-never-upgraded, determinism.

No golden-master files: both surfaces are small discrete spaces better expressed as orderings + invariants than frozen scalars (also sidesteps the `*.csv` regen path). All deterministic — no new external/network dependency.

## Validation

`pytest tests/baseline/` → **32 passed** (17 existing + 15 new); `ruff check` + `ruff format` clean.

Refs #1268