### PR TITLE
fix(deps): refresh app-baseline-kit lock pin to current Workflows main

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -12,7 +12,7 @@ anyio==4.13.0
     #   httpx
     #   openai
     #   starlette
-app-baseline-kit @ git+https://github.com/stranske/Workflows.git@4581ee9c91240b6d3ef628f0f8ff982f6bcaba36#subdirectory=packages/app-baseline-kit
+app-baseline-kit @ git+https://github.com/stranske/Workflows.git@13f94883220bbfb0ca69a4666fb44a49e0ae8172#subdirectory=packages/app-baseline-kit
     # via trip-planner (pyproject.toml)
 ast-serialize==0.3.0
     # via mypy


### PR DESCRIPTION
## Problem (main CI is red)

`requirements.lock` pinned `app-baseline-kit` to Workflows commit `4581ee9c` (the #2203 package-add), while `pyproject.toml` declares the **unpinned** URL `git+https://github.com/stranske/Workflows.git#subdirectory=packages/app-baseline-kit`, which resolves to Workflows `main` HEAD.

This was consistent (both → `4581ee9c`) until Workflows `main` advanced via [#2204](https://github.com/stranske/Workflows/pull/2204) (the `py.typed` marker, now `13f94883`). The unpinned URL then resolved to a *different* commit than the lock pin, so `uv` aborted install:

```
Requirements contain conflicting URLs for package `app-baseline-kit`:
  - git+...Workflows.git@4581ee9c…#subdirectory=packages/app-baseline-kit
  - git+...Workflows.git#subdirectory=packages/app-baseline-kit
```

mypy/tests never ran (`MYPY_OUTCOME: skipped`) — the failure is in the dependency-install step, not the type change from #1278.

## Fix

Regenerate the lock with the documented command (`uv pip compile pyproject.toml --extra dev --universal --output-file requirements.lock`) so the pin tracks current main (`13f94883`). One-line diff. This is the same steady state Counter_Risk already has, and it ensures CI installs the now-typed `baseline_kit` (so the #1278 mypy-override removal is validated on CI here).

## Note / follow-up

This stale-lock-vs-unpinned-URL coupling will recur on every Workflows `main` advance unless consumer locks are refreshed (or the pin strategy is reconciled). Counter_Risk is currently fresh; other future adopters will hit the same. Worth a Workflows-side rollout note — flagging separately.