### PR TITLE
Refresh auth header after session changes

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,154 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+import { login, logout, signup } from "./api/auth";
+import App from "./App";
+import { LoginPage } from "./routes/LoginPage";
+import { SignupPage } from "./routes/SignupPage";
+import type { RootLoaderData } from "./router";
+
+vi.mock("./api/auth", () => ({
+  login: vi.fn(),
+  logout: vi.fn(),
+  signup: vi.fn(),
+}));
+
+const mockedLogin = vi.mocked(login);
+const mockedLogout = vi.mocked(logout);
+const mockedSignup = vi.mocked(signup);
+
+const signedInSession: NonNullable<RootLoaderData["session"]> = {
+  user: {
+    user_id: "user:test",
+    email: "traveler@example.com",
+    display_name: "Traveler",
+  },
+};
+
+function renderAppWithSession(
+  initialSession: RootLoaderData["session"],
+  initialEntries = ["/login"]
+) {
+  let currentSession = initialSession;
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        element: <App />,
+        loader: () => ({ session: currentSession }),
+        children: [
+          {
+            path: "login",
+            element: <LoginPage />,
+          },
+          {
+            path: "signup",
+            element: <SignupPage />,
+          },
+          {
+            path: "trips",
+            element: <section>Saved trips</section>,
+          },
+        ],
+      },
+    ],
+    { initialEntries }
+  );
+
+  return {
+    router,
+    setSession: (session: RootLoaderData["session"]) => {
+      currentSession = session;
+    },
+    ...render(<RouterProvider router={router} />),
+  };
+}
+
+describe("App auth header", () => {
+  afterEach(() => {
+    cleanup();
+    mockedLogin.mockReset();
+    mockedLogout.mockReset();
+    mockedSignup.mockReset();
+  });
+
+  it("refreshes the root header after login without a full reload", async () => {
+    const app = renderAppWithSession(null);
+    mockedLogin.mockImplementation(async () => {
+      app.setSession(signedInSession);
+      return signedInSession;
+    });
+
+    expect(await screen.findByText(/Sign in to continue planning trips/)).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: "Login" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "traveler@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Signed in as Traveler/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: "Trips" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Login" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Signup" })).not.toBeInTheDocument();
+    expect(app.router.state.location.pathname).toBe("/trips");
+  });
+
+  it("refreshes the root header after signup without a full reload", async () => {
+    const app = renderAppWithSession(null, ["/signup"]);
+    mockedSignup.mockImplementation(async () => {
+      app.setSession(signedInSession);
+      return signedInSession;
+    });
+
+    expect(await screen.findByText(/Sign in to continue planning trips/)).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: "Signup" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Display name"), {
+      target: { value: "Traveler" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "traveler@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Signed in as Traveler/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: "Trips" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Login" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Signup" })).not.toBeInTheDocument();
+    expect(app.router.state.location.pathname).toBe("/trips");
+  });
+
+  it("refreshes the root header after logout without a full reload", async () => {
+    const app = renderAppWithSession(signedInSession, ["/trips"]);
+    mockedLogout.mockImplementation(async () => {
+      app.setSession(null);
+      return { signed_out: true };
+    });
+
+    expect(await screen.findByText(/Signed in as Traveler/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign out" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Sign in to continue planning trips/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: "Login" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Signup" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
+    expect(app.router.state.location.pathname).toBe("/login");
+  });
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -93,11 +93,11 @@ describe("App auth header", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Signed in as Traveler/)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Trips" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Login" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Signup" })).not.toBeInTheDocument();
     });
-    expect(screen.getByRole("link", { name: "Trips" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Login" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Signup" })).not.toBeInTheDocument();
     expect(app.router.state.location.pathname).toBe("/trips");
   });
 
@@ -124,11 +124,11 @@ describe("App auth header", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Signed in as Traveler/)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Trips" })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Login" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Signup" })).not.toBeInTheDocument();
     });
-    expect(screen.getByRole("link", { name: "Trips" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Login" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: "Signup" })).not.toBeInTheDocument();
     expect(app.router.state.location.pathname).toBe("/trips");
   });
 
@@ -145,10 +145,10 @@ describe("App auth header", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Sign in to continue planning trips/)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Login" })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Signup" })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
     });
-    expect(screen.getByRole("link", { name: "Login" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Signup" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Sign out" })).not.toBeInTheDocument();
     expect(app.router.state.location.pathname).toBe("/login");
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,12 @@
 import { startTransition, useState } from "react";
-import { NavLink, Outlet, useLoaderData, useNavigate, useRouteError } from "react-router-dom";
+import {
+  NavLink,
+  Outlet,
+  useLoaderData,
+  useNavigate,
+  useRevalidator,
+  useRouteError,
+} from "react-router-dom";
 
 import { logout } from "./api/auth";
 import { getErrorMessage } from "./lib/api/errors";
@@ -39,6 +46,7 @@ export function RootErrorBoundary() {
 export default function App() {
   const { session } = useLoaderData() as RootLoaderData;
   const navigate = useNavigate();
+  const revalidator = useRevalidator();
   const [isSigningOut, setIsSigningOut] = useState(false);
 
   async function handleSignOut() {
@@ -46,6 +54,7 @@ export default function App() {
     try {
       await logout();
       startTransition(() => {
+        revalidator.revalidate();
         navigate("/login");
       });
     } finally {

--- a/frontend/src/routes/LoginPage.test.tsx
+++ b/frontend/src/routes/LoginPage.test.tsx
@@ -11,12 +11,14 @@ vi.mock("../api/auth", () => ({
 
 const mockedLogin = vi.mocked(login);
 const mockedNavigate = vi.fn();
+const mockedRevalidate = vi.fn();
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
     useNavigate: () => mockedNavigate,
+    useRevalidator: () => ({ revalidate: mockedRevalidate }),
     useSearchParams: () => [new URLSearchParams("next=%2Ftrips"), vi.fn()],
   };
 });
@@ -26,6 +28,7 @@ describe("LoginPage", () => {
     cleanup();
     mockedLogin.mockReset();
     mockedNavigate.mockReset();
+    mockedRevalidate.mockReset();
   });
 
   it("submits credentials and navigates to the requested protected route", async () => {
@@ -53,6 +56,7 @@ describe("LoginPage", () => {
         password: "password123",
       });
     });
+    expect(mockedRevalidate).toHaveBeenCalled();
     expect(mockedNavigate).toHaveBeenCalledWith("/trips");
   });
 

--- a/frontend/src/routes/LoginPage.tsx
+++ b/frontend/src/routes/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useState, startTransition } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useRevalidator, useSearchParams } from "react-router-dom";
 
 import { login } from "../api/auth";
 import { getErrorMessage } from "../lib/api/errors";
@@ -14,6 +14,7 @@ function resolveNextPath(searchParams: URLSearchParams): string {
 
 export function LoginPage() {
   const navigate = useNavigate();
+  const revalidator = useRevalidator();
   const [searchParams] = useSearchParams();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -32,6 +33,7 @@ export function LoginPage() {
       });
       const nextPath = resolveNextPath(searchParams);
       startTransition(() => {
+        revalidator.revalidate();
         navigate(nextPath);
       });
     } catch (error) {

--- a/frontend/src/routes/SignupPage.test.tsx
+++ b/frontend/src/routes/SignupPage.test.tsx
@@ -11,12 +11,14 @@ vi.mock("../api/auth", () => ({
 
 const mockedSignup = vi.mocked(signup);
 const mockedNavigate = vi.fn();
+const mockedRevalidate = vi.fn();
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
     useNavigate: () => mockedNavigate,
+    useRevalidator: () => ({ revalidate: mockedRevalidate }),
   };
 });
 
@@ -25,6 +27,7 @@ describe("SignupPage", () => {
     cleanup();
     mockedSignup.mockReset();
     mockedNavigate.mockReset();
+    mockedRevalidate.mockReset();
   });
 
   it("creates an account and routes into the protected trip list", async () => {
@@ -54,6 +57,7 @@ describe("SignupPage", () => {
         password: "password123",
       });
     });
+    expect(mockedRevalidate).toHaveBeenCalled();
     expect(mockedNavigate).toHaveBeenCalledWith("/trips");
   });
 });

--- a/frontend/src/routes/SignupPage.tsx
+++ b/frontend/src/routes/SignupPage.tsx
@@ -1,11 +1,12 @@
 import { FormEvent, useState, startTransition } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useRevalidator } from "react-router-dom";
 
 import { signup } from "../api/auth";
 import { getErrorMessage } from "../lib/api/errors";
 
 export function SignupPage() {
   const navigate = useNavigate();
+  const revalidator = useRevalidator();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -23,6 +24,7 @@ export function SignupPage() {
         password: String(formData.get("password") ?? ""),
       });
       startTransition(() => {
+        revalidator.revalidate();
         navigate("/trips");
       });
     } catch (error) {


### PR DESCRIPTION
Closes #1448

## Summary
- revalidate the root loader after login, signup, and logout session changes
- add auth-header coverage proving the header updates without a full reload

## Validation
- npm test -- src/App.test.tsx
- deliberate break: removed auth revalidation calls and confirmed src/App.test.tsx fails on stale header state
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/expanded React Testing Library + Vitest coverage for login, signup, and logout, asserting header changes, link visibility, session updates, and route navigation.
  * Added assertions that successful login/signup actions trigger route revalidation.

* **Improvements**
  * Enhanced auth flows to revalidate route data during sign-in/sign-up/sign-out transitions, improving consistency of the UI after session changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->