### PR TITLE
fix(ci): run frontend checks on Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
 

--- a/.github/workflows/cross-repo-smoke.yml
+++ b/.github/workflows/cross-repo-smoke.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'trip-planner/frontend/package-lock.json'
 

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'frontend/package-lock.json'
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "vitest": "^4.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Unblocks Renovate #1589 (jsdom 30), whose supported engines exclude the current Node 20 runtime. Aligns each repo-local frontend CI surface with Node 22 and records the matching package engine floor.\n\nValidation: `npm --prefix frontend test` (18 files, 114 tests passed); `git diff --check`. The standalone smoke command needs its CI-provisioned backend URL and was not treated as a code failure.