### PR TITLE
Issue #1417: Persist workspace reoptimization plans

### DIFF
--- a/docs/design-coverage-map.md
+++ b/docs/design-coverage-map.md
@@ -248,7 +248,7 @@ Issues: `#678` (epic), `#694`–`#697`
 | Budget editing + actual-spend capture (`#694`) | `trip_planner/app/routes/budget.py`, `services/budget.py`, `state/budget.py` | `tests/app/test_budget_routes.py` | ✅ Implemented |
 | Policy constraint sync + approval-readiness display (`#695`) | `trip_planner/app/routes/policy.py`, `services/policy.py` | `tests/app/test_policy.py` | ✅ Implemented |
 | Proposal submission + result ingestion (`#696`) | `trip_planner/app/routes/proposal.py`, `integrations/tpp/submission.py`, `results.py` | `tests/app/test_proposal.py`, `tests/integrations/test_submission.py`, `test_results.py` | ✅ Implemented |
-| Reoptimization + exception-handling after policy results (`#697`) | `trip_planner/integrations/tpp/reoptimization.py` | `tests/integrations/test_reoptimization.py` | 🟡 Partial (seam implemented; live TPP call deferred) |
+| Reoptimization + exception-handling after policy results (`#697`) | `trip_planner/integrations/tpp/reoptimization.py`, `trip_planner/app/routes/proposal.py` | `tests/integrations/test_reoptimization.py`, `tests/app/test_proposal.py` | ✅ Implemented |
 
 ---
 
@@ -264,7 +264,7 @@ Design ref: [`docs/live-tpp-execution-reoptimization-epic.md`](live-tpp-executio
 | Proposal lifecycle + submission | `trip_planner/integrations/tpp/submission.py`, `contracts.py` | `tests/integrations/test_submission.py`, `test_tpp_contracts.py` | ✅ Implemented |
 | Result ingestion | `trip_planner/integrations/tpp/results.py` | `tests/integrations/test_results.py` | ✅ Implemented |
 | Planner-turn-driven approval round-trip (in-process) | `trip_planner/app/services/proposal.py` (calls `HTTPTPPIntegrationClient.submit_proposal` + `fetch_evaluation_result`) | `tests/integrations/test_submission.py`, `test_results.py`, `test_tpp_cross_repo_smoke.py` | ✅ Implemented |
-| Reoptimization seam | `trip_planner/integrations/tpp/reoptimization.py` | `tests/integrations/test_reoptimization.py` | 🟡 Partial (seam only; no live round-trip) |
+| Reoptimization seam | `trip_planner/integrations/tpp/reoptimization.py`, `trip_planner/app/routes/proposal.py` | `tests/integrations/test_reoptimization.py`, `tests/app/test_proposal.py` | ✅ Implemented |
 | Live remote TPP transport | `scripts/check_full_product_verification.py`, `docs/verification-logs/live-tpp-pass-2026-05-14.log` | `tests/integrations/test_tpp_transport_httpserver.py`, `tests/integrations/test_tpp_cross_repo_smoke.py`; live verifier PASS captured 2026-05-14 | ✅ Implemented |
 
 **Verification detail:** The remote TPP call path (`integrations/tpp/client.py`) is wired to a real HTTP transport (`HTTPTPPIntegrationClient` dispatches via `urllib.request.urlopen`) and has now been exercised end-to-end through the full-product verifier. The captured 2026-05-14 run started a sibling `Travel-Plan-Permission` service, then completed policy sync, proposal submission, status poll, and evaluation ingestion with `live-tpp PASS`. Default local and CI runs remain opt-in and report `SKIPPED` when `TPP_BASE_URL` / `TPP_REPO_PATH` plus auth are absent.

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -271,6 +271,96 @@ def test_workspace_proposal_evaluation_derives_reoptimization_follow_up(client: 
     assert follow_up["selected_alternative"]["summary"] == "Use a compliant downtown property"
 
 
+def test_non_compliant_reoptimize_surfaces_plan_in_workspace_reload(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Reoptimization plan workspace",
+            "summary": "Persist reoptimization output after a non-compliant policy result.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 3,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    proposal_id = f"proposal:{trip_id}"
+
+    reoptimize_fixture = _load_fixture("reoptimization", "non_compliant_manual_review.json")
+    proposal_payload = reoptimize_fixture["proposal"]
+    proposal_payload["trip_id"] = trip_id
+    proposal_payload["proposal_id"] = proposal_id
+    proposal_payload["source_version"]["trip_id"] = trip_id
+
+    submission_fixture = _load_fixture("proposal_submit_deferred.json")
+    submission_fixture["request"]["trip_id"] = trip_id
+    submission_fixture["request"]["proposal_id"] = proposal_id
+    submission_fixture["request"]["payload"]["proposal_ref"] = proposal_id
+    submitted = client.put(
+        f"/api/workspace/{trip_id}/proposal",
+        json={
+            "proposal": proposal_payload,
+            "request": submission_fixture["request"],
+            "response": submission_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert submitted.status_code == 200
+
+    evaluation_fixture = _load_fixture("results", "non_compliant_evaluation.json")
+    evaluation_fixture["request"]["trip_id"] = trip_id
+    evaluation_fixture["request"]["proposal_id"] = proposal_id
+    result_payload = evaluation_fixture["response"]["result_payload"]
+    result_payload["trip_id"] = trip_id
+    result_payload["proposal_id"] = proposal_id
+    result_payload["proposal_version"] = "proposal-v3"
+    result_payload["evaluation_result"] = reoptimize_fixture["evaluation_result"]
+    result_payload["evaluation_result"]["proposal_id"] = proposal_id
+
+    evaluated = client.put(
+        f"/api/workspace/{trip_id}/proposal/evaluation",
+        json={
+            "request": evaluation_fixture["request"],
+            "response": evaluation_fixture["response"],
+            "proposal_version": "proposal-v3",
+            "scenario_id": "scenario-a",
+        },
+    )
+    assert evaluated.status_code == 200
+
+    reoptimized = client.post(
+        f"/api/workspace/{trip_id}/proposal/reoptimize",
+        json={
+            "comparable_refs": reoptimize_fixture["comparable_refs"],
+            "justification_refs": reoptimize_fixture["justification_refs"],
+        },
+    )
+    assert reoptimized.status_code == 200
+    plan = reoptimized.json()["summary"]["follow_up"]["reoptimization_plan"]
+    assert plan["reaction_kind"] in (
+        "rerank",
+        "narrow_candidates",
+        "regenerate_scenario",
+        "manual_review",
+        "create_exception_candidate",
+    )
+    assert plan["candidate_categories"]
+
+    workspace = client.get(f"/api/workspace/{trip_id}")
+    assert workspace.status_code == 200
+    reloaded_plan = workspace.json()["proposal_state"]["summary"]["follow_up"][
+        "reoptimization_plan"
+    ]
+    assert reloaded_plan["reaction_kind"] == plan["reaction_kind"]
+    assert reloaded_plan["candidate_categories"]
+
+
 def test_workspace_proposal_evaluation_derives_exception_follow_up(client: TestClient) -> None:
     created = client.post(
         "/api/trips",

--- a/tests/fixtures/integrations/tpp/reoptimization/non_compliant_manual_review.json
+++ b/tests/fixtures/integrations/tpp/reoptimization/non_compliant_manual_review.json
@@ -1,0 +1,135 @@
+{
+  "proposal": {
+    "proposal_id": "proposal-1417",
+    "trip_id": "trip-business-reoptimize",
+    "mode": "business",
+    "traveler_context": {
+      "employee_type": "employee",
+      "traveler_experience": "frequent",
+      "home_airport": "ORD",
+      "loyalty_programs": ["United"],
+      "mobility_or_access_needs": []
+    },
+    "selected_options": [
+      {
+        "category": "lodging",
+        "option_id": "hotel-conference",
+        "label": "Conference Hotel",
+        "vendor": "Marriott",
+        "booking_channel": "Navan",
+        "estimated_cost": {
+          "currency": "USD",
+          "typical_amount": 265.0,
+          "min_amount": 265.0,
+          "max_amount": 265.0
+        },
+        "justification_refs": ["justification:lodging:venue-proximity"]
+      }
+    ],
+    "cost_summary": {
+      "currency": "USD",
+      "total_estimated_cost": 265.0,
+      "category_estimates": {
+        "lodging": 265.0
+      },
+      "notes": ["Venue-adjacent hotel keeps arrival window safe."]
+    },
+    "comparables": [
+      {
+        "category": "lodging",
+        "label": "Policy cap hotel",
+        "vendor": "Hilton",
+        "booking_channel": "Navan",
+        "estimated_cost": {
+          "currency": "USD",
+          "typical_amount": 209.0,
+          "min_amount": 209.0,
+          "max_amount": 209.0
+        },
+        "notes": ["Meets lodging cap but extends transfer time."]
+      }
+    ],
+    "justifications": [
+      {
+        "category": "lodging",
+        "summary": "Venue-adjacent lodging protects the keynote arrival window.",
+        "evidence": ["venue_adjacent", "late_checkin_buffer"]
+      }
+    ],
+    "booking_channel_summaries": [
+      {
+        "category": "lodging",
+        "selected_channel": "Navan",
+        "approved": true,
+        "rationale": "Required company booking channel"
+      }
+    ],
+    "approval_notes": [],
+    "constraint_set_id": "policy-q2-client-summit",
+    "source_version": {
+      "version_id": "saved-scenario:compliant-first-v1",
+      "saved_scenario_id": "saved-scenario:compliant-first",
+      "trip_id": "trip-business-reoptimize",
+      "title": "Compliant-first client summit plan",
+      "label": "compliant_first",
+      "created_at": "2026-04-02T10:00:00Z",
+      "created_by": "policy-planner",
+      "scope": "route",
+      "snapshot_refs": {
+        "objective_id": "objective:client-summit",
+        "scenario_search_id": "scenario-search:client-summit",
+        "source_result_set_id": "ranked-result-set:client-summit",
+        "itinerary_scenario_id": "scenario:trip-business-client-summit:1",
+        "ranked_result_set_id": "ranked-result-set:client-summit",
+        "option_set_ids": ["option-set:lodging:conference"],
+        "policy_state_id": "policy-state:q2-client-summit",
+        "business_profile_id": "business-profile-consulting",
+        "notes": ["Primary approval-ready path with compliant booking channels."]
+      },
+      "summary": "Primary scenario retains approved vendors and schedule protection.",
+      "tags": ["business", "approval-ready"],
+      "notes": ["Used as the baseline for business policy review."]
+    }
+  },
+  "evaluation_result": {
+    "evaluation_id": "eval-1417-manual-review",
+    "proposal_id": "proposal-1417",
+    "status": "non_compliant",
+    "approval_requirements": [],
+    "failure_reasons": [],
+    "preferred_alternatives": [],
+    "exception_guidance": [],
+    "notes": ["Policy result needs planner review before re-ranking."],
+    "compliance_score": 0.48
+  },
+  "source_version": {
+    "version_id": "saved-scenario:compliant-first-v1",
+    "saved_scenario_id": "saved-scenario:compliant-first",
+    "trip_id": "trip-business-reoptimize",
+    "title": "Compliant-first client summit plan",
+    "label": "compliant_first",
+    "created_at": "2026-04-02T10:00:00Z",
+    "created_by": "policy-planner",
+    "scope": "route",
+    "snapshot_refs": {
+      "objective_id": "objective:client-summit",
+      "scenario_search_id": "scenario-search:client-summit",
+      "source_result_set_id": "ranked-result-set:client-summit",
+      "itinerary_scenario_id": "scenario:trip-business-client-summit:1",
+      "ranked_result_set_id": "ranked-result-set:client-summit",
+      "option_set_ids": ["option-set:lodging:conference"],
+      "policy_state_id": "policy-state:q2-client-summit",
+      "business_profile_id": "business-profile-consulting",
+      "notes": ["Primary approval-ready path with compliant booking channels."]
+    },
+    "summary": "Primary scenario retains approved vendors and schedule protection.",
+    "tags": ["business", "approval-ready"],
+    "notes": ["Used as the baseline for business policy review."]
+  },
+  "comparable_refs": {
+    "lodging": ["comparable:lodging:policy-cap"]
+  },
+  "justification_refs": {
+    "lodging": ["justification:lodging:venue-proximity"]
+  }
+}

--- a/trip_planner/app/routes/proposal.py
+++ b/trip_planner/app/routes/proposal.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from trip_planner.app.schemas.proposal import (
     WorkspaceProposalEvaluationRequest,
     WorkspaceProposalFollowUpRequest,
+    WorkspaceProposalReoptimizeRequest,
     WorkspaceProposalResponse,
     WorkspaceProposalSubmissionRequest,
 )
@@ -14,6 +15,7 @@ from trip_planner.app.services.proposal import (
     refresh_workspace_proposal_status,
     save_workspace_proposal_evaluation,
     save_workspace_proposal_follow_up,
+    save_workspace_proposal_reoptimize,
     save_workspace_proposal_submission,
 )
 from trip_planner.integrations.tpp import TPPTransportError
@@ -138,6 +140,28 @@ def refresh_workspace_proposal(
         raise HTTPException(status_code=404, detail=str(error)) from error
     except TPPTransportError as error:
         raise HTTPException(status_code=error.status_code, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return WorkspaceProposalResponse.model_validate(result)
+
+
+@router.post("/workspace/{trip_id}/proposal/reoptimize", response_model=WorkspaceProposalResponse)
+def reoptimize_workspace_proposal(
+    trip_id: str,
+    payload: WorkspaceProposalReoptimizeRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> WorkspaceProposalResponse:
+    try:
+        result = save_workspace_proposal_reoptimize(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            comparable_refs=payload.comparable_refs,
+            justification_refs=payload.justification_refs,
+        )
+    except WorkspaceProposalNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     return WorkspaceProposalResponse.model_validate(result)

--- a/trip_planner/app/schemas/proposal.py
+++ b/trip_planner/app/schemas/proposal.py
@@ -61,6 +61,11 @@ class WorkspaceProposalFollowUpRequest(BaseModel):
     requested_exception: WorkspaceProposalExceptionRequest | None = None
 
 
+class WorkspaceProposalReoptimizeRequest(BaseModel):
+    comparable_refs: dict[str, list[str]] = Field(default_factory=dict)
+    justification_refs: dict[str, list[str]] = Field(default_factory=dict)
+
+
 class WorkspaceProposalResponse(BaseModel):
     proposal_state: dict[str, Any] | None = None
     summary: dict[str, Any] = Field(default_factory=dict)

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -8,11 +8,12 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from trip_planner.app.services.auth import AuthenticatedUser
-from trip_planner.business import ExceptionRequest, TripPlanProposal
+from trip_planner.business import ExceptionRequest, PolicyEvaluationResult, TripPlanProposal
 from trip_planner.integrations.tpp import (
     BaseTPPIntegrationClient,
     EvaluationResultIngestionError,
     HTTPTPPIntegrationClient,
+    PolicyReoptimizationContext,
     TPPConfigurationError,
     TPPContractError,
     TPPCorrelationId,
@@ -23,11 +24,13 @@ from trip_planner.integrations.tpp import (
     TPPRequestEnvelope,
     TPPResponseEnvelope,
     TPPRetryMetadata,
+    TPPReoptimizationService,
     TPPTransportError,
     tpp_transport_error_from_exception,
 )
 from trip_planner.persistence.models.proposal import PersistedProposalState
 from trip_planner.persistence.models.trip import PersistedTrip
+from trip_planner.state import ScenarioVersion
 
 
 class WorkspaceProposalNotFoundError(ValueError):
@@ -485,6 +488,7 @@ def _derive_follow_up_state(
             "recommended_action",
             "recommended_label",
             "selected_alternative",
+            "reoptimization_plan",
             "notes",
             "updated_at",
         ):
@@ -886,6 +890,10 @@ def save_workspace_proposal_submission(
         evaluation_record={},
         summary={},
     )
+    stored_proposal_payload = proposal.to_dict()
+    if isinstance(proposal_payload.get("source_version"), dict):
+        stored_proposal_payload["source_version"] = dict(proposal_payload["source_version"])
+
     record.owner_profile_id = _owner_profile_id(trip_record)
     record.proposal_id = proposal.proposal_id
     record.proposal_version = submission.linkage.proposal_version
@@ -893,7 +901,7 @@ def save_workspace_proposal_submission(
     record.organization_id = submission.linkage.organization_id
     record.execution_id = submission.execution_id
     record.submission_status = submission.execution_status.state
-    record.proposal_payload = proposal.to_dict()
+    record.proposal_payload = stored_proposal_payload
     record.submission_record = submission.to_dict()
     _reset_evaluation_state(record)
     record.summary = _build_summary(
@@ -1072,6 +1080,67 @@ def save_workspace_proposal_follow_up(
         evaluation_record=dict(existing.evaluation_record),
         proposal_payload=proposal_payload,
         persisted_follow_up=manual_follow_up,
+    )
+
+    trip_record.updated_at = datetime.now(UTC)
+    db_session.commit()
+    db_session.refresh(existing)
+    return {
+        "proposal_state": _serialize_proposal_state(existing),
+        "summary": dict(existing.summary),
+    }
+
+
+def save_workspace_proposal_reoptimize(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    comparable_refs: dict[str, list[str]],
+    justification_refs: dict[str, list[str]],
+) -> dict[str, Any]:
+    trip_record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    if trip_record.mode != "business":
+        raise ValueError("Only business trips can persist proposal lifecycle state.")
+
+    existing = _get_latest_proposal_state(db_session, trip_id=trip_id, user_id=user.user_id)
+    if existing is None:
+        raise WorkspaceProposalNotFoundError(
+            "Proposal reoptimization cannot run before a proposal submission exists."
+        )
+
+    proposal_payload = dict(existing.proposal_payload)
+    evaluation_payload = dict(existing.evaluation_record.get("evaluation_result") or {})
+    if not evaluation_payload:
+        raise ValueError("Proposal reoptimization requires a stored policy evaluation result.")
+    source_version_payload = proposal_payload.get("source_version")
+    if not isinstance(source_version_payload, dict):
+        raise ValueError("Proposal reoptimization requires proposal.source_version context.")
+
+    plan = TPPReoptimizationService().plan_reoptimization(
+        TripPlanProposal.from_dict(proposal_payload),
+        PolicyEvaluationResult.from_dict(evaluation_payload),
+        PolicyReoptimizationContext(
+            source_version=ScenarioVersion.from_dict(source_version_payload),
+            comparable_refs=comparable_refs,
+            justification_refs=justification_refs,
+        ),
+    )
+
+    follow_up = _resolved_follow_up_payload(existing)
+    follow_up["manual"] = True
+    follow_up["reoptimization_plan"] = plan.to_dict()
+    follow_up["status"] = "reoptimized"
+    follow_up["path"] = "reoptimization"
+    follow_up["title"] = follow_up.get("title") or "Reoptimization plan ready"
+    follow_up["summary"] = follow_up.get("summary") or plan.target_title
+    follow_up["updated_at"] = _now_iso()
+
+    existing.summary = _build_summary(
+        submission_record=dict(existing.submission_record),
+        evaluation_record=dict(existing.evaluation_record),
+        proposal_payload=proposal_payload,
+        persisted_follow_up=follow_up,
     )
 
     trip_record.updated_at = datetime.now(UTC)

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -2123,6 +2123,7 @@ def _public_workspace_follow_up(follow_up: Any) -> dict[str, Any] | None:
         "notes",
         "selected_alternative",
         "requested_exception",
+        "reoptimization_plan",
     }
     return {key: deepcopy(value) for key, value in follow_up.items() if key in public_keys}
 
@@ -2151,6 +2152,7 @@ def _public_workspace_proposal_state(proposal_state: Any) -> dict[str, Any] | No
         "follow_up_status",
         "follow_up_title",
         "follow_up_summary",
+        "follow_up",
     }
     public_summary = {
         key: deepcopy(value)


### PR DESCRIPTION
Closes #1417

## Summary
- add POST /api/workspace/{trip_id}/proposal/reoptimize and persist deterministic TPP reoptimization plans under summary.follow_up.reoptimization_plan
- preserve proposal source_version context through proposal submission so reoptimization can reconstruct the source scenario
- add a fixture-backed acceptance test proving non-compliant results produce a plan that survives workspace reload
- update the design coverage map to mark the reoptimization seam implemented

## Validation
- PYTEST_ADDOPTS=--no-cov pytest tests/app/test_proposal.py::test_non_compliant_reoptimize_surfaces_plan_in_workspace_reload -q
- PYTEST_ADDOPTS=--no-cov pytest tests/integrations/test_reoptimization.py -q
- python -m ruff check trip_planner/app/routes/proposal.py trip_planner/app/schemas/proposal.py trip_planner/app/services/proposal.py trip_planner/app/services/workspace.py tests/app/test_proposal.py
- git diff --check origin/main
- make full-product-check (exits 0; local leisure/business PASS; frontend-runtime-smoke, map-provider, planner-llm, live-tpp SKIPPED due missing local deps/env)

## Deliberate-break evidence
- Temporarily removed the save_workspace_proposal_reoptimize import in trip_planner/app/routes/proposal.py
- PYTEST_ADDOPTS=--no-cov pytest tests/app/test_proposal.py::test_non_compliant_reoptimize_surfaces_plan_in_workspace_reload -x -q failed as expected with NameError: save_workspace_proposal_reoptimize is not defined
- Restored the import; the focused test passes again


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reoptimization endpoint that allows users to trigger a reoptimization workflow for non-compliant proposals, returning a reoptimization plan that persists when the workspace is reloaded.

* **Documentation**
  * Updated design coverage documentation to reflect completed reoptimization implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->