### PR TITLE
chore: sync workflow templates

### DIFF
--- a/WORKFLOW_USER_GUIDE.md
+++ b/WORKFLOW_USER_GUIDE.md
@@ -146,6 +146,7 @@ Issue: "Add user authentication"
 | `agents:optimize` | Issue | Analyze and suggest improvements |
 | `agents:apply-suggestions` | Issue | Apply optimization suggestions |
 | `agents:auto-pilot` | Issue | Full end-to-end automation |
+| `agents:allow-change` | PR | Permission signal for `agents-guard`; automatically applied to dependency-bot PRs by `maint-auto-label-dep-prs.yml` |
 | `agents:capability-check` | Issue | Check if agent can complete |
 | `agents:decompose` | Issue | Break into smaller issues |
 | `agents:dedup` | Issue | Check for duplicates |

--- a/scripts/aggregate_agent_metrics.py
+++ b/scripts/aggregate_agent_metrics.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
+from src.ndjson_parser import read_ndjson_file
+
 _DEFAULT_METRICS_DIR = "agent-metrics"
 _DEFAULT_OUTPUT = "agent-metrics-summary.md"
 _DEFAULT_JSON_OUTPUT = "agent-metrics-summary.json"
@@ -289,79 +291,30 @@ def _parse_error_counter(parse_error_details: list[ParseErrorDetail], field: str
     return counts
 
 
-def _read_ndjson(files: Iterable[Path]) -> tuple[list[dict[str, Any]], list[ParseErrorDetail]]:
+def _canonical_parse_error_detail(path: Path, error: str) -> ParseErrorDetail:
+    line_match = re.search(r":(\d+): ", error)
+    line = int(line_match.group(1)) if line_match else None
+    if "invalid JSON" in error:
+        reason = "invalid-json"
+    elif "expected object" in error:
+        reason = "non-object-json"
+    elif "legacy-json-fallback-buffer-limit" in error:
+        reason = "legacy-json-fallback-buffer-limit"
+    else:
+        reason = "unreadable-file"
+    return _parse_error_detail(path, line, reason)
+
+
+def read_metric_ndjson_files(
+    files: Iterable[Path],
+) -> tuple[list[dict[str, Any]], list[ParseErrorDetail]]:
     entries: list[dict[str, Any]] = []
     errors: list[ParseErrorDetail] = []
     for path in files:
-        try:
-            handle = path.open("r", encoding="utf-8")
-        except OSError:
-            errors.append(_parse_error_detail(path, None, "unreadable-file"))
-            continue
-        file_entries: list[dict[str, Any]] = []
-        file_errors: list[ParseErrorDetail] = []
-        raw_lines_for_fallback: list[str] = []
-        raw_fallback_bytes = 0
-        raw_fallback_truncated = False
-        with handle:
-            for line_number, line in enumerate(handle, start=1):
-                raw = line.strip()
-                if not raw:
-                    continue
-                if not file_entries and not raw_fallback_truncated:
-                    raw_bytes = len(raw.encode("utf-8")) + 1
-                    fallback_within_limit = (
-                        len(raw_lines_for_fallback) < _MAX_LEGACY_JSON_FALLBACK_LINES
-                        and raw_fallback_bytes + raw_bytes <= _MAX_LEGACY_JSON_FALLBACK_BYTES
-                    )
-                    if fallback_within_limit:
-                        raw_fallback_bytes += raw_bytes
-                        raw_lines_for_fallback.append(raw)
-                    else:
-                        raw_fallback_truncated = True
-                        raw_lines_for_fallback = []
-                try:
-                    parsed = json.loads(raw)
-                except json.JSONDecodeError:
-                    _append_parse_error_detail(
-                        file_errors,
-                        _parse_error_detail(path, line_number, "invalid-json"),
-                    )
-                    continue
-                if isinstance(parsed, dict):
-                    file_entries.append(_attach_metric_source(parsed, path))
-                    raw_lines_for_fallback = []
-                else:
-                    _append_parse_error_detail(
-                        file_errors,
-                        _parse_error_detail(path, line_number, "non-object-json"),
-                    )
-        if file_errors and not file_entries and raw_fallback_truncated:
-            _append_parse_error_detail(
-                file_errors,
-                _parse_error_detail(path, None, "legacy-json-fallback-buffer-limit"),
-            )
-        if (
-            file_errors
-            and not file_entries
-            and raw_lines_for_fallback
-            and not raw_fallback_truncated
-        ):
-            try:
-                parsed_file = json.loads("\n".join(raw_lines_for_fallback))
-            except json.JSONDecodeError:
-                pass
-            else:
-                if isinstance(parsed_file, dict):
-                    file_entries.append(_attach_metric_source(parsed_file, path))
-                    file_errors = []
-                elif isinstance(parsed_file, list) and all(
-                    isinstance(item, dict) for item in parsed_file
-                ):
-                    file_entries.extend(_attach_metric_source(item, path) for item in parsed_file)
-                    file_errors = []
-        entries.extend(file_entries)
-        errors.extend(file_errors)
+        file_entries, file_errors = read_ndjson_file(path)
+        entries.extend(_attach_metric_source(entry, path) for entry in file_entries)
+        for error in file_errors:
+            _append_parse_error_detail(errors, _canonical_parse_error_detail(path, error))
     return entries, errors
 
 
@@ -1599,7 +1552,7 @@ def main() -> int:
         print("No metrics files found to aggregate.", file=sys.stderr)
         return 0
 
-    entries, parse_error_details = _read_ndjson(files)
+    entries, parse_error_details = read_metric_ndjson_files(files)
     summary = build_summary(
         entries,
         _parse_error_count(parse_error_details),


### PR DESCRIPTION
## Sync Summary

### Files Updated
- aggregate_agent_metrics.py: Aggregates downloaded weekly agent metrics - required by agents-weekly-metrics.yml
- WORKFLOW_USER_GUIDE.md: Workflow user guide - explains the CI/agent system for repo consumers

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `82b96aedb50654a9b7d167ef25de9143c53d5882`
**Template hash:** `e1c7d12b52f2`
**Sync branch:** `sync/workflows-e1c7d12b52f2`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"82b96aedb50654a9b7d167ef25de9143c53d5882","template_hash":"e1c7d12b52f2","sync_branch":"sync/workflows-e1c7d12b52f2","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27599483668","run_attempt":"1","changes_count":2} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference documentation for the `agents:allow-change` label used for permission signals, noting it is automatically applied to dependency-bot PRs.

* **Chores**
  * Refactored metric aggregation script with improved error handling for data parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->