### PR TITLE
docs: document app-baseline-kit dependency pattern

### DIFF
--- a/docs/baseline-kit-dependency.md
+++ b/docs/baseline-kit-dependency.md
@@ -1,0 +1,3 @@
+# app-baseline-kit dependency
+
+trip-planner is the **reference implementation of Pattern A**, the fleet default. `app-baseline-kit` is declared unpinned at `@main` in `pyproject.toml` (`[project.optional-dependencies].dev`) and excluded from `requirements.lock` via `[tool.uv.pip] no-emit-package = ["app-baseline-kit"]`. This permanently avoids the `uv` "conflicting URLs for package app-baseline-kit" error that occurs when an unpinned pyproject URL and a SHA-pinned lock URL disagree (this repo's CI broke that way after Workflows PR #2204). At test time the package is resolved directly from Workflows `main` HEAD by the editable install; `tests/test_dependency_version_alignment.py` subtracts the no-emit names so it does not flag the now-absent package. No change needed.


### PR DESCRIPTION
Adds a repo-local justification doc at `docs/baseline-kit-dependency.md` explaining why trip-planner carries `app-baseline-kit` as the **Pattern A reference implementation** (fleet default):

- Declared unpinned at `@main` in `pyproject.toml` (`[project.optional-dependencies].dev`).
- Excluded from `requirements.lock` via `[tool.uv.pip] no-emit-package = ["app-baseline-kit"]`.
- This permanently avoids the `uv` "conflicting URLs for package app-baseline-kit" error (unpinned pyproject URL vs. SHA-pinned lock URL), which broke this repo's CI after Workflows PR #2204.
- At test time the package resolves directly from Workflows `main` HEAD via the editable install; `tests/test_dependency_version_alignment.py` subtracts the no-emit names.

Doc-only change. No dependency change — the existing pattern is justified and stays as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)