### PR TITLE
fix(deps): stop pinning app-baseline-kit in requirements.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,15 @@ dev = [
 requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
+# Do not emit app-baseline-kit into requirements.lock. It is consumed from the
+# Workflows monorepo via an unpinned `@main` git URL (see [project.optional-
+# dependencies].dev), so freezing a commit SHA in the lock conflicts with that
+# URL the moment Workflows main advances ("conflicting URLs for package
+# app-baseline-kit" -> uv install aborts). Leaving it unpinned lets the editable
+# project install resolve it from main, with no lock to keep refreshed.
+[tool.uv.pip]
+no-emit-package = ["app-baseline-kit"]
+
 [tool.setuptools.packages.find]
 include = ["scripts*", "trip_planner*"]
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,8 +12,6 @@ anyio==4.13.0
     #   httpx
     #   openai
     #   starlette
-app-baseline-kit @ git+https://github.com/stranske/Workflows.git@13f94883220bbfb0ca69a4666fb44a49e0ae8172#subdirectory=packages/app-baseline-kit
-    # via trip-planner (pyproject.toml)
 ast-serialize==0.3.0
     # via mypy
 black==26.3.1
@@ -225,3 +223,6 @@ xxhash==3.7.0
     # via langsmith
 zstandard==0.25.0
     # via langsmith
+
+# The following packages were excluded from the output:
+# app-baseline-kit

--- a/tests/test_dependency_version_alignment.py
+++ b/tests/test_dependency_version_alignment.py
@@ -52,6 +52,18 @@ def test_all_pyproject_dependencies_are_in_lock() -> None:
         for entry in group:
             declared.add(_split_spec(entry).lower())
 
+    # Packages intentionally excluded from the lock via uv's no-emit-package
+    # (monorepo deps consumed from an unpinned @main git URL, e.g.
+    # app-baseline-kit) are not expected to be pinned in requirements.lock.
+    no_emit = {
+        _split_spec(name).lower()
+        for name in pyproject.get("tool", {})
+        .get("uv", {})
+        .get("pip", {})
+        .get("no-emit-package", [])
+    }
+    declared -= no_emit
+
     lock_versions = _load_lock_versions(Path("requirements.lock"))
 
     missing = []


### PR DESCRIPTION
## Durable fix for the lock/pin conflict that reddened CI after Workflows #2204

`app-baseline-kit` is consumed via an unpinned `@main` git URL in `pyproject.toml`, but `uv pip compile` froze it to a commit SHA in `requirements.lock`. CI installs the lock **and** the editable project together, so the package is declared both pinned and unpinned — they agree only until Workflows `main` advances, then uv aborts:

```
Requirements contain conflicting URLs for package `app-baseline-kit`
```

PR #1279 refreshed the SHA as an emergency green-restore, but that just resets the clock. This is the permanent fix.

## Change

- `pyproject.toml`: `[tool.uv.pip] no-emit-package = ["app-baseline-kit"]`
- `requirements.lock`: regenerated — the `app-baseline-kit` line drops out (every other, versioned dep stays pinned)

The editable project install resolves `baseline_kit` from `@main`; there is no frozen SHA to keep refreshed. Conflict class eliminated.

## Verification (uv 0.10.3, local)

- `uv pip install -r requirements.lock -e ".[app,dev]"` → **Resolved 74 packages, no conflict**
- Compile emits `# excluded from the output: app-baseline-kit`; `pytest-regressions`/`pyyaml` still pinned

Convention documented in Workflows `docs/ops/CONSUMER_REPO_MAINTENANCE.md` (companion PR).