### PR TITLE
Codex bootstrap for #1332

### DIFF
--- a/agents/codex-1332.md
+++ b/agents/codex-1332.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #1332 -->

--- a/agents/codex-1332.md
+++ b/agents/codex-1332.md
@@ -1,1 +1,0 @@
-<!-- bootstrap for codex on issue #1332 -->

--- a/frontend/src/components/workspace/panels/RouteTradeoffsPanel.tsx
+++ b/frontend/src/components/workspace/panels/RouteTradeoffsPanel.tsx
@@ -1,19 +1,32 @@
-import type { ReactNode } from "react";
+type RouteTradeoffMetric = {
+  label: string;
+  value: string;
+  testId?: string;
+};
 
-type RouteTradeoffsPanelProps = {
+type RouteTradeoffCard = {
+  id: string;
+  kicker: string;
+  title: string;
+  summary: string;
+  comparisonNote: string;
+  highlights: string[];
+  isSelected: boolean;
+  metrics: RouteTradeoffMetric[];
+};
+
+export type RouteTradeoffsPanelProps = {
   compactLayout: boolean;
   showPolicyPosture: boolean;
-  hasScenarios: boolean;
+  scenarios: RouteTradeoffCard[];
   emptyMessage: string;
-  children: ReactNode;
 };
 
 export function RouteTradeoffsPanel({
   compactLayout,
   showPolicyPosture,
-  hasScenarios,
+  scenarios,
   emptyMessage,
-  children,
 }: RouteTradeoffsPanelProps) {
   return (
     <section className="status-card">
@@ -24,7 +37,39 @@ export function RouteTradeoffsPanel({
           ? "Cost, route burden, feasibility, and approval posture stay scannable here without forcing you into raw planning notes."
           : "Cost, route burden, and feasibility stay scannable here without forcing you into raw planning notes."}
       </p>
-      {hasScenarios ? children : <p className="muted-copy">{emptyMessage}</p>}
+      {scenarios.length > 0 ? (
+        <div className="scenario-review-grid" aria-label="Scenario review board">
+          {scenarios.map((scenario) => (
+            <article
+              key={scenario.id}
+              className={`scenario-card scenario-review-card${
+                scenario.isSelected ? " scenario-card-active" : ""
+              }`}
+              aria-label={`${scenario.title} review summary`}
+            >
+              <p className="scenario-kicker">{scenario.kicker}</p>
+              <h3>{scenario.title}</h3>
+              <p>{scenario.summary}</p>
+              <dl className="workspace-meta scenario-review-metrics">
+                {scenario.metrics.map((metric) => (
+                  <div key={`${scenario.id}-${metric.label}`}>
+                    <dt>{metric.label}</dt>
+                    <dd data-testid={metric.testId}>{metric.value}</dd>
+                  </div>
+                ))}
+              </dl>
+              <p className="muted-copy">{scenario.comparisonNote}</p>
+              <ul className="focus-area-list scenario-highlight-list">
+                {scenario.highlights.slice(0, 2).map((highlight) => (
+                  <li key={highlight}>{highlight}</li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="muted-copy">{emptyMessage}</p>
+      )}
     </section>
   );
 }

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1185,6 +1185,24 @@ function WorkspacePageContent({
     currentWorkspace.proposal_state?.proposal_state_id ?? "no-proposal",
     Object.keys(workspaceDebugSections).sort().join("|"),
   ].join(":");
+  const routeTradeoffCards = routeComparison.scenarios.map((scenario) => {
+    const reviewMetrics = buildScenarioReviewMetrics(currentWorkspace, scenario, panelVisibility);
+
+    return {
+      id: scenario.scenario_id,
+      kicker: scenario.recommended_for_selection ? "recommended" : scenario.status,
+      title: scenario.title,
+      summary: scenario.summary,
+      comparisonNote: scenario.comparison_note,
+      highlights: scenario.highlights,
+      isSelected: scenario.scenario_id === selectedScenarioId,
+      metrics: reviewMetrics.map((metric) => ({
+        label: metric.label,
+        value: metric.value,
+        testId: metric.label === "Approval posture" ? "policy-posture" : undefined,
+      })),
+    };
+  });
   function handleScenarioSelection(scenarioId: string) {
     setSelectedScenarioId(scenarioId);
     setSelectedSegmentId(null);
@@ -2080,60 +2098,13 @@ function WorkspacePageContent({
         <RouteTradeoffsPanel
           compactLayout={isCompactLayout}
           showPolicyPosture={panelVisibility.showPolicyPosture}
-          hasScenarios={routeComparison.scenarios.length > 0}
+          scenarios={routeTradeoffCards}
           emptyMessage={
             currentWorkspace.runtime_state.status === "partial"
               ? "Add a little more trip detail before route comparison can start."
               : "No route ideas are available yet, so there is nothing to compare."
           }
-        >
-            <div className="scenario-review-grid" aria-label="Scenario review board">
-              {routeComparison.scenarios.map((scenario) => {
-                const reviewMetrics = buildScenarioReviewMetrics(
-                  currentWorkspace,
-                  scenario,
-                  panelVisibility
-                );
-                const isSelected = scenario.scenario_id === selectedScenarioId;
-
-                return (
-                  <article
-                    key={scenario.scenario_id}
-                    className={`scenario-card scenario-review-card${
-                      isSelected ? " scenario-card-active" : ""
-                    }`}
-                    aria-label={`${scenario.title} review summary`}
-                  >
-                    <p className="scenario-kicker">
-                      {scenario.recommended_for_selection ? "recommended" : scenario.status}
-                    </p>
-                    <h3>{scenario.title}</h3>
-                    <p>{scenario.summary}</p>
-                    <dl className="workspace-meta scenario-review-metrics">
-                      {reviewMetrics.map((metric) => (
-                        <div key={`${scenario.scenario_id}-${metric.label}`}>
-                          <dt>{metric.label}</dt>
-                          <dd
-                            data-testid={
-                              metric.label === "Approval posture" ? "policy-posture" : undefined
-                            }
-                          >
-                            {metric.value}
-                          </dd>
-                        </div>
-                      ))}
-                    </dl>
-                    <p className="muted-copy">{scenario.comparison_note}</p>
-                    <ul className="focus-area-list scenario-highlight-list">
-                      {scenario.highlights.slice(0, 2).map((highlight) => (
-                        <li key={highlight}>{highlight}</li>
-                      ))}
-                    </ul>
-                  </article>
-                );
-              })}
-            </div>
-        </RouteTradeoffsPanel>
+        />
 
         <section className={STATUS_CARD_CLASS}>
           <p className="status-label">Saved ideas</p>


### PR DESCRIPTION
### Keepalive: OFF
<!-- meta:issue:1332 -->

### Source Issue #1332: [Follow-up] Refactor WorkspacePage.tsx to extract the full JSX (PR #1330)

Base: main
Head: codex/issue-1332

Source: https://github.com/stranske/trip-planner/issues/1332

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #1330 addressed issue #1309, but verification identified remaining concerns (**CONCERNS**). This follow-up focuses on completing the panel extraction in `WorkspacePage.tsx`, reducing parent-file complexity in a meaningful way, and adding the missing test coverage and deliberate-break path required for verification.

#### Tasks
- [ ] Create the file `frontend/src/components/workspace/panels/PlannerPanel.tsx` with a basic component structure and TypeScript props interface
- [ ] Move the Planner panel JSX markup from `WorkspacePage.tsx` into the PlannerPanel component
- [ ] Identify and move panel-specific state hooks and handlers used only by Planner into PlannerPanel.tsx
- [ ] Update `WorkspacePage.tsx` to import and render the PlannerPanel component with required props
- [ ] Remove the now-unused Planner JSX and logic from WorkspacePage.tsx
- [ ] Move the Approval Packet and policy panel JSX markup from `WorkspacePage.tsx` into the PolicyPanel component
- [ ] Identify and move panel-specific state hooks and handlers used only by Policy panel into PolicyPanel.tsx
- [ ] Remove the now-unused Policy panel JSX and logic from WorkspacePage.tsx
- [ ] Add an element with `data-testid="approval-packet"` to the extracted Approval Packet render output in `frontend/src/components/workspace/panels/PolicyPanel.tsx`.
- [ ] Move the Route Tradeoffs panel JSX markup from `WorkspacePage.tsx` into the RouteTradeoffsPanel component
- [ ] Identify and move panel-specific state hooks and handlers used only by Route Tradeoffs into RouteTradeoffsPanel.tsx
- [ ] Remove the now-unused Route Tradeoffs JSX and logic from WorkspacePage.tsx
- [ ] Define an explicit TypeScript props interface for each extracted panel component and pass all required data and callbacks from `WorkspacePage.tsx` through props.
- [ ] Implement a deliberate-break branch in `frontend/src/routes/WorkspacePage.tsx` that throws an intentional error when enabled by a dedicated feature flag or test hook.
- [ ] Add a test in WorkspacePage.test.tsx that verifies PlannerPanel renders when WorkspacePage is mounted
- [ ] Add a test in WorkspacePage.test.tsx that verifies required props are passed to at least one extracted panel component
- [ ] Add a test in WorkspacePage.test.tsx that verifies the approval-packet element is present using getByTestId
- [ ] Add a test in WorkspacePage.test.tsx that verifies rendering WorkspacePage throws an error when the deliberate-break flag is enabled
- [ ] Add a test in WorkspacePage.test.tsx that verifies rendering WorkspacePage succeeds without throwing when the deliberate-break flag is disabled or unset
- [ ] Add or update `frontend/src/routes/WorkspacePage.test.tsx` to verify the tab control structure by asserting that the rendered output includes one tablist and multiple tabs.

#### Acceptance Criteria
- [ ] `frontend/src/components/workspace/panels/PlannerPanel.tsx` exists and exports a React component named `PlannerPanel`, and `frontend/src/routes/WorkspacePage.tsx` imports `PlannerPanel` from that file and renders `<PlannerPanel` at least once.
- [ ] `frontend/src/components/workspace/panels/PolicyPanel.tsx` exists and exports a React component named `PolicyPanel`, and `frontend/src/routes/WorkspacePage.tsx` imports `PolicyPanel` from that file and renders `<PolicyPanel` at least once.
- [ ] `frontend/src/components/workspace/panels/RouteTradeoffsPanel.tsx` exists and exports a React component named `RouteTradeoffsPanel`, and `frontend/src/routes/WorkspacePage.tsx` imports `RouteTradeoffsPanel` from that file and renders `<RouteTradeoffsPanel` at least once.
- [ ] `frontend/src/components/workspace/panels/PolicyPanel.tsx` renders at least one element with the exact attribute `data-testid="approval-packet"`.
- [ ] Each extracted panel file (`PlannerPanel.tsx`, `PolicyPanel.tsx`, `RouteTradeoffsPanel.tsx`) declares an explicit TypeScript props interface or type for the component props, and the component function is typed to use that interface/type.
- [ ] `frontend/src/routes/WorkspacePage.tsx` passes at least one prop into each extracted panel component instance (`PlannerPanel`, `PolicyPanel`, and `RouteTradeoffsPanel`) rather than rendering them as zero-prop stubs.
- [ ] `frontend/src/routes/WorkspacePage.test.tsx` includes a test that renders `WorkspacePage` and asserts that the approval packet element is present via `getByTestId('approval-packet')` or equivalent.
- [ ] `frontend/src/routes/WorkspacePage.test.tsx` includes assertions that `WorkspacePage` renders the extracted panel components' content, covering Planner, Policy, and Route Tradeoffs panel output.
- [ ] `frontend/src/routes/WorkspacePage.test.tsx` includes at least one test that verifies data or callback props from `WorkspacePage.tsx` reach an extracted panel component, either by mocking the panel component and asserting received props or by asserting behavior driven by those props.
- [ ] `frontend/src/routes/WorkspacePage.tsx` contains a deliberate-break branch that throws an `Error` only when a dedicated feature flag or test hook is enabled.
- [ ] `frontend/src/routes/WorkspacePage.test.tsx` contains one test that verifies rendering `WorkspacePage` throws when the deliberate-break flag/test hook is enabled, and a separate test that verifies normal render does not throw when the flag/test hook is disabled or unset.
- [ ] Rendering `WorkspacePage` in tests produces exactly one element with `role="tablist"` and at least two elements with `role="tab"`.
- [ ] The total line count of `frontend/src/routes/WorkspacePage.tsx` is reduced by at least 100 lines compared to the pre-refactor version.
- [ ] The strings "Planner", "Approval Packet", and "Route Tradeoffs" appear only in import statements and component tags (e.g., `<PlannerPanel`) in WorkspacePage.tsx, not within JSX element hierarchies more than 2 levels deep.
<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



<!-- follow-up-depth: 1 -->
## Why
PR #1330 addressed issue #1309, but verification identified remaining concerns (**CONCERNS**). This follow-up focuses on completing the panel extraction in `WorkspacePage.tsx`, reducing parent-file complexity in a meaningful way, and adding the missing test coverage and deliberate-break path required for verification.

## Source
- Original PR: #1330
- Parent issue: #1309

## Tasks
- [ ] Create the file `frontend/src/components/workspace/panels/PlannerPanel.tsx` with a basic component structure and TypeScript props interface
- [ ] Move the Planner panel JSX markup from `WorkspacePage.tsx` into the PlannerPanel component
- [ ] Identify and move panel-specific state hooks and handlers used only by Planner into PlannerPanel.tsx
- [ ] Update `WorkspacePage.tsx` to import and render the PlannerPanel component with required props
- [ ] Remove the now-unused Planner JSX and logic from WorkspacePage.tsx
- [ ] Move the Approval Packet and policy panel JSX markup from `WorkspacePage.tsx` into the PolicyPanel component
- [ ] Identify and move panel-specific state hooks and handlers used only by Policy panel into PolicyPanel.tsx
- [ ] Remove the now-unused Policy panel JSX and logic from WorkspacePage.tsx
- [ ] Add an element with `data-testid="approval-packet"` to the extracted Approval Packet render output in `frontend/src/components/workspace/panels/PolicyPanel.tsx`.
- [ ] Move the Route Tradeoffs panel JSX markup from `WorkspacePage.tsx` into the RouteTradeoffsPanel component
- [ ] Identify and move panel-specific state hooks and handlers used only by Route Tradeoffs into RouteTradeoffsPanel.tsx
- [ ] Remove the now-unused Route Tradeoffs JSX and logic from WorkspacePage.tsx
- [ ] Define an explicit TypeScript props interface for each extracted panel component and pass all required data and callbacks from `WorkspacePage.tsx` through props.
- [ ] Implement a deliberate-break branch in `frontend/src/routes/WorkspacePage.tsx` that throws an intentional error when enabled by a dedicated feature flag or test hook.
- [ ] Add a test in WorkspacePage.test.tsx that verifies PlannerPanel renders when WorkspacePage is mounted
- [ ] Add a test in WorkspacePage.test.tsx that verifies required props are passed to at least one extracted panel component
- [ ] Add a test in WorkspacePage.test.tsx that verifies the approval-packet element is present using getByTestId
- [ ] Add a test in WorkspacePage.test.tsx that verifies rendering WorkspacePage throws an error when the deliberate-break flag is enabled
- [ ] Add a test in WorkspacePage.test.tsx that verifies rendering WorkspacePage succeeds without throwing when the deliberate-break flag is disabled or unset
- [ ] Add or update `frontend/src/routes/WorkspacePage.test.tsx` to verify the tab control structure by asserting that the rendered output includes one tablist and multiple tabs.

## Deferred Tasks (Requires Human)
- [ ] Identify state variables and hooks in WorkspacePage.tsx that are exclusively used by PlannerPanel and move them into that component
- [ ] Identify state variables and hooks in WorkspacePage.tsx that are exclusively used by PolicyPanel and move them into that component
- [ ] Identify state variables and hooks in WorkspacePage.tsx that are exclusively used by RouteTradeoffsPanel and move them into that component
- [ ] Remove unused state variables and hooks from WorkspacePage.tsx after panel extraction is complete
- [ ] Verify that shared state required by multiple panels remains in WorkspacePage.tsx

## Acceptance Criteria
- [ ] `frontend/src/components/workspace/panels/PlannerPanel.tsx` exists and exports a React component named `PlannerPanel`, and `frontend/src/routes/WorkspacePage.tsx` imports `PlannerPanel` from that file and renders `<PlannerPanel` at least once.
- [ ] `frontend/src/components/workspace/panels/PolicyPanel.tsx` exists and exports a React component named `PolicyPanel`, and `frontend/src/routes/WorkspacePage.tsx` imports `PolicyPanel` from that file and renders `<PolicyPanel` at least once.
- [ ] `frontend/src/components/workspace/panels/RouteTradeoffsPanel.tsx` exists and exports a React component named `RouteTradeoffsPanel`, and `frontend/src/routes/WorkspacePage.tsx` imports `RouteTradeoffsPanel` from that file and renders `<RouteTradeoffsPanel` at least once.
- [ ] `frontend/src/components/workspace/panels/PolicyPanel.tsx` renders at least one element with the exact attribute `data-testid="approval-packet"`.
- [ ] Each extracted panel file (`PlannerPanel.tsx`, `PolicyPanel.tsx`, `RouteTradeoffsPanel.tsx`) declares an explicit TypeScript props interface or type for the component props, and the component function is typed to use that interface/type.
- [ ] `frontend/src/routes/WorkspacePage.tsx` passes at least one prop into each extracted panel component instance (`PlannerPanel`, `PolicyPanel`, and `RouteTradeoffsPanel`) rather than rendering them as zero-prop stubs.
- [ ] `frontend/src/routes/WorkspacePage.test.tsx` includes a test that renders `WorkspacePage` and asserts that the approval packet element is present via `getByTestId('approval-packet')` or equivalent.
- [ ] `frontend/src/routes/WorkspacePage.test.tsx` includes assertions that `WorkspacePage` renders the extracted panel components' content, covering Planner, Policy, and Route Tradeoffs panel output.
- [ ] `frontend/src/routes/WorkspacePage.test.tsx` includes at least one test that verifies data or callback props from `WorkspacePage.tsx` reach an extracted panel component, either by mocking the panel component and asserting received props or by asserting behavior driven by those props.
- [ ] `frontend/src/routes/WorkspacePage.tsx` contains a deliberate-break branch that throws an `Error` only when a dedicated feature flag or test hook is enabled.
- [ ] `frontend/src/routes/WorkspacePage.test.tsx` contains one test that verifies rendering `WorkspacePage` throws when the deliberate-break flag/test hook is enabled, and a separate test that verifies normal render does not throw when the flag/test hook is disabled or unset.
- [ ] Rendering `WorkspacePage` in tests produces exactly one element with `role="tablist"` and at least two elements with `role="tab"`.
- [ ] The total line count of `frontend/src/routes/WorkspacePage.tsx` is reduced by at least 100 lines compared to the pre-refactor version.
- [ ] The strings "Planner", "Approval Packet", and "Route Tradeoffs" appear only in import statements and component tags (e.g., `<PlannerPanel`) in WorkspacePage.tsx, not within JSX element hierarchies more than 2 levels deep.

## Implementation Notes
Focus the refactor on real extraction, not wrapper components. The previous attempt did not materially reduce `WorkspacePage.tsx` complexity, so move the actual panel JSX plus panel-local logic into:
- `frontend/src/components/workspace/panels/PlannerPanel.tsx`
- `frontend/src/components/workspace/panels/PolicyPanel.tsx`
- `frontend/src/components/workspace/panels/RouteTradeoffsPanel.tsx`

Keep `WorkspacePage.tsx` responsible only for orchestration, shared layout, and props passed into extracted panels. If state, hooks, or handlers are only used by one panel, move them into that panel component and delete the unused parent logic.

Preserve the Approval Packet UI structure during extraction rather than wrapping it in a placeholder. Add `data-testid="approval-packet"` inside `PolicyPanel.tsx` so tests can reliably target it.

For the deliberate-break requirement, add a clearly gated branch in `frontend/src/routes/WorkspacePage.tsx` that throws only when a dedicated feature flag or test hook is enabled. Ensure the normal render path is unaffected and covered by tests.

Tests should live in `frontend/src/routes/WorkspacePage.test.tsx` and cover:
- extracted panel rendering from `WorkspacePage`
- prop/data flow into extracted panels
- presence of `approval-packet`
- deliberate-break enabled vs. disabled behavior
- tab structure using role-based assertions

Deferred for human follow-up, not required in this issue:
- long-term ownership model for shared state between `WorkspacePage.tsx` and extracted panels
- production-safe mechanism and scope for the deliberate-break feature flag or test hook

<details>
<summary>Advisory items (non-blocking)</summary>

- Post-merge verification cannot confirm the documented deliberate-break experiment from code alone; however, the added regression test is aligned with that requirement.
- Post-merge verification cannot confirm the documented deliberate-break experiment from code alone

</details>

<details>
<summary>Background (previous attempt context)</summary>

- The previous attempt created overly thin 19-line stub panel files that only wrapped JSX without removing state/prop complexity from `WorkspacePage.tsx`.
  - Why it failed: the stubs did not actually encapsulate the original complex functionality, leaving a bloated monolith and unextracted logic.
  - What to do instead: perform a comprehensive extraction that moves the full content—JSX, state hooks, and inline logic—from `WorkspacePage.tsx` into the dedicated panel components so both rendering and functionality are encapsulated.

- The deliberate-break feature was claimed but not implemented in the code artifacts.
  - Why it failed: the break was not actually integrated into `WorkspacePage.tsx`, so tests cannot confirm its existence.
  - What to do instead: implement a clearly controlled deliberate-break mechanism, protected by a feature flag or test condition, so its effect is visible in both code and tests.

</details>

<!-- issue-pr-context:formatted-body:v1 {"sha256":"839bb020a258bf2b316b34c7a0b6251aa7d39baeca2a09f7f69303f3e2c1fa21","workflows":["agents-auto-pilot","agents-issue-optimizer","agents-63-issue-intake","issue_formatter","issue_optimizer"]} -->



</details>

—
PR created automatically to engage Codex.