### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/verifier_verdict_json.py
+++ b/.github/scripts/verifier_verdict_json.py
@@ -79,11 +79,17 @@ def build_verdict(output: str) -> dict[str, Any]:
         verdict = _normalize_verdict(candidate.get("verdict"))
         if not verdict:
             continue
+        candidate_needs_attention = candidate.get("needs_attention")
+        needs_attention = (
+            candidate_needs_attention
+            if isinstance(candidate_needs_attention, bool)
+            else verdict != "pass"
+        )
         return {
             **candidate,
             "verdict": verdict,
             "source": "structured-json",
-            "needs_attention": bool(candidate.get("needs_attention", verdict != "pass")),
+            "needs_attention": needs_attention,
         }
 
     return {

--- a/scripts/check_deliberate_break.py
+++ b/scripts/check_deliberate_break.py
@@ -279,6 +279,15 @@ def verify_spec(
             command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
             timeout=exc.timeout,
         )
+    except subprocess.CalledProcessError as exc:
+        return _json_result(
+            VERDICT_BROKEN,
+            reason="tamper-check-failed",
+            command=list(exc.cmd) if isinstance(exc.cmd, (tuple, list)) else str(exc.cmd),
+            returncode=exc.returncode,
+            stdout=exc.stdout,
+            stderr=exc.stderr,
+        )
 
     try:
         _ensure_pytest_runtime_deps()

--- a/tools/evaluate_model_benchmark.py
+++ b/tools/evaluate_model_benchmark.py
@@ -157,7 +157,9 @@ def evaluate_benchmark(payload: dict[str, Any], policy: dict[str, Any]) -> dict[
     # from realized outcomes (see tools/harvest_verifier_corpus.py) can never be
     # grown by the harvester, so holding them to the machine-harvestable floor
     # made `approved` unreachable without hand-labelling. See #2819.
-    raw_overrides = approval.get("minimum_cases_per_category_overrides") or {}
+    raw_overrides = approval.get("minimum_cases_per_category_overrides")
+    if raw_overrides is None:
+        raw_overrides = {}
     if not isinstance(raw_overrides, dict):
         raise ValueError("approval_stage.minimum_cases_per_category_overrides must be an object")
     category_floors: dict[str, int] = {}


### PR DESCRIPTION
## Sync Summary

### Files Updated
- check_deliberate_break.py: Opt-in Gate helper that proves named deliberate-break acceptance tests fail against the base implementation
- verifier_verdict_json.py: Extracts structured post-merge verifier verdict JSON without trusting diff text
- evaluate_model_benchmark.py: Deterministic paired model benchmark evaluator - computes confidence-bound quality gates and cost/latency ranking

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `e92136d61e5d96a0e774181a317aa6c5c60f0d1c`
**Template hash:** `ee152fd2c1f5`
**Consumer-sync plan ID:** `sha256:ee152fd2c1f59e836833e522cfeda62dab23f129a0ab9b263e58cc3bfc8f05d4`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-ee152fd2c1f5`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"e92136d61e5d96a0e774181a317aa6c5c60f0d1c","template_hash":"ee152fd2c1f5","plan_id":"sha256:ee152fd2c1f59e836833e522cfeda62dab23f129a0ab9b263e58cc3bfc8f05d4","sync_phase":"canary","sync_branch":"sync/workflows-ee152fd2c1f5","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"30873237711","run_attempt":"1","changes_count":3} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:ee152fd2c1f59e836833e522cfeda62dab23f129a0ab9b263e58cc3bfc8f05d4","generation":"ee152fd2c1f5","repository":"stranske/trip-planner","desired_tree_hash":"a73be02931dd5129de72d7eb531b2d5af89dd4cc","source_commit":"e92136d61e5d96a0e774181a317aa6c5c60f0d1c","lease_expires_at":"2026-08-07T02:58:17Z","predecessor_prs":[],"successor_prs":[]} -->