### PR TITLE
Issue #1307: de-duplicate snapshot ingestion helpers

### DIFF
--- a/scripts/sync_test_dependencies.py
+++ b/scripts/sync_test_dependencies.py
@@ -38,11 +38,11 @@ PYTEST_TOML_FILES = (
     Path("pytest.toml"),
     Path(".pytest.toml"),
 )
-PYTEST_INI_CONFIGS = (
+PYTEST_INI_CONFIGS: tuple[tuple[Path, tuple[str, ...]], ...] = (
     (Path("pytest.ini"), ("pytest",)),
     (Path(".pytest.ini"), ("pytest",)),
 )
-PYTEST_FALLBACK_INI_CONFIGS = (
+PYTEST_FALLBACK_INI_CONFIGS: tuple[tuple[Path, tuple[str, ...]], ...] = (
     (Path("tox.ini"), ("pytest",)),
     (Path("setup.cfg"), ("tool:pytest", "pytest")),
 )

--- a/tests/ingestion/test_common_dedupe.py
+++ b/tests/ingestion/test_common_dedupe.py
@@ -1,0 +1,38 @@
+from trip_planner.ingestion._common import _dedupe_conflicts
+from trip_planner.sources import AttributeConflict
+
+
+def test_dedupe_conflicts_preserves_distinct_attribute_rows() -> None:
+    conflicts = [
+        AttributeConflict(
+            conflict_id="conflict-shared",
+            attribute_path="booking_terms.refundable",
+            reason="source_disagreement",
+            status="needs_review",
+            values_by_source={"source-a": "yes", "source-b": "no"},
+        ),
+        AttributeConflict(
+            conflict_id="conflict-shared",
+            attribute_path="booking_terms.deposit",
+            reason="source_disagreement",
+            status="needs_review",
+            values_by_source={"source-a": "none", "source-b": "required"},
+        ),
+        AttributeConflict(
+            conflict_id="conflict-shared",
+            attribute_path="booking_terms.deposit",
+            reason="source_disagreement",
+            status="needs_review",
+            values_by_source={"source-a": "none", "source-b": "required"},
+        ),
+    ]
+
+    deduped = _dedupe_conflicts(conflicts)
+
+    assert [
+        (conflict.conflict_id, conflict.attribute_path, conflict.status)
+        for conflict in deduped
+    ] == [
+        ("conflict-shared", "booking_terms.refundable", "needs_review"),
+        ("conflict-shared", "booking_terms.deposit", "needs_review"),
+    ]

--- a/trip_planner/ingestion/_common.py
+++ b/trip_planner/ingestion/_common.py
@@ -13,6 +13,8 @@ from trip_planner._validators import (
 from trip_planner.sources import (
     AdapterIssue,
     AttributeConflict,
+    DeduplicationDecision,
+    EntityResolution,
     NormalizationHandoff,
     ProvenanceReference,
     QualityValueFitSummary,
@@ -97,7 +99,9 @@ def build_provenance_reference(
             "freshness_days", payload.get("freshness_days")
         ),
         trust_snapshot=SourceTrustSignals(**trust_payload) if trust_payload else None,
-        quality_value_fit=(QualityValueFitSummary(**quality_payload) if quality_payload else None),
+        quality_value_fit=(
+            QualityValueFitSummary(**quality_payload) if quality_payload else None
+        ),
         notes=payload.get("provenance_notes", []),
     )
 
@@ -114,6 +118,63 @@ def warning_from_issue(issue: AdapterIssue) -> IngestionWarning:
 
 def unresolved_conflicts(conflicts: list[AttributeConflict]) -> list[AttributeConflict]:
     return [conflict for conflict in conflicts if conflict.status != "selected"]
+
+
+def _records_for_decision(
+    records: list[RawSourceRecord],
+    decision: DeduplicationDecision,
+    resolution_map: dict[str, EntityResolution],
+) -> list[RawSourceRecord]:
+    ordered_ids = _record_ids_for_decision(decision, resolution_map)
+    if not ordered_ids:
+        return []
+    by_id = {record.record_id: record for record in records}
+    return [by_id[record_id] for record_id in ordered_ids if record_id in by_id]
+
+
+def _record_ids_for_decision(
+    decision: DeduplicationDecision,
+    resolution_map: dict[str, EntityResolution],
+) -> list[str]:
+    record_ids: list[str] = []
+    for resolution_id in decision.resolution_ids:
+        resolution = resolution_map.get(resolution_id)
+        if resolution is None:
+            continue
+        for candidate in resolution.match_candidates:
+            record_ids.extend(candidate.source_record_ids)
+    return list(dict.fromkeys(record_ids))
+
+
+def _resolution_for_record(
+    record_id: str,
+    resolutions: list[EntityResolution],
+) -> EntityResolution | None:
+    for resolution in resolutions:
+        for candidate in resolution.match_candidates:
+            if record_id in candidate.source_record_ids:
+                return resolution
+    return None
+
+
+def _dedupe_conflicts(conflicts: list[AttributeConflict]) -> list[AttributeConflict]:
+    deduped: list[AttributeConflict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for conflict in conflicts:
+        key = (conflict.conflict_id, conflict.attribute_path, conflict.status)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(conflict)
+    return deduped
+
+
+def _contribution_kind(source_category: str) -> str:
+    if source_category == "official_operational":
+        return "operational"
+    if source_category in {"editorial", "specialist_non_commercial"}:
+        return "editorial"
+    return "inventory"
 
 
 def make_handoff(

--- a/trip_planner/ingestion/activity_pipeline.py
+++ b/trip_planner/ingestion/activity_pipeline.py
@@ -20,6 +20,11 @@ from trip_planner.sources import (
 from ._common import (
     IngestionSummary,
     IngestionWarning,
+    _contribution_kind,
+    _dedupe_conflicts,
+    _record_ids_for_decision,
+    _records_for_decision,
+    _resolution_for_record,
     build_provenance_reference,
     make_handoff,
     unresolved_conflicts,
@@ -43,11 +48,18 @@ class ActivityIngestionResult:
         require_non_empty(self.snapshot_id, "snapshot_id")
         if any(not isinstance(item, ActivityOption) for item in self.activity_options):
             raise ValueError("activity_options must contain ActivityOption instances")
-        if any(not isinstance(item, AttributeConflict) for item in self.unresolved_conflicts):
-            raise ValueError("unresolved_conflicts must contain AttributeConflict instances")
+        if any(
+            not isinstance(item, AttributeConflict)
+            for item in self.unresolved_conflicts
+        ):
+            raise ValueError(
+                "unresolved_conflicts must contain AttributeConflict instances"
+            )
         if any(not isinstance(item, IngestionWarning) for item in self.warnings):
             raise ValueError("warnings must contain IngestionWarning instances")
-        if self.handoff is not None and not isinstance(self.handoff, NormalizationHandoff):
+        if self.handoff is not None and not isinstance(
+            self.handoff, NormalizationHandoff
+        ):
             raise ValueError("handoff must be a NormalizationHandoff when provided")
         if not isinstance(self.summary, IngestionSummary):
             raise ValueError("summary must be an IngestionSummary")
@@ -71,7 +83,9 @@ def ingest_activity_snapshot(
     resolutions = resolutions or []
     dedup_decisions = dedup_decisions or []
     warnings = [warning_from_issue(issue) for issue in snapshot.issues]
-    resolution_map = {resolution.resolution_id: resolution for resolution in resolutions}
+    resolution_map = {
+        resolution.resolution_id: resolution for resolution in resolutions
+    }
     emitted_ids: set[str] = set()
     filtered_record_ids: list[str] = []
     low_confidence_option_ids: list[str] = []
@@ -80,7 +94,10 @@ def ingest_activity_snapshot(
     provenance_refs: list[ProvenanceReference] = []
 
     for decision in dedup_decisions:
-        if decision.entity_scope != "activity" or decision.option_kind != snapshot.option_kind:
+        if (
+            decision.entity_scope != "activity"
+            or decision.option_kind != snapshot.option_kind
+        ):
             continue
         record_ids = _record_ids_for_decision(decision, resolution_map)
         records = _records_for_decision(snapshot.records, decision, resolution_map)
@@ -88,7 +105,9 @@ def ingest_activity_snapshot(
         if decision.decision == "suppress":
             emitted_ids.update(record_ids)
             filtered_record_ids.extend(
-                record_id for record_id in record_ids if record_id not in filtered_record_ids
+                record_id
+                for record_id in record_ids
+                if record_id not in filtered_record_ids
             )
             continue
         if decision.decision in {"keep_separate", "needs_review"}:
@@ -109,9 +128,14 @@ def ingest_activity_snapshot(
                     snapshot,
                     _separate_option_id(decision.canonical_entity_id, record),
                 )
-                option.notes.extend([f"dedup_decision:{decision.decision_id}", *decision.notes])
+                option.notes.extend(
+                    [f"dedup_decision:{decision.decision_id}", *decision.notes]
+                )
                 option.feasibility.constraints.extend(
-                    [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                    [
+                        f"{conflict.attribute_path}:{conflict.reason}"
+                        for conflict in unresolved
+                    ]
                 )
                 record_warnings = record.payload.get("normalization_warnings", [])
                 if record_warnings:
@@ -143,7 +167,9 @@ def ingest_activity_snapshot(
                 )
             )
             continue
-        option = _activity_option_from_records(records, snapshot, decision.canonical_entity_id)
+        option = _activity_option_from_records(
+            records, snapshot, decision.canonical_entity_id
+        )
         option.notes.extend([f"dedup_decision:{decision.decision_id}", *decision.notes])
         option.feasibility.constraints.extend(
             [
@@ -178,13 +204,21 @@ def ingest_activity_snapshot(
             [record], snapshot, _canonical_option_id(record, resolution)
         )
         if resolution is not None:
-            option.notes.extend([f"resolution:{resolution.resolution_id}", *resolution.notes])
+            option.notes.extend(
+                [f"resolution:{resolution.resolution_id}", *resolution.notes]
+            )
             unresolved = unresolved_conflicts(resolution.conflicts)
             preserved_conflicts.extend(unresolved)
             option.feasibility.constraints.extend(
-                [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                [
+                    f"{conflict.attribute_path}:{conflict.reason}"
+                    for conflict in unresolved
+                ]
             )
-            if resolution.review_required or _lowest_match_confidence(resolution) < 0.75:
+            if (
+                resolution.review_required
+                or _lowest_match_confidence(resolution) < 0.75
+            ):
                 low_confidence_option_ids.append(option.option_id)
         record_warnings = record.payload.get("normalization_warnings", [])
         if record_warnings:
@@ -241,32 +275,6 @@ def ingest_activity_snapshot(
     )
 
 
-def _records_for_decision(
-    records: list[RawSourceRecord],
-    decision: DeduplicationDecision,
-    resolution_map: dict[str, EntityResolution],
-) -> list[RawSourceRecord]:
-    ordered_ids = _record_ids_for_decision(decision, resolution_map)
-    if not ordered_ids:
-        return []
-    by_id = {record.record_id: record for record in records}
-    return [by_id[record_id] for record_id in ordered_ids if record_id in by_id]
-
-
-def _record_ids_for_decision(
-    decision: DeduplicationDecision,
-    resolution_map: dict[str, EntityResolution],
-) -> list[str]:
-    record_ids: list[str] = []
-    for resolution_id in decision.resolution_ids:
-        resolution = resolution_map.get(resolution_id)
-        if resolution is None:
-            continue
-        for candidate in resolution.match_candidates:
-            record_ids.extend(candidate.source_record_ids)
-    return list(dict.fromkeys(record_ids))
-
-
 def _activity_option_from_records(
     records: list[RawSourceRecord],
     snapshot: RawSnapshot,
@@ -316,18 +324,9 @@ def _activity_option_from_records(
     return ActivityOption.from_dict(payload)
 
 
-def _resolution_for_record(
-    record_id: str,
-    resolutions: list[EntityResolution],
-) -> EntityResolution | None:
-    for resolution in resolutions:
-        for candidate in resolution.match_candidates:
-            if record_id in candidate.source_record_ids:
-                return resolution
-    return None
-
-
-def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution | None) -> str:
+def _canonical_option_id(
+    record: RawSourceRecord, resolution: EntityResolution | None
+) -> str:
     if resolution is not None:
         return resolution.canonical_entity_id
     payload_option_id = record.payload.get("option_id")
@@ -344,18 +343,6 @@ def _lowest_match_confidence(resolution: EntityResolution) -> float:
     if not resolution.match_candidates:
         return 0.0
     return min(candidate.confidence for candidate in resolution.match_candidates)
-
-
-def _dedupe_conflicts(conflicts: list[AttributeConflict]) -> list[AttributeConflict]:
-    deduped: list[AttributeConflict] = []
-    seen: set[tuple[str, str, str]] = set()
-    for conflict in conflicts:
-        key = (conflict.conflict_id, conflict.attribute_path, conflict.status)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(conflict)
-    return deduped
 
 
 def _merge_string_lists(*lists: Any) -> list[str]:
@@ -384,11 +371,3 @@ def _merge_mapping(existing: Any, incoming: Any) -> dict[str, Any]:
             if key not in result or result[key] in ("", None, [], {}):
                 result[key] = value
     return result
-
-
-def _contribution_kind(source_category: str) -> str:
-    if source_category == "official_operational":
-        return "operational"
-    if source_category in {"editorial", "specialist_non_commercial"}:
-        return "editorial"
-    return "inventory"

--- a/trip_planner/ingestion/destination_pipeline.py
+++ b/trip_planner/ingestion/destination_pipeline.py
@@ -20,6 +20,11 @@ from trip_planner.sources import (
 from ._common import (
     IngestionSummary,
     IngestionWarning,
+    _contribution_kind,
+    _dedupe_conflicts,
+    _record_ids_for_decision,
+    _records_for_decision,
+    _resolution_for_record,
     build_provenance_reference,
     make_handoff,
     unresolved_conflicts,
@@ -43,11 +48,18 @@ class DestinationIngestionResult:
         require_non_empty(self.snapshot_id, "snapshot_id")
         if any(not isinstance(item, Destination) for item in self.destinations):
             raise ValueError("destinations must contain Destination instances")
-        if any(not isinstance(item, AttributeConflict) for item in self.unresolved_conflicts):
-            raise ValueError("unresolved_conflicts must contain AttributeConflict instances")
+        if any(
+            not isinstance(item, AttributeConflict)
+            for item in self.unresolved_conflicts
+        ):
+            raise ValueError(
+                "unresolved_conflicts must contain AttributeConflict instances"
+            )
         if any(not isinstance(item, IngestionWarning) for item in self.warnings):
             raise ValueError("warnings must contain IngestionWarning instances")
-        if self.handoff is not None and not isinstance(self.handoff, NormalizationHandoff):
+        if self.handoff is not None and not isinstance(
+            self.handoff, NormalizationHandoff
+        ):
             raise ValueError("handoff must be a NormalizationHandoff when provided")
         if not isinstance(self.summary, IngestionSummary):
             raise ValueError("summary must be an IngestionSummary")
@@ -71,7 +83,9 @@ def ingest_destination_snapshot(
     resolutions = resolutions or []
     dedup_decisions = dedup_decisions or []
     warnings = [warning_from_issue(issue) for issue in snapshot.issues]
-    resolution_map = {resolution.resolution_id: resolution for resolution in resolutions}
+    resolution_map = {
+        resolution.resolution_id: resolution for resolution in resolutions
+    }
     emitted_ids: set[str] = set()
     filtered_record_ids: list[str] = []
     low_confidence_destination_ids: list[str] = []
@@ -80,7 +94,10 @@ def ingest_destination_snapshot(
     provenance_refs: list[ProvenanceReference] = []
 
     for decision in dedup_decisions:
-        if decision.entity_scope != "destination" or decision.option_kind != snapshot.option_kind:
+        if (
+            decision.entity_scope != "destination"
+            or decision.option_kind != snapshot.option_kind
+        ):
             continue
         record_ids = _record_ids_for_decision(decision, resolution_map)
         records = _records_for_decision(snapshot.records, decision, resolution_map)
@@ -88,7 +105,9 @@ def ingest_destination_snapshot(
         if decision.decision == "suppress":
             emitted_ids.update(record_ids)
             filtered_record_ids.extend(
-                record_id for record_id in record_ids if record_id not in filtered_record_ids
+                record_id
+                for record_id in record_ids
+                if record_id not in filtered_record_ids
             )
             continue
         if decision.decision in {"keep_separate", "needs_review"}:
@@ -154,7 +173,9 @@ def ingest_destination_snapshot(
             continue
         resolution = _resolution_for_record(record.record_id, resolutions)
         destination_id = _canonical_destination_id(record, resolution)
-        destination, refs = _destination_from_records([record], snapshot, destination_id)
+        destination, refs = _destination_from_records(
+            [record], snapshot, destination_id
+        )
         if resolution is not None:
             destination = _append_resolution_refs(
                 destination,
@@ -163,7 +184,10 @@ def ingest_destination_snapshot(
             )
             unresolved = unresolved_conflicts(resolution.conflicts)
             preserved_conflicts.extend(unresolved)
-            if resolution.review_required or _lowest_match_confidence(resolution) < 0.75:
+            if (
+                resolution.review_required
+                or _lowest_match_confidence(resolution) < 0.75
+            ):
                 low_confidence_destination_ids.append(destination.destination_id)
         _append_record_warnings(destination, [record], warnings)
         destinations.append(destination)
@@ -183,7 +207,8 @@ def ingest_destination_snapshot(
         degraded_options=sum(
             1
             for destination in destinations
-            if destination.operational_notes or any(ref.notes for ref in destination.source_refs)
+            if destination.operational_notes
+            or any(ref.notes for ref in destination.source_refs)
         ),
         unresolved_conflicts=len(preserved_conflicts),
         low_confidence_option_ids=sorted(set(low_confidence_destination_ids)),
@@ -241,7 +266,9 @@ def _destination_from_records(
                 contribution_kind=ref.contribution_kind,
                 summary=ref.summary,
                 freshness_days_at_capture=ref.freshness_days_at_capture,
-                notes=_merge_scalar_list(ref.notes, record.payload.get("ingestion_notes", [])),
+                notes=_merge_scalar_list(
+                    ref.notes, record.payload.get("ingestion_notes", [])
+                ),
             )
         )
         provenance_refs.append(ref)
@@ -325,7 +352,9 @@ def _resolution_source_ref(
 ) -> list[DestinationSourceRef]:
     notes = [f"resolution:{resolution.resolution_id}", *resolution.notes]
     unresolved = unresolved_conflicts(resolution.conflicts)
-    notes.extend(f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved)
+    notes.extend(
+        f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved
+    )
     return [
         DestinationSourceRef(
             provenance_id=f"{snapshot.snapshot_id}:{resolution.resolution_id}",
@@ -355,32 +384,6 @@ def _append_resolution_refs(
                 destination.source_refs.append(ref)
                 existing_ids.add(ref.provenance_id)
     return destination
-
-
-def _records_for_decision(
-    records: list[RawSourceRecord],
-    decision: DeduplicationDecision,
-    resolution_map: dict[str, EntityResolution],
-) -> list[RawSourceRecord]:
-    ordered_ids = _record_ids_for_decision(decision, resolution_map)
-    if not ordered_ids:
-        return []
-    by_id = {record.record_id: record for record in records}
-    return [by_id[record_id] for record_id in ordered_ids if record_id in by_id]
-
-
-def _record_ids_for_decision(
-    decision: DeduplicationDecision,
-    resolution_map: dict[str, EntityResolution],
-) -> list[str]:
-    record_ids: list[str] = []
-    for resolution_id in decision.resolution_ids:
-        resolution = resolution_map.get(resolution_id)
-        if resolution is None:
-            continue
-        for candidate in resolution.match_candidates:
-            record_ids.extend(candidate.source_record_ids)
-    return list(dict.fromkeys(record_ids))
 
 
 def _resolutions_for_decision(
@@ -415,18 +418,9 @@ def _resolutions_for_record(
     return matched
 
 
-def _resolution_for_record(
-    record_id: str,
-    resolutions: list[EntityResolution],
-) -> EntityResolution | None:
-    for resolution in resolutions:
-        for candidate in resolution.match_candidates:
-            if record_id in candidate.source_record_ids:
-                return resolution
-    return None
-
-
-def _canonical_destination_id(record: RawSourceRecord, resolution: EntityResolution | None) -> str:
+def _canonical_destination_id(
+    record: RawSourceRecord, resolution: EntityResolution | None
+) -> str:
     if resolution is not None:
         return resolution.canonical_entity_id
     payload_destination_id = record.payload.get("destination_id")
@@ -443,18 +437,6 @@ def _lowest_match_confidence(resolution: EntityResolution) -> float:
     if not resolution.match_candidates:
         return 0.0
     return min(candidate.confidence for candidate in resolution.match_candidates)
-
-
-def _dedupe_conflicts(conflicts: list[AttributeConflict]) -> list[AttributeConflict]:
-    deduped: list[AttributeConflict] = []
-    seen: set[tuple[str, str, str]] = set()
-    for conflict in conflicts:
-        key = (conflict.conflict_id, conflict.attribute_path, conflict.status)
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(conflict)
-    return deduped
 
 
 def _merge_sequence(existing: Any, incoming: Any) -> list[Any]:
@@ -499,11 +481,3 @@ def _destination_role(source_category: str) -> str:
     if source_category in {"editorial", "specialist_non_commercial"}:
         return "experience"
     return "identity"
-
-
-def _contribution_kind(source_category: str) -> str:
-    if source_category == "official_operational":
-        return "operational"
-    if source_category in {"editorial", "specialist_non_commercial"}:
-        return "editorial"
-    return "inventory"

--- a/trip_planner/ingestion/lodging_pipeline.py
+++ b/trip_planner/ingestion/lodging_pipeline.py
@@ -20,6 +20,10 @@ from trip_planner.sources import (
 from ._common import (
     IngestionSummary,
     IngestionWarning,
+    _dedupe_conflicts,
+    _record_ids_for_decision,
+    _records_for_decision,
+    _resolution_for_record,
     build_provenance_reference,
     make_handoff,
     unresolved_conflicts,
@@ -43,11 +47,18 @@ class LodgingIngestionResult:
         require_non_empty(self.snapshot_id, "snapshot_id")
         if any(not isinstance(item, LodgingOption) for item in self.lodging_options):
             raise ValueError("lodging_options must contain LodgingOption instances")
-        if any(not isinstance(item, AttributeConflict) for item in self.unresolved_conflicts):
-            raise ValueError("unresolved_conflicts must contain AttributeConflict instances")
+        if any(
+            not isinstance(item, AttributeConflict)
+            for item in self.unresolved_conflicts
+        ):
+            raise ValueError(
+                "unresolved_conflicts must contain AttributeConflict instances"
+            )
         if any(not isinstance(item, IngestionWarning) for item in self.warnings):
             raise ValueError("warnings must contain IngestionWarning instances")
-        if self.handoff is not None and not isinstance(self.handoff, NormalizationHandoff):
+        if self.handoff is not None and not isinstance(
+            self.handoff, NormalizationHandoff
+        ):
             raise ValueError("handoff must be a NormalizationHandoff when provided")
         if not isinstance(self.summary, IngestionSummary):
             raise ValueError("summary must be an IngestionSummary")
@@ -71,7 +82,9 @@ def ingest_lodging_snapshot(
     resolutions = resolutions or []
     dedup_decisions = dedup_decisions or []
     warnings = [warning_from_issue(issue) for issue in snapshot.issues]
-    resolution_map = {resolution.resolution_id: resolution for resolution in resolutions}
+    resolution_map = {
+        resolution.resolution_id: resolution for resolution in resolutions
+    }
     emitted_ids: set[str] = set()
     filtered_record_ids: list[str] = []
     low_confidence_option_ids: list[str] = []
@@ -80,15 +93,22 @@ def ingest_lodging_snapshot(
     provenance_refs: list[ProvenanceReference] = []
 
     for decision in dedup_decisions:
-        if decision.entity_scope != "lodging" or decision.option_kind != snapshot.option_kind:
+        if (
+            decision.entity_scope != "lodging"
+            or decision.option_kind != snapshot.option_kind
+        ):
             continue
         record_ids = _record_ids_for_decision(decision, resolution_map)
-        candidate_records = _records_for_decision(snapshot.records, decision, resolution_map)
+        candidate_records = _records_for_decision(
+            snapshot.records, decision, resolution_map
+        )
         preserved_conflicts.extend(unresolved_conflicts(decision.preserved_conflicts))
         if decision.decision == "suppress":
             emitted_ids.update(record_ids)
             filtered_record_ids.extend(
-                record_id for record_id in record_ids if record_id not in filtered_record_ids
+                record_id
+                for record_id in record_ids
+                if record_id not in filtered_record_ids
             )
             continue
         if decision.decision in {"keep_separate", "needs_review"}:
@@ -109,9 +129,14 @@ def ingest_lodging_snapshot(
                     snapshot,
                     _separate_option_id(decision.canonical_entity_id, record),
                 )
-                option.notes.extend([f"dedup_decision:{decision.decision_id}", *decision.notes])
+                option.notes.extend(
+                    [f"dedup_decision:{decision.decision_id}", *decision.notes]
+                )
                 option.feasibility.constraints.extend(
-                    [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                    [
+                        f"{conflict.attribute_path}:{conflict.reason}"
+                        for conflict in unresolved
+                    ]
                 )
                 record_warnings = record.payload.get("normalization_warnings", [])
                 if record_warnings:
@@ -180,13 +205,21 @@ def ingest_lodging_snapshot(
             [record], snapshot, _canonical_option_id(record, resolution)
         )
         if resolution is not None:
-            option.notes.extend([f"resolution:{resolution.resolution_id}", *resolution.notes])
+            option.notes.extend(
+                [f"resolution:{resolution.resolution_id}", *resolution.notes]
+            )
             unresolved = unresolved_conflicts(resolution.conflicts)
             preserved_conflicts.extend(unresolved)
             option.feasibility.constraints.extend(
-                [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                [
+                    f"{conflict.attribute_path}:{conflict.reason}"
+                    for conflict in unresolved
+                ]
             )
-            if resolution.review_required or _lowest_match_confidence(resolution) < 0.75:
+            if (
+                resolution.review_required
+                or _lowest_match_confidence(resolution) < 0.75
+            ):
                 low_confidence_option_ids.append(option.option_id)
         record_warnings = record.payload.get("normalization_warnings", [])
         if record_warnings:
@@ -228,7 +261,9 @@ def ingest_lodging_snapshot(
             warning.warning_id for warning in warnings if warning.severity == "error"
         ],
         provenance_refs=provenance_refs,
-        notes=["Lodging ingestion scaffolding emitted normalized options from raw snapshots."],
+        notes=[
+            "Lodging ingestion scaffolding emitted normalized options from raw snapshots."
+        ],
     )
     return LodgingIngestionResult(
         pipeline_id=f"lodging-ingestion:{snapshot.snapshot_id}",
@@ -239,32 +274,6 @@ def ingest_lodging_snapshot(
         handoff=handoff,
         summary=summary,
     )
-
-
-def _records_for_decision(
-    records: list[RawSourceRecord],
-    decision: DeduplicationDecision,
-    resolution_map: dict[str, EntityResolution],
-) -> list[RawSourceRecord]:
-    ordered_ids = _record_ids_for_decision(decision, resolution_map)
-    if not ordered_ids:
-        return []
-    by_id = {record.record_id: record for record in records}
-    return [by_id[record_id] for record_id in ordered_ids if record_id in by_id]
-
-
-def _record_ids_for_decision(
-    decision: DeduplicationDecision,
-    resolution_map: dict[str, EntityResolution],
-) -> list[str]:
-    record_ids: list[str] = []
-    for resolution_id in decision.resolution_ids:
-        resolution = resolution_map.get(resolution_id)
-        if resolution is None:
-            continue
-        for candidate in resolution.match_candidates:
-            record_ids.extend(candidate.source_record_ids)
-    return list(dict.fromkeys(record_ids))
 
 
 def _lodging_option_from_records(
@@ -303,18 +312,9 @@ def _lodging_option_from_records(
     return LodgingOption.from_dict(payload)
 
 
-def _resolution_for_record(
-    record_id: str,
-    resolutions: list[EntityResolution],
-) -> EntityResolution | None:
-    for resolution in resolutions:
-        for candidate in resolution.match_candidates:
-            if record_id in candidate.source_record_ids:
-                return resolution
-    return None
-
-
-def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution | None) -> str:
+def _canonical_option_id(
+    record: RawSourceRecord, resolution: EntityResolution | None
+) -> str:
     if resolution is not None:
         return resolution.canonical_entity_id
     return f"lodging-{record.provider_entity_id}"
@@ -328,10 +328,3 @@ def _lowest_match_confidence(resolution: EntityResolution) -> float:
     if not resolution.match_candidates:
         return 1.0
     return min(candidate.confidence for candidate in resolution.match_candidates)
-
-
-def _dedupe_conflicts(conflicts: list[AttributeConflict]) -> list[AttributeConflict]:
-    deduped: dict[str, AttributeConflict] = {}
-    for conflict in conflicts:
-        deduped[conflict.conflict_id] = conflict
-    return list(deduped.values())

--- a/trip_planner/ingestion/transport_pipeline.py
+++ b/trip_planner/ingestion/transport_pipeline.py
@@ -19,6 +19,10 @@ from trip_planner.sources import (
 from ._common import (
     IngestionSummary,
     IngestionWarning,
+    _dedupe_conflicts,
+    _record_ids_for_decision,
+    _records_for_decision,
+    _resolution_for_record,
     build_provenance_reference,
     make_handoff,
     unresolved_conflicts,
@@ -40,13 +44,22 @@ class TransportIngestionResult:
     def __post_init__(self) -> None:
         require_non_empty(self.pipeline_id, "pipeline_id")
         require_non_empty(self.snapshot_id, "snapshot_id")
-        if any(not isinstance(item, TransportOption) for item in self.transport_options):
+        if any(
+            not isinstance(item, TransportOption) for item in self.transport_options
+        ):
             raise ValueError("transport_options must contain TransportOption instances")
-        if any(not isinstance(item, AttributeConflict) for item in self.unresolved_conflicts):
-            raise ValueError("unresolved_conflicts must contain AttributeConflict instances")
+        if any(
+            not isinstance(item, AttributeConflict)
+            for item in self.unresolved_conflicts
+        ):
+            raise ValueError(
+                "unresolved_conflicts must contain AttributeConflict instances"
+            )
         if any(not isinstance(item, IngestionWarning) for item in self.warnings):
             raise ValueError("warnings must contain IngestionWarning instances")
-        if self.handoff is not None and not isinstance(self.handoff, NormalizationHandoff):
+        if self.handoff is not None and not isinstance(
+            self.handoff, NormalizationHandoff
+        ):
             raise ValueError("handoff must be a NormalizationHandoff when provided")
         if not isinstance(self.summary, IngestionSummary):
             raise ValueError("summary must be an IngestionSummary")
@@ -70,7 +83,9 @@ def ingest_transport_snapshot(
     resolutions = resolutions or []
     dedup_decisions = dedup_decisions or []
     warnings = [warning_from_issue(issue) for issue in snapshot.issues]
-    resolution_map = {resolution.resolution_id: resolution for resolution in resolutions}
+    resolution_map = {
+        resolution.resolution_id: resolution for resolution in resolutions
+    }
     emitted_ids: set[str] = set()
     filtered_record_ids: list[str] = []
     low_confidence_option_ids: list[str] = []
@@ -79,7 +94,10 @@ def ingest_transport_snapshot(
     provenance_refs = []
 
     for decision in dedup_decisions:
-        if decision.entity_scope != "transport" or decision.option_kind != snapshot.option_kind:
+        if (
+            decision.entity_scope != "transport"
+            or decision.option_kind != snapshot.option_kind
+        ):
             continue
         record_ids = _record_ids_for_decision(decision, resolution_map)
         records = _records_for_decision(snapshot.records, decision, resolution_map)
@@ -87,7 +105,9 @@ def ingest_transport_snapshot(
         if decision.decision == "suppress":
             emitted_ids.update(record_ids)
             filtered_record_ids.extend(
-                record_id for record_id in record_ids if record_id not in filtered_record_ids
+                record_id
+                for record_id in record_ids
+                if record_id not in filtered_record_ids
             )
             continue
         if decision.decision in {"keep_separate", "needs_review"}:
@@ -108,9 +128,14 @@ def ingest_transport_snapshot(
                     snapshot,
                     _separate_option_id(decision.canonical_entity_id, record),
                 )
-                option.notes.extend([f"dedup_decision:{decision.decision_id}", *decision.notes])
+                option.notes.extend(
+                    [f"dedup_decision:{decision.decision_id}", *decision.notes]
+                )
                 option.feasibility.constraints.extend(
-                    [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                    [
+                        f"{conflict.attribute_path}:{conflict.reason}"
+                        for conflict in unresolved
+                    ]
                 )
                 record_warnings = record.payload.get("normalization_warnings", [])
                 if record_warnings:
@@ -142,7 +167,9 @@ def ingest_transport_snapshot(
                 )
             )
             continue
-        option = _transport_option_from_records(records, snapshot, decision.canonical_entity_id)
+        option = _transport_option_from_records(
+            records, snapshot, decision.canonical_entity_id
+        )
         option.notes.extend([f"dedup_decision:{decision.decision_id}", *decision.notes])
         option.feasibility.constraints.extend(
             [
@@ -177,13 +204,21 @@ def ingest_transport_snapshot(
             [record], snapshot, _canonical_option_id(record, resolution)
         )
         if resolution is not None:
-            option.notes.extend([f"resolution:{resolution.resolution_id}", *resolution.notes])
+            option.notes.extend(
+                [f"resolution:{resolution.resolution_id}", *resolution.notes]
+            )
             unresolved = unresolved_conflicts(resolution.conflicts)
             preserved_conflicts.extend(unresolved)
             option.feasibility.constraints.extend(
-                [f"{conflict.attribute_path}:{conflict.reason}" for conflict in unresolved]
+                [
+                    f"{conflict.attribute_path}:{conflict.reason}"
+                    for conflict in unresolved
+                ]
             )
-            if resolution.review_required or _lowest_match_confidence(resolution) < 0.75:
+            if (
+                resolution.review_required
+                or _lowest_match_confidence(resolution) < 0.75
+            ):
                 low_confidence_option_ids.append(option.option_id)
         record_warnings = record.payload.get("normalization_warnings", [])
         if record_warnings:
@@ -225,7 +260,9 @@ def ingest_transport_snapshot(
             warning.warning_id for warning in warnings if warning.severity == "error"
         ],
         provenance_refs=provenance_refs,
-        notes=["Transport ingestion scaffolding emitted normalized options from raw snapshots."],
+        notes=[
+            "Transport ingestion scaffolding emitted normalized options from raw snapshots."
+        ],
     )
     return TransportIngestionResult(
         pipeline_id=f"transport-ingestion:{snapshot.snapshot_id}",
@@ -236,32 +273,6 @@ def ingest_transport_snapshot(
         handoff=handoff,
         summary=summary,
     )
-
-
-def _records_for_decision(
-    records: list[RawSourceRecord],
-    decision: DeduplicationDecision,
-    resolution_map: dict[str, EntityResolution],
-) -> list[RawSourceRecord]:
-    ordered_ids = _record_ids_for_decision(decision, resolution_map)
-    if not ordered_ids:
-        return []
-    by_id = {record.record_id: record for record in records}
-    return [by_id[record_id] for record_id in ordered_ids if record_id in by_id]
-
-
-def _record_ids_for_decision(
-    decision: DeduplicationDecision,
-    resolution_map: dict[str, EntityResolution],
-) -> list[str]:
-    record_ids: list[str] = []
-    for resolution_id in decision.resolution_ids:
-        resolution = resolution_map.get(resolution_id)
-        if resolution is None:
-            continue
-        for candidate in resolution.match_candidates:
-            record_ids.extend(candidate.source_record_ids)
-    return list(dict.fromkeys(record_ids))
 
 
 def _transport_option_from_records(
@@ -297,18 +308,9 @@ def _transport_option_from_records(
     return TransportOption.from_dict(payload)
 
 
-def _resolution_for_record(
-    record_id: str,
-    resolutions: list[EntityResolution],
-) -> EntityResolution | None:
-    for resolution in resolutions:
-        for candidate in resolution.match_candidates:
-            if record_id in candidate.source_record_ids:
-                return resolution
-    return None
-
-
-def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution | None) -> str:
+def _canonical_option_id(
+    record: RawSourceRecord, resolution: EntityResolution | None
+) -> str:
     if resolution is not None:
         return resolution.canonical_entity_id
     return f"transport-{record.provider_entity_id}"
@@ -322,10 +324,3 @@ def _lowest_match_confidence(resolution: EntityResolution) -> float:
     if not resolution.match_candidates:
         return 1.0
     return min(candidate.confidence for candidate in resolution.match_candidates)
-
-
-def _dedupe_conflicts(conflicts: list[AttributeConflict]) -> list[AttributeConflict]:
-    deduped: dict[str, AttributeConflict] = {}
-    for conflict in conflicts:
-        deduped[conflict.conflict_id] = conflict
-    return list(deduped.values())

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,23 @@
+## 2026-06-05T05:08Z - opener lane issue #1307 ingestion dedupe
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1307` (`De-duplicate the four snapshot ingestion pipelines`).
+- Branch: `codex/issue-1307-ingestion-dedupe`, base `origin/main` `19774df45`.
+- Selection notes: raw opener cap was below limit (`total_opener_owned=1`, `raw_cap_reached=false`). Existing opener-owned Trend PR #5440 remains scoped/non-repairable on the strict-config owner/product decision; no cap-drain repair was available. High-priority liveness items #5343 and LMS #180 remained scoped, #5389 remains scoped through PR #5440, Workflows #2228/#2229 are already served by merged PRs, and trip-planner #1306 is a tracking epic. #1307 was the oldest unlinked implementation issue with no existing PR.
+- Implementation:
+  - Moved shared dedup decision record lookup, record-id lookup, per-record resolution lookup, conflict dedupe, and contribution-kind helpers into `trip_planner/ingestion/_common.py`.
+  - Rewired destination, lodging, activity, and transport ingestion pipelines to use the common helpers, removing their duplicate helper definitions.
+  - Converged `_dedupe_conflicts` on tuple-key semantics `(conflict_id, attribute_path, status)` so distinct conflict rows sharing one id are preserved.
+  - Added `tests/ingestion/test_common_dedupe.py` covering the shared tuple-key behavior.
+- Validation:
+  - `python -m pytest tests/ingestion -q` -> 18 passed.
+  - `python -m ruff check trip_planner/ingestion tests/ingestion/test_common_dedupe.py` -> passed.
+  - Grep gate: all four entity pipeline files returned `0` for local `_records_for_decision`, `_record_ids_for_decision`, `_resolution_for_record`, `_dedupe_conflicts`, and `_contribution_kind` definitions; `_common.py` has exactly one `_dedupe_conflicts`.
+  - Public import gate printed `ingest_destination_snapshot`, `ingest_lodging_snapshot`, `ingest_activity_snapshot`, and `ingest_transport_snapshot`.
+  - `git diff --check` -> passed.
+  - Deliberate-break gate: temporarily replaced shared `_dedupe_conflicts` with conflict-id-only dict logic; `tests/ingestion/test_common_dedupe.py::test_dedupe_conflicts_preserves_distinct_attribute_rows` failed because the distinct refundable row was dropped. Restored tuple-key behavior and reran ingestion suite green.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
+
 ## 2026-06-01T01:55Z - closer lane PR #1283 review fix pushed
 
 - Repo: `stranske/trip-planner`

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -9,9 +9,11 @@
   - Rewired destination, lodging, activity, and transport ingestion pipelines to use the common helpers, removing their duplicate helper definitions.
   - Converged `_dedupe_conflicts` on tuple-key semantics `(conflict_id, attribute_path, status)` so distinct conflict rows sharing one id are preserved.
   - Added `tests/ingestion/test_common_dedupe.py` covering the shared tuple-key behavior.
+  - Post-open CI recovery: fixed `scripts/sync_test_dependencies.py` mypy tuple-shape inference by annotating pytest ini config constants as variadic string tuples.
 - Validation:
   - `python -m pytest tests/ingestion -q` -> 18 passed.
   - `python -m ruff check trip_planner/ingestion tests/ingestion/test_common_dedupe.py` -> passed.
+  - `python -m mypy --config-file pyproject.toml --exclude .workflows-lib scripts/sync_test_dependencies.py` -> passed after the CI recovery.
   - Grep gate: all four entity pipeline files returned `0` for local `_records_for_decision`, `_record_ids_for_decision`, `_resolution_for_record`, `_dedupe_conflicts`, and `_contribution_kind` definitions; `_common.py` has exactly one `_dedupe_conflicts`.
   - Public import gate printed `ingest_destination_snapshot`, `ingest_lodging_snapshot`, `ingest_activity_snapshot`, and `ingest_transport_snapshot`.
   - `git diff --check` -> passed.


### PR DESCRIPTION
Closes #1307

## Summary
- move shared dedup-decision record lookup, per-record resolution lookup, conflict dedupe, and contribution-kind helpers into `trip_planner/ingestion/_common.py`
- wire destination, lodging, activity, and transport ingestion pipelines to the common helpers
- preserve distinct conflict rows with tuple-key dedupe and add direct regression coverage

## Validation
- `python -m pytest tests/ingestion -q` -> 18 passed
- `python -m ruff check trip_planner/ingestion tests/ingestion/test_common_dedupe.py` -> passed
- grep gate: four entity pipelines define zero local `_records_for_decision`, `_record_ids_for_decision`, `_resolution_for_record`, `_dedupe_conflicts`, or `_contribution_kind`; `_common.py` defines one `_dedupe_conflicts`
- public import gate printed all four ingest entrypoint names
- `git diff --check` -> passed
- deliberate-break gate: conflict-id-only shared dedupe made `tests/ingestion/test_common_dedupe.py::test_dedupe_conflicts_preserves_distinct_attribute_rows` fail by dropping a distinct attribute row; restored tuple-key dedupe and reran green