### PR TITLE
deps: sync dev tool versions

### DIFF
--- a/.github/workflows/autofix-versions.env
+++ b/.github/workflows/autofix-versions.env
@@ -5,11 +5,11 @@
 # Runtime dependencies (PyYAML, Pydantic, Hypothesis) should be managed via Dependabot
 # in each consumer repo's pyproject.toml directly, NOT synced from this file.
 BLACK_VERSION=26.5.1
-RUFF_VERSION=0.15.20
+RUFF_VERSION=0.15.22
 ISORT_VERSION=8.0.1
 DOCFORMATTER_VERSION=1.7.8
-MYPY_VERSION=2.1.0
+MYPY_VERSION=2.3.0
 PYTEST_VERSION=9.1.1
 PYTEST_COV_VERSION=7.1.0
 PYTEST_XDIST_VERSION=3.8.0
-COVERAGE_VERSION=7.15.1
+COVERAGE_VERSION=7.15.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ dependencies = [
 [project.optional-dependencies]
 app = []
 dev = [
-    "ruff==0.15.20",
-    "mypy>=2.1.0",
+    "ruff==0.15.22",
+    "mypy==2.3.0",
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "black>=26.5.1",
+    "black==26.5.1",
     "httpx==0.28.1",
     "PyYAML==6.0.3",
     "types-PyYAML==6.0.12.20260518",

--- a/requirements.lock
+++ b/requirements.lock
@@ -37,7 +37,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     #   click
     #   pytest
     #   tqdm
-coverage==7.15.1
+coverage==7.15.2
     # via pytest-cov
 distro==1.9.0
     # via
@@ -93,7 +93,7 @@ markupsafe==3.0.3
     # via
     #   mako
     #   werkzeug
-mypy==2.2.0
+mypy==2.3.0
     # via trip-planner (pyproject.toml)
 mypy-extensions==1.1.0
     # via
@@ -181,7 +181,7 @@ rpds-py==2026.6.3
     # via
     #   jsonschema
     #   referencing
-ruff==0.15.20
+ruff==0.15.22
     # via trip-planner (pyproject.toml)
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
## Dev Tool Version Sync

This PR updates dev tool versions in `pyproject.toml` and related generated dependency files to match the central version pins from [stranske/Workflows](https://github.com/stranske/Workflows).

### Changes
```
Found 6 version updates:
  - ruff: ==0.15.20 -> ==0.15.22
  - black: >=26.5.1 -> ==26.5.1
  - mypy: >=2.1.0 -> ==2.3.0
  - requirements.lock:coverage: 7.15.1 -> ==7.15.2
  - requirements.lock:mypy: 2.2.0 -> ==2.3.0
  - requirements.lock:ruff: 0.15.20 -> ==0.15.22

Run with --apply to update dependency files
```

### Why
Consistent dev tool versions across repos ensures:
- CI behaviors match between repos
- No surprises from version drift
- Easier debugging when tools behave the same everywhere

---
**Source:** `.github/workflows/autofix-versions.env`