### PR TITLE
Label fallback map as route sketch

### DIFF
--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -227,13 +227,16 @@ describe("TripMap", () => {
   it("keeps provider diagnostics out of the normal traveler map", () => {
     renderTripMap();
 
+    expect(screen.getByRole("heading", { name: "Route sketch for Rail-first route" })).toBeInTheDocument();
     expect(screen.getByLabelText("Map view confidence")).toHaveTextContent(
       "Regional route review"
     );
     expect(screen.getByText("Schematic preview — not a live map")).toBeInTheDocument();
+    expect(screen.getByText("Route sketch mode")).toBeInTheDocument();
     expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Provider misconfigured/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Provider error/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: /route geometry overlay/i })).not.toBeInTheDocument();
   });
 
   it("labels the keyed provider surface as a schematic preview", () => {
@@ -242,10 +245,15 @@ describe("TripMap", () => {
 
     renderTripMap();
 
+    expect(screen.getByRole("heading", { name: "Map for Rail-first route" })).toBeInTheDocument();
     expect(screen.getByText("Schematic preview — not a live map")).toBeInTheDocument();
+    expect(screen.queryByText("Route sketch mode")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass(
       "map-route-google-maps-js"
     );
+    expect(
+      screen.getByRole("img", { name: "Route geometry overlay for Rail-first route" })
+    ).toBeInTheDocument();
     expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -169,11 +169,15 @@ function ActiveTripMap({
     mapSurface.routeSegments.find(
       (segment) => segment.id === mapSurface.workspaceView.selectedSegmentId
     ) ?? null;
+  const isFallbackSketch = mapSurface.provider.kind === "fallback";
+  const mapHeading = isFallbackSketch
+    ? `Route sketch for ${activeScenario.title}`
+    : `Map for ${activeScenario.title}`;
 
   return (
     <section className="status-card map-card">
       <p className="status-label">Trip map</p>
-      <h2>Map for {activeScenario.title}</h2>
+      <h2>{mapHeading}</h2>
       <p>{activeScenario.summary}</p>
       <div className="map-provider-banner" aria-label="Map view confidence">
         <span
@@ -247,6 +251,11 @@ function ActiveTripMap({
             <span className="map-preview-badge" aria-label={SCHEMATIC_PREVIEW_BADGE_TEXT}>
               {SCHEMATIC_PREVIEW_BADGE_TEXT}
             </span>
+            {isFallbackSketch ? (
+              <span className="map-preview-badge map-preview-badge-warning">
+                Route sketch mode
+              </span>
+            ) : null}
             <span>{mapSurface.visibleRouteSegments.length} shown segment(s)</span>
             <span>{mapSurface.visibleMarkers.length} shown marker(s)</span>
             {mapSurface.visibleFocusCues.length > 0 ? (

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1259,7 +1259,7 @@ describe("WorkspacePage", () => {
     const routeContextMap = screen.getByLabelText("Route context map");
 
     expect(screen.getAllByRole("heading", { name: "Kyoto base with Uji day trip" }).length).toBeGreaterThan(0);
-    expect(screen.getByRole("heading", { name: "Map for Kyoto base with Uji day trip" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Route sketch for Kyoto base with Uji day trip" })).toBeInTheDocument();
     expect(within(routeContextMap).getAllByText("Kyoto").length).toBeGreaterThan(0);
     expect(within(routeContextMap).getAllByText("Uji").length).toBeGreaterThan(0);
     expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
@@ -1903,7 +1903,7 @@ describe("WorkspacePage", () => {
     });
 
     expect(
-      screen.getByRole("heading", { name: "Map for Kyoto base with Uji day trip" })
+      screen.getByRole("heading", { name: "Route sketch for Kyoto base with Uji day trip" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("kyoto -> uji -> kyoto").length).toBeGreaterThan(0);
     expect(screen.getByText("93 / 100 planner score")).toBeInTheDocument();
@@ -1911,7 +1911,7 @@ describe("WorkspacePage", () => {
     await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
 
     expect(
-      screen.getByRole("heading", { name: "Map for Kyoto plus Osaka fallback" })
+      screen.getByRole("heading", { name: "Route sketch for Kyoto plus Osaka fallback" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("kyoto -> osaka -> kyoto").length).toBeGreaterThan(0);
     expect(screen.getByText("88 / 100 planner score")).toBeInTheDocument();
@@ -2003,7 +2003,7 @@ describe("WorkspacePage", () => {
     expect(screen.getAllByText("Moderate travel friction with a clear cultural center of gravity.").length).toBeGreaterThan(0);
     await user.click(screen.getByRole("button", { name: "Compare 2. Kyoto plus Osaka fallback" }));
     expect(
-      screen.getByRole("heading", { name: "Map for Kyoto plus Osaka fallback" })
+      screen.getByRole("heading", { name: "Route sketch for Kyoto plus Osaka fallback" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("Osaka rainy-day fallback").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Higher transfer load to preserve nightlife breadth.").length).toBeGreaterThan(0);
@@ -2295,7 +2295,7 @@ describe("WorkspacePage", () => {
     });
 
     expect(screen.queryByText(/needs at least an origin and destination/)).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Map for Kyoto base with Uji day trip" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Route sketch for Kyoto base with Uji day trip" })).toBeInTheDocument();
     expect(within(screen.getByLabelText("Route context map")).getAllByText("Kyoto").length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
Closes #1449

## Summary
- Retitle fallback map mode as a route sketch when no provider-backed map is available.
- Add a route-sketch badge to fallback mode while keeping the provider-backed route geometry path labelled as a map.
- Extend the TripMap test to assert fallback sketch treatment and provider SVG geometry.

## Validation
- npm_config_cache=/tmp/pd-workloop-npm-cache npm test -- src/components/maps/TripMap.test.tsx
- npm_config_cache=/tmp/pd-workloop-npm-cache npm run build
- git diff --check
- Deliberate break: temporarily restored the fallback heading to `Map for ...`; TripMap test failed on the route-sketch heading assertion, then the fix was restored and tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Map headings now dynamically update to display "Route sketch for..." instead of "Map for..." when operating in fallback sketch mode
  * New "Route sketch mode" warning indicator appears to provide clear visual feedback about the map's operational state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->