### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.14
+RUFF_VERSION=0.15.17
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
 MYPY_VERSION=2.1.0
-PYTEST_VERSION=9.0.3
+PYTEST_VERSION=9.1.0
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.14.0
+COVERAGE_VERSION=7.14.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = [
 [project.optional-dependencies]
 app = []
 dev = [
-    "ruff>=0.15.14",
+    "ruff>=0.15.17",
     "mypy>=2.1.0",
-    "pytest==9.0.3",
+    "pytest>=9.1.0",
     "pytest-cov==7.1.0",
     "black>=26.5.1",
     "httpx==0.28.1",

--- a/requirements.lock
+++ b/requirements.lock
@@ -32,7 +32,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   click
     #   pytest
     #   tqdm
-coverage==7.14.0
+coverage==7.14.1
     # via pytest-cov
 distro==1.9.0
     # via openai
@@ -128,7 +128,7 @@ pydantic-core==2.46.3
     # via pydantic
 pygments==2.20.0
     # via pytest
-pytest==9.0.3
+pytest==9.1.0
     # via
     #   trip-planner (pyproject.toml)
     #   app-baseline-kit
@@ -162,7 +162,7 @@ requests==2.33.1
     #   tiktoken
 requests-toolbelt==1.0.0
     # via langsmith
-ruff==0.15.14
+ruff==0.15.17
     # via trip-planner (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` to match the central
version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 5 version updates:
  - ruff: >=0.15.14 -> >=0.15.17
  - pytest: ==9.0.3 -> >=9.1.0
  - requirements.lock:coverage: 7.14.0 -> ==7.14.1
  - requirements.lock:pytest: 9.0.3 -> ==9.1.0
  - requirements.lock:ruff: 0.15.14 -> ==0.15.17

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`