### PR TITLE
Issue #1320: wire source mix slider

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -620,6 +620,7 @@ export type WorkspaceData = {
     status: "ready" | "partial" | "empty";
     title: string;
     summary: string;
+    commerciality_preference?: number;
   };
   feasibility_summary: FeasibilitySummary;
   inventory_summary: {
@@ -639,6 +640,7 @@ export type WorkspaceData = {
       status: "ready" | "partial" | "empty";
       title: string;
       summary: string;
+      commerciality_preference?: number;
     };
   };
   budget_state: BudgetWorkspaceState;
@@ -783,9 +785,15 @@ export async function fetchPlannerSession(tripId: string): Promise<PlannerSessio
   });
 }
 
+export type PlannerToolCallRequest = {
+  tool_name: string;
+  arguments?: Record<string, unknown>;
+};
+
 export async function submitPlannerTurn(
   tripId: string,
-  message: string
+  message: string,
+  toolCalls: PlannerToolCallRequest[] = []
 ): Promise<PlannerSessionResponse> {
   return fetchJson<PlannerSessionResponse>({
     path: `/api/planner/${tripId}/turns`,
@@ -794,7 +802,7 @@ export async function submitPlannerTurn(
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ message }),
+    body: JSON.stringify({ message, tool_calls: toolCalls }),
   });
 }
 

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1535,7 +1535,16 @@ describe("WorkspacePage", () => {
     await waitFor(() => {
       expect(mockedSubmitPlannerTurn).toHaveBeenCalledWith(
         "trip-leisure-kyoto-draft",
-        "Keep Uji, but reduce transfer pressure."
+        "Keep Uji, but reduce transfer pressure.",
+        [
+          {
+            tool_name: "build_daily_menu",
+            arguments: {
+              commercial_target: 0.5,
+              time_budget_minutes: 360,
+            },
+          },
+        ]
       );
     });
     await waitFor(() => {
@@ -1562,6 +1571,47 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Planner diagnostics")).toBeInTheDocument();
     expect(screen.getByText("read_workspace_state: Read the current workspace state.")).toBeInTheDocument();
     expect(screen.getByLabelText("Message the planner")).toHaveValue("");
+  });
+
+  it("posts the selected commercial source mix with planner turns", async () => {
+    const user = userEvent.setup();
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        inventory_summary: {
+          ...workspacePayload.inventory_summary,
+          runtime_state: {
+            ...workspacePayload.inventory_summary.runtime_state,
+            commerciality_preference: 0.25,
+          },
+        },
+      }),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    const slider = await screen.findByLabelText("Commercial source mix target");
+    fireEvent.change(slider, { target: { value: "0.85" } });
+    await user.type(screen.getByLabelText("Message the planner"), "Build a balanced day menu.");
+    await user.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => {
+      expect(mockedSubmitPlannerTurn).toHaveBeenCalledWith(
+        "trip-leisure-kyoto-draft",
+        "Build a balanced day menu.",
+        [
+          {
+            tool_name: "build_daily_menu",
+            arguments: {
+              commercial_target: 0.85,
+              time_budget_minutes: 360,
+            },
+          },
+        ]
+      );
+    });
+    expect(screen.getByText("15% editorial / 85% commercial")).toBeInTheDocument();
   });
 
   it("fills traveler-friendly prompt suggestions into the planner message box", async () => {

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -30,6 +30,7 @@ import {
   type RouteOptionActionType,
   type RuntimeScenarioComparison,
   submitPlannerOptionFeedback,
+  type PlannerToolCallRequest,
   type SavedScenarioRecord,
   type WorkspaceData,
 } from "../api/workspace";
@@ -784,6 +785,14 @@ function mergePlannerSessionState(
   };
 }
 
+function sourceMixTargetFromWorkspace(workspace: WorkspaceData): number {
+  const rawPreference =
+    workspace.inventory_summary.runtime_state.commerciality_preference ??
+    workspace.runtime_state.commerciality_preference;
+  const parsed = typeof rawPreference === "number" ? rawPreference : Number(rawPreference);
+  return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : 0.5;
+}
+
 const hiddenPlannerBlockKinds = new Set(["debug", "tool_call", "tool_trace", "diagnostic"]);
 
 function legacyStructuredBlocks(message: PlannerMessage): PlannerStructuredBlock[] {
@@ -1042,6 +1051,9 @@ function WorkspacePageContent({
   );
   const [plannerSession, setPlannerSession] = useState<PlannerSessionResponse | null>(null);
   const [plannerConversationDraft, setPlannerConversationDraft] = useState("");
+  const [sourceMixTarget, setSourceMixTarget] = useState(() =>
+    sourceMixTargetFromWorkspace(workspace)
+  );
   const [plannerConversationNotice, setPlannerConversationNotice] = useState<string | null>(null);
   const [plannerConversationError, setPlannerConversationError] = useState<string | null>(null);
   const [plannerConversationBusyLabel, setPlannerConversationBusyLabel] = useState<string | null>(
@@ -1072,6 +1084,7 @@ function WorkspacePageContent({
     const previousWorkspace = previousWorkspaceRef.current;
     previousWorkspaceRef.current = workspace;
     setCurrentWorkspace(workspace);
+    setSourceMixTarget(sourceMixTargetFromWorkspace(workspace));
     setSelectedScenarioId(resolveMapScenarioId(workspace));
     setSelectedMapScope("regional");
     setSelectedSegmentId(null);
@@ -1298,8 +1311,17 @@ function WorkspacePageContent({
     setPlannerConversationError(null);
     setPlannerConversationBusyLabel("Sending planner turn...");
     plannerSessionLoadVersion.current += 1;
+    const toolCalls: PlannerToolCallRequest[] = [
+      {
+        tool_name: "build_daily_menu",
+        arguments: {
+          commercial_target: sourceMixTarget,
+          time_budget_minutes: 360,
+        },
+      },
+    ];
     try {
-      const nextPlannerSession = await submitPlannerTurn(trip.trip_id, message);
+      const nextPlannerSession = await submitPlannerTurn(trip.trip_id, message, toolCalls);
       startTransition(() => {
         setPlannerSession(nextPlannerSession);
         setCurrentWorkspace((current) => mergePlannerSessionState(current, nextPlannerSession));
@@ -1319,6 +1341,25 @@ function WorkspacePageContent({
     setPlannerConversationNotice("Draft added. Edit it if needed, then send it to the planner.");
     setPlannerConversationError(null);
     plannerConversationTextareaRef.current?.focus();
+  }
+
+  function handleSourceMixTargetChange(value: number) {
+    const boundedValue = Math.max(0, Math.min(1, value));
+    setSourceMixTarget(boundedValue);
+    setCurrentWorkspace((current) => ({
+      ...current,
+      runtime_state: {
+        ...current.runtime_state,
+        commerciality_preference: boundedValue,
+      },
+      inventory_summary: {
+        ...current.inventory_summary,
+        runtime_state: {
+          ...current.inventory_summary.runtime_state,
+          commerciality_preference: boundedValue,
+        },
+      },
+    }));
   }
 
   async function handleBudgetSave(payload: BudgetPlanUpsertPayload) {
@@ -1978,6 +2019,33 @@ function WorkspacePageContent({
               ))}
             </div>
           )}
+        </section>
+
+        <section className={STATUS_CARD_CLASS}>
+          <p className="status-label">Source mix</p>
+          <h2>Commercial balance</h2>
+          <p>
+            Set the target mix for daily-menu re-ranking before asking the planner for a slate.
+          </p>
+          <label className="source-mix-control">
+            <span>
+              {Math.round((1 - sourceMixTarget) * 100)}% editorial /{" "}
+              {Math.round(sourceMixTarget * 100)}% commercial
+            </span>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={sourceMixTarget}
+              aria-label="Commercial source mix target"
+              onChange={(event) => handleSourceMixTargetChange(Number(event.target.value))}
+            />
+          </label>
+          <p className="muted-copy">
+            The target is sent with planner turns as a calibrated menu tool call; source quality
+            scoring stays unchanged.
+          </p>
         </section>
 
         <section className={STATUS_CARD_CLASS}>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -946,6 +946,19 @@ a {
   transform: translateY(1px);
 }
 
+.source-mix-control {
+  display: grid;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+  color: var(--color-ink-soft);
+  font-weight: 700;
+}
+
+.source-mix-control input {
+  width: 100%;
+  accent-color: var(--color-mint-deep);
+}
+
 .planner-route-focus {
   border: 1px solid rgba(56, 117, 107, 0.2);
   border-radius: 8px;

--- a/tests/itinerary/test_source_mix_calibration.py
+++ b/tests/itinerary/test_source_mix_calibration.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from trip_planner.itinerary.daily_menu import SourceMix, build_daily_menu
+from tests.itinerary.test_daily_menu import CTX, kyoto_day_candidates
+
+
+def test_slider_shifts_realized_mix() -> None:
+    candidates = kyoto_day_candidates()
+
+    editorial = build_daily_menu("t", 0, candidates, 360, SourceMix(0.15), context_tags=CTX)
+    commercial = build_daily_menu("t", 0, candidates, 360, SourceMix(0.85), context_tags=CTX)
+
+    assert editorial.rollup.realized_commercial_mix < commercial.rollup.realized_commercial_mix
+    assert abs(editorial.rollup.realized_commercial_mix - 0.15) <= SourceMix(0.15).tolerance
+    assert abs(commercial.rollup.realized_commercial_mix - 0.85) <= SourceMix(0.85).tolerance

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -1012,6 +1012,7 @@ def build_inventory_summary_payload(
             "status": "ready",
             "title": "Runtime inventory is ready",
             "summary": "Persisted trip context is rich enough to assemble comparison-ready inventory bundles.",
+            "commerciality_preference": 0.5,
             "issues": [],
         }
     elif assembly_input is not None and assembly_input.snapshot.issues:

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -2,7 +2,7 @@
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
 - Source repo: `stranske/trip-planner`; source issue `#1320` (`Wire the commercial↔non-commercial slider to calibrated re-ranking (point-7 P3)`).
-- Branch: `codex/issue-1320-source-mix`, base `origin/main` `0a9b3144d`.
+- Branch: `codex/issue-1320-source-mix`, base `origin/main` `0a9b3144d`; PR #1344.
 - Selection notes: raw opener cap was open (`total_opener_owned=0`, `raw_cap_reached=false`) after mandatory cap-health/infra repair. Priority searches found only scoped high-priority Trend #5343 and LMS #180; #1319/#1309/#1332 are verifier/follow-up sequencing; #1306 is an epic. #1320 was the oldest unlinked implementation issue outside scoped/linked lanes.
 - Implementation:
   - Surfaced `inventory_summary.runtime_state.commerciality_preference` with a ready-state default.
@@ -18,7 +18,9 @@
   - `npm exec --cache /private/tmp/codex-npm-cache-trip-1320 -- tsc -b` -> passed.
   - `python -m ruff check trip_planner/app/services/inventory.py tests/itinerary/test_source_mix_calibration.py tests/app/test_planner_build_daily_menu_tool.py` -> passed.
   - `git diff --check` -> passed.
-- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns async CI/review after PR creation.
+- PR/routing: opened PR #1344 at https://github.com/stranske/trip-planner/pull/1344. PR is open/non-draft, closes #1320, and has `agent:codex`, `agents:keepalive`, `autofix`, and `agent:retry`.
+- Post-open repair: `opener-repair-infra-stalls.py` dispatched Gate Followups because cap-health lagged on `needs-dispatch-evidence`. Direct `gh pr checks 1344` showed fresh current-head Python CI, Runtime CI, Cross-Repo Smoke, and guard jobs pending/passing after the dispatch, alongside stale cancelled initial workflow rows. Helper cap-health still lagged on the branch-scoped Gate Followups evidence at 2026-06-06T01:11Z.
+- Next action: keepalive owns async CI/review; opener should move to the next eligible issue on a future round after cap/drain discovery.
 
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,27 +1,3 @@
-## 2026-06-06T01:09Z - opener lane issue #1320 source mix slider
-
-- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
-- Source repo: `stranske/trip-planner`; source issue `#1320` (`Wire the commercial↔non-commercial slider to calibrated re-ranking (point-7 P3)`).
-- Branch: `codex/issue-1320-source-mix`, base `origin/main` `0a9b3144d`; PR #1344.
-- Selection notes: raw opener cap was open (`total_opener_owned=0`, `raw_cap_reached=false`) after mandatory cap-health/infra repair. Priority searches found only scoped high-priority Trend #5343 and LMS #180; #1319/#1309/#1332 are verifier/follow-up sequencing; #1306 is an epic. #1320 was the oldest unlinked implementation issue outside scoped/linked lanes.
-- Implementation:
-  - Surfaced `inventory_summary.runtime_state.commerciality_preference` with a ready-state default.
-  - Extended the frontend planner-turn API wrapper to post explicit planner tool calls.
-  - Added a WorkspacePage source-mix slider that keeps local runtime preference state and posts `build_daily_menu` with `commercial_target` plus a bounded time budget when the traveler sends a planner turn.
-  - Added a named calibration regression test proving low vs high source-mix targets change realized commercial mix within tolerance.
-- Validation:
-  - `python -m pytest tests/itinerary/test_source_mix_calibration.py::test_slider_shifts_realized_mix -q` -> 1 passed.
-  - Deliberate-break gate: temporarily made `calibrate()` ignore `mix`; the named test failed with both low/high targets realizing `0.14`. Restored the penalty and reran green.
-  - `python -m pytest tests/app/test_planner_build_daily_menu_tool.py -q` -> 3 passed.
-  - `npm --prefix frontend test -- WorkspacePage` -> 52 passed (expected deliberate-break stderr from existing test).
-  - `npm --prefix frontend test` -> 16 files passed, 108 tests passed (expected deliberate-break stderr from existing test).
-  - `npm exec --cache /private/tmp/codex-npm-cache-trip-1320 -- tsc -b` -> passed.
-  - `python -m ruff check trip_planner/app/services/inventory.py tests/itinerary/test_source_mix_calibration.py tests/app/test_planner_build_daily_menu_tool.py` -> passed.
-  - `git diff --check` -> passed.
-- PR/routing: opened PR #1344 at https://github.com/stranske/trip-planner/pull/1344. PR is open/non-draft, closes #1320, and has `agent:codex`, `agents:keepalive`, `autofix`, and `agent:retry`.
-- Post-open repair: `opener-repair-infra-stalls.py` dispatched Gate Followups because cap-health lagged on `needs-dispatch-evidence`. Direct `gh pr checks 1344` showed fresh current-head Python CI, Runtime CI, Cross-Repo Smoke, and guard jobs pending/passing after the dispatch, alongside stale cancelled initial workflow rows. Helper cap-health still lagged on the branch-scoped Gate Followups evidence at 2026-06-06T01:11Z.
-- Next action: keepalive owns async CI/review; opener should move to the next eligible issue on a future round after cap/drain discovery.
-
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,25 @@
+## 2026-06-06T01:09Z - opener lane issue #1320 source mix slider
+
+- Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.
+- Source repo: `stranske/trip-planner`; source issue `#1320` (`Wire the commercial↔non-commercial slider to calibrated re-ranking (point-7 P3)`).
+- Branch: `codex/issue-1320-source-mix`, base `origin/main` `0a9b3144d`.
+- Selection notes: raw opener cap was open (`total_opener_owned=0`, `raw_cap_reached=false`) after mandatory cap-health/infra repair. Priority searches found only scoped high-priority Trend #5343 and LMS #180; #1319/#1309/#1332 are verifier/follow-up sequencing; #1306 is an epic. #1320 was the oldest unlinked implementation issue outside scoped/linked lanes.
+- Implementation:
+  - Surfaced `inventory_summary.runtime_state.commerciality_preference` with a ready-state default.
+  - Extended the frontend planner-turn API wrapper to post explicit planner tool calls.
+  - Added a WorkspacePage source-mix slider that keeps local runtime preference state and posts `build_daily_menu` with `commercial_target` plus a bounded time budget when the traveler sends a planner turn.
+  - Added a named calibration regression test proving low vs high source-mix targets change realized commercial mix within tolerance.
+- Validation:
+  - `python -m pytest tests/itinerary/test_source_mix_calibration.py::test_slider_shifts_realized_mix -q` -> 1 passed.
+  - Deliberate-break gate: temporarily made `calibrate()` ignore `mix`; the named test failed with both low/high targets realizing `0.14`. Restored the penalty and reran green.
+  - `python -m pytest tests/app/test_planner_build_daily_menu_tool.py -q` -> 3 passed.
+  - `npm --prefix frontend test -- WorkspacePage` -> 52 passed (expected deliberate-break stderr from existing test).
+  - `npm --prefix frontend test` -> 16 files passed, 108 tests passed (expected deliberate-break stderr from existing test).
+  - `npm exec --cache /private/tmp/codex-npm-cache-trip-1320 -- tsc -b` -> passed.
+  - `python -m ruff check trip_planner/app/services/inventory.py tests/itinerary/test_source_mix_calibration.py tests/app/test_planner_build_daily_menu_tool.py` -> passed.
+  - `git diff --check` -> passed.
+- Next action: open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`; keepalive owns async CI/review after PR creation.
+
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.


### PR DESCRIPTION
Closes #1320

## Summary
- surface a workspace runtime commerciality preference for ready inventory
- add a WorkspacePage source-mix slider and post it as a build_daily_menu tool call with planner turns
- add a named calibration regression proving low/high slider targets shift realized source mix

## Validation
- python -m pytest tests/itinerary/test_source_mix_calibration.py::test_slider_shifts_realized_mix -q
- deliberate-break gate: made calibrate() ignore mix; named test failed with both targets realizing 0.14; restored and reran green
- python -m pytest tests/app/test_planner_build_daily_menu_tool.py -q
- npm --prefix frontend test -- WorkspacePage
- npm --prefix frontend test
- npm exec --cache /private/tmp/codex-npm-cache-trip-1320 -- tsc -b
- python -m ruff check trip_planner/app/services/inventory.py tests/itinerary/test_source_mix_calibration.py tests/app/test_planner_build_daily_menu_tool.py
- git diff --check
