### PR TITLE
chore: sync workflow templates

### DIFF
--- a/docs/MODEL_SELECTION_POLICY.md
+++ b/docs/MODEL_SELECTION_POLICY.md
@@ -64,6 +64,25 @@ records. Do not hand-enter aggregate rates or recommendation rankings.
 An approved evidence record uses `kind: workload-benchmark` and
 `status: passed`. The freshness gate rejects an approved decision without it.
 
+### Advisory vs. blocking findings
+
+`tools/check_model_registry_freshness.py` separates its findings into two
+classes, and by default only one of them fails the gate:
+
+- **Blocking (structural):** a malformed registry, a selection or slot that
+  points at an absent or blocked model, or an *approved* selection with no
+  passing workload-benchmark evidence. These mean work could be wrong, so they
+  fail the gate (exit 1).
+- **Advisory (cadence):** a review whose `review_by` date has simply passed
+  (`review_overdue`, `provisional_overdue`, `selection_review_overdue`). A due
+  review is not a danger signal — the provisional incumbents remain a valid
+  runtime baseline — so it never fails the default gate and never blocks
+  unrelated work. It is surfaced instead by the `maint-77` scheduled run, which
+  opens a non-blocking tracking issue.
+
+Pass `--strict` to fail on *any* finding (used where a PR itself edits model
+configuration and should be proven fresh before merging).
+
 ## Incumbents and Candidates
 
 The existing OpenAI, Anthropic, and GitHub Models verifier choices are recorded
@@ -71,6 +90,19 @@ as provisional incumbents. They remain the runtime baseline while the pilot is
 assembled and run; catalog discovery can add candidates but cannot change a
 selection. A replacement requires paired workload evidence that passes every
 quality gate and an explicit approval update.
+
+### Prepared promotions and rollbacks
+
+`tools/prepare_model_promotion.py` (run by `maint-86`) can *prepare* a selection
+change from a passing benchmark, but never applies one on its own. It only
+prepares a candidate that is the **same family** as the incumbent (e.g. openai
+`gpt-5.x`, anthropic `claude-<line>`), **passed every quality gate** (including
+paired non-inferiority), and costs **≤** the incumbent per accepted review.
+Cross-family swaps are never auto-prepared. It writes the registry mutation
+(recording the prior selection in `selection_history`) and opens a PR; merging
+that PR is the human approval this policy requires — `human_approval_required`
+stays true. The inverse path prepares a rollback to the prior selection when the
+active model shows a failed workload-benchmark (a quality-gate breach).
 
 ## Catalog Discovery
 

--- a/scripts/check_test_dependencies.sh
+++ b/scripts/check_test_dependencies.sh
@@ -131,11 +131,7 @@ if [ "$all_ok" = true ]; then
     echo -e "${GREEN}All required dependencies are available!${NC}"
     echo ""
     echo "You can run the full test suite with:"
-    if [ -x ./scripts/run_tests.sh ]; then
-        echo "  ./scripts/run_tests.sh"
-    else
-        echo "  python -m pytest"
-    fi
+    echo "  python -m pytest"
     exit 0
 else
     echo -e "${RED}Some required dependencies are missing!${NC}"

--- a/tools/check_model_registry_freshness.py
+++ b/tools/check_model_registry_freshness.py
@@ -30,6 +30,30 @@ DEFAULT_POLICY_PATH = _REPO_ROOT / "config" / "model_selection_policy.json"
 DEFAULT_MAX_AGE_DAYS = 30
 VALID_SELECTION_STATUSES = {"provisional", "approved"}
 
+# Time-cadence findings mean "a review is due", NOT "this work is dangerous".
+# They are advisory: reported and surfaced as a tracking issue, but they never
+# fail the gate (and so never block unrelated fleet-wide work). Only structural
+# findings — a malformed registry, an absent/blocked model, an APPROVED
+# selection with no passing evidence — indicate work could be wrong, and those
+# still block. Use --strict to fail on any finding (e.g. gating a PR that itself
+# edits model config).
+ADVISORY_FINDING_KINDS = frozenset(
+    {
+        "review_overdue",
+        "provisional_overdue",
+        "selection_review_overdue",
+    }
+)
+
+
+def partition_findings(
+    findings: list[dict[str, str]],
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Split findings into (blocking, advisory)."""
+    advisory = [f for f in findings if f.get("kind") in ADVISORY_FINDING_KINDS]
+    blocking = [f for f in findings if f.get("kind") not in ADVISORY_FINDING_KINDS]
+    return blocking, advisory
+
 
 def _normalize_provider(provider: str) -> str:
     normalized = (provider or "").strip().lower()
@@ -403,6 +427,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--max-age-days", type=int, default=DEFAULT_MAX_AGE_DAYS)
     parser.add_argument("--today", type=str, default=None)
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail (exit 1) on ANY finding, including advisory cadence findings.",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -421,15 +450,34 @@ def main(argv: list[str] | None = None) -> int:
         max_age_days=args.max_age_days,
         policy=policy,
     )
+    blocking, advisory = partition_findings(findings)
     if args.json:
-        print(json.dumps({"fresh": not findings, "findings": findings}, indent=2))
+        print(
+            json.dumps(
+                {
+                    "fresh": not findings,
+                    "ok": not blocking,
+                    "blocking": blocking,
+                    "advisory": advisory,
+                    "findings": findings,
+                },
+                indent=2,
+            )
+        )
     elif findings:
-        print(f"Model registry freshness: {len(findings)} finding(s):")
-        for finding in findings:
-            print(f"  [{finding['kind']}] {finding['detail']}")
+        print(f"Model registry freshness: {len(blocking)} blocking, {len(advisory)} advisory:")
+        for finding in blocking:
+            print(f"  [BLOCK] [{finding['kind']}] {finding['detail']}")
+        for finding in advisory:
+            print(f"  [advisory] [{finding['kind']}] {finding['detail']}")
     else:
         print("Model registry is fresh: decisions, evidence, and slots are consistent.")
-    return 1 if findings else 0
+
+    if args.strict:
+        return 1 if findings else 0
+    # Default: only structural/dangerous findings fail the gate. A merely-overdue
+    # review is advisory and must never block unrelated work.
+    return 1 if blocking else 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tools/requirements-llm.txt
+++ b/tools/requirements-llm.txt
@@ -9,7 +9,7 @@
 #   release resolve a mutually compatible core version.
 langchain==1.3.14
 langchain-community==0.4.2
-langchain-openai==1.4.1
-langchain-anthropic==1.5.2
+langchain-openai==1.3.5
+langchain-anthropic==1.4.8
 pydantic==2.13.4
 requests==2.34.2


### PR DESCRIPTION
## Sync Summary

### Files Updated
- requirements-llm.txt: Pinned LLM dependencies - exact-sync guarded for agent workflows
- check_test_dependencies.sh: Checks test dependencies match - required by reusable CI workflow
- check_model_registry_freshness.py: Model-registry freshness gate - validates dated decisions, evidence, lifecycle, and profile-based slots
- MODEL_SELECTION_POLICY.md: Auditable auxiliary-model evaluation, selection, and refresh policy

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `d362a6c6adcd1306de28d9b126a2d04d6faead0c`
**Template hash:** `2f4345e78a60`
**Sync branch:** `sync/workflows-2f4345e78a60`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"d362a6c6adcd1306de28d9b126a2d04d6faead0c","template_hash":"2f4345e78a60","sync_branch":"sync/workflows-2f4345e78a60","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"30190268037","run_attempt":"1","changes_count":4} -->