### PR TITLE
chore: refresh consumer CI config (llm_slots bump + drop double-CI trigger)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/config/llm_slots.json
+++ b/config/llm_slots.json
@@ -3,12 +3,12 @@
     {
       "name": "slot1",
       "provider": "openai",
-      "model": "gpt-5.2"
+      "model": "gpt-5.4"
     },
     {
       "name": "slot2",
       "provider": "anthropic",
-      "model": "claude-sonnet-4-5-20250929"
+      "model": "claude-sonnet-4-6"
     },
     {
       "name": "slot3",


### PR DESCRIPTION
Fleet-hygiene fixes from the Workflows audit §4. Fixes applied: llm_slots(→gpt-5.4/sonnet-4-6) rm-pull_request-trigger. llm_slots was frozen at 2-gen-old models (create_only sync); the prohibited `pull_request:` trigger double-ran CI (the reusable Gate already covers PRs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow trigger and config-only model ID updates; no runtime auth, data, or application logic changes in this diff.
> 
> **Overview**
> **CI** no longer runs on `pull_request` to `main`—only `push` to `main` and `workflow_dispatch` remain—so Python CI isn’t double-fired when the reusable workflow already covers PRs.
> 
> **LLM slots** in `config/llm_slots.json` are refreshed: OpenAI slot **gpt-5.2 → gpt-5.4**, Anthropic slot **claude-sonnet-4-5-20250929 → claude-sonnet-4-6**; slot3 is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41f6699c14e0dbc6ace3bfacb09233ea0d03418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->