### PR TITLE
docs: seed UX Review log (docs/ux-review/REVIEW_LOG.md)

### DIFF
--- a/docs/ux-review/REVIEW_LOG.md
+++ b/docs/ux-review/REVIEW_LOG.md
@@ -3,6 +3,7 @@
 Diff-anchored record of UX Review (`/ux-review`) passes. Detailed artifacts live in `Orchestrator/ux_reviews/`.
 
 ## 2026-06-22 — Vite SPA + FastAPI (synthetic demo seed) — commit `3e25681` — overall 7.0/10 (gate PASS)
+
 - **Scope:** full-stack local (Vite `:5173` + FastAPI `:8000` on SQLite), the repo's documented synthetic demo seed (`TRIP_PLANNER_SEED_DEMO`, `demo@trip-planner.local`). Also serves as Travel-Plan-Permission's UI.
 - **Coverage:** login ✓; Saved Trips list ✓; Workspace ✓; Plan / Compare / Map / Budget tabs ✓; scenario comparison ✓ (3 routes with time/transfers/cost). NOT driven: Notebook / Policy tabs, signup, create-trip.
 - **Scores:** wired 6.5 / usability 7.0 / help_clarity 7.0 / workflow 7.5 — **PASS**. The most fully-functional app in the fleet (completes login → trips → workspace → scenario comparison end-to-end, well-guided with NEXT-ACTION + approval-readiness).

--- a/docs/ux-review/REVIEW_LOG.md
+++ b/docs/ux-review/REVIEW_LOG.md
@@ -1,0 +1,12 @@
+# UX Review Log — trip-planner
+
+Diff-anchored record of UX Review (`/ux-review`) passes. Detailed artifacts live in `Orchestrator/ux_reviews/`.
+
+## 2026-06-22 — Vite SPA + FastAPI (synthetic demo seed) — commit `3e25681` — overall 7.0/10 (gate PASS)
+- **Scope:** full-stack local (Vite `:5173` + FastAPI `:8000` on SQLite), the repo's documented synthetic demo seed (`TRIP_PLANNER_SEED_DEMO`, `demo@trip-planner.local`). Also serves as Travel-Plan-Permission's UI.
+- **Coverage:** login ✓; Saved Trips list ✓; Workspace ✓; Plan / Compare / Map / Budget tabs ✓; scenario comparison ✓ (3 routes with time/transfers/cost). NOT driven: Notebook / Policy tabs, signup, create-trip.
+- **Scores:** wired 6.5 / usability 7.0 / help_clarity 7.0 / workflow 7.5 — **PASS**. The most fully-functional app in the fleet (completes login → trips → workspace → scenario comparison end-to-end, well-guided with NEXT-ACTION + approval-readiness).
+- **Findings → filed:**
+  - Header stays logged-out after login — root loader `session` not revalidated (`frontend/src/App.tsx:40`, gating at `:63-83`) → **#1448**.
+  - Map tab shows no visual map, only a text "approximate sketch" (`frontend/src/components/maps/TripMap.tsx:176`, `mapSurface.ts:809`; README-acknowledged follow-on) → **#1449**.
+- **Next focus:** drive Notebook / Policy tabs + signup + create-trip; revisit Map once a provider is wired.


### PR DESCRIPTION
Diff-anchored per-repo UX Review record. Seeded with the 2026-06-22 full-stack pass (overall 7.0/10, gate PASS; findings #1448/#1449).

Related to #1448
Related to #1449
<!-- workflow-source:review_followup -->

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new UX Review Log entry capturing results from a full application UI review, including which screens/features were validated, overall score and sub-scores, recorded findings with their issue references, and the next set of areas to test for continued coverage expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
