### PR TITLE
chore(mypy): fix typecheck failure on main (PYTEST_FALLBACK_INI_CONFIGS annotation)

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -41,7 +41,7 @@ PYTEST_INI_CONFIGS = (
     (Path("pytest.ini"), ("pytest",)),
     (Path(".pytest.ini"), ("pytest",)),
 )
-PYTEST_FALLBACK_INI_CONFIGS = (
+PYTEST_FALLBACK_INI_CONFIGS: tuple[tuple[Path, tuple[str, ...]], ...] = (
     (Path("tox.ini"), ("pytest",)),
     (Path("setup.cfg"), ("tool:pytest", "pytest")),
 )


### PR DESCRIPTION
## Why
`Python CI / typecheck-mypy` is the sole failing job on `main` (`Found 1 error in 1 file (checked 339 source files)`):
`scripts/sync_test_dependencies.py:44 — Incompatible types in assignment (expression has type "tuple[str, str]", variable has type "tuple[str]")`.

mypy infers the inner tuple type as `tuple[str]` from the 1-element first entry `("pytest",)`, so the 2-element `("tool:pytest", "pytest")` mismatches.

## Change
Annotate `PYTEST_FALLBACK_INI_CONFIGS: tuple[tuple[Path, tuple[str, ...]], ...]`. Pure type annotation; no runtime behavior change. (`PYTEST_INI_CONFIGS` does not need it — both its entries are 1-element.)

## Acceptance
- [ ] `Python CI / typecheck-mypy` passes (0 errors) on this PR.
- [ ] All other CI jobs remain green (no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)