### PR TITLE
Issue #1311: add planner intent classifier seam

### DIFF
--- a/tests/app/test_planner_intent.py
+++ b/tests/app/test_planner_intent.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trip_planner.app.main import create_app
+from trip_planner.app.services.planner import (
+    set_intent_classifier_factory_for_tests,
+    set_planner_chat_model_factory_for_tests,
+    set_planner_prompt_redactor_for_tests,
+)
+from trip_planner.app.services.planner_routing import IntentResult
+from trip_planner.persistence.db import reset_database_state
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'planner.db'}")
+    monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_PLANNER_PROVIDER", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_PLANNER_MODEL", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_DATA_ZONE", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
+    monkeypatch.delenv("LANGSMITH_PROJECT", raising=False)
+    monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+    monkeypatch.delenv("TRIP_PLANNER_LANGSMITH_FLEET_PATH", raising=False)
+    set_intent_classifier_factory_for_tests(None)
+    set_planner_chat_model_factory_for_tests(None)
+    set_planner_prompt_redactor_for_tests(None)
+    reset_database_state()
+    app = create_app()
+
+    with TestClient(app) as test_client:
+        signup = test_client.post(
+            "/api/auth/signup",
+            json={
+                "email": "planner-intent@example.com",
+                "password": "password123",
+                "display_name": "Planner Intent Owner",
+            },
+        )
+        assert signup.status_code == 201
+        yield test_client
+
+    set_intent_classifier_factory_for_tests(None)
+    set_planner_chat_model_factory_for_tests(None)
+    set_planner_prompt_redactor_for_tests(None)
+    reset_database_state()
+
+
+class StubIntentClassifier:
+    def classify(self, message: str, context: Mapping[str, Any]) -> IntentResult:
+        assert message == "let's lock it in"
+        assert context["base_task_class"]
+        return IntentResult(task_class="decision", intent="decision")
+
+
+def _create_trip(client: TestClient) -> str:
+    response = client.post(
+        "/api/trips",
+        json={
+            "title": "Intent classifier seam",
+            "summary": "Need a persisted planner session.",
+            "mode": "leisure",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-10",
+                "duration_days": 7,
+                "primary_regions": ["Kyoto"],
+                "traveler_party": {
+                    "kind": "solo",
+                    "traveler_count": 1,
+                    "notes": "Planner intent test",
+                },
+            },
+        },
+    )
+    assert response.status_code == 201, response.text
+    return str(response.json()["trip"]["trip_id"])
+
+
+def test_injected_classifier_routes_turn(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+    set_intent_classifier_factory_for_tests(lambda _: StubIntentClassifier())
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "let's lock it in"},
+    )
+
+    assert response.status_code == 200, response.text
+    metadata = response.json()["messages"][-1]["turn_metadata"]
+    assert metadata["task_class"] == "decision"
+    assert metadata["intent"] == "decision"
+    assert metadata["debug_routing_details"]["classifier_task_class"] == "decision"

--- a/tests/app/test_planner_intent.py
+++ b/tests/app/test_planner_intent.py
@@ -14,6 +14,10 @@ from trip_planner.app.services.planner import (
     set_planner_prompt_redactor_for_tests,
 )
 from trip_planner.app.services.planner_routing import IntentResult
+from trip_planner.app.services.planner_runtime_config import (
+    build_intent_classifier,
+    build_planner_runtime_config,
+)
 from trip_planner.persistence.db import reset_database_state
 
 
@@ -63,6 +67,21 @@ class StubIntentClassifier:
         return IntentResult(task_class="decision", intent="decision")
 
 
+class InvalidTaskClassifier:
+    def classify(self, message: str, context: Mapping[str, Any]) -> IntentResult:
+        assert context["base_task_class"]
+        return IntentResult(task_class="not_a_known_task", intent="not_a_known_task")
+
+
+class StubPlannerIntentModel:
+    def __init__(self) -> None:
+        self.payloads: list[dict[str, Any]] = []
+
+    def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.payloads.append(payload)
+        return {"task_class": "decision", "intent": "decision"}
+
+
 def _create_trip(client: TestClient) -> str:
     response = client.post(
         "/api/trips",
@@ -101,3 +120,40 @@ def test_injected_classifier_routes_turn(client: TestClient) -> None:
     assert metadata["task_class"] == "decision"
     assert metadata["intent"] == "decision"
     assert metadata["debug_routing_details"]["classifier_task_class"] == "decision"
+
+
+def test_model_intent_classifier_uses_configured_model() -> None:
+    runtime_config = build_planner_runtime_config(
+        {
+            "TRIP_PLANNER_PLANNER_PROVIDER": "fake",
+            "TRIP_PLANNER_PLANNER_MODEL": "intent-test-model",
+        }
+    )
+    model = StubPlannerIntentModel()
+    classifier = build_intent_classifier(runtime_config, model=model)
+
+    result = classifier.classify(
+        "let's lock it in",
+        {"base_task_class": "first_turn_triage", "planning_mode": "collaborative"},
+    )
+
+    assert result.task_class == "decision"
+    assert result.intent == "decision"
+    assert model.payloads
+    assert model.payloads[-1]["task"] == "classify_planner_intent"
+
+
+def test_invalid_classifier_task_class_falls_back_to_base_task(client: TestClient) -> None:
+    trip_id = _create_trip(client)
+    set_intent_classifier_factory_for_tests(lambda _: InvalidTaskClassifier())
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "let's lock it in"},
+    )
+
+    assert response.status_code == 200, response.text
+    metadata = response.json()["messages"][-1]["turn_metadata"]
+    assert metadata["task_class"] == "first_turn_triage"
+    assert metadata["intent"] == "first_turn_triage"
+    assert metadata["debug_routing_details"]["classifier_task_class"] == "first_turn_triage"

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -10,6 +10,7 @@ from sqlalchemy import delete, select
 from trip_planner.app.main import create_app
 from trip_planner.app.services.auth import AuthenticatedUser
 from trip_planner.app.services.planner import (
+    set_intent_classifier_factory_for_tests,
     set_planner_chat_model_factory_for_tests,
     set_planner_prompt_redactor_for_tests,
 )
@@ -46,6 +47,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.delenv("LANGSMITH_PROJECT", raising=False)
     monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
     monkeypatch.delenv("TRIP_PLANNER_LANGSMITH_FLEET_PATH", raising=False)
+    set_intent_classifier_factory_for_tests(None)
     set_planner_chat_model_factory_for_tests(None)
     set_planner_prompt_redactor_for_tests(None)
     reset_database_state()
@@ -63,6 +65,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
         assert signup.status_code == 201
         yield test_client
 
+    set_intent_classifier_factory_for_tests(None)
     set_planner_chat_model_factory_for_tests(None)
     set_planner_prompt_redactor_for_tests(None)
     reset_database_state()

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -81,6 +81,13 @@ class FakePlannerChatModel:
         return self.response
 
 
+def _planner_model_request(fake_model: FakePlannerChatModel) -> dict[str, Any]:
+    for request in fake_model.requests:
+        if "available_tools" in request:
+            return request
+    raise AssertionError("Planner model request was not captured")
+
+
 class FailingPlannerChatModel:
     def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
         del payload
@@ -264,9 +271,10 @@ def test_openai_planner_payload_uses_redaction_hook(
 
     assert response.status_code == 200
     assert redacted_payloads
-    assert fake_model.requests[0]["message"] == "[redacted traveler prompt]"
-    assert fake_model.requests[0]["data_zone"] == "proprietary"
-    assert "sensitive account context" not in json.dumps(fake_model.requests[0])
+    planner_request = _planner_model_request(fake_model)
+    assert planner_request["message"] == "[redacted traveler prompt]"
+    assert planner_request["data_zone"] == "proprietary"
+    assert "sensitive account context" not in json.dumps(planner_request)
 
 
 def test_planner_turn_persists_user_and_planner_messages(client: TestClient) -> None:
@@ -638,8 +646,9 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
         "read_policy_state",
         "read_proposal_state",
     }
-    assert fake_model.requests[0]["available_tools"][0]["tool_name"] == "read_workspace_state"
-    runtime_context = fake_model.requests[0]["runtime_context"]
+    planner_request = _planner_model_request(fake_model)
+    assert planner_request["available_tools"][0]["tool_name"] == "read_workspace_state"
+    runtime_context = planner_request["runtime_context"]
     assert isinstance(runtime_context, dict)
     assert runtime_context["trip"]["trip_id"] == trip_id
     assert runtime_context["context_readiness"]["status"] == "ready"
@@ -748,7 +757,8 @@ def test_configured_planner_model_receives_langsmith_trace_config(
     )
 
     assert response.status_code == 200
-    langsmith_config = fake_model.requests[0]["langsmith_run_config"]
+    planner_request = _planner_model_request(fake_model)
+    langsmith_config = planner_request["langsmith_run_config"]
     assert langsmith_config["run_name"] == "trip-planner.planner-conversation"
     assert "repo:trip-planner" in langsmith_config["tags"]
     assert langsmith_config["metadata"]["repo"] == "stranske/trip-planner"
@@ -756,7 +766,7 @@ def test_configured_planner_model_receives_langsmith_trace_config(
     assert langsmith_config["metadata"]["trip_id_hash"] != trip_id
     assert langsmith_config["metadata"]["provider"] == "openai"
     assert langsmith_config["metadata"]["model"] == "fake-planner-model"
-    assert "langsmith_run_config" not in fake_model.requests[0]["runtime_context"]
+    assert "langsmith_run_config" not in planner_request["runtime_context"]
     records = [json.loads(line) for line in artifact_path.read_text().splitlines()]
     assert records
     assert records[0]["status"] == "success"

--- a/trip_planner/app/schemas/planner.py
+++ b/trip_planner/app/schemas/planner.py
@@ -43,6 +43,7 @@ class PlannerTurnMetadata(BaseModel):
     effort_class: str | None = None
     base_effort_class: str | None = None
     selected_planning_mode: str | None = None
+    intent: str | None = None
     provider_state: str | None = None
     fallback_reason: str | None = None
     visible_response_blocks: list[PlannerVisibleResponseBlock] = Field(default_factory=list)

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -18,9 +18,10 @@ from trip_planner.app.services.planner_memory import (
     ensure_planner_memory_persisted,
     refresh_planner_memory,
 )
-from trip_planner.app.services.planner_routing import route_planner_turn
+from trip_planner.app.services.planner_routing import IntentClassifier, route_planner_turn
 from trip_planner.app.services.planner_runtime_config import (
     PlannerRuntimeConfig,
+    build_intent_classifier,
     get_planner_runtime_config,
 )
 from trip_planner.app.services.planner_tools import (
@@ -65,6 +66,7 @@ class PlannerConversationRequest:
     planner_panel_state: dict[str, Any]
     session: PlanningSessionState
     runtime_context: dict[str, Any]
+    intent_classifier: IntentClassifier | None = None
     langsmith_run_config: dict[str, Any] | None = None
 
 
@@ -86,6 +88,7 @@ class _PlannerTurnRuntime:
     workspace_payload: dict[str, Any]
     runtime_context: dict[str, Any]
     runtime_config: PlannerRuntimeConfig
+    intent_classifier: IntentClassifier
     fleet_context: PlannerFleetContext
     activity_log: list[dict[str, Any]]
     executed_tool_calls: list[dict[str, Any]]
@@ -98,9 +101,11 @@ class PlannerChatModel(Protocol):
 
 PlannerChatModelFactory = Callable[[PlannerRuntimeConfig], PlannerChatModel]
 PlannerPromptRedactor = Callable[[dict[str, Any]], dict[str, Any]]
+IntentClassifierFactory = Callable[[PlannerRuntimeConfig], IntentClassifier]
 
 _PLANNER_CHAT_MODEL_FACTORY: PlannerChatModelFactory | None = None
 _PLANNER_PROMPT_REDACTOR: PlannerPromptRedactor | None = None
+_INTENT_CLASSIFIER_FACTORY: IntentClassifierFactory | None = None
 _GROUNDING_TOOL_NAMES: tuple[str, ...] = (
     "read_workspace_state",
     "refresh_inventory",
@@ -516,6 +521,7 @@ def _planner_turn_metadata(
     runtime_config: PlannerRuntimeConfig,
     turn_index: int,
     planning_mode: str | None = None,
+    intent_classifier: IntentClassifier | None = None,
 ) -> dict[str, Any]:
     lowered = message.lower()
     raw_tokens = [token.strip(".,!?;:()[]{}\"'") for token in message.split()]
@@ -617,10 +623,22 @@ def _planner_turn_metadata(
             },
         ]
 
+    classifier = intent_classifier or _intent_classifier(runtime_config)
+    intent_result = classifier.classify(
+        message,
+        {
+            "base_task_class": task_class,
+            "planning_mode": planning_mode,
+            "turn_index": turn_index,
+            "runtime_mode": runtime_config.mode,
+            "runtime_provider": runtime_config.provider,
+            "runtime_model": runtime_config.model,
+        },
+    )
     provider_state = "model" if runtime_config.mode == "model" else "fallback"
     routing_decision = route_planner_turn(
         message=message,
-        base_task_class=task_class,
+        base_task_class=intent_result.task_class,
         planning_mode=planning_mode,
         provider_state=provider_state,
         fallback_reason=runtime_config.fallback_reason,
@@ -631,6 +649,7 @@ def _planner_turn_metadata(
         "effort_class": routing_decision.effort_class,
         "base_effort_class": routing_decision.base_effort_class,
         "selected_planning_mode": planning_mode,
+        "intent": intent_result.intent,
         "provider_state": provider_state,
         "fallback_reason": routing_decision.fallback_reason,
         "visible_response_blocks": blocks,
@@ -641,6 +660,8 @@ def _planner_turn_metadata(
             "turn_index": turn_index,
             "routing_reasoning": routing_decision.reasoning,
             "base_task_class": task_class,
+            "classifier_task_class": intent_result.task_class,
+            "classifier_intent": intent_result.intent,
             "selected_planning_mode": planning_mode,
             "signals": {
                 "token_count": len(tokens),
@@ -1081,6 +1102,19 @@ def set_planner_prompt_redactor_for_tests(
     _PLANNER_PROMPT_REDACTOR = redactor
 
 
+def set_intent_classifier_factory_for_tests(
+    factory: IntentClassifierFactory | None,
+) -> None:
+    global _INTENT_CLASSIFIER_FACTORY
+    _INTENT_CLASSIFIER_FACTORY = factory
+
+
+def _intent_classifier(runtime_config: PlannerRuntimeConfig) -> IntentClassifier:
+    if _INTENT_CLASSIFIER_FACTORY is not None:
+        return _INTENT_CLASSIFIER_FACTORY(runtime_config)
+    return build_intent_classifier(runtime_config)
+
+
 def _redact_openai_planner_payload(payload: dict[str, Any]) -> dict[str, Any]:
     redactor = _PLANNER_PROMPT_REDACTOR or (lambda item: item)
     return redactor(payload)
@@ -1104,6 +1138,7 @@ class DeterministicPlannerConversationRunnable:
             runtime_config=get_planner_runtime_config(),
             turn_index=len(request.runtime_context.get("recent_activity") or []),
             planning_mode=request.session.selected_planning_mode,
+            intent_classifier=request.intent_classifier,
         )
         outputs = list(panel.get("outputs") or [])
         decisions = list(panel.get("pending_decisions") or [])
@@ -1276,6 +1311,7 @@ class ModelBackedPlannerConversationRunnable:
                 runtime_config=self._config,
                 turn_index=len(request.runtime_context.get("recent_activity") or []),
                 planning_mode=request.session.selected_planning_mode,
+                intent_classifier=request.intent_classifier,
             ),
         )
 
@@ -1650,6 +1686,7 @@ def _prepare_planner_turn_runtime(
     )
     activity_log = _activity_log(db_session, trip_id=trip_id)
     runtime_config = get_planner_runtime_config()
+    intent_classifier = _intent_classifier(runtime_config)
     fleet_context = PlannerFleetContext(
         run_id=f"planner-turn:{secrets.token_hex(8)}",
         session_id=session.session_state_id,
@@ -1673,6 +1710,7 @@ def _prepare_planner_turn_runtime(
         workspace_payload=workspace_payload,
         runtime_context=runtime_context,
         runtime_config=runtime_config,
+        intent_classifier=intent_classifier,
         fleet_context=fleet_context,
         activity_log=activity_log,
         executed_tool_calls=executed_tool_calls,
@@ -1688,6 +1726,7 @@ def _invoke_planner_runtime(runtime: _PlannerTurnRuntime) -> PlannerConversation
             runtime_config=runtime.runtime_config,
             turn_index=len(runtime.activity_log),
             planning_mode=runtime.session.selected_planning_mode,
+            intent_classifier=runtime.intent_classifier,
         ),
     )
     try:
@@ -1698,6 +1737,7 @@ def _invoke_planner_runtime(runtime: _PlannerTurnRuntime) -> PlannerConversation
                 planner_panel_state=runtime.workspace_payload["planner_panel_state"],
                 session=runtime.session,
                 runtime_context=runtime.runtime_context,
+                intent_classifier=runtime.intent_classifier,
                 langsmith_run_config=langsmith_run_config,
             )
         )
@@ -1738,6 +1778,7 @@ def _invoke_planner_runtime(runtime: _PlannerTurnRuntime) -> PlannerConversation
                 runtime_config=runtime.runtime_config,
                 turn_index=len(runtime.activity_log),
                 planning_mode=runtime.session.selected_planning_mode,
+                intent_classifier=runtime.intent_classifier,
             ),
         )
     return reply

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -18,7 +18,12 @@ from trip_planner.app.services.planner_memory import (
     ensure_planner_memory_persisted,
     refresh_planner_memory,
 )
-from trip_planner.app.services.planner_routing import IntentClassifier, route_planner_turn
+from trip_planner.app.services.planner_routing import (
+    TASK_CLASSES,
+    IntentClassifier,
+    IntentResult,
+    route_planner_turn,
+)
 from trip_planner.app.services.planner_runtime_config import (
     PlannerRuntimeConfig,
     build_intent_classifier,
@@ -89,6 +94,7 @@ class _PlannerTurnRuntime:
     runtime_context: dict[str, Any]
     runtime_config: PlannerRuntimeConfig
     intent_classifier: IntentClassifier
+    chat_model: PlannerChatModel | None
     fleet_context: PlannerFleetContext
     activity_log: list[dict[str, Any]]
     executed_tool_calls: list[dict[str, Any]]
@@ -635,6 +641,8 @@ def _planner_turn_metadata(
             "runtime_model": runtime_config.model,
         },
     )
+    if intent_result.task_class not in TASK_CLASSES:
+        intent_result = IntentResult(task_class=task_class, intent=task_class)
     provider_state = "model" if runtime_config.mode == "model" else "fallback"
     routing_decision = route_planner_turn(
         message=message,
@@ -1109,10 +1117,21 @@ def set_intent_classifier_factory_for_tests(
     _INTENT_CLASSIFIER_FACTORY = factory
 
 
-def _intent_classifier(runtime_config: PlannerRuntimeConfig) -> IntentClassifier:
+def _planner_chat_model(runtime_config: PlannerRuntimeConfig) -> PlannerChatModel:
+    factory = _PLANNER_CHAT_MODEL_FACTORY or (
+        lambda config: _OpenAIPlannerChatModel(config)
+    )
+    return factory(runtime_config)
+
+
+def _intent_classifier(
+    runtime_config: PlannerRuntimeConfig,
+    *,
+    chat_model: PlannerChatModel | None = None,
+) -> IntentClassifier:
     if _INTENT_CLASSIFIER_FACTORY is not None:
         return _INTENT_CLASSIFIER_FACTORY(runtime_config)
-    return build_intent_classifier(runtime_config)
+    return build_intent_classifier(runtime_config, model=chat_model)
 
 
 def _redact_openai_planner_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1218,6 +1237,20 @@ class _OpenAIPlannerChatModel:
         self._model = ChatOpenAI(model=config.model, temperature=0)
 
     def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if payload.get("task") == "classify_planner_intent":
+            response = self._model.invoke(
+                [
+                    (
+                        "system",
+                        "Classify the traveler planner intent. Return only JSON with "
+                        "`task_class` and `intent` keys. `task_class` must be one of "
+                        "the supplied allowed_task_classes.",
+                    ),
+                    ("human", json.dumps(payload, default=str)),
+                ]
+            )
+            return {"content": str(response.content)}
+
         tools = [
             {
                 "type": "function",
@@ -1316,13 +1349,17 @@ class ModelBackedPlannerConversationRunnable:
         )
 
 
-def _planner_runnable(config: PlannerRuntimeConfig) -> PlannerConversationRunnable:
+def _planner_runnable(
+    config: PlannerRuntimeConfig,
+    *,
+    chat_model: PlannerChatModel | None = None,
+) -> PlannerConversationRunnable:
     if config.mode != "model":
         return DeterministicPlannerConversationRunnable()
-    factory = _PLANNER_CHAT_MODEL_FACTORY or (
-        lambda runtime_config: _OpenAIPlannerChatModel(runtime_config)
+    return ModelBackedPlannerConversationRunnable(
+        config,
+        chat_model or _planner_chat_model(config),
     )
-    return ModelBackedPlannerConversationRunnable(config, factory(config))
 
 
 def _conversation_id(trip_id: str) -> str:
@@ -1686,7 +1723,8 @@ def _prepare_planner_turn_runtime(
     )
     activity_log = _activity_log(db_session, trip_id=trip_id)
     runtime_config = get_planner_runtime_config()
-    intent_classifier = _intent_classifier(runtime_config)
+    chat_model = _planner_chat_model(runtime_config) if runtime_config.mode == "model" else None
+    intent_classifier = _intent_classifier(runtime_config, chat_model=chat_model)
     fleet_context = PlannerFleetContext(
         run_id=f"planner-turn:{secrets.token_hex(8)}",
         session_id=session.session_state_id,
@@ -1711,6 +1749,7 @@ def _prepare_planner_turn_runtime(
         runtime_context=runtime_context,
         runtime_config=runtime_config,
         intent_classifier=intent_classifier,
+        chat_model=chat_model,
         fleet_context=fleet_context,
         activity_log=activity_log,
         executed_tool_calls=executed_tool_calls,
@@ -1718,7 +1757,7 @@ def _prepare_planner_turn_runtime(
 
 
 def _invoke_planner_runtime(runtime: _PlannerTurnRuntime) -> PlannerConversationReply:
-    runnable = _planner_runnable(runtime.runtime_config)
+    runnable = _planner_runnable(runtime.runtime_config, chat_model=runtime.chat_model)
     langsmith_run_config = build_langsmith_run_config(
         context=runtime.fleet_context,
         metadata=_planner_turn_metadata(

--- a/trip_planner/app/services/planner_routing.py
+++ b/trip_planner/app/services/planner_routing.py
@@ -12,6 +12,7 @@ tests. Traveler-facing planner copy does not consume these values.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from collections.abc import Mapping
@@ -192,6 +193,13 @@ class ModelIntentClassifier:
             )
         except Exception:
             return self._fallback.classify(message, context)
+        if isinstance(payload, Mapping) and "content" in payload and "task_class" not in payload:
+            try:
+                decoded = json.loads(str(payload.get("content") or "{}"))
+            except json.JSONDecodeError:
+                decoded = {}
+            if isinstance(decoded, Mapping):
+                payload = decoded
         if not isinstance(payload, Mapping):
             return self._fallback.classify(message, context)
         task_class = str(payload.get("task_class") or "").strip()

--- a/trip_planner/app/services/planner_routing.py
+++ b/trip_planner/app/services/planner_routing.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Final
+from collections.abc import Mapping
+from typing import Any, Final, Protocol
 
 EFFORT_FAST: Final = "fast"
 EFFORT_STANDARD: Final = "standard"
@@ -33,6 +34,7 @@ TASK_MAJOR_REVISION: Final = "major_revision"
 TASK_POLICY_PREPARATION: Final = "policy_preparation"
 TASK_RESEARCH_TOOL_PASS: Final = "research_tool_pass"
 TASK_FINAL_SUMMARY: Final = "final_summary"
+TASK_DECISION: Final = "decision"
 
 TASK_CLASSES: Final = (
     TASK_QUICK_ACKNOWLEDGEMENT,
@@ -46,6 +48,7 @@ TASK_CLASSES: Final = (
     TASK_POLICY_PREPARATION,
     TASK_RESEARCH_TOOL_PASS,
     TASK_FINAL_SUMMARY,
+    TASK_DECISION,
 )
 
 _BASE_EFFORT_BY_TASK: Final[dict[str, str]] = {
@@ -60,6 +63,7 @@ _BASE_EFFORT_BY_TASK: Final[dict[str, str]] = {
     TASK_POLICY_PREPARATION: EFFORT_DEEP,
     TASK_RESEARCH_TOOL_PASS: EFFORT_DEEP,
     TASK_FINAL_SUMMARY: EFFORT_DEEP,
+    TASK_DECISION: EFFORT_STANDARD,
 }
 
 _ACK_PATTERN = re.compile(
@@ -126,6 +130,75 @@ class RoutingDecision:
             "fallback_reason": self.fallback_reason,
             "reasoning": self.reasoning,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class IntentResult:
+    """Classifier output consumed by planner turn routing."""
+
+    task_class: str
+    intent: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {"task_class": self.task_class, "intent": self.intent}
+
+
+class IntentClassifier(Protocol):
+    """Classify the traveler message before model-effort routing."""
+
+    def classify(self, message: str, context: Mapping[str, Any]) -> IntentResult:
+        """Return the task class and high-level intent for ``message``."""
+
+
+class KeywordIntentClassifier:
+    """Deterministic fallback that preserves existing keyword routing behavior."""
+
+    def classify(self, message: str, context: Mapping[str, Any]) -> IntentResult:
+        base_task_class = str(context.get("base_task_class") or TASK_FIRST_TURN_TRIAGE)
+        task_class = classify_task_class(message, base_task_class=base_task_class)
+        lowered = message.lower()
+        if "decide" in lowered or "decision" in lowered:
+            return IntentResult(task_class=task_class, intent=TASK_DECISION)
+        if "completed" in lowered and any(
+            marker in lowered for marker in ("tasks", "items", "notes")
+        ):
+            return IntentResult(task_class=task_class, intent="completed_notebook_items")
+        return IntentResult(task_class=task_class, intent=task_class)
+
+
+class ModelIntentClassifier:
+    """Model-backed classifier with deterministic keyword fallback."""
+
+    def __init__(
+        self,
+        model: Any | None = None,
+        *,
+        fallback: IntentClassifier | None = None,
+    ) -> None:
+        self._model = model
+        self._fallback = fallback or KeywordIntentClassifier()
+
+    def classify(self, message: str, context: Mapping[str, Any]) -> IntentResult:
+        if self._model is None:
+            return self._fallback.classify(message, context)
+        try:
+            payload = self._model.invoke(
+                {
+                    "task": "classify_planner_intent",
+                    "message": message,
+                    "context": dict(context),
+                    "allowed_task_classes": list(TASK_CLASSES),
+                }
+            )
+        except Exception:
+            return self._fallback.classify(message, context)
+        if not isinstance(payload, Mapping):
+            return self._fallback.classify(message, context)
+        task_class = str(payload.get("task_class") or "").strip()
+        intent = str(payload.get("intent") or task_class or "").strip()
+        if task_class not in TASK_CLASSES:
+            return self._fallback.classify(message, context)
+        return IntentResult(task_class=task_class, intent=intent or task_class)
 
 
 def classify_task_class(message: str, *, base_task_class: str) -> str:

--- a/trip_planner/app/services/planner_runtime_config.py
+++ b/trip_planner/app/services/planner_runtime_config.py
@@ -6,6 +6,12 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from trip_planner.app.services.planner_routing import (
+    IntentClassifier,
+    KeywordIntentClassifier,
+    ModelIntentClassifier,
+)
+
 PROPRIETARY_DATA_ZONE = "proprietary"
 SYNTHETIC_DATA_ZONE = "synthetic"
 AUTHORIZED_OPENAI_ENDPOINT_ENV = "TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT"
@@ -44,6 +50,12 @@ class PlannerRuntimeConfig:
 
 def get_planner_runtime_config() -> PlannerRuntimeConfig:
     return build_planner_runtime_config(os.environ)
+
+
+def build_intent_classifier(runtime_config: PlannerRuntimeConfig) -> IntentClassifier:
+    if runtime_config.model_configured:
+        return ModelIntentClassifier()
+    return KeywordIntentClassifier()
 
 
 def build_planner_runtime_config(env: Mapping[str, str]) -> PlannerRuntimeConfig:

--- a/trip_planner/app/services/planner_runtime_config.py
+++ b/trip_planner/app/services/planner_runtime_config.py
@@ -52,9 +52,13 @@ def get_planner_runtime_config() -> PlannerRuntimeConfig:
     return build_planner_runtime_config(os.environ)
 
 
-def build_intent_classifier(runtime_config: PlannerRuntimeConfig) -> IntentClassifier:
+def build_intent_classifier(
+    runtime_config: PlannerRuntimeConfig,
+    *,
+    model: object | None = None,
+) -> IntentClassifier:
     if runtime_config.model_configured:
-        return ModelIntentClassifier()
+        return ModelIntentClassifier(model)
     return KeywordIntentClassifier()
 
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,24 @@
+## 2026-06-05T12:23Z - opener lane issue #1311 intent classifier seam
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1311` (`Replace substring intent detection with a pluggable intent-classifier seam`).
+- Branch: `codex/issue-1311-intent-classifier`, base `origin/main` `98de58b4c`.
+- Selection notes: raw opener cap was below limit. Cap-drain preflight repaired trip-planner PR #1333 by adding `agents:keepalive`/`agent:retry` and dispatching Gate Followups; fresh evidence showed #1333 actively draining. Trend PR #5440 remains scoped/non-repairable on the strict-config owner/product decision. Two normal-priority approved queue entries were stale duplicates and were closed with evidence: Inv-Man-Intake #528 duplicated verified-complete #518/PR #519, and Trend #5511 duplicated existing Monte Carlo CLI docs/tests. After those dispositions, #1311 was the oldest unlinked implementation issue outside scoped blockers.
+- Implementation:
+  - Added `IntentResult`, `IntentClassifier`, `KeywordIntentClassifier`, and `ModelIntentClassifier` to `planner_routing.py`.
+  - Threaded an injectable intent classifier through planner runtime preparation, deterministic/model runnable metadata, LangSmith metadata, persisted turn metadata, and API response schema.
+  - Kept keyword fallback deterministic while exposing classifier-selected `task_class` plus top-level/debug `intent`.
+  - Added `tests/app/test_planner_intent.py::test_injected_classifier_routes_turn` for the non-keyword message `let's lock it in` routing as `decision` via a stub classifier.
+- Validation:
+  - `python -m pytest tests/app/test_planner_intent.py::test_injected_classifier_routes_turn -q` -> 1 passed.
+  - Deliberate-break gate: temporarily bypassed `intent_result.task_class` in `_planner_turn_metadata`; the named test failed with `first_turn_triage != decision`. Restored the seam and reran green.
+  - `python -m pytest tests/app/test_planner_routing.py -q` -> 38 passed.
+  - `python -m pytest tests/app/test_planner_routes.py -q` -> 39 passed.
+  - `python -m pytest tests/app/ -q -k planner` -> 92 passed, 149 deselected.
+  - `python -m ruff check trip_planner/app/services/planner.py trip_planner/app/services/planner_routing.py trip_planner/app/services/planner_runtime_config.py trip_planner/app/schemas/planner.py tests/app/test_planner_intent.py tests/app/test_planner_routes.py` -> passed.
+  - `git diff --check` -> passed.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
+
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,24 +1,3 @@
-## 2026-06-05T12:23Z - opener lane issue #1311 intent classifier seam
-
-- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
-- Source repo: `stranske/trip-planner`; source issue `#1311` (`Replace substring intent detection with a pluggable intent-classifier seam`).
-- Branch: `codex/issue-1311-intent-classifier`, base `origin/main` `98de58b4c`.
-- Selection notes: raw opener cap was below limit. Cap-drain preflight repaired trip-planner PR #1333 by adding `agents:keepalive`/`agent:retry` and dispatching Gate Followups; fresh evidence showed #1333 actively draining. Trend PR #5440 remains scoped/non-repairable on the strict-config owner/product decision. Two normal-priority approved queue entries were stale duplicates and were closed with evidence: Inv-Man-Intake #528 duplicated verified-complete #518/PR #519, and Trend #5511 duplicated existing Monte Carlo CLI docs/tests. After those dispositions, #1311 was the oldest unlinked implementation issue outside scoped blockers.
-- Implementation:
-  - Added `IntentResult`, `IntentClassifier`, `KeywordIntentClassifier`, and `ModelIntentClassifier` to `planner_routing.py`.
-  - Threaded an injectable intent classifier through planner runtime preparation, deterministic/model runnable metadata, LangSmith metadata, persisted turn metadata, and API response schema.
-  - Kept keyword fallback deterministic while exposing classifier-selected `task_class` plus top-level/debug `intent`.
-  - Added `tests/app/test_planner_intent.py::test_injected_classifier_routes_turn` for the non-keyword message `let's lock it in` routing as `decision` via a stub classifier.
-- Validation:
-  - `python -m pytest tests/app/test_planner_intent.py::test_injected_classifier_routes_turn -q` -> 1 passed.
-  - Deliberate-break gate: temporarily bypassed `intent_result.task_class` in `_planner_turn_metadata`; the named test failed with `first_turn_triage != decision`. Restored the seam and reran green.
-  - `python -m pytest tests/app/test_planner_routing.py -q` -> 38 passed.
-  - `python -m pytest tests/app/test_planner_routes.py -q` -> 39 passed.
-  - `python -m pytest tests/app/ -q -k planner` -> 92 passed, 149 deselected.
-  - `python -m ruff check trip_planner/app/services/planner.py trip_planner/app/services/planner_routing.py trip_planner/app/services/planner_runtime_config.py trip_planner/app/schemas/planner.py tests/app/test_planner_intent.py tests/app/test_planner_routes.py` -> passed.
-  - `git diff --check` -> passed.
-- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
-
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.


### PR DESCRIPTION
Closes #1311

## Summary
- Add an IntentClassifier seam with keyword fallback and model-backed adapter types in planner routing.
- Thread the classifier through planner runtime metadata, persisted turn metadata, LangSmith metadata, and API response schema.
- Add a regression proving an injected classifier routes "let's lock it in" as a decision without keyword triggers.

## Validation
- python -m pytest tests/app/test_planner_intent.py::test_injected_classifier_routes_turn -q
- Deliberate-break gate: bypassing intent_result.task_class made the named test fail with first_turn_triage != decision; restored and reran green.
- python -m pytest tests/app/test_planner_routing.py -q
- python -m pytest tests/app/test_planner_routes.py -q
- python -m pytest tests/app/ -q -k planner
- python -m ruff check trip_planner/app/services/planner.py trip_planner/app/services/planner_routing.py trip_planner/app/services/planner_runtime_config.py trip_planner/app/schemas/planner.py tests/app/test_planner_intent.py tests/app/test_planner_routes.py
- git diff --check