### PR TITLE
chore: sync workflow templates

### DIFF
--- a/scripts/check_agents_md_freshness.py
+++ b/scripts/check_agents_md_freshness.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Warn when the managed Orchestrator AGENTS.md section cites stale repo facts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MANAGED_START = "<!-- BEGIN orch-playbook -->"
+MANAGED_END = "<!-- END orch-playbook -->"
+PATH_SUFFIXES = {
+    ".cfg",
+    ".ini",
+    ".js",
+    ".json",
+    ".md",
+    ".py",
+    ".sh",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    value: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"kind": self.kind, "value": self.value, "message": self.message}
+
+
+def managed_section(text: str) -> str | None:
+    start = text.find(MANAGED_START)
+    end = text.find(MANAGED_END, start + len(MANAGED_START)) if start >= 0 else -1
+    if start < 0 or end < 0 or end < start:
+        return None
+    return text[start : end + len(MANAGED_END)]
+
+
+def _clean_ref(value: str) -> str:
+    value = value.strip().strip("\"'")
+    value = re.sub(r"[:#]L?\d+(?:-L?\d+)?$", "", value)
+    return value
+
+
+def _looks_like_path(value: str) -> bool:
+    if value.startswith(("./", "../", ".github/", "docs/", "scripts/", "templates/", "tools/")):
+        return True
+    path = Path(value)
+    return "/" in value or path.suffix.lower() in PATH_SUFFIXES
+
+
+def _path_exists(repo_root: Path, ref: str) -> bool:
+    return (repo_root / ref).exists()
+
+
+def _command_exists(repo_root: Path, ref: str) -> bool:
+    parts = ref.split()
+    if not parts:
+        return True
+    command = parts[0]
+    if command.startswith(("./", "../")) or "/" in command:
+        return (repo_root / command).exists()
+    return shutil.which(command) is not None
+
+
+def _check_command_ref(repo_root: Path, ref: str) -> list[Finding]:
+    findings: list[Finding] = []
+    if not _command_exists(repo_root, ref):
+        findings.append(Finding("command", ref, f"referenced command not found: {ref}"))
+    for arg in ref.split()[1:]:
+        arg = _clean_ref(arg)
+        if "=" in arg:
+            _, arg = arg.split("=", 1)
+            arg = _clean_ref(arg)
+        if _looks_like_path(arg) and not _path_exists(repo_root, arg):
+            findings.append(Finding("path", arg, f"referenced path not found: {arg}"))
+    return findings
+
+
+def cited_refs(section: str) -> list[str]:
+    refs: list[str] = []
+    for raw in re.findall(r"`([^`]+)`", section):
+        value = _clean_ref(raw)
+        if not value or value.startswith(("http://", "https://")):
+            continue
+        refs.append(value)
+    return refs
+
+
+def check_agents_md(repo_root: Path, agents_md: Path | None = None) -> list[Finding]:
+    agents_path = agents_md or repo_root / "AGENTS.md"
+    if not agents_path.exists():
+        return []
+    section = managed_section(agents_path.read_text(encoding="utf-8"))
+    if section is None:
+        return []
+
+    findings: list[Finding] = []
+    seen: set[tuple[str, str]] = set()
+    for ref in cited_refs(section):
+        if " " in ref:
+            for finding in _check_command_ref(repo_root, ref):
+                key = (finding.kind, finding.value)
+                if key not in seen:
+                    findings.append(finding)
+                seen.add(key)
+        elif _looks_like_path(ref):
+            key = ("path", ref)
+            if key not in seen and not _path_exists(repo_root, ref):
+                findings.append(Finding("path", ref, f"referenced path not found: {ref}"))
+            seen.add(key)
+    return findings
+
+
+def _emit_github_warnings(findings: list[Finding]) -> None:
+    for finding in findings:
+        message = finding.message.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
+        print(f"::warning title=AGENTS.md freshness::{message}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--agents-md", type=Path)
+    parser.add_argument("--github-annotations", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--strict", action="store_true", help="Exit non-zero when findings are present."
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve()
+    agents_md = args.agents_md.resolve() if args.agents_md else None
+    findings = check_agents_md(repo_root, agents_md)
+
+    if args.as_json:
+        print(json.dumps({"findings": [finding.as_dict() for finding in findings]}, indent=2))
+    elif findings:
+        for finding in findings:
+            print(finding.message)
+    else:
+        print("AGENTS.md managed section freshness check passed.")
+
+    if args.github_annotations and findings:
+        _emit_github_warnings(findings)
+
+    return 1 if args.strict and findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Sync Summary

### Files Updated
- check_agents_md_freshness.py: Warns when the generated Orchestrator AGENTS.md playbook section cites stale repo paths or commands

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `2baf871360a6ebf83c2b24dd7eafd94d7f262733`
**Template hash:** `97e42ef43aa5`
**Sync branch:** `sync/workflows-97e42ef43aa5`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"2baf871360a6ebf83c2b24dd7eafd94d7f262733","template_hash":"97e42ef43aa5","sync_branch":"sync/workflows-97e42ef43aa5","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"27896078945","run_attempt":"1","changes_count":1} -->