### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -62,19 +62,29 @@ jobs:
         if: steps.issue.outputs.exempt != 'true'
         run: |
           set +e
+          report_file="$(mktemp)"
+          error_file="$(mktemp)"
+          trap 'rm -f "$report_file" "$error_file"' EXIT
           if [[ ! -f .github/scripts/issue_format.py ]]; then
             echo "validator absent — skipping while this repo is mid-sync"
             echo "rc=skip" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 .github/scripts/issue_format.py body.md > report.md
+          python3 .github/scripts/issue_format.py body.md > "$report_file" 2> "$error_file"
           rc=$?
           set -e
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
-          cat report.md || true
+          cat "$report_file" || true
+          if [[ "$rc" -eq 1 && -s "$error_file" ]]; then
+            echo "::error::issue-format validator failed unexpectedly"
+            cat "$error_file" >&2
+            exit 1
+          fi
           if [[ "$rc" -ne 0 && "$rc" -ne 1 ]]; then
+            cat "$error_file" >&2
             exit "$rc"
           fi
+          cp "$report_file" report.md
 
       - name: Invalidate stale format completion after an invalid issue change
         if: >-


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `e95cc4712065c1cdeffc411112cf6219e010e3a0`
**Template hash:** `ff0125177aea`
**Consumer-sync plan ID:** `sha256:ff0125177aeaac7238fce37eb948715092c3c1bfc2ce2ca489aa5fc1ae829f61`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-ff0125177aea`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"e95cc4712065c1cdeffc411112cf6219e010e3a0","template_hash":"ff0125177aea","plan_id":"sha256:ff0125177aeaac7238fce37eb948715092c3c1bfc2ce2ca489aa5fc1ae829f61","sync_phase":"canary","sync_branch":"sync/workflows-ff0125177aea","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31227220104","run_attempt":"1","changes_count":1} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:ff0125177aeaac7238fce37eb948715092c3c1bfc2ce2ca489aa5fc1ae829f61","generation":"ff0125177aea","repository":"stranske/trip-planner","desired_tree_hash":"3640889c5478a146422a95b19e16907cb5e6d0a4","source_commit":"e95cc4712065c1cdeffc411112cf6219e010e3a0","lease_expires_at":"2026-08-10T23:29:17Z","predecessor_prs":[],"successor_prs":[]} -->