### PR TITLE
Issue #1314: add planner prompt contract

### DIFF
--- a/tests/app/test_planner_prompt_contract.py
+++ b/tests/app/test_planner_prompt_contract.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from trip_planner.app.services.planner import (
+    _CLARIFYING_SKIP_AFFORDANCE,
+    _PLANNER_SYSTEM_PROMPT,
+    _planner_response_structured_blocks,
+    _planner_turn_metadata,
+)
+from trip_planner.app.services.planner_routing import IntentResult
+from trip_planner.app.services.planner_runtime_config import build_planner_runtime_config
+
+
+class BaseTaskClassifier:
+    def classify(self, message: str, context: Mapping[str, Any]) -> IntentResult:
+        return IntentResult(
+            task_class=str(context["base_task_class"]),
+            intent=str(context["base_task_class"]),
+        )
+
+
+def _metadata_for(message: str) -> dict[str, Any]:
+    return _planner_turn_metadata(
+        message=message,
+        runtime_config=build_planner_runtime_config({}),
+        turn_index=0,
+        intent_classifier=BaseTaskClassifier(),
+    )
+
+
+def test_system_prompt_contract() -> None:
+    prompt = _PLANNER_SYSTEM_PROMPT.lower()
+
+    assert "concise" in prompt
+    assert "lead with concrete options" in prompt
+    assert "uncertainty" in prompt
+
+
+def test_first_turn_triage_question_cap() -> None:
+    open_ended = _metadata_for("help")
+    partial_plan = _metadata_for("We want a quiet trip with museums")
+
+    for metadata in (open_ended, partial_plan):
+        question_blocks = [
+            block
+            for block in metadata["visible_response_blocks"]
+            if block["kind"] == "clarifying_questions"
+        ]
+        assert question_blocks
+        for block in question_blocks:
+            assert len(block["items"]) <= 3
+            assert _CLARIFYING_SKIP_AFFORDANCE in block["items"]
+
+
+def test_low_confidence_surfaces_uncertainty() -> None:
+    blocks = _planner_response_structured_blocks(
+        content="Compare these options next.",
+        metadata={
+            "visible_response_blocks": [
+                {
+                    "kind": "guidance",
+                    "title": "Guidance",
+                    "items": ["Compare two routes before choosing."],
+                }
+            ]
+        },
+        panel={"pending_decisions": [], "option_set": {"options": []}, "next_step_actions": []},
+        runtime_context={"source_confidence_summary": {"confidence_label": "sparse"}},
+        tool_calls=[],
+    )
+
+    text = " ".join(
+        item
+        for block in blocks
+        for item in list(block.get("items") or [])
+    ).lower()
+    assert "source coverage is thin" in text
+    assert "uncertain" in text

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -331,6 +331,20 @@ _NON_DESTINATION_CAPITALIZED_TOKENS = {
     "not",
     "please",
 }
+_CLARIFYING_SKIP_AFFORDANCE = (
+    "You can skip any of these and we'll proceed with reasonable defaults."
+)
+_LOW_CONFIDENCE_LABELS = {"sparse", "uncertain"}
+_LOW_CONFIDENCE_UNCERTAINTY_LINE = (
+    "Source coverage is thin, so treat these options as uncertain until more evidence is attached."
+)
+_PLANNER_SYSTEM_PROMPT = (
+    "You are a trip-scoped planner. Use only the listed app tools for "
+    "workspace, inventory, scenario, budget, policy, or proposal facts. "
+    "Do not invent persisted state. Keep answers concise, lead with concrete "
+    "options before discussion, and explicitly state uncertainty when source "
+    "coverage is thin."
+)
 
 
 def _structured_block(
@@ -350,6 +364,10 @@ def _structured_block(
         "metadata": dict(metadata or {}),
         "hidden": hidden,
     }
+
+
+def _bounded_clarifying_items(items: list[str]) -> list[str]:
+    return [*items[:2], _CLARIFYING_SKIP_AFFORDANCE]
 
 
 def _looks_like_destination_token(token: str, index: int) -> bool:
@@ -556,11 +574,13 @@ def _planner_turn_metadata(
             {
                 "kind": "clarifying_questions",
                 "title": "Quick questions",
-                "items": [
-                    "Where are you considering going?",
-                    "When would you like to travel?",
-                    "What would make this trip feel successful?",
-                ],
+                "items": _bounded_clarifying_items(
+                    [
+                        "Where are you considering going?",
+                        "When would you like to travel?",
+                        "What would make this trip feel successful?",
+                    ]
+                ),
             },
         ]
     elif constraint_hits >= 5 or question_hits >= 3 or len(tokens) >= 45:
@@ -622,10 +642,12 @@ def _planner_turn_metadata(
             {
                 "kind": "clarifying_questions",
                 "title": "Targeted questions",
-                "items": [
-                    "What dates or trip length should the planner assume?",
-                    "Which tradeoff matters most: budget, pace, lodging, route, or approvals?",
-                ],
+                "items": _bounded_clarifying_items(
+                    [
+                        "What dates or trip length should the planner assume?",
+                        "Which tradeoff matters most: budget, pace, lodging, route, or approvals?",
+                    ]
+                ),
             },
         ]
 
@@ -854,6 +876,38 @@ def _build_summary_block(
     )
 
 
+def _confidence_label_from_runtime_context(runtime_context: dict[str, Any]) -> str:
+    for value in (
+        runtime_context.get("confidence_label"),
+        (runtime_context.get("source_confidence") or {}).get("confidence_label")
+        if isinstance(runtime_context.get("source_confidence"), dict)
+        else None,
+        (runtime_context.get("source_confidence_summary") or {}).get("confidence_label")
+        if isinstance(runtime_context.get("source_confidence_summary"), dict)
+        else None,
+    ):
+        label = str(value or "").strip().lower()
+        if label:
+            return label
+    return ""
+
+
+def _surface_low_confidence_uncertainty(
+    *,
+    blocks: list[dict[str, Any]],
+    runtime_context: dict[str, Any],
+) -> None:
+    if _confidence_label_from_runtime_context(runtime_context) not in _LOW_CONFIDENCE_LABELS:
+        return
+    for block in blocks:
+        if str(block.get("kind") or "") != "summary":
+            continue
+        items = list(block.get("items") or [])
+        if _LOW_CONFIDENCE_UNCERTAINTY_LINE not in items:
+            block["items"] = [_LOW_CONFIDENCE_UNCERTAINTY_LINE, *items[:2]]
+        return
+
+
 def _build_question_block(
     *,
     metadata: dict[str, Any],
@@ -870,10 +924,13 @@ def _build_question_block(
         )
     if not question_items:
         return None
+    question_items = _dedupe_preserve_order(question_items)
+    if len(question_items) > 4 and _CLARIFYING_SKIP_AFFORDANCE in question_items:
+        question_items.remove(_CLARIFYING_SKIP_AFFORDANCE)
     return _structured_block(
         kind="question",
         title="Questions to settle",
-        items=_dedupe_preserve_order(question_items)[:4],
+        items=question_items[:4],
     )
 
 
@@ -1045,6 +1102,7 @@ def _planner_response_structured_blocks(
         if block is not None:
             blocks.append(block)
 
+    _surface_low_confidence_uncertainty(blocks=blocks, runtime_context=runtime_context)
     return blocks
 
 
@@ -1275,9 +1333,7 @@ class _OpenAIPlannerChatModel:
             [
                 (
                     "system",
-                    "You are a trip-scoped planner. Use only the listed app tools for "
-                    "workspace, inventory, scenario, budget, policy, or proposal facts. "
-                    "Do not invent persisted state.",
+                    _PLANNER_SYSTEM_PROMPT,
                 ),
                 (
                     "human",


### PR DESCRIPTION
Closes #1314

## Summary
- Add a planner system-prompt contract for concise, option-first answers with explicit uncertainty when source coverage is thin.
- Cap clarifying-question metadata blocks at three items while preserving a skip affordance.
- Surface sparse/uncertain source confidence in planner summary blocks and add prompt-contract regression coverage.

## Validation
- python -m pytest tests/app/test_planner_prompt_contract.py -q
- Deliberate-break gate: changing the question cap helper to emit three questions plus the skip affordance made test_first_turn_triage_question_cap fail with len(items) == 4 > 3; restored and reran green.
- python -m pytest tests/app/test_planner_routes.py tests/app/test_planner_routing.py tests/app/test_planner_turn_e2e.py -q
- python -m ruff check trip_planner/app/services/planner.py tests/app/test_planner_prompt_contract.py
- git diff --check