### PR TITLE
chore(render): set trip-planner-db plan free -> basic-256mb

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -26,5 +26,8 @@ services:
 
 databases:
   - name: trip-planner-db
-    plan: free
+    # Paid instance: free Render Postgres expires + is deleted after ~30 days,
+    # which suspended this DB and crashed deploys. Upgraded to basic-256mb so the
+    # Blueprint matches the dashboard and a sync can't revert it to free.
+    plan: basic-256mb
     databaseName: trip_planner


### PR DESCRIPTION
## Why
`trip-planner-db` is **Blueprint-managed**. With `plan: free` it expired and was suspended by Render after ~30 days (the "database expired" emails + failed deploys). The instance has now been upgraded to **Basic-256mb** ($6.30/mo incl. 1 GB storage) in the dashboard.

## Change
Set `databases[].plan` to `basic-256mb` so the Blueprint matches the live instance. Otherwise a Blueprint sync could revert the DB back to `free` and re-suspend it.

Docs confirm `basic-256mb` is the valid Blueprint plan identifier for the 256 MB Basic Postgres instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded database service plan configuration to ensure improved reliability and prevent potential service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->