### PR TITLE
Issue #1308: extract shared ranking validators

### DIFF
--- a/tests/ranking/test_base_ranking_engine.py
+++ b/tests/ranking/test_base_ranking_engine.py
@@ -1,0 +1,19 @@
+from trip_planner.ranking.base import BaseRankingEngine
+from trip_planner.ranking.business import BusinessRankingEngine
+from trip_planner.ranking.leisure import LeisureRankingEngine
+
+
+def test_shared_validators_defined_once() -> None:
+    for method_name in (
+        "validate_feasibility_outputs",
+        "validate_candidate_set",
+        "validate_bundles",
+    ):
+        base_method = getattr(BaseRankingEngine, method_name)
+        assert getattr(LeisureRankingEngine, method_name) is base_method
+        assert getattr(BusinessRankingEngine, method_name) is base_method
+
+
+def test_component_weights_stay_distinct() -> None:
+    assert round(sum(LeisureRankingEngine.COMPONENT_WEIGHTS.values()), 4) == 0.9
+    assert round(sum(BusinessRankingEngine.COMPONENT_WEIGHTS.values()), 4) == 1.0

--- a/tests/ranking/test_business_ranking.py
+++ b/tests/ranking/test_business_ranking.py
@@ -425,6 +425,19 @@ def test_business_ranking_reorders_candidates_by_business_constraints(
     assert results.results[0].score > results.results[1].score
 
 
+def test_business_rank_bundles_rejects_empty_bundle_sequence() -> None:
+    profile, objectives, constraint_set = _objectives_for_scenario("compliant_conference_trip.json")
+
+    with pytest.raises(ValueError, match="bundles must contain at least one InventoryBundle"):
+        BusinessRankingEngine().rank_bundles(
+            profile,
+            objectives,
+            [],
+            trip_id="trip-empty-business",
+            constraint_set=constraint_set,
+        )
+
+
 def test_business_ranking_uses_provided_feasibility_outputs() -> None:
     profile, objectives, constraint_set = _objectives_for_scenario(
         "schedule_sensitive_client_trip.json"

--- a/tests/ranking/test_leisure_ranking.py
+++ b/tests/ranking/test_leisure_ranking.py
@@ -356,6 +356,16 @@ def test_fixture_profiles_produce_expected_rank_order(fixture_name: str) -> None
     )
 
 
+def test_leisure_rank_bundles_rejects_empty_bundle_sequence() -> None:
+    with pytest.raises(ValueError, match="bundles must contain at least one InventoryBundle"):
+        LeisureRankingEngine().rank_bundles(
+            _profile_from_fixture("depth_oriented_urban_trip.json"),
+            _objectives_from_fixture("depth_oriented_urban_trip.json"),
+            [],
+            trip_id="trip-empty-leisure",
+        )
+
+
 def test_depth_oriented_profile_ranks_urban_culture_first() -> None:
     engine = LeisureRankingEngine()
     ranked = engine.rank_candidate_set(

--- a/trip_planner/ranking/__init__.py
+++ b/trip_planner/ranking/__init__.py
@@ -1,13 +1,11 @@
 """Canonical ranking-result contracts shared by later ranking modules."""
 
-from .business import BusinessRankingEngine
 from .explanations import (
     EXPLANATION_RECORD_TYPES,
     EXPLANATION_TARGET_KINDS,
     ExplanationRecord,
     build_source_confidence_explanation,
 )
-from .leisure import LeisureRankingEngine
 from .models import (
     ADJUSTMENT_KINDS,
     RANK_RESULT_KINDS,
@@ -21,12 +19,16 @@ from .models import (
     ScoreConfidenceSummary,
     ScoreContribution,
 )
+from .base import BaseRankingEngine
+from .business import BusinessRankingEngine
+from .leisure import LeisureRankingEngine
 
 __all__ = [
     "ADJUSTMENT_KINDS",
     "EXPLANATION_RECORD_TYPES",
     "EXPLANATION_TARGET_KINDS",
     "BusinessRankingEngine",
+    "BaseRankingEngine",
     "RANK_RESULT_KINDS",
     "RISK_SEVERITIES",
     "SCHEMA_VERSION",

--- a/trip_planner/ranking/base.py
+++ b/trip_planner/ranking/base.py
@@ -1,0 +1,53 @@
+"""Shared ranking-engine validation guards."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+from trip_planner.candidates import CandidateSet
+from trip_planner.options import InventoryBundle
+
+if TYPE_CHECKING:
+    from trip_planner.itinerary.feasibility import FeasibilityAssessment
+
+
+class BaseRankingEngine:
+    """Own validation guards common to leisure and business ranking engines."""
+
+    def validate_feasibility_outputs(
+        self,
+        feasibility_outputs: (
+            Mapping[str, FeasibilityAssessment] | Sequence[FeasibilityAssessment] | None
+        ),
+    ) -> dict[str, FeasibilityAssessment]:
+        from trip_planner.itinerary.feasibility import FeasibilityAssessment
+
+        if feasibility_outputs is None:
+            return {}
+        if isinstance(feasibility_outputs, Mapping):
+            values = dict(feasibility_outputs)
+        elif isinstance(feasibility_outputs, Sequence):
+            values = {item.bundle_id: item for item in feasibility_outputs}
+        else:
+            raise ValueError(
+                "feasibility_outputs must be a mapping, a sequence of FeasibilityAssessment values, or None"
+            )
+        if any(not isinstance(item, FeasibilityAssessment) for item in values.values()):
+            raise ValueError("feasibility_outputs must contain FeasibilityAssessment instances")
+        return values
+
+    def validate_candidate_set(self, candidate_set: CandidateSet) -> CandidateSet:
+        if not isinstance(candidate_set, CandidateSet):
+            raise ValueError("candidate_set must be a CandidateSet")
+        return candidate_set
+
+    def validate_bundles(self, bundles: Sequence[InventoryBundle]) -> list[InventoryBundle]:
+        if isinstance(bundles, (str, bytes)) or not isinstance(bundles, Sequence):
+            raise ValueError("bundles must be a sequence of InventoryBundle instances")
+        bundle_list = list(bundles)
+        if not bundle_list:
+            raise ValueError("bundles must contain at least one InventoryBundle")
+        if any(not isinstance(item, InventoryBundle) for item in bundle_list):
+            raise ValueError("bundles must contain InventoryBundle instances")
+        return bundle_list

--- a/trip_planner/ranking/business.py
+++ b/trip_planner/ranking/business.py
@@ -23,6 +23,7 @@ from trip_planner.itinerary import evaluate_bundle_feasibility
 from trip_planner.itinerary.feasibility import FeasibilityAssessment
 from trip_planner.options import InventoryBundle
 
+from .base import BaseRankingEngine
 from .explanations import ExplanationRecord
 from .models import (
     RankedResult,
@@ -118,7 +119,7 @@ class _RankableBusinessCandidate:
     source_refs: list[str]
 
 
-class BusinessRankingEngine:
+class BusinessRankingEngine(BaseRankingEngine):
     """Rank business candidates without replacing policy evaluation or approvals.
 
     Scoring semantics
@@ -178,41 +179,6 @@ class BusinessRankingEngine:
         if constraint_set is not None and not isinstance(constraint_set, PolicyConstraintSet):
             raise ValueError("constraint_set must be a PolicyConstraintSet when provided")
         return constraint_set
-
-    def validate_feasibility_outputs(
-        self,
-        feasibility_outputs: (
-            Mapping[str, FeasibilityAssessment] | Sequence[FeasibilityAssessment] | None
-        ),
-    ) -> dict[str, FeasibilityAssessment]:
-        if feasibility_outputs is None:
-            return {}
-        if isinstance(feasibility_outputs, Mapping):
-            values = dict(feasibility_outputs)
-        elif isinstance(feasibility_outputs, Sequence):
-            values = {item.bundle_id: item for item in feasibility_outputs}
-        else:
-            raise ValueError(
-                "feasibility_outputs must be a mapping, a sequence of FeasibilityAssessment values, or None"
-            )
-        if any(not isinstance(item, FeasibilityAssessment) for item in values.values()):
-            raise ValueError("feasibility_outputs must contain FeasibilityAssessment instances")
-        return values
-
-    def validate_candidate_set(self, candidate_set: CandidateSet) -> CandidateSet:
-        if not isinstance(candidate_set, CandidateSet):
-            raise ValueError("candidate_set must be a CandidateSet")
-        return candidate_set
-
-    def validate_bundles(self, bundles: Sequence[InventoryBundle]) -> list[InventoryBundle]:
-        if isinstance(bundles, (str, bytes)) or not isinstance(bundles, Sequence):
-            raise ValueError("bundles must be a sequence of InventoryBundle instances")
-        bundle_list = list(bundles)
-        if not bundle_list:
-            raise ValueError("bundles must contain at least one InventoryBundle")
-        if any(not isinstance(item, InventoryBundle) for item in bundle_list):
-            raise ValueError("bundles must contain InventoryBundle instances")
-        return bundle_list
 
     def rank_candidate_set(
         self,

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -21,6 +21,7 @@ from trip_planner.options import InventoryBundle
 from trip_planner.preferences import LeisurePreferenceProfile
 from trip_planner.preferences.models import Anchor
 
+from .base import BaseRankingEngine
 from .explanations import ExplanationRecord
 from .models import (
     RankedResult,
@@ -117,7 +118,7 @@ class _RankableCandidate:
     source_refs: list[str]
 
 
-class LeisureRankingEngine:
+class LeisureRankingEngine(BaseRankingEngine):
     """Rank leisure candidates without bypassing upstream profile or objective layers."""
 
     BASELINE_SCORE = 0.2
@@ -140,41 +141,6 @@ class LeisureRankingEngine:
         if not isinstance(objectives, ItineraryObjectives):
             raise ValueError("objectives must be an ItineraryObjectives")
         return objectives
-
-    def validate_feasibility_outputs(
-        self,
-        feasibility_outputs: (
-            Mapping[str, FeasibilityAssessment] | Sequence[FeasibilityAssessment] | None
-        ),
-    ) -> dict[str, FeasibilityAssessment]:
-        if feasibility_outputs is None:
-            return {}
-        if isinstance(feasibility_outputs, Mapping):
-            values = dict(feasibility_outputs)
-        elif isinstance(feasibility_outputs, Sequence):
-            values = {item.bundle_id: item for item in feasibility_outputs}
-        else:
-            raise ValueError(
-                "feasibility_outputs must be a mapping, a sequence of FeasibilityAssessment values, or None"
-            )
-        if any(not isinstance(item, FeasibilityAssessment) for item in values.values()):
-            raise ValueError("feasibility_outputs must contain FeasibilityAssessment instances")
-        return values
-
-    def validate_candidate_set(self, candidate_set: CandidateSet) -> CandidateSet:
-        if not isinstance(candidate_set, CandidateSet):
-            raise ValueError("candidate_set must be a CandidateSet")
-        return candidate_set
-
-    def validate_bundles(self, bundles: Sequence[InventoryBundle]) -> list[InventoryBundle]:
-        if isinstance(bundles, (str, bytes)) or not isinstance(bundles, Sequence):
-            raise ValueError("bundles must be a sequence of InventoryBundle instances")
-        bundle_list = list(bundles)
-        if not bundle_list:
-            raise ValueError("bundles must contain at least one InventoryBundle")
-        if any(not isinstance(item, InventoryBundle) for item in bundle_list):
-            raise ValueError("bundles must contain InventoryBundle instances")
-        return bundle_list
 
     def rank_candidate_set(
         self,

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,25 @@
+## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1308` (`Extract a shared BaseRankingEngine for leisure and business ranking`).
+- Branch: `codex/issue-1308-base-ranking-engine`, base `origin/main` `035c39da8`.
+- Selection notes: raw opener cap was below limit (`total_opener_owned=1`, `raw_cap_reached=false`). Existing opener-owned Trend PR #5440 remains scoped/non-repairable on the strict-config owner/product decision. High-priority Trend #5343 was freshly scoped because merged PR #5374 already delivered the code and the remaining blocker is owner public demo URL/screenshots/network evidence or waiver. LMS #180 remains scoped. trip-planner #1306 is a tracking epic; #1307 is already served by merged PR #1327. #1308 was the oldest unlinked implementation issue outside scoped blockers.
+- Implementation:
+  - Added `trip_planner/ranking/base.py` with shared `BaseRankingEngine` validators for feasibility outputs, candidate sets, and bundle sequences.
+  - Re-parented `LeisureRankingEngine` and `BusinessRankingEngine` to inherit the shared validators while leaving subclass-specific profile/objective validation, weights, and scoring internals in place.
+  - Reordered ranking package exports so direct base imports do not reintroduce the existing itinerary/ranking partial-initialization cycle.
+  - Added `tests/ranking/test_base_ranking_engine.py` for shared method identity and distinct component-weight sums.
+  - Added empty-bundle regression coverage in the business and leisure ranking suites so the deliberate-break gate proves both engines use the shared guard.
+- Validation:
+  - `python -m pytest tests/ranking/test_base_ranking_engine.py -q` -> 2 passed.
+  - `python -m pytest tests/ranking/test_business_ranking.py tests/ranking/test_leisure_ranking.py -q` -> 27 passed after restoring the deliberate break.
+  - `python -m pytest tests/ranking/ -q` -> 63 passed.
+  - `python -m ruff check trip_planner/ranking tests/ranking/test_base_ranking_engine.py tests/ranking/test_business_ranking.py tests/ranking/test_leisure_ranking.py` -> passed.
+  - `git diff --check` -> passed.
+  - Grep gate: `leisure.py` and `business.py` each have 0 local `def validate_feasibility_outputs`; `base.py` has the single definition.
+  - Deliberate-break gate: temporarily removed the empty-bundle guard from `BaseRankingEngine.validate_bundles`; `python -m pytest tests/ranking/test_business_ranking.py tests/ranking/test_leisure_ranking.py -q` failed the new business and leisure empty-bundle assertions with `results must contain at least one RankedResult`. Restored the guard and reran green.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
+
 ## 2026-06-05T05:08Z - opener lane issue #1307 ingestion dedupe
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -18,7 +18,9 @@
   - `git diff --check` -> passed.
   - Grep gate: `leisure.py` and `business.py` each have 0 local `def validate_feasibility_outputs`; `base.py` has the single definition.
   - Deliberate-break gate: temporarily removed the empty-bundle guard from `BaseRankingEngine.validate_bundles`; `python -m pytest tests/ranking/test_business_ranking.py tests/ranking/test_leisure_ranking.py -q` failed the new business and leisure empty-bundle assertions with `results must contain at least one RankedResult`. Restored the guard and reran green.
-- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
+- PR/routing: opened PR #1328 at https://github.com/stranske/trip-planner/pull/1328. PR is open/non-draft, closes #1308, and has `agent:codex`, `agents:keepalive`, `autofix`, and post-repair `agent:retry`.
+- Post-open repair: initial cap-health classified #1328 as `needs-dispatch-evidence`; `opener-repair-infra-stalls.py` added `agent:retry` and dispatched Gate Followups. Fresh cap-health at 2026-06-05T06:10:03Z classifies #1328 as `draining` with active Gate evidence on the branch.
+- Next action: keepalive owns PR #1328 CI/review; opener should move to the next eligible issue on a future round after cap/drain discovery.
 
 ## 2026-06-05T05:08Z - opener lane issue #1307 ingestion dedupe
 


### PR DESCRIPTION
Closes #1308

## Summary
- add BaseRankingEngine as the single owner for shared ranking validators
- re-parent leisure and business ranking engines onto the base while preserving distinct weights/scoring
- add shared-method identity tests plus empty-bundle regression coverage

## Validation
- python -m pytest tests/ranking/test_base_ranking_engine.py -q
- python -m pytest tests/ranking/test_business_ranking.py tests/ranking/test_leisure_ranking.py -q
- python -m pytest tests/ranking/ -q
- python -m ruff check trip_planner/ranking tests/ranking/test_base_ranking_engine.py tests/ranking/test_business_ranking.py tests/ranking/test_leisure_ranking.py
- git diff --check

## Deliberate-break gate
- Temporarily removed the empty-bundle guard from BaseRankingEngine.validate_bundles.
- python -m pytest tests/ranking/test_business_ranking.py tests/ranking/test_leisure_ranking.py -q failed both empty-bundle assertions.
- Restored the guard and reran the focused suites green.