### PR TITLE
Issue #1319: add static booking radar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ include = ["scripts*", "trip_planner*"]
 [tool.setuptools.package-data]
 trip_planner = [
     "resources/business/*.json",
+    "resources/logistics/*.json",
     "resources/options/bundles/*.json",
     "resources/preferences/*.json",
 ]

--- a/tests/app/test_planner_booking_radar_tool.py
+++ b/tests/app/test_planner_booking_radar_tool.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trip_planner.app.services import planner_tools
+from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.app.services.planner_tools import execute_planner_tool_call, list_planner_tools
+
+
+def _workspace_payload() -> dict[str, Any]:
+    return {
+        "session": {"session_state_id": "session-1"},
+        "trip_record": {"trip": {"trip_id": "trip-swiss-spain", "title": "Alps to Andalucia"}},
+        "planner_panel_state": {"trip": {"trip_id": "trip-swiss-spain"}},
+        "inventory_summary": {
+            "runtime_state": {"status": "ready"},
+            "bundles": [
+                {
+                    "bundle_id": "bundle-rail-culture",
+                    "title": "Rail plus Granada anchor",
+                    "transport_options": [
+                        {
+                            "option_id": "transport-glacier",
+                            "mode": "rail",
+                            "operator": "Glacier Express",
+                            "route": "Zermatt to St Moritz",
+                        }
+                    ],
+                    "activity_options": [
+                        {
+                            "option_id": "act-alhambra",
+                            "name": "Alhambra Nasrid Palaces",
+                            "activity_kind": "sight",
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
+def test_read_booking_radar_tool_registered_and_dispatches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert any(tool["tool_name"] == "read_booking_radar" for tool in list_planner_tools())
+
+    monkeypatch.setattr(
+        planner_tools,
+        "get_workspace_payload",
+        lambda *args, **kwargs: _workspace_payload(),
+    )
+    db_session = SimpleNamespace(info={})
+    user = AuthenticatedUser(
+        user_id="user-1",
+        email="planner@example.com",
+        display_name="Planner",
+    )
+
+    result = execute_planner_tool_call(
+        db_session,  # type: ignore[arg-type]
+        user=user,
+        trip_id="trip-swiss-spain",
+        tool_name="read_booking_radar",
+        arguments={"appetite": "anchored"},
+    ).to_dict()
+
+    assert result["status"] == "completed"
+    assert result["output"]["radar_state"] == "ready"
+    assert result["output"]["flag_count"] == 2
+    assert {flag["item"] for flag in result["output"]["flags"]} == {
+        "Glacier Express seat reservation",
+        "Alhambra Nasrid Palaces timed entry",
+    }

--- a/tests/logistics/test_booking_radar.py
+++ b/tests/logistics/test_booking_radar.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from trip_planner.logistics.booking_radar import scan_trip
+
+
+def test_flags_known_scarce_items() -> None:
+    trip = {
+        "transport_segments": [
+            {
+                "mode": "rail",
+                "operator": "Glacier Express",
+                "route": "Zermatt to St Moritz",
+            }
+        ],
+        "pois": [
+            {
+                "name": "Alhambra Nasrid Palaces",
+                "activity_kind": "sight",
+            }
+        ],
+    }
+
+    flags = scan_trip(trip)
+    by_item = {flag.item: flag for flag in flags}
+
+    assert "Glacier Express seat reservation" in by_item
+    assert "Alhambra Nasrid Palaces timed entry" in by_item
+    assert by_item["Glacier Express seat reservation"].deadline_rule
+    assert by_item["Glacier Express seat reservation"].backup
+    assert by_item["Alhambra Nasrid Palaces timed entry"].deadline_rule
+    assert by_item["Alhambra Nasrid Palaces timed entry"].backup
+
+
+def test_no_release_item_never_promises_release() -> None:
+    trip = {
+        "pois": [
+            {
+                "name": "Classic Inca Trail trek",
+                "summary": "Four-day operator-led Machu Picchu trek.",
+            }
+        ],
+    }
+
+    flags = scan_trip(trip)
+    flag = next(item for item in flags if item.item == "Inca Trail permit")
+
+    assert flag.release_pattern == "none"
+    assert "release" not in flag.backup.casefold()
+    assert "operator" in flag.deadline_rule.casefold()

--- a/tests/logistics/test_booking_radar.py
+++ b/tests/logistics/test_booking_radar.py
@@ -47,3 +47,43 @@ def test_no_release_item_never_promises_release() -> None:
     assert flag.release_pattern == "none"
     assert "release" not in flag.backup.casefold()
     assert "operator" in flag.deadline_rule.casefold()
+
+
+def test_declared_lists_bound_match_surface() -> None:
+    trip = {
+        "transport_segments": [],
+        "pois": [],
+        "inventory_summary": {
+            "bundles": [
+                {
+                    "title": "Glacier Express and Alhambra research notes",
+                    "summary": "Contains text that should not count as a saved transport segment or POI.",
+                }
+            ]
+        },
+    }
+
+    assert scan_trip(trip) == []
+
+
+def test_minimal_appetite_truncates_but_keeps_no_release_flags() -> None:
+    trip = {
+        "transport_segments": [
+            {"mode": "rail", "operator": "Glacier Express", "route": "Zermatt St Moritz"},
+            {"mode": "rail", "operator": "Bernina Express", "route": "Tirano Chur"},
+            {"mode": "rail", "operator": "Eurostar", "route": "London Paris"},
+            {"mode": "rail", "route": "Paris Milan"},
+        ],
+        "pois": [
+            {"name": "Classic Inca Trail trek"},
+            {"name": "Alhambra Nasrid Palaces"},
+            {"name": "The Last Supper"},
+            {"name": "Half Dome"},
+        ],
+    }
+
+    minimal_flags = scan_trip(trip, appetite="minimal")
+    expansive_flags = scan_trip(trip, appetite="expansive")
+
+    assert len(minimal_flags) < len(expansive_flags)
+    assert any(flag.item == "Inca Trail permit" for flag in minimal_flags)

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -24,6 +24,7 @@ from trip_planner.itinerary.daily_menu import (
     SourceMix,
     build_daily_menu as assemble_daily_menu,
 )
+from trip_planner.logistics.booking_radar import BookingFlag, scan_trip
 from trip_planner.sources import (
     QualityValueFitSummary,
     SourceQualityScorer,
@@ -90,6 +91,10 @@ _TOOL_DEFINITIONS: tuple[PlannerToolDefinition, ...] = (
             "Build a deterministic activity menu digest from current workspace activities, "
             "time budget, and commerciality mix."
         ),
+    ),
+    PlannerToolDefinition(
+        tool_name="read_booking_radar",
+        description="Read static advance-booking flags for scarce transport, sight, and permit items.",
     ),
     PlannerToolDefinition(
         tool_name="read_map_provider_status",
@@ -705,6 +710,73 @@ def _build_daily_menu(
             "tier_histogram": menu.rollup.tier_histogram,
             "candidate_count": len(menu.candidates),
             "selected_stops": digest,
+        },
+    )
+
+
+def _booking_radar_trip_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    inventory = payload["inventory_summary"]
+    trip_record = payload.get("trip_record") or {}
+    planner_trip = payload.get("planner_panel_state", {}).get("trip") or {}
+    transport_options: list[dict[str, Any]] = []
+    activity_options: list[dict[str, Any]] = []
+    destinations: list[dict[str, Any]] = []
+    for bundle in inventory.get("bundles") or []:
+        if not isinstance(bundle, dict):
+            continue
+        transport_options.extend(
+            item for item in bundle.get("transport_options", []) if isinstance(item, dict)
+        )
+        activity_options.extend(
+            item for item in bundle.get("activity_options", []) if isinstance(item, dict)
+        )
+        for nested_bundle in bundle.get("bundles") or []:
+            if not isinstance(nested_bundle, dict):
+                continue
+            destinations.extend(
+                item for item in nested_bundle.get("destinations", []) if isinstance(item, dict)
+            )
+    return {
+        "trip": trip_record.get("trip") or planner_trip,
+        "transport_segments": transport_options,
+        "pois": [*activity_options, *destinations],
+        "inventory": inventory,
+    }
+
+
+def _booking_flag_digest(flags: list[BookingFlag], *, limit: int) -> list[dict[str, str]]:
+    return [flag.to_dict() for flag in flags[: max(1, min(limit, 12))]]
+
+
+def _read_booking_radar(
+    db_session: Session,
+    user: AuthenticatedUser,
+    trip_id: str,
+    arguments: dict[str, Any],
+) -> PlannerToolResult:
+    payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
+    appetite = str(arguments.get("appetite") or "anchored")
+    flags = scan_trip(_booking_radar_trip_payload(payload), appetite=appetite)
+    limit = _bounded_menu_limit(arguments.get("limit", 12))
+    digest = _booking_flag_digest(flags, limit=limit)
+    return PlannerToolResult(
+        tool_name="read_booking_radar",
+        status="completed" if digest else "not_available",
+        summary=(
+            f"Read {len(digest)} advance-booking flag(s) for the active trip."
+            if digest
+            else "No static advance-booking flags matched the active trip."
+        ),
+        mutates_state=False,
+        refs=_ref_list(
+            payload["session"]["session_state_id"],
+            *(flag["pattern_id"] for flag in digest),
+        ),
+        output={
+            "radar_state": "ready" if digest else "clear",
+            "appetite": appetite,
+            "flag_count": len(flags),
+            "flags": digest,
         },
     )
 
@@ -1344,6 +1416,7 @@ _TOOL_HANDLERS: dict[str, PlannerToolHandler] = {
     "read_source_summary": _read_source_summary,
     "read_source_quality_summary": _read_source_quality_summary,
     "build_daily_menu": _build_daily_menu,
+    "read_booking_radar": _read_booking_radar,
     "read_map_provider_status": _read_map_provider_status,
     "read_route_geometry": _read_route_geometry,
     "refresh_route_comparison": _refresh_route_comparison,

--- a/trip_planner/logistics/__init__.py
+++ b/trip_planner/logistics/__init__.py
@@ -1,0 +1,5 @@
+"""Logistics helpers for deterministic trip planning checks."""
+
+from trip_planner.logistics.booking_radar import BookingFlag, scan_trip
+
+__all__ = ["BookingFlag", "scan_trip"]

--- a/trip_planner/logistics/booking_radar.py
+++ b/trip_planner/logistics/booking_radar.py
@@ -1,0 +1,217 @@
+"""Static advance-booking radar for known scarce trip items."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from importlib import resources
+from typing import Any
+
+_SPACE_RE = re.compile(r"[^a-z0-9]+")
+_APPETITE_LIMITS = {
+    "minimal": 3,
+    "anchored": 6,
+    "expansive": 12,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class BookingFlag:
+    item: str
+    why: str
+    deadline_rule: str
+    confidence: str
+    release_pattern: str
+    backup: str
+    matched_on: str
+    pattern_id: str
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def scan_trip(trip: dict[str, Any], *, appetite: str = "anchored") -> list[BookingFlag]:
+    """Return static advance-booking flags for matching trip segments and POIs."""
+
+    if not isinstance(trip, dict):
+        raise ValueError("trip must be a dictionary")
+    matches = [
+        flag
+        for pattern in _load_patterns()
+        for flag in _match_pattern(pattern, trip)
+    ]
+    deduped = _dedupe(matches)
+    deduped.sort(key=_flag_sort_key)
+    return _apply_appetite_limit(deduped, appetite)
+
+
+def _load_patterns() -> list[dict[str, Any]]:
+    data = (
+        resources.files("trip_planner.resources.logistics")
+        .joinpath("must_prebook.json")
+        .read_text(encoding="utf-8")
+    )
+    payload = json.loads(data)
+    patterns = payload.get("patterns", [])
+    if not isinstance(patterns, list):
+        raise ValueError("must_prebook.json must contain a patterns list")
+    return [pattern for pattern in patterns if isinstance(pattern, dict)]
+
+
+def _match_pattern(pattern: dict[str, Any], trip: dict[str, Any]) -> list[BookingFlag]:
+    scope = str(pattern.get("scope") or "").strip()
+    if scope == "transport":
+        candidates = _transport_candidates(trip)
+    elif scope == "poi":
+        candidates = _poi_candidates(trip)
+    else:
+        return []
+    flags: list[BookingFlag] = []
+    for candidate in candidates:
+        if _candidate_matches(pattern, candidate):
+            flags.append(_flag_from_pattern(pattern, matched_on=candidate["matched_on"]))
+    return flags
+
+
+def _transport_candidates(trip: dict[str, Any]) -> list[dict[str, str]]:
+    candidates: list[dict[str, str]] = []
+    for item in _iter_nested_dicts(trip):
+        mode = _text(item.get("mode") or item.get("transport_mode") or item.get("category"))
+        operator = _text(item.get("operator") or item.get("provider") or item.get("carrier"))
+        route_text = _joined(
+            item.get("route"),
+            item.get("route_name"),
+            item.get("title"),
+            item.get("name"),
+            item.get("summary"),
+            item.get("from"),
+            item.get("origin"),
+            item.get("to"),
+            item.get("destination"),
+        )
+        if not any((mode, operator, route_text)):
+            continue
+        candidates.append(
+            {
+                "mode": mode,
+                "operator": operator,
+                "route": route_text,
+                "matched_on": _joined(operator, route_text, mode),
+            }
+        )
+    return candidates
+
+
+def _poi_candidates(trip: dict[str, Any]) -> list[dict[str, str]]:
+    candidates: list[dict[str, str]] = []
+    for item in _iter_nested_dicts(trip):
+        name = _text(item.get("name") or item.get("title") or item.get("label"))
+        if not name:
+            continue
+        place_kind = _text(item.get("place_kind") or item.get("activity_kind") or item.get("kind"))
+        aliases = _joined(
+            item.get("poi"),
+            item.get("site"),
+            item.get("destination"),
+            item.get("summary"),
+            item.get("notes"),
+        )
+        candidates.append(
+            {
+                "name": name,
+                "aliases": aliases,
+                "kind": place_kind,
+                "matched_on": _joined(name, aliases),
+            }
+        )
+    return candidates
+
+
+def _candidate_matches(pattern: dict[str, Any], candidate: dict[str, str]) -> bool:
+    terms = [
+        _normalized(term)
+        for term in pattern.get("match_terms", [])
+        if isinstance(term, str) and term.strip()
+    ]
+    haystack = _normalized(" ".join(candidate.values()))
+    if not terms or not any(term in haystack for term in terms):
+        return False
+    modes = [
+        _normalized(mode)
+        for mode in pattern.get("modes", [])
+        if isinstance(mode, str) and mode.strip()
+    ]
+    return not modes or any(mode in haystack for mode in modes)
+
+
+def _flag_from_pattern(pattern: dict[str, Any], *, matched_on: str) -> BookingFlag:
+    return BookingFlag(
+        item=str(pattern["item"]),
+        why=str(pattern["why"]),
+        deadline_rule=str(pattern["deadline_rule"]),
+        confidence=str(pattern["confidence"]),
+        release_pattern=str(pattern["release_pattern"]),
+        backup=str(pattern["backup"]),
+        matched_on=matched_on,
+        pattern_id=str(pattern["id"]),
+    )
+
+
+def _iter_nested_dicts(value: Any) -> list[dict[str, Any]]:
+    found: list[dict[str, Any]] = []
+    if isinstance(value, dict):
+        found.append(value)
+        for child in value.values():
+            found.extend(_iter_nested_dicts(child))
+    elif isinstance(value, list):
+        for child in value:
+            found.extend(_iter_nested_dicts(child))
+    return found
+
+
+def _dedupe(flags: list[BookingFlag]) -> list[BookingFlag]:
+    by_pattern: dict[str, BookingFlag] = {}
+    for flag in flags:
+        by_pattern.setdefault(flag.pattern_id, flag)
+    return list(by_pattern.values())
+
+
+def _flag_sort_key(flag: BookingFlag) -> tuple[int, int, str]:
+    release_rank = 0 if flag.release_pattern == "none" else 1
+    confidence_rank = {"high": 0, "medium": 1, "low": 2}.get(flag.confidence, 3)
+    return (release_rank, confidence_rank, flag.item)
+
+
+def _apply_appetite_limit(flags: list[BookingFlag], appetite: str) -> list[BookingFlag]:
+    limit = _APPETITE_LIMITS.get(str(appetite or "anchored").strip().lower(), 6)
+    required = [flag for flag in flags if flag.release_pattern == "none" or flag.confidence == "high"]
+    selected: list[BookingFlag] = []
+    for flag in [*required, *flags]:
+        if flag not in selected:
+            selected.append(flag)
+        if len(selected) >= limit and flag not in required:
+            break
+    return selected
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, list):
+        return " ".join(_text(item) for item in value)
+    if isinstance(value, dict):
+        return " ".join(_text(item) for item in value.values())
+    return str(value)
+
+
+def _joined(*values: Any) -> str:
+    return " ".join(part for part in (_text(value).strip() for value in values) if part)
+
+
+def _normalized(value: str) -> str:
+    return _SPACE_RE.sub(" ", value.casefold()).strip()

--- a/trip_planner/logistics/booking_radar.py
+++ b/trip_planner/logistics/booking_radar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from importlib import resources
 from typing import Any
 
@@ -28,7 +28,16 @@ class BookingFlag:
     pattern_id: str
 
     def to_dict(self) -> dict[str, str]:
-        return asdict(self)
+        return {
+            "item": self.item,
+            "why": self.why,
+            "deadline_rule": self.deadline_rule,
+            "confidence": self.confidence,
+            "release_pattern": self.release_pattern,
+            "backup": self.backup,
+            "matched_on": self.matched_on,
+            "pattern_id": self.pattern_id,
+        }
 
 
 def scan_trip(trip: dict[str, Any], *, appetite: str = "anchored") -> list[BookingFlag]:
@@ -76,7 +85,7 @@ def _match_pattern(pattern: dict[str, Any], trip: dict[str, Any]) -> list[Bookin
 
 def _transport_candidates(trip: dict[str, Any]) -> list[dict[str, str]]:
     candidates: list[dict[str, str]] = []
-    for item in _iter_nested_dicts(trip):
+    for item in _candidate_items(trip, "transport_segments"):
         mode = _text(item.get("mode") or item.get("transport_mode") or item.get("category"))
         operator = _text(item.get("operator") or item.get("provider") or item.get("carrier"))
         route_text = _joined(
@@ -105,7 +114,7 @@ def _transport_candidates(trip: dict[str, Any]) -> list[dict[str, str]]:
 
 def _poi_candidates(trip: dict[str, Any]) -> list[dict[str, str]]:
     candidates: list[dict[str, str]] = []
-    for item in _iter_nested_dicts(trip):
+    for item in _candidate_items(trip, "pois"):
         name = _text(item.get("name") or item.get("title") or item.get("label"))
         if not name:
             continue
@@ -156,6 +165,13 @@ def _flag_from_pattern(pattern: dict[str, Any], *, matched_on: str) -> BookingFl
         matched_on=matched_on,
         pattern_id=str(pattern["id"]),
     )
+
+
+def _candidate_items(trip: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    declared = trip.get(key)
+    if isinstance(declared, list):
+        return [item for item in declared if isinstance(item, dict)]
+    return _iter_nested_dicts(trip)
 
 
 def _iter_nested_dicts(value: Any) -> list[dict[str, Any]]:

--- a/trip_planner/resources/logistics/__init__.py
+++ b/trip_planner/resources/logistics/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged logistics knowledge-base resources."""

--- a/trip_planner/resources/logistics/must_prebook.json
+++ b/trip_planner/resources/logistics/must_prebook.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "0.1.0",
+  "patterns": [
+    {
+      "id": "rail-glacier-express-seat",
+      "scope": "transport",
+      "item": "Glacier Express seat reservation",
+      "match_terms": ["glacier express", "zermatt st moritz", "st moritz zermatt"],
+      "modes": ["rail", "train"],
+      "why": "Panoramic rail tickets do not replace the mandatory seat reservation, and popular departures can sell out.",
+      "deadline_rule": "reserve weeks ahead for peak dates",
+      "confidence": "high",
+      "release_pattern": "scheduled",
+      "backup": "Use regional rail legs on the same corridor or shift to a less constrained departure."
+    },
+    {
+      "id": "rail-bernina-express-seat",
+      "scope": "transport",
+      "item": "Bernina Express seat reservation",
+      "match_terms": ["bernina express", "tirano chur", "chur tirano"],
+      "modes": ["rail", "train"],
+      "why": "Panoramic-car seats require a separate reservation from the rail ticket.",
+      "deadline_rule": "reserve weeks ahead for peak dates",
+      "confidence": "high",
+      "release_pattern": "scheduled",
+      "backup": "Use regional trains over the Bernina route if panoramic seats are unavailable."
+    },
+    {
+      "id": "rail-eurostar-cross-channel",
+      "scope": "transport",
+      "item": "Eurostar cross-channel rail",
+      "match_terms": ["eurostar", "london paris", "paris london"],
+      "modes": ["rail", "train"],
+      "why": "International high-speed rail has capacity controls and better fares before close-in dates.",
+      "deadline_rule": "book as soon as the travel date is firm",
+      "confidence": "medium",
+      "release_pattern": "scheduled",
+      "backup": "Keep a flight or ferry routing as a timing fallback."
+    },
+    {
+      "id": "rail-paris-italy-high-speed",
+      "scope": "transport",
+      "item": "Paris-Italy high-speed rail",
+      "match_terms": ["paris milan", "paris italy", "tgv inoui italy", "frecciarossa paris"],
+      "modes": ["rail", "train"],
+      "why": "Cross-border high-speed seats can be capacity-limited and sell through before local legs.",
+      "deadline_rule": "book once route and date are stable",
+      "confidence": "medium",
+      "release_pattern": "scheduled",
+      "backup": "Break the route into domestic legs or compare a short-haul flight."
+    },
+    {
+      "id": "permit-inca-trail",
+      "scope": "poi",
+      "item": "Inca Trail permit",
+      "match_terms": ["inca trail", "machu picchu trek"],
+      "why": "Classic Inca Trail access is permit-limited and operator-managed; there is no ordinary late release to wait for.",
+      "deadline_rule": "secure with an authorized operator months ahead",
+      "confidence": "high",
+      "release_pattern": "none",
+      "backup": "Use an alternate Sacred Valley trek or a non-permit Machu Picchu visit plan."
+    },
+    {
+      "id": "sight-alhambra-nasrid",
+      "scope": "poi",
+      "item": "Alhambra Nasrid Palaces timed entry",
+      "match_terms": ["alhambra", "nasrid palace", "nasrid palaces"],
+      "why": "Nasrid Palaces entry is timed and often sells out separately from broader Granada planning.",
+      "deadline_rule": "reserve a timed palace slot weeks ahead",
+      "confidence": "high",
+      "release_pattern": "scheduled",
+      "backup": "Hold a Granada day with Generalife/Alcazaba focus or use a reputable guided slot if available."
+    },
+    {
+      "id": "sight-last-supper",
+      "scope": "poi",
+      "item": "The Last Supper timed ticket",
+      "match_terms": ["last supper", "cenacolo vinciano", "santa maria delle grazie"],
+      "why": "Small timed-entry inventory makes same-week availability unreliable.",
+      "deadline_rule": "reserve when ticket blocks open",
+      "confidence": "high",
+      "release_pattern": "scheduled",
+      "backup": "Use a Milan art itinerary that does not depend on Cenacolo entry."
+    },
+    {
+      "id": "permit-half-dome-lottery",
+      "scope": "poi",
+      "item": "Half Dome permit lottery",
+      "match_terms": ["half dome", "yosemite half dome"],
+      "why": "Cable access requires a permit lottery rather than a normal admission ticket.",
+      "deadline_rule": "enter the seasonal or daily lottery before committing the hike day",
+      "confidence": "high",
+      "release_pattern": "allotment",
+      "backup": "Plan a Yosemite hike day around Clouds Rest, Mist Trail, or Glacier Point instead."
+    }
+  ]
+}

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,17 @@
+## 2026-06-05T23:16Z - opener lane issue #1319 booking radar
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1319` (`Book-ahead radar v0 -- flag "must-prebook" items from a static knowledge base`).
+- Branch: `codex/issue-1319-booking-radar`, base `origin/main` `1d192c5c3`.
+- Selection notes: raw opener cap was below limit (`total_opener_owned=0`, `raw_cap_reached=false`). Existing high-priority Trend #5343 and LMS #180 remain scoped for owner deployment/evidence blockers; Trend #5422 and TPP #1154 are verifier/follow-up sequencing; approved Inv-Man-Intake queue item duplicated verified-complete issue #518 / PR #519 and was closed as duplicate #531 before selecting this unlinked implementation issue.
+- Implementation: added static `must_prebook.json` logistics knowledge base, deterministic `trip_planner.logistics.booking_radar.scan_trip`, package-data wiring, and read-only `read_booking_radar` planner tool.
+- Validation:
+  - `python -m pytest tests/logistics/test_booking_radar.py tests/app/test_planner_booking_radar_tool.py -q` -> 3 passed.
+  - `python -m ruff check trip_planner/logistics trip_planner/app/services/planner_tools.py tests/logistics/test_booking_radar.py tests/app/test_planner_booking_radar_tool.py` -> passed.
+  - `git diff --check` -> passed.
+  - Deliberate-break gate: temporarily removed the Glacier Express entry from `must_prebook.json`; `tests/logistics/test_booking_radar.py::test_flags_known_scarce_items` failed because the Glacier Express flag disappeared. Restored the entry and reran focused tests green.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
+
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,19 +1,3 @@
-## 2026-06-05T23:16Z - opener lane issue #1319 booking radar
-
-- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
-- Source repo: `stranske/trip-planner`; source issue `#1319` (`Book-ahead radar v0 -- flag "must-prebook" items from a static knowledge base`).
-- Branch: `codex/issue-1319-booking-radar`, base `origin/main` `1d192c5c3`.
-- Selection notes: raw opener cap was below limit (`total_opener_owned=0`, `raw_cap_reached=false`). Existing high-priority Trend #5343 and LMS #180 remain scoped for owner deployment/evidence blockers; Trend #5422 and TPP #1154 are verifier/follow-up sequencing; approved Inv-Man-Intake queue item duplicated verified-complete issue #518 / PR #519 and was closed as duplicate #531 before selecting this unlinked implementation issue.
-- Implementation: added static `must_prebook.json` logistics knowledge base, deterministic `trip_planner.logistics.booking_radar.scan_trip`, package-data wiring, and read-only `read_booking_radar` planner tool.
-- Validation:
-  - `python -m pytest tests/logistics/test_booking_radar.py tests/app/test_planner_booking_radar_tool.py -q` -> 3 passed.
-  - `python -m ruff check trip_planner/logistics trip_planner/app/services/planner_tools.py tests/logistics/test_booking_radar.py tests/app/test_planner_booking_radar_tool.py` -> passed.
-  - `git diff --check` -> passed.
-  - Deliberate-break gate: temporarily removed the Glacier Express entry from `must_prebook.json`; `tests/logistics/test_booking_radar.py::test_flags_known_scarce_items` failed because the Glacier Express flag disappeared. Restored the entry and reran focused tests green.
-- PR/routing: opened PR #1343 at https://github.com/stranske/trip-planner/pull/1343. PR is open/non-draft, closes #1319, and has `agent:codex`, `agents:keepalive`, `autofix`, and `agent:retry`.
-- Post-open repair: cap-health at 2026-06-05T23:10Z lagged behind live checks and classified #1343 as `needs-dispatch-evidence`. Direct PR checks already showed active CI/Gate/verifier jobs, and `opener-repair-infra-stalls.py` dispatched Gate Followups anyway. Fresh direct `gh pr checks 1343` showed the new Gate path with current CI jobs pending/in progress; cap-health still lagged at 2026-06-05T23:11Z.
-- Next action: keepalive owns PR #1343 CI/review; opener should move to the next eligible issue on a future round after cap/drain discovery.
-
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -10,7 +10,9 @@
   - `python -m ruff check trip_planner/logistics trip_planner/app/services/planner_tools.py tests/logistics/test_booking_radar.py tests/app/test_planner_booking_radar_tool.py` -> passed.
   - `git diff --check` -> passed.
   - Deliberate-break gate: temporarily removed the Glacier Express entry from `must_prebook.json`; `tests/logistics/test_booking_radar.py::test_flags_known_scarce_items` failed because the Glacier Express flag disappeared. Restored the entry and reran focused tests green.
-- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns CI/review after PR creation.
+- PR/routing: opened PR #1343 at https://github.com/stranske/trip-planner/pull/1343. PR is open/non-draft, closes #1319, and has `agent:codex`, `agents:keepalive`, `autofix`, and `agent:retry`.
+- Post-open repair: cap-health at 2026-06-05T23:10Z lagged behind live checks and classified #1343 as `needs-dispatch-evidence`. Direct PR checks already showed active CI/Gate/verifier jobs, and `opener-repair-infra-stalls.py` dispatched Gate Followups anyway. Fresh direct `gh pr checks 1343` showed the new Gate path with current CI jobs pending/in progress; cap-health still lagged at 2026-06-05T23:11Z.
+- Next action: keepalive owns PR #1343 CI/review; opener should move to the next eligible issue on a future round after cap/drain discovery.
 
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 


### PR DESCRIPTION
Closes #1319

## Summary
- add a packaged static must-prebook logistics knowledge base for rail, sight, and permit constraints
- add deterministic booking-radar scanning with appetite-bounded flags and no live availability calls
- expose a read-only read_booking_radar planner tool over current workspace inventory

## Validation
- python -m pytest tests/logistics/test_booking_radar.py tests/app/test_planner_booking_radar_tool.py -q
- python -m pytest tests/logistics/ tests/app/test_planner_booking_radar_tool.py -q
- deliberate-break gate: temporarily removed the Glacier Express entry from must_prebook.json; tests/logistics/test_booking_radar.py::test_flags_known_scarce_items failed because the Glacier Express flag disappeared; restored and reran green
- python -m ruff check trip_planner/logistics trip_planner/app/services/planner_tools.py tests/logistics/test_booking_radar.py tests/app/test_planner_booking_radar_tool.py
- git diff --check