### PR TITLE
Issue #1317: clamp ranking final scores

### DIFF
--- a/tests/ranking/test_score_bounds.py
+++ b/tests/ranking/test_score_bounds.py
@@ -1,0 +1,39 @@
+from tests.ranking.test_business_ranking import (
+    _compliant_conference_bundle,
+    _objectives_for_scenario,
+)
+from tests.ranking.test_leisure_ranking import (
+    _objectives_from_fixture,
+    _profile_from_fixture,
+    _urban_culture_bundle,
+)
+from trip_planner.ranking import BusinessRankingEngine, LeisureRankingEngine
+
+
+def test_final_score_within_unit_interval() -> None:
+    business_profile, business_objectives, constraint_set = _objectives_for_scenario(
+        "compliant_conference_trip.json"
+    )
+    business_result = BusinessRankingEngine().rank_bundles(
+        business_profile,
+        business_objectives,
+        [_compliant_conference_bundle()],
+        trip_id="trip-score-bound-business",
+        constraint_set=constraint_set,
+    ).results[0]
+
+    leisure_result = LeisureRankingEngine().rank_bundles(
+        _profile_from_fixture("depth_oriented_urban_trip.json"),
+        _objectives_from_fixture("depth_oriented_urban_trip.json"),
+        [_urban_culture_bundle()],
+        trip_id="trip-score-bound-leisure",
+    ).results[0]
+
+    for result in (business_result, leisure_result):
+        assert 0.0 <= result.score <= 1.0
+        assert 0.0 <= result.score_breakdown.final_score <= 1.0
+        assert result.score == result.score_breakdown.final_score
+        assert any(
+            penalty.reason_code == "score_upper_bound_cap"
+            for penalty in result.score_breakdown.penalties
+        )

--- a/trip_planner/ranking/business.py
+++ b/trip_planner/ranking/business.py
@@ -289,14 +289,14 @@ class BusinessRankingEngine(BaseRankingEngine):
                 assessment,
                 constraint_set=constraint_set,
             )
+            bonuses: list[ScoreAdjustment] = []
             # Accumulate before rounding so the hard-block cap is exact.
             accumulated_score = self.BASELINE_SCORE
             accumulated_score += sum(item.weighted_impact for item in contributions)
             accumulated_score -= sum(item.amount for item in penalties)
             accumulated_score -= sum(item.amount for item in missing_data_penalties)
 
-            # Hard constraint: disallowed inventory cannot be outweighed by preference.
-            # Add an explicit capping penalty so the ScoreBreakdown arithmetic stays exact.
+            # Add explicit cap/floor adjustments so ScoreBreakdown arithmetic stays exact.
             hard_blocked = self._has_disallowed_inventory(candidate.bundle)
             if hard_blocked and accumulated_score > self.HARD_BLOCK_SCORE_CAP:
                 cap_amount = accumulated_score - self.HARD_BLOCK_SCORE_CAP
@@ -315,6 +315,34 @@ class BusinessRankingEngine(BaseRankingEngine):
                     )
                 ]
                 final_score = self.HARD_BLOCK_SCORE_CAP
+            elif accumulated_score > 1.0:
+                cap_amount = accumulated_score - 1.0
+                penalties = list(penalties) + [
+                    ScoreAdjustment(
+                        adjustment_id=f"penalty:{candidate.bundle.bundle_id}:score-upper-bound",
+                        label="Score upper-bound cap",
+                        kind="penalty",
+                        amount=cap_amount,
+                        reason_code="score_upper_bound_cap",
+                        summary="Score capped at 1.0 so final_score remains on the unit interval.",
+                        affected_factor_keys=["final_score"],
+                    )
+                ]
+                final_score = 1.0
+            elif accumulated_score < 0.0:
+                floor_amount = abs(accumulated_score)
+                bonuses = [
+                    ScoreAdjustment(
+                        adjustment_id=f"bonus:{candidate.bundle.bundle_id}:score-lower-bound",
+                        label="Score lower-bound floor",
+                        kind="bonus",
+                        amount=floor_amount,
+                        reason_code="score_lower_bound_floor",
+                        summary="Score floored at 0.0 so final_score remains on the unit interval.",
+                        affected_factor_keys=["final_score"],
+                    )
+                ]
+                final_score = 0.0
             else:
                 final_score = _round(accumulated_score)
 
@@ -326,10 +354,13 @@ class BusinessRankingEngine(BaseRankingEngine):
                 breakdown_notes.append(
                     f"Hard policy block applied: score capped at {self.HARD_BLOCK_SCORE_CAP}."
                 )
+            if final_score in {0.0, 1.0} and accumulated_score != final_score:
+                breakdown_notes.append("Unit-interval score bound applied to final_score.")
             breakdown = ScoreBreakdown(
                 baseline_score=self.BASELINE_SCORE,
                 component_contributions=contributions,
                 penalties=penalties,
+                bonuses=bonuses,
                 missing_data_penalties=missing_data_penalties,
                 final_score=final_score,
                 notes=breakdown_notes,

--- a/trip_planner/ranking/leisure.py
+++ b/trip_planner/ranking/leisure.py
@@ -343,13 +343,48 @@ class LeisureRankingEngine(BaseRankingEngine):
         missing_data_penalties = self._build_missing_data_penalties(profile, assessment)
 
         baseline_score = self.BASELINE_SCORE
-        final_score = _round(
+        accumulated_score = (
             baseline_score
             + sum(item.weighted_impact for item in contributions)
             + sum(item.amount for item in bonuses)
             - sum(item.amount for item in penalties)
             - sum(item.amount for item in missing_data_penalties)
         )
+        if accumulated_score > 1.0:
+            cap_amount = accumulated_score - 1.0
+            penalties = list(penalties) + [
+                ScoreAdjustment(
+                    adjustment_id=f"penalty:{bundle.bundle_id}:score-upper-bound",
+                    label="Score upper-bound cap",
+                    kind="penalty",
+                    amount=cap_amount,
+                    reason_code="score_upper_bound_cap",
+                    summary="Score capped at 1.0 so final_score remains on the unit interval.",
+                    affected_factor_keys=["final_score"],
+                )
+            ]
+            final_score = 1.0
+        elif accumulated_score < 0.0:
+            floor_amount = abs(accumulated_score)
+            bonuses = list(bonuses) + [
+                ScoreAdjustment(
+                    adjustment_id=f"bonus:{bundle.bundle_id}:score-lower-bound",
+                    label="Score lower-bound floor",
+                    kind="bonus",
+                    amount=floor_amount,
+                    reason_code="score_lower_bound_floor",
+                    summary="Score floored at 0.0 so final_score remains on the unit interval.",
+                    affected_factor_keys=["final_score"],
+                )
+            ]
+            final_score = 0.0
+        else:
+            final_score = _round(accumulated_score)
+        breakdown_notes = [
+            "Feasibility output informs ranking friction but does not replace preference or objective fit.",
+        ]
+        if final_score in {0.0, 1.0} and accumulated_score != final_score:
+            breakdown_notes.append("Unit-interval score bound applied to final_score.")
         score_breakdown = ScoreBreakdown(
             baseline_score=baseline_score,
             component_contributions=contributions,
@@ -357,9 +392,7 @@ class LeisureRankingEngine(BaseRankingEngine):
             bonuses=bonuses,
             missing_data_penalties=missing_data_penalties,
             final_score=final_score,
-            notes=[
-                "Feasibility output informs ranking friction but does not replace preference or objective fit.",
-            ],
+            notes=breakdown_notes,
         )
         confidence_summary = self._confidence_summary(profile, assessment)
         unresolved_risks = self._risk_flags(profile, assessment)

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,21 @@
+## 2026-06-05T18:05Z - opener lane issue #1317 score bounds
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1317` (`Clamp ranking final_score to [0,1] so scores are comparable`).
+- Branch: `codex/issue-1317-score-bounds`, base `origin/main` `453f1741e`.
+- Selection notes: raw opener cap was below limit (`total_opener_owned=2`, `raw_cap_reached=false`). Trend #5440 remains scoped/non-repairable on the strict-config owner/product decision. trip-planner #1340 has clean/green direct check evidence and is a closer-drain candidate despite stale helper `runner-failed` classification. Scoped high-priority Trend #5343 and LMS #180 remain excluded. #1317 was the oldest unlinked implementation issue outside scoped/linked lanes.
+- Implementation:
+  - Added explicit upper-bound penalties and lower-bound bonuses in business ranking so returned `final_score` remains in `[0,1]` while preserving `ScoreBreakdown` arithmetic.
+  - Added the same unit-interval score-bound handling to leisure ranking.
+  - Added focused regression coverage using existing high-signal business and leisure fixtures that exceeded 1.0 on main.
+- Validation:
+  - `python -m pytest tests/ranking/test_score_bounds.py::test_final_score_within_unit_interval -q` -> 1 passed.
+  - Deliberate-break gate: temporarily disabled the business upper-bound clamp; the named test failed with `AssertionError: assert 1.0459 <= 1.0`. Restored the clamp and reran green.
+  - `python -m ruff check trip_planner/ranking/business.py trip_planner/ranking/leisure.py tests/ranking/test_score_bounds.py` -> passed.
+  - `python -m pytest tests/ranking/ -q` -> 64 passed.
+  - `git diff --check origin/main` -> passed.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
+
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,21 +1,3 @@
-## 2026-06-05T18:05Z - opener lane issue #1317 score bounds
-
-- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
-- Source repo: `stranske/trip-planner`; source issue `#1317` (`Clamp ranking final_score to [0,1] so scores are comparable`).
-- Branch: `codex/issue-1317-score-bounds`, base `origin/main` `453f1741e`.
-- Selection notes: raw opener cap was below limit (`total_opener_owned=2`, `raw_cap_reached=false`). Trend #5440 remains scoped/non-repairable on the strict-config owner/product decision. trip-planner #1340 has clean/green direct check evidence and is a closer-drain candidate despite stale helper `runner-failed` classification. Scoped high-priority Trend #5343 and LMS #180 remain excluded. #1317 was the oldest unlinked implementation issue outside scoped/linked lanes.
-- Implementation:
-  - Added explicit upper-bound penalties and lower-bound bonuses in business ranking so returned `final_score` remains in `[0,1]` while preserving `ScoreBreakdown` arithmetic.
-  - Added the same unit-interval score-bound handling to leisure ranking.
-  - Added focused regression coverage using existing high-signal business and leisure fixtures that exceeded 1.0 on main.
-- Validation:
-  - `python -m pytest tests/ranking/test_score_bounds.py::test_final_score_within_unit_interval -q` -> 1 passed.
-  - Deliberate-break gate: temporarily disabled the business upper-bound clamp; the named test failed with `AssertionError: assert 1.0459 <= 1.0`. Restored the clamp and reran green.
-  - `python -m ruff check trip_planner/ranking/business.py trip_planner/ranking/leisure.py tests/ranking/test_score_bounds.py` -> passed.
-  - `python -m pytest tests/ranking/ -q` -> 64 passed.
-  - `git diff --check origin/main` -> passed.
-- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
-
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.


### PR DESCRIPTION
Closes #1317

## Summary
- Clamp business and leisure ranking final scores to the unit interval while preserving ScoreBreakdown arithmetic.
- Add explicit score-bound adjustments so capped/floored scores remain explainable in the breakdown.
- Add regression coverage for high-signal business and leisure bundles that exceeded 1.0 on main.

## Validation
- `python -m pytest tests/ranking/test_score_bounds.py::test_final_score_within_unit_interval -q`
- Deliberate break: temporarily disabled the business upper-bound clamp; the named test failed with `AssertionError: assert 1.0459 <= 1.0`; restored and reran green.
- `python -m ruff check trip_planner/ranking/business.py trip_planner/ranking/leisure.py tests/ranking/test_score_bounds.py`
- `python -m pytest tests/ranking/ -q`
- `git diff --check origin/main`