### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/scripts/issue_format.py
+++ b/.github/scripts/issue_format.py
@@ -38,8 +38,8 @@ cosmetic. Without it a body whose ONLY "Tasks" and "Acceptance Criteria" lines
 sit inside a ```bash fence validates as conforming — a false negative that lets
 an unactionable issue through the guard. Well-written issues quote commands and
 expected output in fences constantly, so this is the common case, not an edge
-one. Any change to heading detection must keep a fenced-heading case in
-tests/scripts/test_issue_format.py.
+one. Any change to heading detection must keep a fenced-heading case in the
+upstream Workflows test `tests/scripts/test_issue_format.py`.
 
 Pure stdlib on purpose — it must run on a bare runner with no install step.
 """
@@ -83,7 +83,14 @@ def _headings(body: str) -> list[tuple[str, int, int]]:
             marker = fence_match.group(1)
             if fence is None:
                 fence = (marker[0], len(marker))
-            elif marker[0] == fence[0] and len(marker) >= fence[1]:
+            elif (
+                marker[0] == fence[0]
+                and len(marker) >= fence[1]
+                and re.fullmatch(
+                    rf"\s{{0,3}}(?:`{{{fence[1]},}}|~{{{fence[1]},}})\s*",
+                    line,
+                )
+            ):
                 fence = None
             continue
         if fence is not None:
@@ -96,7 +103,7 @@ def _headings(body: str) -> list[tuple[str, int, int]]:
 
 def _find(body: str, aliases: tuple[str, ...]) -> int | None:
     for text, idx, _ in _headings(body):
-        if text in aliases:
+        if any(text == alias or text.startswith(f"{alias} (") for alias in aliases):
             return idx
     return None
 

--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -76,10 +76,9 @@ jobs:
             exit "$rc"
           fi
 
-      - name: Invalidate stale format completion after an invalid edit
+      - name: Invalidate stale format completion after an invalid issue change
         if: >-
-          steps.issue.outputs.exempt != 'true' && github.event.action == 'edited' &&
-          steps.validate.outputs.rc == '1'
+          steps.issue.outputs.exempt != 'true' && steps.validate.outputs.rc == '1'
         env:
           GH_TOKEN: ${{ github.token }}
           NUMBER: ${{ steps.issue.outputs.number }}
@@ -87,8 +86,11 @@ jobs:
           set -euo pipefail
           if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
               --jq '.labels[].name' | grep -qx 'agents:formatted'; then
-            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"
-            echo "Invalid issue edit — cleared agents:formatted before rerouting."
+            if gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:formatted"; then
+              echo "Invalid issue body — cleared agents:formatted before rerouting."
+            else
+              echo "::warning::could not remove stale agents:formatted"
+            fi
           fi
 
       - name: Route non-conforming issue to the optimizer


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- issue_format.py: Pure-stdlib validator for AGENT_ISSUE_FORMAT compliance. Single fleet definition of agent-processable; used by agents-issue-format-guard.yml and callable directly by local filers to pre-flight before gh issue create (non-zero exit = unfit). Do not fork per repo.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `1e9ad1e59df0e939966de0b97a0769d62899587c`
**Template hash:** `d8ad9cb0a4e8`
**Consumer-sync plan ID:** `sha256:d8ad9cb0a4e803f6de8830403aad87be700b94eae98c54bbf3a2b91f6de84a57`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-d8ad9cb0a4e8`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"1e9ad1e59df0e939966de0b97a0769d62899587c","template_hash":"d8ad9cb0a4e8","plan_id":"sha256:d8ad9cb0a4e803f6de8830403aad87be700b94eae98c54bbf3a2b91f6de84a57","sync_phase":"canary","sync_branch":"sync/workflows-d8ad9cb0a4e8","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31175127441","run_attempt":"1","changes_count":2} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:d8ad9cb0a4e803f6de8830403aad87be700b94eae98c54bbf3a2b91f6de84a57","generation":"d8ad9cb0a4e8","repository":"stranske/trip-planner","desired_tree_hash":"01a3746c850030258658bb2e6c7eef414acc9115","source_commit":"1e9ad1e59df0e939966de0b97a0769d62899587c","lease_expires_at":"2026-08-10T11:42:55Z","predecessor_prs":[],"successor_prs":[]} -->