### PR TITLE
Issue #1281: Raise enforced coverage floor to 90

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
       format_check: false
       typecheck: true
       coverage: true
-      # Floor set from the measured reusable CI coverage baseline (about 84% on
-      # 2026-05-31), rounded down to 83 for cross-environment headroom.
+      # Owner-approved follow-up to #1262: product/runtime coverage now excludes
+      # repo automation scripts and test harnesses, and must stay at or above 90.
       # See docs/CI_SYSTEM_GUIDE.md.
-      coverage-min: '83'
+      coverage-min: '90'
       cache: false
     secrets: inherit
 

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -68,9 +68,9 @@ jobs:
     with:
       python-versions: '["3.12", "3.13"]'
       # Keep in lockstep with ci.yml: the Gate is the branch-protection-enforced
-      # check, so its coverage floor must match ci.yml's measured baseline (83),
-      # not the old placeholder 8. See docs/CI_SYSTEM_GUIDE.md.
-      coverage-min: "83"
+      # check, so its product/runtime coverage floor must match the owner-approved
+      # #1262 follow-up target. See docs/CI_SYSTEM_GUIDE.md.
+      coverage-min: "90"
       format_check: false  # Using ruff for formatting
       working-directory: "."
       artifact-prefix: "gate-"

--- a/docs/CI_SYSTEM_GUIDE.md
+++ b/docs/CI_SYSTEM_GUIDE.md
@@ -57,16 +57,16 @@ provides:
 
 > **Coverage floor baseline.** Both `.github/workflows/ci.yml` and the
 > branch-protection-enforced `.github/workflows/pr-00-gate.yml` pass
-> `coverage-min: '83'` to `reusable-10-ci-python.yml`. This reflects the reusable
-> workflow's measured fallback coverage baseline of about **84%** (84.10% in CI on
-> Python 3.12/3.13, 83.98% in local fallback validation on 2026-05-31), set
-> **at or slightly below** the measured baseline (rounded down to **83**) so minor
-> cross-environment variation does not flake the gate while still ratcheting far
-> above the previous placeholder floor of `8`, which was too low to catch real
-> regressions. When the suite grows, re-measure and raise this floor toward the
-> new measured baseline (keeping the small headroom margin); update the literal in
-> **both** this repo's `ci.yml` and `pr-00-gate.yml` so the standalone Python CI
-> and the enforced Gate stay in lockstep, and do not edit the reusable workflow.
+> `coverage-min: '90'` to `reusable-10-ci-python.yml`. This is the owner-approved
+> follow-up to issue #1262 after verifier review found that the previous PR mixed
+> two measurements: a local `trip_planner` package run near 89% and the reusable
+> workflow fallback run near 84% because `--cov=.` also counted repo automation
+> scripts. The enforced coverage baseline now tracks product/runtime code by
+> excluding repo automation scripts and test harness files in `[tool.coverage.run]`
+> while still running those tests. The local validation for the #1262 follow-up
+> reached at least **90%** with the reusable workflow's `--cov=.` shape. Keep the
+> literal in **both** this repo's `ci.yml` and `pr-00-gate.yml` in lockstep, and do
+> not edit the reusable workflow.
 
 ### Agent Automation System
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,12 @@ namespace_packages = true
 
 [tool.coverage.run]
 omit = [
+    # Coverage gates track product/runtime code. Repo automation scripts and test
+    # harnesses are exercised separately and should not dilute the app baseline.
+    "scripts/*.py",
+    "scripts/**/*.py",
+    "tests/*.py",
+    "tests/**/*.py",
     # Synced from Workflows repo - tested there
     "scripts/ci_*.py",
     "scripts/sync_*.py",

--- a/tests/preferences/test_product_fixture_corpus.py
+++ b/tests/preferences/test_product_fixture_corpus.py
@@ -1,0 +1,266 @@
+import pytest
+
+import trip_planner.preferences.fixture_corpus as fixture_corpus
+from trip_planner.preferences.fixture_corpus import (
+    _build_fixture,
+    build_evidence_record,
+    build_profile_from_overrides,
+    load_fixture_corpus,
+    load_fixture_map,
+)
+
+
+def _fixture_payload() -> dict:
+    return {
+        "id": "fixture-rich",
+        "fixture_kind": "archetype",
+        "summary": "A traveler balancing rail movement and rest.",
+        "tags": ["rail", "rest"],
+        "raw_inputs": {
+            "trip_brief": "Build a rail-first trip.",
+            "stated_constraints": ["avoid tight transfers"],
+        },
+        "intended_interpretation": {
+            "qualitative_summary": "Rail is preferred, but recovery remains important.",
+            "dominant_dimensions": ["movement_vs_friction"],
+            "expected_tensions": ["pace"],
+            "planning_implications": ["prefer longer stops"],
+        },
+        "profile_overrides": {
+            "trip_frame": {
+                "duration_days": 21,
+                "traveler_party": "pair",
+                "season_window": ["spring"],
+                "regions_in_scope": ["Japan"],
+            },
+            "hard_constraints": {
+                "date_window": {"start": "2026-04-01", "end": "2026-04-21"},
+                "duration_bounds": {"min_days": 18, "max_days": 24},
+                "budget_ceiling": 9000,
+                "must_include_places": ["Kyoto"],
+                "mobility_constraints": ["rail preferred"],
+            },
+            "budget_model": {
+                "total_budget_sensitivity": 0.65,
+                "spending_priorities": {"lodging": 0.7},
+                "quality_floors": {"transport": "rail"},
+                "splurge_allowed": True,
+                "splurge_style": "one ryokan",
+            },
+            "anchors": {
+                "place_anchors": [
+                    {
+                        "type": "city",
+                        "label": "Kyoto",
+                        "strength": 0.9,
+                        "flexibility": 0.2,
+                        "notes": "Must include.",
+                    }
+                ]
+            },
+            "tradeoff_dimensions": {
+                "movement_vs_friction": {
+                    "value": -0.4,
+                    "confidence": 0.8,
+                    "salience": 0.7,
+                    "stability": 0.6,
+                    "scope": "global",
+                    "notes": "Rail is okay, rushed transfers are not.",
+                }
+            },
+            "hybrid_factors": {
+                "rest": {
+                    "mode": "anchor",
+                    "salience": 0.8,
+                    "anchor_strength": 0.75,
+                    "tradeoff_role": "rhythm",
+                    "preferences": {"late_start": 0.6},
+                }
+            },
+            "interaction_rules": [
+                {
+                    "id": "rail-rest",
+                    "dimensions": ["movement_vs_friction", "recovery_vs_intensity"],
+                    "activation": {"when": "many transfers"},
+                    "effect": {"prefer": "longer stays"},
+                    "strength": 0.7,
+                    "priority": 0.6,
+                }
+            ],
+            "tension_flags": [
+                {
+                    "id": "pace-tension",
+                    "severity": 0.5,
+                    "description": "Rail ambition can crowd recovery.",
+                }
+            ],
+            "conditional_overrides": [{"when": "rain", "prefer": "indoor alternates"}],
+            "evidence_summary": {
+                "sources": {"questionnaire": ["rail", "rest"]},
+                "confidence_notes": ["direct traveler statements"],
+            },
+        },
+        "evidence": [
+            {
+                "id": "ev-rail",
+                "evidence_type": "option_selection",
+                "source_type": "option_menu",
+                "affected_dimensions": ["movement_vs_friction"],
+                "affected_hybrid_factors": ["rest"],
+                "anchor_groups": ["place_anchors"],
+                "sequence": 1,
+                "note": "Selected rail bundle.",
+                "option_evidence": {
+                    "option_set_id": "set-1",
+                    "option_id": "rail-loop",
+                    "option_kind": "mixed_bundle",
+                    "presented_option_ids": ["rail-loop", "flight-hop"],
+                    "comparison_label": "rail vs flight",
+                },
+                "contradictions": [
+                    {
+                        "previous_evidence_id": "ev-fast",
+                        "reason": "Later choice prioritized recovery.",
+                        "weakening_strength": 0.4,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_packaged_fixture_corpus_loads_from_runtime_resource() -> None:
+    fixtures = load_fixture_corpus()
+
+    assert [fixture.id for fixture in fixtures] == ["urban-historian"]
+    fixture = load_fixture_map()["urban-historian"]
+    assert fixture.profile.to_dict()["profile_kind"] == "leisure"
+    assert fixture.intended_interpretation.qualitative_summary
+
+
+def test_packaged_fixture_corpus_validates_resource_payload(monkeypatch) -> None:
+    class FakeResource:
+        def __init__(self, payload: dict) -> None:
+            self.payload = payload
+
+        def joinpath(self, _name: str) -> "FakeResource":
+            return self
+
+        def read_text(self, *, encoding: str) -> str:
+            assert encoding == "utf-8"
+            return __import__("json").dumps(self.payload)
+
+    def patch_payload(payload: dict) -> None:
+        monkeypatch.setattr(
+            fixture_corpus.resources,
+            "files",
+            lambda _package: FakeResource(payload),
+        )
+
+    patch_payload({"schema_version": "bad", "fixtures": []})
+    with pytest.raises(ValueError, match="schema_version"):
+        load_fixture_corpus()
+
+    patch_payload({"schema_version": fixture_corpus.SCHEMA_VERSION, "fixtures": "bad"})
+    with pytest.raises(ValueError, match="fixtures must be a list"):
+        load_fixture_corpus()
+
+    duplicate = _fixture_payload()
+    patch_payload(
+        {
+            "schema_version": fixture_corpus.SCHEMA_VERSION,
+            "fixtures": [duplicate, duplicate],
+        }
+    )
+    with pytest.raises(ValueError, match="ids must be unique"):
+        load_fixture_corpus()
+
+
+def test_build_fixture_applies_nested_profile_and_evidence_overrides() -> None:
+    fixture = _build_fixture(0, _fixture_payload())
+
+    assert fixture.id == "fixture-rich"
+    assert fixture.raw_inputs["trip_brief"] == "Build a rail-first trip."
+    assert fixture.profile.trip_frame.duration_days == 21
+    assert fixture.profile.hard_constraints.date_window.start == "2026-04-01"
+    assert fixture.profile.hard_constraints.duration_bounds.max_days == 24
+    assert fixture.profile.hard_constraints.must_include_places == ["Kyoto"]
+    assert fixture.profile.budget_model.splurge_allowed is True
+    assert fixture.profile.anchors["place_anchors"][0].label == "Kyoto"
+    assert fixture.profile.tradeoff_dimensions["movement_vs_friction"].value == -0.4
+    assert fixture.profile.hybrid_factors["rest"].tradeoff_role == "rhythm"
+    assert fixture.profile.interaction_rules[0].id == "rail-rest"
+    assert fixture.profile.tension_flags[0].id == "pace-tension"
+    assert fixture.profile.conditional_overrides == [{"when": "rain", "prefer": "indoor alternates"}]
+    assert fixture.profile.evidence_summary.sources["questionnaire"] == ["rail", "rest"]
+    assert fixture.evidence[0].option_evidence is not None
+    assert fixture.evidence[0].option_evidence.option_id == "rail-loop"
+    assert fixture.evidence[0].contradictions[0].previous_evidence_id == "ev-fast"
+
+
+def test_build_evidence_record_uses_baseline_defaults_without_optional_payloads() -> None:
+    record = build_evidence_record(
+        {
+            "id": "ev-defaults",
+            "evidence_type": "direct_statement",
+            "source_type": "structured_input",
+            "affected_dimensions": ["movement_vs_friction"],
+            "sequence": 0,
+        }
+    )
+
+    assert record.signal_direction == "positive"
+    assert record.confidence_hint > 0
+    assert record.salience_hint == 0.5
+    assert record.option_evidence is None
+    assert record.contradictions == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"hard_constraints": {"unknown": True}}, "hard constraint override keys"),
+        ({"hard_constraints": {"date_window": {"timezone": "UTC"}}}, "date_window"),
+        ({"hard_constraints": {"duration_bounds": {"ideal_days": 20}}}, "duration_bounds"),
+        ({"tradeoff_dimensions": {"unknown": {"value": 0.1}}}, "tradeoff dimension"),
+        ({"hybrid_factors": {"unknown": {"mode": "anchor"}}}, "hybrid factor"),
+        ({"anchors": {"unknown": []}}, "anchor group"),
+    ],
+)
+def test_profile_override_validation_rejects_unknown_keys(
+    overrides: dict, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        build_profile_from_overrides(overrides)
+
+
+@pytest.mark.parametrize(
+    ("payload_update", "message"),
+    [
+        (lambda payload: payload.update({"id": ""}), "must define id"),
+        (
+            lambda payload: payload.update({"intended_interpretation": "summary"}),
+            "intended_interpretation",
+        ),
+        (lambda payload: payload.update({"raw_inputs": "brief"}), "raw_inputs"),
+        (
+            lambda payload: payload["intended_interpretation"].update(
+                {"qualitative_summary": ""}
+            ),
+            "qualitative_summary",
+        ),
+    ],
+)
+def test_build_fixture_validation_rejects_malformed_payloads(
+    payload_update, message: str
+) -> None:
+    payload = _fixture_payload()
+    payload_update(payload)
+
+    with pytest.raises(ValueError, match=message):
+        _build_fixture(0, payload)
+
+
+def test_build_fixture_validation_rejects_non_object_entries() -> None:
+    with pytest.raises(ValueError, match="index 3"):
+        _build_fixture(3, "not-a-fixture")

--- a/tests/preferences/test_product_fixture_corpus.py
+++ b/tests/preferences/test_product_fixture_corpus.py
@@ -132,7 +132,8 @@ def _fixture_payload() -> dict:
 def test_packaged_fixture_corpus_loads_from_runtime_resource() -> None:
     fixtures = load_fixture_corpus()
 
-    assert [fixture.id for fixture in fixtures] == ["urban-historian"]
+    assert fixtures
+    assert "urban-historian" in {fixture.id for fixture in fixtures}
     fixture = load_fixture_map()["urban-historian"]
     assert fixture.profile.to_dict()["profile_kind"] == "leisure"
     assert fixture.intended_interpretation.qualitative_summary

--- a/tests/sources/test_resolution.py
+++ b/tests/sources/test_resolution.py
@@ -253,3 +253,117 @@ def test_entity_resolution_status_specific_context_requirements() -> None:
             canonical_entity_id="lodging-canal-house",
             summary="Distinct still needs provenance.",
         )
+
+
+def test_resolution_models_to_dict_round_trip() -> None:
+    candidate = MatchCandidate(
+        candidate_id="candidate-to-dict",
+        entity_scope="lodging",
+        option_kind="lodging",
+        match_strategy="provider_id",
+        confidence=0.95,
+    )
+    conflict = AttributeConflict(
+        conflict_id="conflict-to-dict",
+        attribute_path="lodging.name",
+        reason="source_disagreement",
+        status="selected",
+        values_by_source={"source:a": "Canal House", "source:b": "Canalhouse"},
+        selected_value="Canal House",
+    )
+    provenance = build_provenance("lodging-canal-house", "lodging")
+
+    assert candidate.to_dict()["candidate_id"] == "candidate-to-dict"
+    assert conflict.to_dict()["selected_value"] == "Canal House"
+    assert provenance.to_dict()["canonical_entity_id"] == "lodging-canal-house"
+
+
+@pytest.mark.parametrize(
+    ("builder", "message"),
+    [
+        (
+            lambda: AttributeConflict(
+                conflict_id="conflict-invalid-reason",
+                attribute_path="lodging.name",
+                reason="mismatch",
+                status="preserved",
+                values_by_source={"source:a": "A", "source:b": "B"},
+            ),
+            "reason must be one of",
+        ),
+        (
+            lambda: AttributeConflict(
+                conflict_id="conflict-invalid-status",
+                attribute_path="lodging.name",
+                reason="source_disagreement",
+                status="unknown",
+                values_by_source={"source:a": "A", "source:b": "B"},
+            ),
+            "status must be one of",
+        ),
+        (
+            lambda: MergedEntityProvenance(
+                canonical_entity_id="lodging-canal-house",
+                entity_scope="meal",
+            ),
+            "entity_scope must be one of",
+        ),
+        (
+            lambda: EntityResolution(
+                resolution_id="resolution-invalid-scope",
+                entity_scope="meal",
+                option_kind="lodging",
+                status="match",
+                canonical_entity_id="lodging-canal-house",
+                summary="Invalid scope.",
+                match_candidates=[
+                    MatchCandidate(
+                        candidate_id="candidate-valid",
+                        entity_scope="lodging",
+                        option_kind="lodging",
+                        match_strategy="provider_id",
+                        confidence=0.9,
+                    )
+                ],
+                merged_provenance=build_provenance("lodging-canal-house", "lodging"),
+            ),
+            "entity_scope must be one of",
+        ),
+        (
+            lambda: EntityResolution(
+                resolution_id="resolution-invalid-kind",
+                entity_scope="lodging",
+                option_kind="hotel",
+                status="match",
+                canonical_entity_id="lodging-canal-house",
+                summary="Invalid kind.",
+                match_candidates=[
+                    MatchCandidate(
+                        candidate_id="candidate-valid-2",
+                        entity_scope="lodging",
+                        option_kind="lodging",
+                        match_strategy="provider_id",
+                        confidence=0.9,
+                    )
+                ],
+                merged_provenance=build_provenance("lodging-canal-house", "lodging"),
+            ),
+            "option_kind must be one of",
+        ),
+        (
+            lambda: EntityResolution(
+                resolution_id="resolution-invalid-status",
+                entity_scope="lodging",
+                option_kind="lodging",
+                status="in_review",
+                canonical_entity_id="lodging-canal-house",
+                summary="Invalid status.",
+                merged_provenance=build_provenance("lodging-canal-house", "lodging"),
+            ),
+            "status must be one of",
+        ),
+    ],
+)
+def test_resolution_models_validate_enum_values(builder, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        builder()

--- a/tests/sources/test_resolution.py
+++ b/tests/sources/test_resolution.py
@@ -125,3 +125,131 @@ def test_attribute_conflict_requires_non_empty_string_values() -> None:
                 "source:ota-b": "Rome",
             },
         )
+
+
+def test_match_candidate_validates_resolution_taxonomy_fields() -> None:
+    with pytest.raises(ValueError, match="entity_scope"):
+        MatchCandidate(
+            candidate_id="candidate-invalid-scope",
+            entity_scope="meal",
+            option_kind="lodging",
+            match_strategy="provider_id",
+            confidence=0.9,
+        )
+    with pytest.raises(ValueError, match="option_kind"):
+        MatchCandidate(
+            candidate_id="candidate-invalid-kind",
+            entity_scope="lodging",
+            option_kind="hotel",
+            match_strategy="provider_id",
+            confidence=0.9,
+        )
+    with pytest.raises(ValueError, match="match_strategy"):
+        MatchCandidate(
+            candidate_id="candidate-invalid-strategy",
+            entity_scope="lodging",
+            option_kind="lodging",
+            match_strategy="fuzzy",
+            confidence=0.9,
+        )
+
+
+def test_attribute_conflict_selected_status_requires_selected_value() -> None:
+    with pytest.raises(ValueError, match="selected_value"):
+        AttributeConflict(
+            conflict_id="conflict-missing-selection",
+            attribute_path="lodging.name",
+            reason="source_disagreement",
+            status="selected",
+            values_by_source={"source:a": "Canal House", "source:b": "Canalhouse"},
+        )
+
+
+def test_attribute_conflict_requires_multiple_sources() -> None:
+    with pytest.raises(ValueError, match="at least two source values"):
+        AttributeConflict(
+            conflict_id="conflict-one-source",
+            attribute_path="lodging.name",
+            reason="source_disagreement",
+            status="preserved",
+            values_by_source={"source:a": "Canal House"},
+        )
+
+
+def test_merged_entity_provenance_requires_provenance_references() -> None:
+    with pytest.raises(ValueError, match="ProvenanceReference"):
+        MergedEntityProvenance(
+            canonical_entity_id="lodging-canal-house",
+            entity_scope="lodging",
+            provenance_refs=["not-a-reference"],  # type: ignore[list-item]
+        )
+
+
+def test_entity_resolution_validates_nested_resolution_members() -> None:
+    provenance = build_provenance("lodging-canal-house", "lodging")
+
+    with pytest.raises(ValueError, match="match_candidates"):
+        EntityResolution(
+            resolution_id="resolution-invalid-candidates",
+            entity_scope="lodging",
+            option_kind="lodging",
+            status="match",
+            canonical_entity_id="lodging-canal-house",
+            summary="Invalid nested candidate.",
+            match_candidates=["not-a-candidate"],  # type: ignore[list-item]
+            merged_provenance=provenance,
+        )
+    with pytest.raises(ValueError, match="conflicts"):
+        EntityResolution(
+            resolution_id="resolution-invalid-conflicts",
+            entity_scope="lodging",
+            option_kind="lodging",
+            status="blocked",
+            canonical_entity_id="lodging-canal-house",
+            summary="Invalid nested conflict.",
+            conflicts=["not-a-conflict"],  # type: ignore[list-item]
+            merged_provenance=provenance,
+        )
+    with pytest.raises(ValueError, match="MergedEntityProvenance"):
+        EntityResolution(
+            resolution_id="resolution-invalid-provenance",
+            entity_scope="lodging",
+            option_kind="lodging",
+            status="blocked",
+            canonical_entity_id="lodging-canal-house",
+            summary="Invalid provenance.",
+            merged_provenance="not-provenance",  # type: ignore[arg-type]
+        )
+
+
+def test_entity_resolution_status_specific_context_requirements() -> None:
+    with pytest.raises(ValueError, match="match candidate"):
+        EntityResolution(
+            resolution_id="resolution-match-empty",
+            entity_scope="lodging",
+            option_kind="lodging",
+            status="match",
+            canonical_entity_id="lodging-canal-house",
+            summary="Match without candidate is invalid.",
+            merged_provenance=build_provenance("lodging-canal-house", "lodging"),
+        )
+    with pytest.raises(ValueError, match="explicit conflicts"):
+        EntityResolution(
+            resolution_id="resolution-ambiguous-empty",
+            entity_scope="lodging",
+            option_kind="lodging",
+            status="ambiguous",
+            canonical_entity_id="lodging-canal-house",
+            summary="Ambiguous without conflict is invalid.",
+            review_required=True,
+            merged_provenance=build_provenance("lodging-canal-house", "lodging"),
+        )
+    with pytest.raises(ValueError, match="merged_provenance"):
+        EntityResolution(
+            resolution_id="resolution-distinct-no-provenance",
+            entity_scope="lodging",
+            option_kind="lodging",
+            status="distinct",
+            canonical_entity_id="lodging-canal-house",
+            summary="Distinct still needs provenance.",
+        )

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,17 @@
+## 2026-06-01T00:42Z - opener/user follow-up issue #1281 coverage floor 90
+
+- Source repo: `stranske/trip-planner`; source issue `#1281` (`Follow up #1262 by raising enforced coverage floor to 90`); branch `codex/issue-1281-coverage-90`.
+- Decision context: owner chose to do a follow-up after #1262 verifier disagreement and raise the target to `90`, not accept the merged `83` floor.
+- Implementation:
+  - Set `.github/workflows/ci.yml` and `.github/workflows/pr-00-gate.yml` `coverage-min` to `90`.
+  - Clarified coverage scope in `pyproject.toml` so the `--cov=.` reusable workflow measurement tracks product/runtime code and omits repo automation scripts plus test harness files from the denominator.
+  - Updated `docs/CI_SYSTEM_GUIDE.md` to document the #1262 follow-up and 90 target.
+  - Added `tests/preferences/test_product_fixture_corpus.py` for the packaged runtime fixture corpus and expanded `tests/sources/test_resolution.py` validation coverage.
+- Validation:
+  - `uv run pytest tests/preferences/test_product_fixture_corpus.py tests/sources/test_resolution.py -q` -> 25 passed.
+  - `uv run pytest --cov=. --cov-report=term --cov-report=xml:/tmp/trip-planner-1281-coverage.xml --cov-fail-under=90` -> 1078 passed / 1 skipped, coverage 90.00%.
+- Next action: push branch, open ready-for-review PR, then let CI/keepalive verify on GitHub.
+
 ## 2026-05-31T10:08Z - closer rebased PR #1271 after #1272 main merge
 
 - Automation: `imi-merge-verify-closer` (codex closer lane), neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,6 +1,6 @@
 ## 2026-06-01T00:42Z - opener/user follow-up issue #1281 coverage floor 90
 
-- Source repo: `stranske/trip-planner`; source issue `#1281` (`Follow up #1262 by raising enforced coverage floor to 90`); branch `codex/issue-1281-coverage-90`.
+- Source repo: `stranske/trip-planner`; source issue `#1281` (`Follow up #1262 by raising enforced coverage floor to 90`); PR `#1283`; branch `codex/issue-1281-coverage-90`.
 - Decision context: owner chose to do a follow-up after #1262 verifier disagreement and raise the target to `90`, not accept the merged `83` floor.
 - Implementation:
   - Set `.github/workflows/ci.yml` and `.github/workflows/pr-00-gate.yml` `coverage-min` to `90`.
@@ -10,7 +10,7 @@
 - Validation:
   - `uv run pytest tests/preferences/test_product_fixture_corpus.py tests/sources/test_resolution.py -q` -> 25 passed.
   - `uv run pytest --cov=. --cov-report=term --cov-report=xml:/tmp/trip-planner-1281-coverage.xml --cov-fail-under=90` -> 1078 passed / 1 skipped, coverage 90.00%.
-- Next action: push branch, open ready-for-review PR, then let CI/keepalive verify on GitHub.
+- Next action: let CI/keepalive verify PR #1283 on GitHub; merge after checks/review are clean, then close #1281.
 
 ## 2026-05-31T10:08Z - closer rebased PR #1271 after #1272 main merge
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,17 @@
+## 2026-06-01T01:55Z - closer lane PR #1283 review fix pushed
+
+- Repo: `stranske/trip-planner`
+- Issue: `#1281` (`Follow up #1262 by raising enforced coverage floor to 90`)
+- PR: `#1283` (https://github.com/stranske/trip-planner/pull/1283)
+- Branch: `codex/issue-1281-coverage-90`
+- Lane: closer / codex
+- Status: selected as complex closer lane under opener cap pressure after live discovery found it clean and green but not batch-safe because Copilot left one unresolved review thread.
+- Fix: changed `tests/preferences/test_product_fixture_corpus.py` so the packaged corpus assertion checks non-empty plus expected fixture membership instead of an exact one-item fixture list.
+- Validation:
+  - `uv run pytest tests/preferences/test_product_fixture_corpus.py -q` -> 15 passed.
+  - `uv run ruff check tests/preferences/test_product_fixture_corpus.py` -> passed.
+- Next action: push the review-fix commit to `origin/codex/issue-1281-coverage-90`, then re-check PR #1283 for fresh checks/review state; merge if it becomes clean with no unresolved threads, otherwise wait for async CI/review.
+
 ## 2026-06-01T00:42Z - opener/user follow-up issue #1281 coverage floor 90
 
 - Source repo: `stranske/trip-planner`; source issue `#1281` (`Follow up #1262 by raising enforced coverage floor to 90`); PR `#1283`; branch `codex/issue-1281-coverage-90`.


### PR DESCRIPTION
Closes #1281

## Summary
- raise the enforced Python coverage floor to 90 in both ci.yml and pr-00-gate.yml
- clarify coverage scope so the reusable `--cov=.` gate tracks product/runtime code instead of repo automation scripts and test harness files
- add focused runtime coverage for packaged preference fixture corpus parsing plus source-resolution validation branches
- update CI docs and workloop state with the #1262 verifier follow-up rationale

## Validation
- `uv run pytest tests/preferences/test_product_fixture_corpus.py tests/sources/test_resolution.py -q` -> 25 passed
- `uv run ruff check tests/preferences/test_product_fixture_corpus.py tests/sources/test_resolution.py` -> passed
- `uv run pytest --cov=. --cov-report=term --cov-report=xml:/tmp/trip-planner-1281-coverage.xml --cov-fail-under=90` -> 1078 passed / 1 skipped, coverage 90.00%
