### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/agents-guard.js
+++ b/.github/scripts/agents-guard.js
@@ -10,8 +10,6 @@ const path = require('path');
 const DEFAULT_MARKER = '<!-- agents-guard-marker -->';
 
 const DEFAULT_PROTECTED_PATHS = ['.github/workflows/agents-*.yml'];
-const DEPENDENCY_UPDATE_BOT_LOGINS = new Set(['dependabot[bot]', 'renovate[bot]']);
-const TRUSTED_DEPENDENCY_AUTHOR_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
 const LEGACY_ALLOW_REMOVED_PATHS = [
   // Keepalive consolidation retired the standalone keepalive sweeps.
   '.github/workflows/agents-75-keepalive-on-gate.yml',
@@ -398,83 +396,6 @@ function extractLabelNames(labels) {
   );
 }
 
-function parseActionReferenceLine(line) {
-  const match = String(line || '').match(/^\s*(?:-\s*)?uses:\s*["']?([^@\s#'"]+)@([^\s#'"]+)["']?(?:\s*(?:#.*)?)?$/i);
-  if (!match) {
-    return null;
-  }
-
-  return {
-    action: match[1].toLowerCase(),
-    ref: match[2],
-  };
-}
-
-function sameActionSequence(left, right) {
-  if (left.length !== right.length) {
-    return false;
-  }
-
-  for (let index = 0; index < left.length; index += 1) {
-    if (left[index].action !== right[index].action) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function sameActionRefSequence(left, right) {
-  if (left.length !== right.length) {
-    return false;
-  }
-
-  for (let index = 0; index < left.length; index += 1) {
-    if (left[index].action !== right[index].action || left[index].ref !== right[index].ref) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-function patchChangesOnlyActionReferences(patch) {
-  if (!patch || typeof patch !== 'string') {
-    return false;
-  }
-
-  const removedRefs = [];
-  const addedRefs = [];
-  for (const rawLine of patch.split(/\r?\n/)) {
-    if (!rawLine || rawLine.startsWith('+++') || rawLine.startsWith('---')) {
-      continue;
-    }
-
-    const marker = rawLine[0];
-    if (marker !== '+' && marker !== '-') {
-      continue;
-    }
-
-    const parsed = parseActionReferenceLine(rawLine.slice(1));
-    if (!parsed) {
-      return false;
-    }
-
-    if (marker === '-') {
-      removedRefs.push(parsed);
-    } else {
-      addedRefs.push(parsed);
-    }
-  }
-
-  if (removedRefs.length === 0 || addedRefs.length === 0) {
-    return false;
-  }
-
-  return sameActionSequence(removedRefs, addedRefs) &&
-    !sameActionRefSequence(removedRefs, addedRefs);
-}
-
 function evaluateGuard({
   files = [],
   labels = [],
@@ -483,7 +404,6 @@ function evaluateGuard({
   protectedPaths = DEFAULT_PROTECTED_PATHS,
   labelName = 'agents:allow-change',
   authorLogin = '',
-  authorAssociation = '',
   marker = DEFAULT_MARKER,
   repository = process.env.GITHUB_REPOSITORY || '',
 } = {}) {
@@ -604,37 +524,16 @@ function evaluateGuard({
   }
 
   const normalizedAuthor = authorLogin ? String(authorLogin).toLowerCase() : '';
-  const normalizedAuthorAssociation = authorAssociation
-    ? String(authorAssociation).toUpperCase()
-    : '';
-  const authorIsCodeowner = Boolean(
-    normalizedAuthor && codeownerLogins.has(normalizedAuthor),
-  );
+  const authorIsCodeowner = normalizedAuthor && codeownerLogins.has(normalizedAuthor);
   const hasExternalApproval = [...codeownerLogins].some((login) => approvedLogins.has(login));
-  const hasCodeownerApproval = Boolean(hasExternalApproval || authorIsCodeowner);
+  const hasCodeownerApproval = hasExternalApproval || authorIsCodeowner;
 
   const hasProtectedChanges = modifiedProtectedPaths.size > 0;
-  const protectedChangesAreDependencyOnly = hasProtectedChanges && relevantFiles
-    .filter((file) => file.status === 'modified' && matchProtectedPath(file.filename || ''))
-    .every((file) => patchChangesOnlyActionReferences(file.patch || ''));
-  const isDependencyUpdateBot = Boolean(
-    normalizedAuthor && DEPENDENCY_UPDATE_BOT_LOGINS.has(normalizedAuthor),
-  );
-  const authorCanUseDependencyBypass = Boolean(
-    isDependencyUpdateBot ||
-      (normalizedAuthorAssociation &&
-        TRUSTED_DEPENDENCY_AUTHOR_ASSOCIATIONS.has(normalizedAuthorAssociation)),
-  );
-  // Security note: the `agents:allow-change` label can bypass CODEOWNER approval
-  // only for protected workflow dependency reference updates. This keeps routine
-  // action version alignment moving while arbitrary workflow logic edits still
-  // require CODEOWNER review.
-  const hasDependencyUpgradeBypass = Boolean(
-    hasAllowLabel &&
-      authorCanUseDependencyBypass &&
-      protectedChangesAreDependencyOnly,
-  );
-  const needsApproval = hasProtectedChanges && !hasCodeownerApproval && !hasDependencyUpgradeBypass;
+  // Security note: Allow `agents:allow-change` label to bypass CODEOWNER approval
+  // ONLY for automated dependency PRs from known bots (dependabot, renovate).
+  // Human PRs or other bot PRs still require CODEOWNER approval even with label.
+  const isAutomatedPR = normalizedAuthor && (normalizedAuthor === 'dependabot[bot]' || normalizedAuthor === 'renovate[bot]');
+  const needsApproval = hasProtectedChanges && !hasCodeownerApproval && !(hasAllowLabel && isAutomatedPR);
   const needsLabel = hasProtectedChanges && !hasAllowLabel && !hasCodeownerApproval;
 
   const failureReasons = [];
@@ -720,10 +619,6 @@ function evaluateGuard({
     authorIsCodeowner,
     needsLabel,
     needsApproval,
-    hasDependencyUpgradeBypass,
-    protectedChangesAreDependencyOnly,
-    isDependencyUpdateBot,
-    authorCanUseDependencyBypass,
     modifiedProtectedPaths: [...modifiedProtectedPaths],
     touchedProtectedPaths: [...touchedProtectedPaths],
     fatalViolations,
@@ -738,7 +633,6 @@ module.exports = {
   evaluateGuard,
   parseCodeowners,
   globToRegExp,
-  patchChangesOnlyActionReferences,
   validatePullRequestTargetSafety,
   detectPullRequestTargetViolations,
 };

--- a/.github/workflows/agents-guard.yml
+++ b/.github/workflows/agents-guard.yml
@@ -208,8 +208,6 @@ jobs:
             const authorLogin =
               context.payload.pull_request.user &&
               context.payload.pull_request.user.login;
-            const authorAssociation =
-              context.payload.pull_request.author_association || '';
             const { owner, repo } = context.repo;
             const baseRef = context.payload.pull_request.base.sha;
             const labelName = 'agents:allow-change';
@@ -422,7 +420,6 @@ jobs:
               protectedPaths,
               labelName,
               authorLogin,
-              authorAssociation,
               marker,
             });
 

--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1
+        uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/WORKFLOW_USER_GUIDE.md
+++ b/WORKFLOW_USER_GUIDE.md
@@ -165,7 +165,7 @@ Issue: "Add user authentication"
 | `agent:needs-attention` | Human intervention required |
 | `agents:auto-pilot-pause` | Auto-pilot paused |
 | `agents:auto-pilot-failed` | Auto-pilot stopped due to errors |
-| `agents:allow-change` | Permission signal for `agents-guard`; bypasses guard-level CODEOWNER approval only for dependency-only `uses:` reference updates from Dependabot/Renovate or repository owner/member/collaborator PRs. Auto-applied to dependency-bot PRs by `maint-auto-label-dep-prs.yml`; arbitrary workflow logic edits still require review. |
+| `agents:allow-change` | Permission signal for `agents-guard`; bypasses CODEOWNER approval only for automated dependency PRs from Dependabot/Renovate. Auto-applied by `maint-auto-label-dep-prs.yml`; manual application does not bypass guard enforcement. |
 | `needs-human` | Escalated to human |
 | `follow-up` | Created as follow-up to another issue/PR |
 | `duplicate` | Potential duplicate detected |
@@ -850,7 +850,7 @@ The Workflows repository includes maintenance workflows that handle sync, update
 **Trigger:** When Dependabot or Renovate opens a PR
 
 **Labels Applied:**
-- `agents:allow-change` (so dependency-bot protected-workflow version updates can use the guarded dependency-update lane)
+- `agents:allow-change` (so protected-workflow changes can be reviewed without manual label work)
 
 **Use When:** Automatic, no action needed
 

--- a/docs/LABELS.md
+++ b/docs/LABELS.md
@@ -609,14 +609,10 @@ These labels trigger the post-merge verifier workflow on a merged PR.
 **Trigger:** Agent guard evaluation
 
 **Effect:**
-1. Signals maintainer permission for protected automation changes after the
-   change has been justified.
-2. Allows the guard to pass without Code Owner approval only when every
-   protected workflow diff is limited to `uses: owner/action@ref` dependency
-   reference updates and the PR author is Dependabot, Renovate, or a repository
-   owner/member/collaborator.
-3. Does not bypass review for protected workflow logic edits, deletes, renames,
-   or dependency changes whose patch cannot be inspected.
+1. Allows protected automation changes, such as Dependabot or workflow-adjacent
+   edits, after the change has been justified.
+2. Prevents `agents-guard` from blocking PRs that would otherwise require
+   explicit permission.
 
 **Consumers:** `.github/scripts/agents-guard.js`,
 `.github/workflows/maint-auto-label-dep-prs.yml`.

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -7,7 +7,7 @@
 # - Use strict X.Y.Z pins for direct workflow dependencies.
 # - Do not pin `langchain-core` directly here; let the selected `langchain`
 #   release resolve a mutually compatible core version.
-langchain==1.3.10
+langchain==1.3.9
 langchain-community==0.4.2
 langchain-openai==1.3.2
 langchain-anthropic==1.4.6


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-guard.yml: Agents guard - enforces agents workflow protections (Health 45)
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch
- requirements-llm.txt: Pinned LLM dependencies - exact-sync guarded for agent workflows
- agents-guard.js: Health 45 agents guard logic used by the workflow protections
- LABELS.md: Label definitions and usage
- WORKFLOW_USER_GUIDE.md: Workflow user guide - explains the CI/agent system for repo consumers

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `c713d035050b9b9afd2a6b9bf88b862bb3e83880`
**Template hash:** `7c028f789893`
**Sync branch:** `sync/workflows-7c028f789893`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"c713d035050b9b9afd2a6b9bf88b862bb3e83880","template_hash":"7c028f789893","sync_branch":"sync/workflows-7c028f789893","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27836562904","run_attempt":"1","changes_count":6} -->