### PR TITLE
test(workspace): make deliberate-break test leak-proof to fix flaky Runtime CI

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useLoaderData } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -896,6 +896,10 @@ function workspaceWithUnequalRouteGeometry(): WorkspaceData {
 
 describe("WorkspacePage", () => {
   beforeEach(() => {
+    // Defensively clear the deliberate-break fault flag before every test. Even if
+    // a prior test somehow leaks it, no later test can render the workspace into
+    // the break hook with a stale `true` value.
+    delete (window as WorkspaceTestWindow).__TRIP_PLANNER_WORKSPACE_BREAK__;
     mockedFetchPlannerSession.mockResolvedValue(plannerSessionPayload);
     mockedSubmitPlannerTurn.mockResolvedValue(plannerSessionPayload);
     mockedSubmitRouteOptionAction.mockResolvedValue(workspacePayload);
@@ -926,11 +930,28 @@ describe("WorkspacePage", () => {
     mockedSetNotebookFocus.mockReset();
   });
 
-  it("throws only when the workspace deliberate-break hook is enabled", () => {
+  it("throws only when the workspace deliberate-break hook is enabled", async () => {
     mockedUseLoaderData.mockReturnValue({ workspace: Promise.resolve(workspacePayload) });
-    (window as WorkspaceTestWindow).__TRIP_PLANNER_WORKSPACE_BREAK__ = true;
+    const workspaceWindow = window as WorkspaceTestWindow;
+    workspaceWindow.__TRIP_PLANNER_WORKSPACE_BREAK__ = true;
 
-    expect(() => renderWorkspacePage()).toThrow("Workspace deliberate break enabled");
+    try {
+      expect(() => renderWorkspacePage()).toThrow("Workspace deliberate break enabled");
+    } finally {
+      // Clear the fault flag and unmount synchronously, before yielding to the
+      // event loop. React's concurrent error recovery re-renders <WorkspacePage>
+      // on a later task; if that retry lands while the flag is still set it raises
+      // an uncaught "deliberate break" error that vitest attributes to whichever
+      // test happens to be running, intermittently failing the whole suite.
+      delete workspaceWindow.__TRIP_PLANNER_WORKSPACE_BREAK__;
+      cleanup();
+    }
+
+    // Drain any pending recovery render / loader microtasks now that the flag is
+    // cleared, so nothing can re-enter the deliberate-break hook in a later test.
+    await act(async () => {
+      await Promise.resolve();
+    });
   });
 
   it("renders normally when the workspace deliberate-break hook is disabled", async () => {


### PR DESCRIPTION
## Workflow Source

Started from:
- [x] Local Codex/user request

Automation intent:
- [ ] Verifier should review this
- [ ] Keepalive may manage this PR
- [x] Human-only unless checks fail

Notes:
Fixes an intermittent test-isolation failure in `frontend/src/routes/WorkspacePage.test.tsx` that non-deterministically fails the `Verify full-stack runtime` step of `Runtime CI`, blocking ALL PRs through the gate (e.g. failed on PR #1377's first run with zero frontend changes; passed on re-run and on PR #1376).

## Summary

The test `"throws only when the workspace deliberate-break hook is enabled"` sets the global `window.__TRIP_PLANNER_WORKSPACE_BREAK__` fault flag and asserts `renderWorkspacePage()` throws synchronously. The flag was cleared (and the tree unmounted) only in `afterEach` — *after* the test body had already yielded to the event loop.

**Root cause (verified locally):** When `<WorkspacePage>` throws during the initial render with no error boundary, React 18's concurrent error recovery re-renders the component on a *later* task and re-dispatches the error as a jsdom `window` `error` event. Normally `act` flushes that retry synchronously and `toThrow` catches it. Under load, the retry can slip past the synchronous assertion and fire **while the flag is still set** (before `afterEach` clears it), producing an **uncaught** `Workspace deliberate break enabled` error. vitest attributes that uncaught error to whichever test is then running — intermittently failing the suite. The observed victim was `"posts the selected commercial source mix with planner turns"` (the break re-render prevented `submitPlannerTurn` from being called).

Instrumenting the break hook confirmed the mechanism: the first break site is evaluated **4×** with the flag set during this one test (two error-recovery render passes, each DEV double-invoked), each re-throw dispatched as a `window` `error` event. The flake is timing on whether one of those re-renders escapes the synchronous `act` flush.

**Fix** (test-only — the deliberate-break hook and the `toThrow` assertion are unchanged, so the error-boundary gate is preserved):
- Clear the fault flag and `cleanup()` **synchronously** in a `finally`, immediately after `toThrow`, so the flag is already false before any event-loop yield — a late recovery re-render can no longer re-enter the hook.
- Drain pending recovery-render / loader microtasks with `await act(...)` while this test still owns the error context.
- Defensively clear the flag in `beforeEach` as well, so a leaked value can never bleed into a later test.

## Testing

- `cd frontend && for i in $(seq 1 20); do npx vitest run src/routes/WorkspacePage.test.tsx || break; done` → **20/20 pass**.
- Full frontend suite (`npm --prefix frontend test`, the exact command the gate runs) → **8/8 loop iterations, 108 tests each**.
- `npx tsc -b` (the typecheck inside `npm run build`) → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test cleanup procedures to prevent cross-test state pollution and ensure reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->