### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/maint-76-claude-code-review.yml
+++ b/.github/workflows/maint-76-claude-code-review.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Run Claude Code Review
         id: claude
         continue-on-error: true
-        uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35 # v1
+        uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: '*'

--- a/tools/llm_registry.py
+++ b/tools/llm_registry.py
@@ -70,17 +70,26 @@ def normalize_provider(value: str | None) -> str | None:
     return None
 
 
-def _registry_path() -> Path:
-    configured = os.environ.get(ENV_MODEL_REGISTRY_CONFIG)
-    return Path(configured) if configured else DEFAULT_MODEL_REGISTRY_CONFIG_PATH
+def _configured_path(env_name: str, default: Path) -> Path | None:
+    configured = os.environ.get(env_name)
+    if configured is None:
+        return default
+    configured = configured.strip()
+    return Path(configured) if configured else None
 
 
-def _slot_path() -> Path:
-    configured = os.environ.get(ENV_SLOT_CONFIG)
-    return Path(configured) if configured else DEFAULT_SLOT_CONFIG_PATH
+def _registry_path() -> Path | None:
+    return _configured_path(ENV_MODEL_REGISTRY_CONFIG, DEFAULT_MODEL_REGISTRY_CONFIG_PATH)
 
 
-def _load_object(path: Path, *, label: str) -> dict[str, object] | None:
+def _slot_path() -> Path | None:
+    return _configured_path(ENV_SLOT_CONFIG, DEFAULT_SLOT_CONFIG_PATH)
+
+
+def _load_object(path: Path | None, *, label: str) -> dict[str, object] | None:
+    if path is None:
+        logger.warning("Cannot load %s: explicit configuration is empty", label)
+        return None
     if not path.is_file():
         return None
     try:
@@ -272,7 +281,7 @@ def configured_model_for_provider(
     # An explicit slot config is an execution allowlist, including when its
     # path is missing or malformed. Never broaden execution because a
     # configured allowlist cannot be read or does not contain this provider.
-    if os.environ.get(ENV_SLOT_CONFIG):
+    if ENV_SLOT_CONFIG in os.environ:
         configured_slots = load_slot_config()
         if not configured_slots:
             return ""
@@ -313,7 +322,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
     if payload is None:
         # An unreadable or missing explicitly configured slot file must fail
         # closed. Only an unconfigured default path permits default slots.
-        if os.environ.get(ENV_SLOT_CONFIG):
+        if ENV_SLOT_CONFIG in os.environ:
             return []
         return fallback_slots
 
@@ -327,7 +336,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
         ).strip()
         for entry in slot_entries
     ):
-        return [] if os.environ.get(ENV_SLOT_CONFIG) else fallback_slots
+        return [] if ENV_SLOT_CONFIG in os.environ else fallback_slots
 
     slots: list[SlotDefinition] = []
     fallback_by_provider = {slot.provider: slot for slot in fallback_slots}
@@ -359,7 +368,7 @@ def load_slot_config(*, github_default_model: str = "") -> list[SlotDefinition]:
             # A caller-supplied slot file is an allowlist and must fail closed.
             # The repository's bundled legacy file is advisory: ignore a stale
             # pin and retain the reviewed registry selection for that provider.
-            if os.environ.get(ENV_SLOT_CONFIG):
+            if ENV_SLOT_CONFIG in os.environ:
                 logger.warning(
                     "Skipping unresolved slot model pin %s/%s; reviewed %s selection is %s",
                     provider,
@@ -431,21 +440,6 @@ def resolve_slots(
     env_slot_prefix: str = "LANGCHAIN_SLOT",
 ) -> list[SlotDefinition]:
     slots = load_slot_config(github_default_model=github_default_model)
-    # Preserve LANGCHAIN_MODEL as an emergency bootstrap only when neither an
-    # explicit ENV_SLOT_CONFIG/LANGCHAIN_SLOT_CONFIG allowlist nor the bundled
-    # default slot file is available. Otherwise empty resolved slots fail closed.
-    if (
-        not slots
-        and not os.environ.get(ENV_SLOT_CONFIG)
-        and not _slot_path().exists()
-        and os.environ.get(env_model_name)
-    ):
-        slots = [
-            SlotDefinition(name=f"slot{index}", provider=provider, model="")
-            for index, provider in enumerate(
-                (PROVIDER_OPENAI, PROVIDER_ANTHROPIC, PROVIDER_GITHUB), start=1
-            )
-        ]
     return apply_slot_env_overrides(
         slots,
         env_model_name=env_model_name,


### PR DESCRIPTION
## Sync Summary

### Files Updated
- maint-76-claude-code-review.yml: Claude Code review (opt-in) - runs only on labeled PRs or manual dispatch
- llm_registry.py: LLM model registry helper - shared slot/model selection and blocked-model enforcement

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `405eeaa1273ed8545c79f7046bdbd797c20c4d89`
**Template hash:** `74048c0bb13f`
**Sync branch:** `sync/workflows-74048c0bb13f`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"405eeaa1273ed8545c79f7046bdbd797c20c4d89","template_hash":"74048c0bb13f","sync_branch":"sync/workflows-74048c0bb13f","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"29873788704","run_attempt":"1","changes_count":2} -->