### PR TITLE
chore: sync workflow templates

### DIFF
--- a/config/model_registry.json
+++ b/config/model_registry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "2.0.0",
   "as_of": "2026-07-10",
-  "review_by": "2026-07-24",
+  "review_by": "2026-08-30",
   "purpose": "Auditable model facts and auxiliary judge/evaluator selections. Coding-worker execution profiles remain in .github/agents/registry.yml::execution_profiles.",
   "selection_policy": "config/model_selection_policy.json",
   "catalog_baselines": {
@@ -238,12 +238,47 @@
     {
       "profile": "verifier-balanced",
       "provider": "openai",
+      "model_id": "gpt-5.6-terra",
+      "status": "provisional",
+      "decided_at": "2026-07-31",
+      "review_by": "2026-08-30",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Provisional selection advanced to the current catalog generation; positioning 'balanced' matches the verifier-balanced profile. This is NOT a benchmark-proven promotion: no passing workload-benchmark evidence exists for this model or for the superseded incumbent, so status stays provisional until the paired pilot runs. Human-approved by merging this PR."
+    },
+    {
+      "profile": "verifier-balanced",
+      "provider": "anthropic",
+      "model_id": "claude-sonnet-5",
+      "status": "provisional",
+      "decided_at": "2026-07-31",
+      "review_by": "2026-08-30",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Provisional selection advanced to the current catalog generation; positioning 'balanced' matches the verifier-balanced profile. Cross-family relative to the superseded claude-opus incumbent, so it was human-initiated rather than auto-prepared. This is NOT a benchmark-proven promotion: no passing workload-benchmark evidence exists for this model or the incumbent, so status stays provisional until the paired pilot runs. Human-approved by merging this PR."
+    },
+    {
+      "profile": "verifier-balanced",
+      "provider": "github-models",
+      "model_id": "openai/gpt-5",
+      "status": "provisional",
+      "decided_at": "2026-07-31",
+      "review_by": "2026-08-30",
+      "evidence_ids": ["catalog-review-2026-07-10"],
+      "rationale": "Provisional catalog fallback advanced to a model confirmed present in the 2026-07-10 GitHub Models catalog baseline. This is NOT a benchmark-proven promotion: no passing workload-benchmark evidence exists for this model or the superseded codex-mini-latest, so status stays provisional until the paired pilot runs. Human-approved by merging this PR."
+    }
+  ],
+  "selection_history": [
+    {
+      "profile": "verifier-balanced",
+      "provider": "openai",
       "model_id": "gpt-5.4",
       "status": "provisional",
       "decided_at": "2026-07-10",
       "review_by": "2026-07-24",
       "evidence_ids": ["catalog-review-2026-07-10"],
-      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate."
+      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate.",
+      "superseded_at": "2026-07-31",
+      "superseded_by": "gpt-5.6-terra",
+      "supersede_reason": "Manual provisional refresh to the current catalog generation; not a benchmark-proven promotion."
     },
     {
       "profile": "verifier-balanced",
@@ -253,7 +288,10 @@
       "decided_at": "2026-07-10",
       "review_by": "2026-07-24",
       "evidence_ids": ["catalog-review-2026-07-10"],
-      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate."
+      "rationale": "Incumbent baseline retained until a paired repository benchmark proves a replacement meets every quality gate.",
+      "superseded_at": "2026-07-31",
+      "superseded_by": "claude-sonnet-5",
+      "supersede_reason": "Manual provisional refresh to the current catalog generation; not a benchmark-proven promotion."
     },
     {
       "profile": "verifier-balanced",
@@ -263,7 +301,10 @@
       "decided_at": "2026-07-10",
       "review_by": "2026-07-24",
       "evidence_ids": ["catalog-review-2026-07-10"],
-      "rationale": "Incumbent fallback retained until catalog availability and paired repository evidence approve a replacement."
+      "rationale": "Incumbent fallback retained until catalog availability and paired repository evidence approve a replacement.",
+      "superseded_at": "2026-07-31",
+      "superseded_by": "openai/gpt-5",
+      "supersede_reason": "Manual provisional refresh to the current catalog generation; not a benchmark-proven promotion."
     }
   ],
   "evidence": [

--- a/config/model_selection_policy.json
+++ b/config/model_selection_policy.json
@@ -18,6 +18,12 @@
       "approval_stage": {
         "minimum_adjudicated_cases": 75,
         "minimum_cases_per_category": 10,
+        "minimum_cases_per_category_overrides": {
+          "stale-verifier-claim": 1,
+          "review-thread-debt": 1,
+          "missing-acceptance-criterion": 1
+        },
+        "minimum_cases_per_category_overrides_note": "These three categories cannot be labelled from realized downstream outcomes, so tools/harvest_verifier_corpus.py never produces them and they remain owner-sourced. Holding them to the machine-harvestable floor of 10 made `approved` unreachable without ~22 hand-labelled cases, so for them the floor asserts REPRESENTATION (at least one adjudicated example of the failure mode) rather than statistical power. The statistical gates (false-pass/false-fail/schema-error Wilson bounds, paired non-inferiority) still run over the whole corpus, and minimum_adjudicated_cases=75 still applies. Raise these toward 10 as owner-labelled cases accumulate. See #2819.",
         "confidence_level": 0.95,
         "quality_gates": {
           "task_success_rate_wilson_lower_bound": 0.85,

--- a/docs/MODEL_SELECTION_POLICY.md
+++ b/docs/MODEL_SELECTION_POLICY.md
@@ -4,7 +4,7 @@
 > `config/llm_slots.json`
 > **Policy version:** `auxiliary-verifier-model-selection-v1`
 > **Reviewed:** 2026-07-10
-> **Next decision review:** 2026-07-24
+> **Next decision review:** 2026-08-30
 
 ## Decision Principle
 
@@ -51,7 +51,15 @@ records. Do not hand-enter aggregate rates or recommendation rankings.
 - Use a frozen, versioned corpus with owner-adjudicated expected outcomes.
 - Run every candidate and baseline on the same cases and prompt version.
 - Use at least 30 cases to retain a candidate and at least 75 cases, with 10 per
-  required failure category, to approve it.
+  required failure category, to approve it. Categories that cannot be labelled
+  from realized downstream outcomes — `stale-verifier-claim`,
+  `review-thread-debt`, `missing-acceptance-criterion` — are exempted from the
+  10-case floor via `approval_stage.minimum_cases_per_category_overrides` and
+  need only be *represented* (≥1 adjudicated case). `tools/harvest_verifier_corpus.py`
+  can never produce them, so holding them to the machine-harvestable floor made
+  approval unreachable without hand-labelling roughly 22 cases. The 75-case total
+  and every statistical gate still apply to the whole corpus; raise these floors
+  toward 10 as owner-labelled cases accumulate. See issue #2819.
 - Report Wilson 95% confidence intervals for task success, false PASS, false
   FAIL, and schema errors.
 - Require the configured bounds and a paired success result no more than two

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -153,6 +153,29 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     required_categories = profile_policy["candidate_stage"]["required_case_categories"]
     minimum_cases = int(approval["minimum_adjudicated_cases"])
     minimum_per_category = int(approval["minimum_cases_per_category"])
+    # Per-category floors may be overridden. Categories that cannot be labelled
+    # from realized outcomes (see tools/harvest_verifier_corpus.py) can never be
+    # grown by the harvester, so holding them to the machine-harvestable floor
+    # made `approved` unreachable without hand-labelling. See #2819.
+    raw_overrides = approval.get("minimum_cases_per_category_overrides") or {}
+    if not isinstance(raw_overrides, dict):
+        raise ValueError("approval_stage.minimum_cases_per_category_overrides must be an object")
+    category_floors: dict[str, int] = {}
+    for category in required_categories:
+        floor = raw_overrides.get(category, minimum_per_category)
+        floor = int(floor)
+        if floor < 1:
+            raise ValueError(
+                "minimum_cases_per_category_overrides values must be >= 1 "
+                f"(got {floor} for {category!r}); every required category must be represented"
+            )
+        category_floors[category] = floor
+    unknown_overrides = sorted(set(raw_overrides) - set(required_categories))
+    if unknown_overrides:
+        raise ValueError(
+            "minimum_cases_per_category_overrides names categories that are not "
+            f"required: {unknown_overrides}"
+        )
     noninferiority_margin = float(gates["paired_success_noninferiority_margin"])
 
     for candidate in candidates:
@@ -161,8 +184,8 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
         gate_results = {
             "minimum_adjudicated_cases": metrics["sample_count"] >= minimum_cases,
             "minimum_cases_per_category": all(
-                metrics["category_counts"].get(category, 0) >= minimum_per_category
-                for category in required_categories
+                metrics["category_counts"].get(category, 0) >= floor
+                for category, floor in category_floors.items()
             ),
             "task_success_rate_wilson_lower_bound": metrics["task_success_rate_wilson_lower_bound"]
             >= float(gates["task_success_rate_wilson_lower_bound"]),


### PR DESCRIPTION
## Sync Summary

### Files Updated
- evaluate_model_benchmark.py: Deterministic paired model benchmark evaluator - computes confidence-bound quality gates and cost/latency ranking
- MODEL_SELECTION_POLICY.md: Auditable auxiliary-model evaluation, selection, and refresh policy
- model_registry.json: Model registry - available LLM models and their capabilities
- model_selection_policy.json: Model selection policy - benchmark gates, measurements, optimization order, and review triggers

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `a84a5582adb3d08b583486883bf6eaa58dcbff61`
**Template hash:** `a6fbe5c668a4`
**Sync branch:** `sync/workflows-a6fbe5c668a4`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"a84a5582adb3d08b583486883bf6eaa58dcbff61","template_hash":"a6fbe5c668a4","sync_branch":"sync/workflows-a6fbe5c668a4","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"30702700358","run_attempt":"1","changes_count":4} -->