### PR TITLE
Issue #1316: bidirectional commerciality preference

### DIFF
--- a/tests/sources/test_source_quality.py
+++ b/tests/sources/test_source_quality.py
@@ -10,6 +10,7 @@ from trip_planner.app.services.inventory import (
     _build_inventory_assembly_input,
     assemble_inventory_bundles_for_trip,
 )
+from trip_planner.app.services.planner_tools import _commerciality_preference_from_runtime_state
 from trip_planner.sources import (
     CONFIDENCE_LABELS,
     ProvenanceReference,
@@ -507,6 +508,23 @@ def test_scorer_rejects_invalid_commerciality_preference() -> None:
     scorer = SourceQualityScorer()
     with pytest.raises(ValueError, match="commerciality_preference"):
         scorer.score_source(_commercial_booking_source(), commerciality_preference=2.0)
+
+
+@pytest.mark.parametrize(
+    ("runtime_state", "expected"),
+    [
+        ({"commerciality_preference": "0.25"}, 0.25),
+        ({"commerciality_preference": ""}, None),
+        ({"commerciality_preference": "low"}, None),
+        ({"commerciality_preference": ["0.2"]}, None),
+        ({"commerciality_preference": 1.5}, None),
+    ],
+)
+def test_runtime_commerciality_preference_ignores_invalid_payloads(
+    runtime_state: dict[str, object],
+    expected: float | None,
+) -> None:
+    assert _commerciality_preference_from_runtime_state(runtime_state) == expected
 
 
 def test_summary_rejects_invalid_subject_kind() -> None:

--- a/tests/sources/test_source_quality.py
+++ b/tests/sources/test_source_quality.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from trip_planner.app.services.inventory import (
@@ -184,6 +186,23 @@ def _sparse_unknown_source() -> SourceRecord:
     )
 
 
+def _commerciality_probe_source(source_id: str, commerciality: float) -> SourceRecord:
+    return replace(
+        _commercial_booking_source(),
+        source_id=source_id,
+        provider_name="Commerciality Probe",
+        display_name="Commerciality Probe",
+        trust_signals=SourceTrustSignals(
+            freshness_days=2,
+            freshness_confidence=0.9,
+            commerciality=commerciality,
+            editorial_independence=0.5,
+            operational_reliability=0.75,
+            review_consistency=0.6,
+        ),
+    )
+
+
 def test_official_operational_source_scores_very_high() -> None:
     scorer = SourceQualityScorer()
     score = scorer.score_source(
@@ -210,6 +229,46 @@ def test_commercial_inventory_source_scores_high() -> None:
     assert score.confidence_label in {"high", "very_high"}
     assert score.confidence >= 0.65
     assert "commercial" in score.tags
+
+
+def test_commerciality_preference_reorders_toward_non_commercial() -> None:
+    scorer = SourceQualityScorer()
+    non_commercial_source = _commerciality_probe_source("non-commercial-probe", 0.15)
+    commercial_source = _commerciality_probe_source("commercial-probe", 0.85)
+
+    non_commercial_preference_scores = {
+        "non_commercial": scorer.score_source(
+            non_commercial_source,
+            commerciality_preference=0.1,
+            intended_option_kind="lodging",
+        ),
+        "commercial": scorer.score_source(
+            commercial_source,
+            commerciality_preference=0.1,
+            intended_option_kind="lodging",
+        ),
+    }
+    commercial_preference_scores = {
+        "non_commercial": scorer.score_source(
+            non_commercial_source,
+            commerciality_preference=0.9,
+            intended_option_kind="lodging",
+        ),
+        "commercial": scorer.score_source(
+            commercial_source,
+            commerciality_preference=0.9,
+            intended_option_kind="lodging",
+        ),
+    }
+
+    assert (
+        non_commercial_preference_scores["non_commercial"].confidence
+        > non_commercial_preference_scores["commercial"].confidence
+    )
+    assert (
+        commercial_preference_scores["commercial"].confidence
+        > commercial_preference_scores["non_commercial"].confidence
+    )
 
 
 def test_crowd_review_source_scores_moderate() -> None:
@@ -442,6 +501,12 @@ def test_scorer_rejects_invalid_traveler_relevance_hint() -> None:
     scorer = SourceQualityScorer()
     with pytest.raises(ValueError, match="traveler_relevance_hint"):
         scorer.score_source(_commercial_booking_source(), traveler_relevance_hint=2.0)
+
+
+def test_scorer_rejects_invalid_commerciality_preference() -> None:
+    scorer = SourceQualityScorer()
+    with pytest.raises(ValueError, match="commerciality_preference"):
+        scorer.score_source(_commercial_booking_source(), commerciality_preference=2.0)
 
 
 def test_summary_rejects_invalid_subject_kind() -> None:

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -27,6 +27,20 @@ from trip_planner.sources import (
 
 _BUNDLE_RESOURCE_PACKAGE = "trip_planner.resources.options.bundles"
 
+_CATEGORY_COMMERCIALITY: dict[str, float] = {
+    "official_operational": 0.20,
+    "managed_travel_policy": 0.35,
+    "commercial_inventory": 0.75,
+    "ratings_reviews": 0.45,
+    "editorial": 0.20,
+    "specialist_non_commercial": 0.15,
+}
+
+
+def _commerciality_for_category(category: str) -> float:
+    return _CATEGORY_COMMERCIALITY.get(category, 0.5)
+
+
 _REGION_GEO_DEFAULTS: dict[str, dict[str, Any]] = {
     "austin": {
         "latitude": 30.2672,
@@ -160,7 +174,7 @@ class PersistedTripInventoryFixtureAdapter(SourceAdapter):
             trust_signals=SourceTrustSignals(
                 freshness_days=0,
                 freshness_confidence=0.7,
-                commerciality=0.5,
+                commerciality=_commerciality_for_category("commercial_inventory"),
                 operational_reliability=0.65,
                 notes=["Fixture source freshness is pinned to the bundled fixture capture date."],
             ),
@@ -364,7 +378,7 @@ class PersistedTripSourceInventoryAdapter(SourceAdapter):
             trust_signals=SourceTrustSignals(
                 freshness_days=0,
                 freshness_confidence=0.85,
-                commerciality=0.7,
+                commerciality=_commerciality_for_category("commercial_inventory"),
                 operational_reliability=0.76,
                 notes=[
                     "Runtime inventory is generated from current persisted trip context.",

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -428,8 +428,11 @@ def _commerciality_preference_from_runtime_state(runtime_state: dict[str, Any]) 
         raw_preference = raw_preference.strip()
         if not raw_preference:
             return None
-    preference = float(raw_preference)
-    require_probability(preference, "runtime_state.commerciality_preference")
+    try:
+        preference = float(raw_preference)
+        require_probability(preference, "runtime_state.commerciality_preference")
+    except (TypeError, ValueError):
+        return None
     return preference
 
 

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -25,6 +25,7 @@ from trip_planner.sources import (
     SourceRecord,
     SourceTrustSignals,
 )
+from trip_planner._validators import require_probability
 
 
 @dataclass(frozen=True, slots=True)
@@ -419,6 +420,19 @@ def _read_source_summary(
     )
 
 
+def _commerciality_preference_from_runtime_state(runtime_state: dict[str, Any]) -> float | None:
+    raw_preference = runtime_state.get("commerciality_preference")
+    if raw_preference is None:
+        return None
+    if isinstance(raw_preference, str):
+        raw_preference = raw_preference.strip()
+        if not raw_preference:
+            return None
+    preference = float(raw_preference)
+    require_probability(preference, "runtime_state.commerciality_preference")
+    return preference
+
+
 def _read_source_quality_summary(
     db_session: Session,
     user: AuthenticatedUser,
@@ -429,6 +443,7 @@ def _read_source_quality_summary(
     payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
     inventory = payload["inventory_summary"]
     runtime_state = inventory.get("runtime_state") or {}
+    commerciality_preference = _commerciality_preference_from_runtime_state(runtime_state)
     scorer = SourceQualityScorer()
     quality_rows = []
     for bundle in _bounded_items(list(inventory.get("bundles") or []), 5):
@@ -442,6 +457,7 @@ def _read_source_quality_summary(
         summary = scorer.summarize(
             source_records,
             subject_kind="option",
+            commerciality_preference=commerciality_preference,
             intended_option_kind=str(bundle.get("bundle_context") or "mixed"),
         )
         row_status = "completed" if summary.contributing_source_count else "missing_source_records"

--- a/trip_planner/sources/quality.py
+++ b/trip_planner/sources/quality.py
@@ -196,6 +196,7 @@ class SourceQualityScorer:
         record: SourceRecord,
         *,
         traveler_relevance_hint: float | None = None,
+        commerciality_preference: float | None = None,
         intended_option_kind: str | None = None,
     ) -> SourceQualityScore:
         if not isinstance(record, SourceRecord):
@@ -207,6 +208,7 @@ class SourceQualityScorer:
             trust_signals=record.trust_signals,
             quality_summary=record.quality_summary,
             traveler_relevance_hint=traveler_relevance_hint,
+            commerciality_preference=commerciality_preference,
             intended_option_kind=intended_option_kind,
             display_label=record.display_name or record.provider_name,
         )
@@ -216,6 +218,7 @@ class SourceQualityScorer:
         reference: ProvenanceReference,
         *,
         traveler_relevance_hint: float | None = None,
+        commerciality_preference: float | None = None,
         intended_option_kind: str | None = None,
     ) -> SourceQualityScore:
         if not isinstance(reference, ProvenanceReference):
@@ -231,6 +234,7 @@ class SourceQualityScorer:
             trust_signals=trust,
             quality_summary=quality,
             traveler_relevance_hint=traveler_relevance_hint,
+            commerciality_preference=commerciality_preference,
             intended_option_kind=intended_option_kind,
             display_label=reference.source_id,
         )
@@ -241,6 +245,7 @@ class SourceQualityScorer:
         *,
         subject_kind: str = "option",
         traveler_relevance_hint: float | None = None,
+        commerciality_preference: float | None = None,
         intended_option_kind: str | None = None,
     ) -> SourceConfidenceSummary:
         if subject_kind not in schema.PROVENANCE_SUBJECT_KINDS:
@@ -277,6 +282,7 @@ class SourceQualityScorer:
                     self.score_source(
                         entry,
                         traveler_relevance_hint=traveler_relevance_hint,
+                        commerciality_preference=commerciality_preference,
                         intended_option_kind=intended_option_kind,
                     )
                 )
@@ -285,6 +291,7 @@ class SourceQualityScorer:
                     self.score_provenance(
                         entry,
                         traveler_relevance_hint=traveler_relevance_hint,
+                        commerciality_preference=commerciality_preference,
                         intended_option_kind=intended_option_kind,
                     )
                 )
@@ -349,11 +356,14 @@ class SourceQualityScorer:
         trust_signals: SourceTrustSignals,
         quality_summary: QualityValueFitSummary,
         traveler_relevance_hint: float | None,
+        commerciality_preference: float | None,
         intended_option_kind: str | None,
         display_label: str,
     ) -> SourceQualityScore:
         if traveler_relevance_hint is not None:
             require_probability(traveler_relevance_hint, "traveler_relevance_hint")
+        if commerciality_preference is not None:
+            require_probability(commerciality_preference, "commerciality_preference")
         if (
             intended_option_kind is not None
             and intended_option_kind not in schema.SOURCE_OPTION_KINDS
@@ -364,7 +374,13 @@ class SourceQualityScorer:
         channel_fit_score = self._channel_fit_score(
             source_category, supported_option_kinds, intended_option_kind
         )
-        provenance_strength = self._provenance_strength(source_category, trust_signals)
+        provenance_strength = self._provenance_strength(
+            source_category,
+            trust_signals,
+            commerciality_preference=(
+                0.5 if commerciality_preference is None else commerciality_preference
+            ),
+        )
         traveler_relevance = self._traveler_relevance(
             source_category, traveler_relevance_hint, quality_summary
         )
@@ -439,7 +455,13 @@ class SourceQualityScorer:
             return _clamp(category_prior + 0.10)
         return _clamp(category_prior - 0.20)
 
-    def _provenance_strength(self, category: str, trust: SourceTrustSignals) -> float:
+    def _provenance_strength(
+        self,
+        category: str,
+        trust: SourceTrustSignals,
+        *,
+        commerciality_preference: float,
+    ) -> float:
         components: list[float] = []
         if trust.operational_reliability is not None:
             components.append(trust.operational_reliability)
@@ -450,9 +472,10 @@ class SourceQualityScorer:
             # with the other reliability signals.
             components.append(trust.editorial_independence)
         if trust.commerciality is not None:
-            # commerciality is informative but does not penalize: commercial-inventory
-            # sources are expected to be commercial. We scale it lightly toward 0.5.
-            components.append(0.4 + 0.2 * trust.commerciality)
+            preference_alignment = (trust.commerciality - 0.5) * (
+                commerciality_preference - 0.5
+            )
+            components.append(_clamp(0.5 + 0.8 * preference_alignment))
         if not components:
             return _CATEGORY_OPERATIONAL_PRIOR.get(category, 0.55) * 0.7
         return _clamp(fmean(components))
@@ -632,6 +655,7 @@ def summarize_sources(
     *,
     subject_kind: str = "option",
     traveler_relevance_hint: float | None = None,
+    commerciality_preference: float | None = None,
     intended_option_kind: str | None = None,
 ) -> SourceConfidenceSummary:
     """Module-level convenience wrapper around :class:`SourceQualityScorer`.
@@ -645,5 +669,6 @@ def summarize_sources(
         records,
         subject_kind=subject_kind,
         traveler_relevance_hint=traveler_relevance_hint,
+        commerciality_preference=commerciality_preference,
         intended_option_kind=intended_option_kind,
     )

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,24 @@
+## 2026-06-05T17:16Z - opener lane issue #1316 commerciality preference
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1316` (`Make source commerciality user-weighted and bidirectional (point-7 P0)`).
+- Branch: `codex/issue-1316-commerciality-preference`, base `origin/main` `e47e64177`.
+- Selection notes: raw opener cap was below limit (`total_opener_owned=2`, `raw_cap_reached=false`). Cap hygiene dispatched Gate Followups for #1339; direct evidence showed #1339 clean/green and ready-for-closer. Trend #5440 remains scoped/non-repairable on the strict-config owner/product decision. High-priority Trend #5343 and LMS #180 remain scoped; Trend #5422 and trip-planner #1309 are already in merged verifier/follow-up sequencing; trip-planner #1314/#1315 are linked to PRs #1338/#1339. #1316 was the oldest unlinked implementation issue outside scoped/linked lanes.
+- Implementation:
+  - Added `commerciality_preference` to `SourceQualityScorer.score_source`, `score_provenance`, `summarize`, and the `summarize_sources` helper.
+  - Replaced the one-directional commerciality boost with a bidirectional preference-alignment term inside provenance strength.
+  - Replaced fixture/runtime inventory hardcoded `commerciality=0.5` and `commerciality=0.7` with category-derived commerciality.
+  - Threaded optional `inventory.runtime_state["commerciality_preference"]` through the source-quality planner tool with probability validation.
+  - Added regression coverage proving non-commercial and commercial preferences reverse otherwise identical source ordering.
+- Validation:
+  - `python -m pytest tests/sources/test_source_quality.py::test_commerciality_preference_reorders_toward_non_commercial -q` -> 1 passed.
+  - Deliberate-break gate: temporarily restored `components.append(0.4 + 0.2 * trust.commerciality)`; the named test failed with `AssertionError: assert 0.7403 > 0.7492`; restored the bidirectional term and reran green.
+  - `python -m pytest tests/sources/test_source_quality.py tests/ranking/test_source_confidence_explanation.py -q` -> 27 passed.
+  - `git grep -nE 'commerciality=0\.(5|7)\b' -- trip_planner/app/services/inventory.py` -> 0 lines via the shell gate; `grep -nE 'commerciality' trip_planner/app/services/inventory.py` shows category-derived assignments.
+  - `python -m ruff check trip_planner/sources/quality.py trip_planner/app/services/inventory.py trip_planner/app/services/planner_tools.py tests/sources/test_source_quality.py` -> passed.
+  - `git diff --check` -> passed.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, and `agent:retry`; keepalive owns CI/review after PR creation.
+
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,24 +1,3 @@
-## 2026-06-05T17:16Z - opener lane issue #1316 commerciality preference
-
-- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
-- Source repo: `stranske/trip-planner`; source issue `#1316` (`Make source commerciality user-weighted and bidirectional (point-7 P0)`).
-- Branch: `codex/issue-1316-commerciality-preference`, base `origin/main` `e47e64177`.
-- Selection notes: raw opener cap was below limit (`total_opener_owned=2`, `raw_cap_reached=false`). Cap hygiene dispatched Gate Followups for #1339; direct evidence showed #1339 clean/green and ready-for-closer. Trend #5440 remains scoped/non-repairable on the strict-config owner/product decision. High-priority Trend #5343 and LMS #180 remain scoped; Trend #5422 and trip-planner #1309 are already in merged verifier/follow-up sequencing; trip-planner #1314/#1315 are linked to PRs #1338/#1339. #1316 was the oldest unlinked implementation issue outside scoped/linked lanes.
-- Implementation:
-  - Added `commerciality_preference` to `SourceQualityScorer.score_source`, `score_provenance`, `summarize`, and the `summarize_sources` helper.
-  - Replaced the one-directional commerciality boost with a bidirectional preference-alignment term inside provenance strength.
-  - Replaced fixture/runtime inventory hardcoded `commerciality=0.5` and `commerciality=0.7` with category-derived commerciality.
-  - Threaded optional `inventory.runtime_state["commerciality_preference"]` through the source-quality planner tool with probability validation.
-  - Added regression coverage proving non-commercial and commercial preferences reverse otherwise identical source ordering.
-- Validation:
-  - `python -m pytest tests/sources/test_source_quality.py::test_commerciality_preference_reorders_toward_non_commercial -q` -> 1 passed.
-  - Deliberate-break gate: temporarily restored `components.append(0.4 + 0.2 * trust.commerciality)`; the named test failed with `AssertionError: assert 0.7403 > 0.7492`; restored the bidirectional term and reran green.
-  - `python -m pytest tests/sources/test_source_quality.py tests/ranking/test_source_confidence_explanation.py -q` -> 27 passed.
-  - `git grep -nE 'commerciality=0\.(5|7)\b' -- trip_planner/app/services/inventory.py` -> 0 lines via the shell gate; `grep -nE 'commerciality' trip_planner/app/services/inventory.py` shows category-derived assignments.
-  - `python -m ruff check trip_planner/sources/quality.py trip_planner/app/services/inventory.py trip_planner/app/services/planner_tools.py tests/sources/test_source_quality.py` -> passed.
-  - `git diff --check` -> passed.
-- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, `autofix`, and `agent:retry`; keepalive owns CI/review after PR creation.
-
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.


### PR DESCRIPTION
Closes #1316

## Summary
- Thread `commerciality_preference` through source quality scoring and planner source-quality summaries.
- Replace the one-directional commerciality boost with a bidirectional preference-alignment contribution.
- Derive runtime inventory commerciality from source category instead of hardcoded fixture/runtime literals.
- Add regression coverage proving low/high preferences reverse otherwise identical source ordering.

## Validation
- `python -m pytest tests/sources/test_source_quality.py::test_commerciality_preference_reorders_toward_non_commercial -q`
- Deliberate break: restoring `components.append(0.4 + 0.2 * trust.commerciality)` made the named test fail with `AssertionError: assert 0.7403 > 0.7492`; restored and reran green.
- `python -m pytest tests/sources/test_source_quality.py tests/ranking/test_source_confidence_explanation.py -q`
- `git grep -nE 'commerciality=0\\.(5|7)\\b' -- trip_planner/app/services/inventory.py` -> 0 lines\n- `python -m ruff check trip_planner/sources/quality.py trip_planner/app/services/inventory.py trip_planner/app/services/planner_tools.py tests/sources/test_source_quality.py`\n- `git diff --check origin/main`