### PR TITLE
chore(mypy): drop baseline_kit ignore_missing_imports override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,6 @@ extend-exclude = '''
 
 [[tool.mypy.overrides]]
 module = [
-    "baseline_kit",
-    "baseline_kit.*",
     "jsonschema",
     "jinja2",
     "langchain_anthropic",


### PR DESCRIPTION
## What

`baseline_kit` now ships a PEP 561 `py.typed` marker (Workflows [#2204](https://github.com/stranske/Workflows/pull/2204), merged to `main`), so mypy can analyze it directly. This removes the now-unnecessary `baseline_kit` / `baseline_kit.*` entries from the `ignore_missing_imports` override.

## Changes

- `pyproject.toml` — drop `baseline_kit` and `baseline_kit.*` from `[[tool.mypy.overrides]]`. The remaining untyped third-party modules (`jsonschema`, `jinja2`, `langchain_*`, `tomlkit`) are untouched.

## Why this is safe now

This PR is intentionally sequenced **after** Workflows #2204 landed on `main`. trip-planner installs `app-baseline-kit` from `git+https://github.com/stranske/Workflows.git` (default branch), so CI now pulls the typed package and mypy resolves `baseline_kit` cleanly.

## Verification

Installed the typed `baseline_kit` into the venv and ran `mypy tests/baseline/*` with the override removed — no `import-untyped` / missing-stub errors. Control: removing the `py.typed` marker reproduces the original error.