### PR TITLE
Expand baseline ranking coverage

### DIFF
--- a/docs/reports/baseline-coverage.md
+++ b/docs/reports/baseline-coverage.md
@@ -1,11 +1,22 @@
 # Trip-planner baseline coverage manifest
 
 - Input parameters: **14**
-- Exercised by a scenario: **3** (21.4%)
+- Exercised by a scenario: **14** (100.0%)
 - Observed read at runtime: **0**
 
 ## Priority parameters
 
 - [x] `cost_total`
+- [x] `cost_base_fare`
+- [x] `cost_taxes_and_fees`
 - [x] `transfer_count`
+- [x] `minimum_connection_minutes`
 - [x] `overall_signal`
+- [x] `schedule_fit_signal`
+- [x] `friction_fit_signal`
+- [x] `experiential_fit_signal`
+- [x] `policy_fit_signal`
+- [x] `self_navigation_burden_signal`
+- [x] `baggage_complexity_signal`
+- [x] `schedule_protection_signal`
+- [x] `connection_risk_signal`

--- a/tests/baseline/catalog.yaml
+++ b/tests/baseline/catalog.yaml
@@ -38,10 +38,87 @@ orderings:
     metric: cost_total
     direction: less_than
     enforce: true
+  - id: rail_base_fare_less_than_flight
+    left: scenic_rail.json
+    right: coastal_flight.json
+    metric: cost_base_fare
+    direction: less_than
+    enforce: true
+  - id: rail_taxes_less_than_flight
+    left: scenic_rail.json
+    right: coastal_flight.json
+    metric: cost_taxes_and_fees
+    direction: less_than
+    enforce: true
+  - id: flight_shorter_connection_than_rail
+    left: coastal_flight.json
+    right: scenic_rail.json
+    metric: minimum_connection_minutes
+    direction: less_than
+    enforce: true
+  - id: flight_better_schedule_fit_than_car
+    left: coastal_flight.json
+    right: regional_rental_car.json
+    metric: schedule_fit_signal
+    direction: greater_than
+    enforce: true
+  - id: flight_better_friction_fit_than_car
+    left: coastal_flight.json
+    right: regional_rental_car.json
+    metric: friction_fit_signal
+    direction: greater_than
+    enforce: true
+  - id: rail_better_experiential_fit_than_ground
+    left: scenic_rail.json
+    right: downtown_local_ground.json
+    metric: experiential_fit_signal
+    direction: greater_than
+    enforce: true
+  - id: ground_better_policy_fit_than_ferry
+    left: downtown_local_ground.json
+    right: island_ferry.json
+    metric: policy_fit_signal
+    direction: greater_than
+    enforce: true
+  - id: car_higher_self_navigation_burden_than_flight
+    left: regional_rental_car.json
+    right: coastal_flight.json
+    metric: self_navigation_burden_signal
+    direction: greater_than
+    enforce: true
+  - id: ferry_higher_baggage_complexity_than_ground
+    left: island_ferry.json
+    right: downtown_local_ground.json
+    metric: baggage_complexity_signal
+    direction: greater_than
+    enforce: true
+  - id: flight_better_schedule_protection_than_car
+    left: coastal_flight.json
+    right: regional_rental_car.json
+    metric: schedule_protection_signal
+    direction: greater_than
+    enforce: true
+  - id: car_lower_connection_risk_than_rail
+    left: regional_rental_car.json
+    right: scenic_rail.json
+    metric: connection_risk_signal
+    direction: less_than
+    enforce: true
 
 # The must-cover metric dimensions (coverage manifest asserts these appear in
 # at least one ordering).
 priority_metrics:
   - cost_total
+  - cost_base_fare
+  - cost_taxes_and_fees
   - transfer_count
+  - minimum_connection_minutes
   - overall_signal
+  - schedule_fit_signal
+  - friction_fit_signal
+  - experiential_fit_signal
+  - policy_fit_signal
+  - self_navigation_burden_signal
+  - baggage_complexity_signal
+  - schedule_protection_signal
+  - connection_risk_signal

--- a/tests/sources/test_source_quality.py
+++ b/tests/sources/test_source_quality.py
@@ -297,6 +297,33 @@ def test_stale_editorial_source_is_flagged_and_uncertain() -> None:
     assert score.confidence > 0.0
 
 
+def test_low_freshness_confidence_marks_stale_editorial_source_uncertain() -> None:
+    scorer = SourceQualityScorer()
+    source = replace(
+        _stale_editorial_source(),
+        trust_signals=SourceTrustSignals(
+            freshness_days=90,
+            freshness_confidence=0.1,
+            commerciality=0.95,
+            editorial_independence=0.05,
+            operational_reliability=0.05,
+            review_consistency=0.05,
+        ),
+        quality_summary=QualityValueFitSummary(
+            quality_signal=0.2,
+            value_signal=0.2,
+            fit_signal=0.1,
+            confidence=0.1,
+        ),
+    )
+
+    score = scorer.score_source(source, intended_option_kind="activity")
+
+    assert score.confidence_label in {"uncertain", "sparse"}
+    assert score.freshness_score < 0.3
+    assert score.confidence < 0.45
+
+
 def test_sparse_unknown_source_does_not_crash_and_is_low_confidence() -> None:
     scorer = SourceQualityScorer()
     score = scorer.score_source(_sparse_unknown_source())

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -18,7 +18,16 @@ Opener lane: materialized `stranske/trip-planner#1363` on branch `codex/issue-13
 
 - Deliberate break: temporarily changed `SourceQualityScorer._freshness_score` to `return _clamp(base)`; the new low-freshness-confidence test failed on `assert 0.3333 < 0.3`. Restored the scorer and reran targeted tests.
 
-- Next action: push the branch, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+- PR: `#1364` (https://github.com/stranske/trip-planner/pull/1364),
+  ready-for-review, non-draft, closing issue `#1363`.
+- Labels verified on PR: `agent:codex`, `agents:keepalive`, `autofix`,
+  `repo-review-approved`, `priority:high`, `codex`, and `codex-automation`.
+- Post-open cap hygiene: `opener-repair-infra-stalls.py` added `agent:retry`
+  and dispatched Gate Followups after cap-health observed a skipped evaluator.
+  Fresh direct PR evidence showed CI/Gate/Verifier/Guard runs pending or green;
+  earlier failing Gate rows were cancelled superseded runs.
+- Next action: keepalive owns PR `#1364`; opener should move to the next
+  eligible issue on a future round after cap/drain discovery.
 
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 

--- a/workloop-state.md
+++ b/workloop-state.md
@@ -1,3 +1,25 @@
+## 2026-06-10T18:20:00Z
+
+Opener lane: materialized `stranske/trip-planner#1363` on branch `codex/issue-1363-baseline-ranking-coverage`.
+
+
+
+- Scope: expand baseline catalog orderings so all 14 transport ranking input metrics are exercised, refresh `docs/reports/baseline-coverage.md`, and add a source-quality regression case for low freshness confidence.
+
+- Validation:
+
+  - `UV_CACHE_DIR=/tmp/uv-cache-pd-workloop BASELINE_REFRESH_REPORT=1 uv run pytest tests/baseline/test_coverage_manifest.py -q`
+
+  - `UV_CACHE_DIR=/tmp/uv-cache-pd-workloop uv run pytest tests/baseline/ -q`
+
+  - `UV_CACHE_DIR=/tmp/uv-cache-pd-workloop uv run pytest tests/ranking/test_leisure_ranking.py tests/ranking/test_business_ranking.py tests/ranking/test_score_bounds.py -q`
+
+  - `UV_CACHE_DIR=/tmp/uv-cache-pd-workloop uv run pytest tests/sources/test_source_quality.py -q`
+
+- Deliberate break: temporarily changed `SourceQualityScorer._freshness_score` to `return _clamp(base)`; the new low-freshness-confidence test failed on `assert 0.3333 < 0.3`. Restored the scorer and reran targeted tests.
+
+- Next action: push the branch, open a ready-for-review PR with `agent:codex`, `agents:keepalive`, and `autofix`.
+
 ## 2026-06-05T06:16Z - opener lane issue #1308 base ranking engine
 
 - Automation: `pd-workloop-resume` (codex opener lane) from the neutral Code workspace.


### PR DESCRIPTION
Closes #1363

## Summary
- expand the baseline catalog with directional orderings for all 14 transport ranking input metrics
- refresh `docs/reports/baseline-coverage.md` from 3/14 to 14/14 exercised metrics
- add a source-quality regression test proving low freshness confidence pulls stale source confidence down

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache-pd-workloop BASELINE_REFRESH_REPORT=1 uv run pytest tests/baseline/test_coverage_manifest.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache-pd-workloop uv run pytest tests/baseline/ -q`
- `UV_CACHE_DIR=/tmp/uv-cache-pd-workloop uv run pytest tests/ranking/test_leisure_ranking.py tests/ranking/test_business_ranking.py tests/ranking/test_score_bounds.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache-pd-workloop uv run pytest tests/sources/test_source_quality.py -q`
- deliberate break: temporarily changed `SourceQualityScorer._freshness_score` to `return _clamp(base)`; `test_low_freshness_confidence_marks_stale_editorial_source_uncertain` failed on `assert 0.3333 < 0.3`; restored and reran targeted checks