### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/workflows/agents-issue-format-guard.yml
+++ b/.github/workflows/agents-issue-format-guard.yml
@@ -141,7 +141,7 @@ jobs:
           if [[ "$live_rc" -ne 1 || -s "$error_file" ]]; then
             echo "::error::issue-format validator failed unexpectedly during label revalidation"
             cat "$error_file" >&2
-            exit "$live_rc"
+            exit 1
           fi
           if gh issue view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json labels \
               --jq '.labels[].name' | grep -qx 'agents:formatted'; then
@@ -254,10 +254,14 @@ jobs:
           if [[ "$format_guard_attempts" -ge "$max_format_guard_attempts" ]]; then
             echo "Format guard exhausted $format_guard_attempts optimizer attempts; pausing issue."
             gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" \
-              --add-label "agents:auto-pilot-pause" --remove-label "agents:format"
-            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body \
-              "<!-- format-guard:attempt-cap -->
-              Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying."
+              --add-label "agents:auto-pilot-pause" \
+              || echo "::warning::could not apply agents:auto-pilot-pause"
+            gh issue edit "$NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "agents:format" \
+              || echo "::warning::could not release agents:format after attempt cap"
+            gh issue comment "$NUMBER" --repo "$GITHUB_REPOSITORY" --body-file - <<EOF
+          <!-- format-guard:attempt-cap -->
+          Automated formatting stopped after $format_guard_attempts optimizer attempts. Fix the issue body manually, then remove agents:auto-pilot-pause before retrying.
+          EOF
             exit 0
           fi
           has_format_label=false

--- a/.github/workflows/agents-issue-optimizer.yml
+++ b/.github/workflows/agents-issue-optimizer.yml
@@ -5,8 +5,7 @@ name: Agents Issue Optimizer
 # nothing and reported 0 for an issue it was re-running every minute. Pin the issue
 # number into the run name so both trigger types are correlatable.
 run-name: >-
-  Agents Issue Optimizer #${{
-  github.event.issue.number || inputs.issue_number }}
+  Agents Issue Optimizer #${{ github.event.issue.number || github.event.inputs.issue_number }}
 
 on:
   issues:
@@ -585,10 +584,14 @@ jobs:
           fi
 
       - name: Release failed format lease
-        if: (failure() || cancelled()) && steps.check.outputs.should_run == 'true' && steps.check.outputs.phase == 'format'
+        if: >-
+          (failure() || cancelled()) &&
+          (steps.check.outputs.phase == 'format' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.phase == 'format') ||
+          (github.event_name == 'issues' && github.event.label.name == 'agents:format'))
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
-          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number }}
+          ISSUE_NUMBER: ${{ steps.check.outputs.issue_number || github.event.inputs.issue_number || github.event.issue.number }}
         run: |
           set -euo pipefail
           # A guard retry may proceed only after the failed format run releases its lease.

--- a/scripts/langchain/issue_formatter.py
+++ b/scripts/langchain/issue_formatter.py
@@ -10,10 +10,12 @@ Run with:
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import re
 import sys
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +47,20 @@ except ImportError:  # pragma: no cover - fallback for direct invocation
 # Maximum issue body size to prevent OpenAI rate limit errors (30k TPM limit)
 # ~4 chars per token, so 50k chars ≈ 12.5k tokens, leaving headroom for prompt + output
 MAX_ISSUE_BODY_SIZE = 50000
+
+
+@lru_cache(maxsize=1)
+def _issue_format_validator() -> Any:
+    """Load the fleet's single issue-format definition without forking it."""
+    validator_path = Path(__file__).resolve().parents[2] / ".github/scripts/issue_format.py"
+    spec = importlib.util.spec_from_file_location("_fleet_issue_format", validator_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - repository invariant
+        raise RuntimeError(f"Cannot load canonical issue-format validator: {validator_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
 
 # Workflow tags written into the reuse marker. Tagging every stage of the
 # auto-pilot format -> optimize -> apply chain lets any stage detect a body it (or
@@ -151,6 +167,7 @@ SECTION_TITLES = {
 
 LIST_ITEM_REGEX = re.compile(r"^(\s*)([-*+]|\d+[.)]|[A-Za-z][.)])\s+(.*)$")
 CHECKBOX_REGEX = re.compile(r"^\[([ xX])\]\s*(.*)$")
+VERIFY_HINT_REGEX = re.compile(r"\(verify:\s*([^\n)]+)\)", re.IGNORECASE)
 
 
 def _context_token_budget() -> int:
@@ -355,6 +372,22 @@ def _format_issue_fallback(issue_body: str) -> str:
     impl_text = join_or_placeholder(impl_lines, "_Not provided._")
     tasks_text = join_or_placeholder(tasks_lines, "- [ ] _Not provided._")
     acceptance_text = join_or_placeholder(acceptance_lines, "- [ ] _Not provided._")
+    try:
+        validator = _issue_format_validator()
+    except (ImportError, OSError, RuntimeError, SyntaxError):
+        # Consumer checkouts can be mid-sync or missing the canonical validator.
+        # Keep the pre-validator fallback usable instead of failing the formatter.
+        validator = None
+    if validator is not None and not validator.GATE.search(acceptance_text):
+        verify_hint = VERIFY_HINT_REGEX.search(tasks_text)
+        if verify_hint:
+            command = verify_hint.group(1).strip().strip("`")
+            if command.startswith("pytest "):
+                command = f"python3 -m {command}"
+            acceptance_text = (
+                f"{acceptance_text}\n"
+                f"- [ ] Run `{command}` and capture the command output in PR validation evidence."
+            )
 
     parts = [
         "## Why",
@@ -387,8 +420,12 @@ def _format_issue_fallback(issue_body: str) -> str:
 def _formatted_output_valid(text: str) -> bool:
     if not text:
         return False
-    required = ["## Tasks", "## Acceptance Criteria"]
-    return all(section in text for section in required)
+    try:
+        return bool(_issue_format_validator().validate(text).ok)
+    except (ImportError, OSError, RuntimeError, SyntaxError):
+        # Preserve the former heading-only behavior until the copy-synced
+        # validator becomes available again.
+        return all(section in text for section in ("## Tasks", "## Acceptance Criteria"))
 
 
 def _select_code_fence(text: str) -> str:
@@ -398,12 +435,10 @@ def _select_code_fence(text: str) -> str:
 
 
 ORIGINAL_ISSUE_SUMMARY = "<summary>Original Issue</summary>"
-# Matches an Original-Issue <details> block (and trailing whitespace) so it can
-# be replaced rather than nested. Non-greedy body, anchored to the closing tag.
-_ORIGINAL_ISSUE_BLOCK_RE = re.compile(
-    r"<details>\s*<summary>Original Issue</summary>.*?</details>[ \t]*\n?",
-    re.DOTALL | re.IGNORECASE,
+_ORIGINAL_ISSUE_OPEN_RE = re.compile(
+    r"<details\b[^>]*>\s*<summary>Original Issue</summary>", re.IGNORECASE
 )
+_DETAILS_TAG_RE = re.compile(r"</?details\b[^>]*>", re.IGNORECASE)
 # Captures the verbatim text fenced inside an Original-Issue block, so an
 # already-embedded original can be recovered (and re-embedded once) instead of
 # being wrapped again.
@@ -415,8 +450,25 @@ _ORIGINAL_ISSUE_INNER_RE = re.compile(
 
 
 def _strip_original_issue_blocks(text: str) -> str:
-    """Remove any embedded Original-Issue <details> block(s) from ``text``."""
-    return _ORIGINAL_ISSUE_BLOCK_RE.sub("", text).rstrip()
+    """Remove complete embedded Original-Issue blocks, including nested details."""
+    kept: list[str] = []
+    cursor = 0
+    while match := _ORIGINAL_ISSUE_OPEN_RE.search(text, cursor):
+        kept.append(text[cursor : match.start()])
+        depth = 1
+        end = match.end()
+        for tag in _DETAILS_TAG_RE.finditer(text, match.end()):
+            depth += -1 if tag.group(0).startswith("</") else 1
+            if depth == 0:
+                end = tag.end()
+                break
+        else:
+            # Leave malformed markup intact rather than silently discarding it.
+            kept.append(text[match.start() :])
+            return "".join(kept).rstrip()
+        cursor = end
+    kept.append(text[cursor:])
+    return "".join(kept).rstrip()
 
 
 def _innermost_original_issue(text: str) -> str | None:
@@ -705,6 +757,7 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
                 pass
 
     formatted = _format_issue_fallback(issue_body)
+    needs_refinement = not _formatted_output_valid(formatted)
     # NOTE: Task decomposition is now handled by agents:optimize step
     # which uses LLM for intelligent splitting. Don't do heuristic
     # splitting here - it causes task explosion (issue #805, #1143).
@@ -716,6 +769,7 @@ def format_issue_body(issue_body: str, *, use_llm: bool = True) -> dict[str, Any
         "provider_used": None,
         "used_llm": False,
         "validation_audit": audit,
+        "needs_refinement": needs_refinement,
     }
 
 


### PR DESCRIPTION
## Sync Summary

### Files Updated
- agents-issue-optimizer.yml: Issue optimizer - LangChain-based issue formatting and optimization (Phase 1)
- agents-issue-format-guard.yml: Issue format guard - validates issues on open/edit/reopen, hold/exemption-label changes, and manual dispatch against AGENT_ISSUE_FORMAT, while durable/wontfix and bot issues remain exempt. Pause and needs-human labels hold dispatch. Any invalid non-exempt issue change on those triggers clears stale agents:formatted state, and hold removal revalidates on resume. Non-conforming unheld work gets agents:format so the optimizer repairs it. Requires .github/scripts/issue_format.py.
- issue_formatter.py: Issue formatter - converts raw text to AGENT_ISSUE_TEMPLATE format

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- renovate.json: File exists and sync_mode is create_only
- cross-repo-smoke.yml: File exists and sync_mode is create_only
- .github/scripts/package.json: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/minimatch: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/brace-expansion: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- .github/scripts/node_modules/balanced-match: Repo installs .github/scripts dependencies from package-lock.json and forbids tracked node_modules
- llm_slots.json: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Source SHA:** `9b73905c80bf08b5aa7c07b6daf18a3e8486e1ca`
**Template hash:** `a63626ce7ac3`
**Consumer-sync plan ID:** `sha256:a63626ce7ac3198e2c5fbc0bf664687a4f0d7ec73fd7741a19511b49cc2e6688`
**Sync phase:** `canary`
**Sync branch:** `sync/workflows-a63626ce7ac3`
**Consumer repo:** `stranske/trip-planner`
**Manifest:** `.github/sync-manifest.yml`

<!-- workflows-consumer-sync:v1 {"schema":"workflows-consumer-sync-pr/v1","consumer_repo":"stranske/trip-planner","source_repository":"stranske/Workflows","source_sha":"9b73905c80bf08b5aa7c07b6daf18a3e8486e1ca","template_hash":"a63626ce7ac3","plan_id":"sha256:a63626ce7ac3198e2c5fbc0bf664687a4f0d7ec73fd7741a19511b49cc2e6688","sync_phase":"canary","sync_branch":"sync/workflows-a63626ce7ac3","manifest":".github/sync-manifest.yml","lifecycle_state":"opened","run_id":"31293105846","run_attempt":"1","changes_count":3} -->
<!-- sync-pr-delivery-record:v1 {"schema":"sync-pr-delivery-record/v1","durable_issue_url":"https://github.com/stranske/Workflows/issues/1836","plan_id":"sha256:a63626ce7ac3198e2c5fbc0bf664687a4f0d7ec73fd7741a19511b49cc2e6688","generation":"a63626ce7ac3","repository":"stranske/trip-planner","desired_tree_hash":"e25d74c3bf8915c81fd97a7434a7d9118123cb37","source_commit":"9b73905c80bf08b5aa7c07b6daf18a3e8486e1ca","lease_expires_at":"2026-08-12T03:46:57Z","predecessor_prs":[],"successor_prs":[]} -->