### PR TITLE
fix(policy): preserve TPP policy verdicts

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,0 +1,16 @@
+{
+  "agent": "codex",
+  "cli_version": "0.144.1",
+  "emitted_at": "2026-08-11T15:05:57.810320Z",
+  "execution_profile": "codex-default",
+  "fallback_models": [
+    "gpt-5.5"
+  ],
+  "operation_role": "worker",
+  "pr_number": "1682",
+  "requested_model": "gpt-5.6-terra",
+  "runner": "reusable-codex-run",
+  "schema": "langsmith-fleet/v1",
+  "selected_model": "gpt-5.6-terra",
+  "selection_reason": "input"
+}

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -254,6 +254,55 @@ def test_workspace_policy_invalid_persisted_blocking_issue_is_unavailable(
     assert payload["summary"]["status"] == "policy_state_invalid"
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "expected_error"),
+    [
+        (
+            "blocking_issues",
+            False,
+            "organization_context.blocking_issues must be provided as a list",
+        ),
+        (
+            "compatible_with_planner_cache",
+            "false",
+            "compatible_with_planner_cache must be a boolean",
+        ),
+    ],
+)
+def test_workspace_policy_invalid_persisted_context_is_unavailable(
+    client: TestClient, field: str, value: object, expected_error: str
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Invalid stored policy context",
+            "summary": "Reject malformed persisted policy fields.",
+            "mode": "business",
+            "trip_frame": {"duration_days": 2, "primary_regions": ["Chicago"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = _load_fixture("standard_policy_sync.json")
+    imported = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={"request": fixture["request"], "response": fixture["response"]},
+    )
+    assert imported.status_code == 200
+
+    with get_session_factory()() as db_session:
+        state = db_session.get(PersistedPolicyState, f"policy-state:{trip_id}")
+        assert state is not None
+        state.organization_context = {**state.organization_context, field: value}
+        db_session.commit()
+
+    response = client.get(f"/api/workspace/{trip_id}/policy")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["policy_evaluation"]["status"] == "policy_unavailable"
+    assert payload["summary"]["validation_error"] == expected_error
+
+
 def test_workspace_policy_import_preserves_cached_state_when_tpp_rejects_cache(
     client: TestClient,
 ) -> None:

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -11,7 +11,8 @@ from trip_planner.app.main import create_app
 from trip_planner.app.services.auth import AuthenticatedUser
 from trip_planner.app.services.policy import _tpp_trip_plan_payload
 from trip_planner.integrations.tpp import client as tpp_client_module
-from trip_planner.persistence.db import reset_database_state
+from trip_planner.persistence.db import get_session_factory, reset_database_state
+from trip_planner.persistence.models.policy import PersistedPolicyState
 from trip_planner.persistence.models.trip import PersistedTrip
 
 
@@ -196,6 +197,61 @@ def test_workspace_policy_import_maps_tpp_failure_to_blocking_reasons(client: Te
         "severity": "blocking",
         "related_category": "policy_sync",
     }
+
+
+def test_workspace_policy_invalid_persisted_blocking_issue_is_unavailable(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Invalid stored policy",
+            "summary": "Keep malformed persisted policy details visible.",
+            "mode": "business",
+            "trip_frame": {"duration_days": 2, "primary_regions": ["Chicago"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = _load_fixture("standard_policy_sync.json")
+    imported = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={"request": fixture["request"], "response": fixture["response"]},
+    )
+    assert imported.status_code == 200
+
+    with get_session_factory()() as db_session:
+        state = db_session.get(PersistedPolicyState, f"policy-state:{trip_id}")
+        assert state is not None
+        state.organization_context = {
+            **state.organization_context,
+            "blocking_issues": [
+                {
+                    "code": "BUD-001",
+                    "summary": "Malformed persisted severity should remain visible.",
+                    "severity": "critical",
+                }
+            ],
+        }
+        db_session.commit()
+
+    response = client.get(f"/api/workspace/{trip_id}/policy")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["policy_evaluation"]["status"] == "policy_unavailable"
+    assert payload["policy_evaluation"]["failure_reasons"] == [
+        {
+            "code": "invalid_persisted_policy_state",
+            "message": (
+                "Stored TPP policy requirements are invalid and cannot be used for compliance "
+                "evaluation: organization_context.blocking_issues[0] is invalid: severity must be "
+                "'warning' or 'blocking'"
+            ),
+            "severity": "blocking",
+            "related_category": "policy_sync",
+        }
+    ]
+    assert payload["summary"]["status"] == "policy_state_invalid"
 
 
 def test_workspace_policy_import_preserves_cached_state_when_tpp_rejects_cache(

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -148,6 +148,8 @@ def test_workspace_policy_import_persists_constraint_set_and_readiness(client: T
     assert payload["policy_state"]["trip_id"] == trip_id
     assert payload["policy_state"]["policy_id"] == "policy-standard-2026-02"
     assert payload["summary"]["required_booking_channels"] == ["Navan", "Concur"]
+    assert payload["summary"]["policy_status"] == "pass"
+    assert payload["summary"]["booking_requirements"][0]["code"] == "approved_booking_channel"
     assert payload["policy_evaluation"]["status"] == "compliant"
     assert payload["proposal"]["constraint_set_id"] == "policy-standard-2026-02"
 
@@ -156,6 +158,80 @@ def test_workspace_policy_import_persists_constraint_set_and_readiness(client: T
     reloaded_payload = reloaded.json()
     assert reloaded_payload["policy_state"]["policy_state_id"] == f"policy-state:{trip_id}"
     assert "Persisted policy storage is limited" in reloaded_payload["policy_state"]["notes"][-2]
+
+
+def test_workspace_policy_import_maps_tpp_failure_to_blocking_reasons(client: TestClient) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Denied policy import",
+            "summary": "Keep TPP denial reasons visible in the workspace.",
+            "mode": "business",
+            "trip_frame": {"duration_days": 2, "primary_regions": ["Chicago"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = _load_fixture("standard_policy_sync.json")
+    context = fixture["response"]["result_payload"]["organization_context"]
+    context["policy_status"] = "fail"
+    context["blocking_issues"] = [
+        {
+            "code": "BUD-001",
+            "summary": "Trip cost exceeds the approved budget cap.",
+            "severity": "blocking",
+        }
+    ]
+
+    imported = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={"request": fixture["request"], "response": fixture["response"]},
+    )
+
+    assert imported.status_code == 200
+    evaluation = imported.json()["policy_evaluation"]
+    assert evaluation["status"] == "non_compliant"
+    assert evaluation["failure_reasons"][0] == {
+        "code": "BUD-001",
+        "message": "Trip cost exceeds the approved budget cap.",
+        "severity": "blocking",
+        "related_category": "policy_sync",
+    }
+
+
+def test_workspace_policy_import_preserves_cached_state_when_tpp_rejects_cache(
+    client: TestClient,
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Cache compatibility import",
+            "summary": "Do not replace a policy cache with an incompatible snapshot.",
+            "mode": "business",
+            "trip_frame": {"duration_days": 2, "primary_regions": ["Chicago"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    fixture = _load_fixture("standard_policy_sync.json")
+    seeded = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={"request": fixture["request"], "response": fixture["response"]},
+    )
+    assert seeded.status_code == 200
+    fixture["response"]["result_payload"]["constraint_set"]["policy_id"] = "policy-new"
+    fixture["response"]["result_payload"]["organization_context"][
+        "compatible_with_planner_cache"
+    ] = False
+
+    incompatible = client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={"request": fixture["request"], "response": fixture["response"]},
+    )
+
+    assert incompatible.status_code == 200
+    payload = incompatible.json()
+    assert payload["policy_state"]["policy_id"] == "policy-standard-2026-02"
+    assert payload["summary"]["status"] == "cache_incompatible"
+    assert payload["policy_evaluation"]["status"] == "policy_unavailable"
 
 
 def test_workspace_policy_import_rejects_leisure_trip(client: TestClient) -> None:

--- a/tests/fixtures/integrations/tpp/policy/invalidated_policy_sync.json
+++ b/tests/fixtures/integrations/tpp/policy/invalidated_policy_sync.json
@@ -62,6 +62,17 @@
       },
       "organization_context": {
         "organization_id": "org-acme",
+        "policy_status": "pass",
+        "contract_version": "2026-04-11",
+        "compatible_with_planner_cache": true,
+        "booking_requirements": [
+          {
+            "code": "approved_booking_channel",
+            "summary": "Book through an approved channel.",
+            "severity": "warning"
+          }
+        ],
+        "blocking_issues": [],
         "approved_channels": [
           "Navan"
         ],

--- a/tests/fixtures/integrations/tpp/policy/standard_policy_sync.json
+++ b/tests/fixtures/integrations/tpp/policy/standard_policy_sync.json
@@ -75,6 +75,17 @@
       },
       "organization_context": {
         "organization_id": "org-acme",
+        "policy_status": "pass",
+        "contract_version": "2026-04-11",
+        "compatible_with_planner_cache": true,
+        "booking_requirements": [
+          {
+            "code": "approved_booking_channel",
+            "summary": "Book through an approved channel.",
+            "severity": "warning"
+          }
+        ],
+        "blocking_issues": [],
         "approved_channels": [
           "Navan",
           "Concur"

--- a/tests/fixtures/integrations/tpp/policy/strict_policy_sync.json
+++ b/tests/fixtures/integrations/tpp/policy/strict_policy_sync.json
@@ -72,6 +72,17 @@
       },
       "organization_context": {
         "organization_id": "org-strict",
+        "policy_status": "pass",
+        "contract_version": "2026-04-11",
+        "compatible_with_planner_cache": true,
+        "booking_requirements": [
+          {
+            "code": "concur_only",
+            "summary": "Book through Concur.",
+            "severity": "blocking"
+          }
+        ],
+        "blocking_issues": [],
         "approved_channels": [
           "Concur"
         ],

--- a/tests/integrations/test_policy_sync.py
+++ b/tests/integrations/test_policy_sync.py
@@ -58,6 +58,7 @@ def test_import_standard_policy_sync_snapshot() -> None:
     ]
     assert summary["policy_status"] == "pass"
     assert summary["compatible_with_planner_cache"] is True
+    assert summary["blocking_issues"] == []
 
 
 def test_policy_sync_rejects_unsupported_contract_version() -> None:

--- a/tests/integrations/test_policy_sync.py
+++ b/tests/integrations/test_policy_sync.py
@@ -48,11 +48,26 @@ def test_import_standard_policy_sync_snapshot() -> None:
         "lodging": 2,
     }
     assert imported.constraint_set.required_booking_channels == ["Navan", "Concur"]
+    assert imported.organization_context.policy_status == "pass"
+    assert imported.organization_context.contract_version == "2026-04-11"
+    assert imported.organization_context.booking_requirements[0].code == "approved_booking_channel"
     assert summary["is_stale"] is False
     assert summary["documentation_rules"] == [
         "retain_receipts",
         "attach_comparables",
     ]
+    assert summary["policy_status"] == "pass"
+    assert summary["compatible_with_planner_cache"] is True
+
+
+def test_policy_sync_rejects_unsupported_contract_version() -> None:
+    fixture = _load_fixture("standard_policy_sync.json")
+    fixture["response"]["result_payload"]["organization_context"]["contract_version"] = "1999-01-01"
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+
+    with pytest.raises(ValueError, match="Unsupported TPP policy contract version"):
+        TPPPolicySyncService(FakeTPPPolicyClient(response)).import_policy_constraints(request)
 
 
 def test_import_stricter_org_policy_preserves_limits_and_triggers() -> None:

--- a/tests/integrations/test_policy_sync.py
+++ b/tests/integrations/test_policy_sync.py
@@ -71,6 +71,19 @@ def test_policy_sync_rejects_unsupported_contract_version() -> None:
         TPPPolicySyncService(FakeTPPPolicyClient(response)).import_policy_constraints(request)
 
 
+@pytest.mark.parametrize("value", ["false", 0])
+def test_policy_sync_rejects_malformed_cache_compatibility_values(value: object) -> None:
+    fixture = _load_fixture("standard_policy_sync.json")
+    fixture["response"]["result_payload"]["organization_context"][
+        "compatible_with_planner_cache"
+    ] = value
+    request = TPPRequestEnvelope.from_dict(fixture["request"])
+    response = TPPResponseEnvelope.from_dict(fixture["response"])
+
+    with pytest.raises(ValueError, match="compatible_with_planner_cache must be a boolean"):
+        TPPPolicySyncService(FakeTPPPolicyClient(response)).import_policy_constraints(request)
+
+
 def test_import_stricter_org_policy_preserves_limits_and_triggers() -> None:
     fixture = _load_fixture("strict_policy_sync.json")
     request = TPPRequestEnvelope.from_dict(fixture["request"])

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -389,6 +389,15 @@ def _normalize_policy_requirements(
     return requirements
 
 
+def _optional_policy_requirements_payload(
+    organization_context: dict[str, Any], key: str
+) -> object:
+    """Default only absent persisted requirements; preserve malformed values for validation."""
+
+    value = organization_context.get(key)
+    return [] if value is None else value
+
+
 def _normalize_constraint_set_payload(record: PersistedPolicyState) -> dict[str, Any]:
     constraint_set = _normalize_json_object(record.constraint_set)
     return {
@@ -432,11 +441,11 @@ def _normalize_organization_context_payload(record: PersistedPolicyState) -> dic
             "compatible_with_planner_cache", True
         ),
         "booking_requirements": _normalize_policy_requirements(
-            organization_context.get("booking_requirements") or [],
+            _optional_policy_requirements_payload(organization_context, "booking_requirements"),
             field_name="organization_context.booking_requirements",
         ),
         "blocking_issues": _normalize_policy_requirements(
-            organization_context.get("blocking_issues") or [],
+            _optional_policy_requirements_payload(organization_context, "blocking_issues"),
             field_name="organization_context.blocking_issues",
         ),
         "approved_channels": _normalize_string_list(organization_context.get("approved_channels")),
@@ -515,11 +524,11 @@ def _build_workspace_policy_payload(
             source_correlation_id=policy_record.source_correlation_id,
             raw_payload=_normalize_json_object(policy_record.raw_payload),
         )
-    except PersistedPolicyStateValidationError as error:
+    except ValueError as error:
         return _invalid_policy_state_payload(
             trip_record=trip_record,
             policy_record=policy_record,
-            error=error,
+            error=PersistedPolicyStateValidationError(str(error)),
         )
     proposal = _proposal_from_import(trip_record, imported)
     policy_evaluation = _policy_evaluation_from_import(trip_record, imported)

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -23,6 +23,7 @@ from trip_planner.integrations.tpp import (
     OrganizationContextSnapshot,
     PolicyConstraintImport,
     PolicyFreshness,
+    TPPPolicyRequirement,
     TPPPolicySyncService,
     TPPRequestEnvelope,
     TPPResponseEnvelope,
@@ -156,6 +157,10 @@ def _summarize_policy_import(imported: PolicyConstraintImport) -> dict[str, Any]
         "policy_id": constraint_set.policy_id,
         "organization_id": constraint_set.organization_id,
         "policy_version": constraint_set.policy_version,
+        "policy_status": org.policy_status,
+        "contract_version": org.contract_version,
+        "compatible_with_planner_cache": org.compatible_with_planner_cache,
+        "booking_requirements": [requirement.to_dict() for requirement in org.booking_requirements],
         "sync_status": freshness.status,
         "is_stale": stale,
         "required_booking_channels": list(constraint_set.required_booking_channels),
@@ -234,7 +239,46 @@ def _policy_evaluation_from_import(
     compliance_score = 1.0
     status = "compliant"
 
-    if _is_effectively_stale(imported):
+    if not imported.organization_context.compatible_with_planner_cache:
+        status = "policy_unavailable"
+        compliance_score = 0.25
+        failure_reasons.append(
+            PolicyFailureReason(
+                code="incompatible_policy_cache",
+                message=(
+                    "TPP reports that this policy snapshot is incompatible with the planner "
+                    "cache; the stored policy state was not replaced."
+                ),
+                severity="blocking",
+                related_category="policy_sync",
+            )
+        )
+        notes.append("TPP policy cache compatibility check failed; refresh is required.")
+    elif imported.organization_context.policy_status == "fail":
+        status = "non_compliant"
+        compliance_score = 0.0
+        blocking_issues = imported.organization_context.blocking_issues
+        if not blocking_issues:
+            failure_reasons.append(
+                PolicyFailureReason(
+                    code="tpp_policy_failed",
+                    message="TPP reported a blocking policy failure without a rule-level reason.",
+                    severity="blocking",
+                    related_category="policy_sync",
+                )
+            )
+        else:
+            failure_reasons.extend(
+                PolicyFailureReason(
+                    code=issue.code,
+                    message=issue.summary,
+                    severity="blocking",
+                    related_category="policy_sync",
+                )
+                for issue in blocking_issues
+            )
+        notes.append("TPP reported a failing policy verdict.")
+    elif _is_effectively_stale(imported):
         status = "non_compliant"
         compliance_score = 0.35
         failure_reasons.append(
@@ -313,6 +357,25 @@ def _normalize_string_list(payload: object) -> list[str]:
     return [value for value in payload if isinstance(value, str) and value]
 
 
+def _normalize_policy_requirements(payload: object) -> list[TPPPolicyRequirement]:
+    if not isinstance(payload, list):
+        return []
+    requirements: list[TPPPolicyRequirement] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        code = item.get("code")
+        summary = item.get("summary")
+        severity = item.get("severity")
+        if not isinstance(code, str) or not isinstance(summary, str) or not isinstance(severity, str):
+            continue
+        try:
+            requirements.append(TPPPolicyRequirement(code=code, summary=summary, severity=severity))
+        except ValueError:
+            continue
+    return requirements
+
+
 def _normalize_constraint_set_payload(record: PersistedPolicyState) -> dict[str, Any]:
     constraint_set = _normalize_json_object(record.constraint_set)
     return {
@@ -347,6 +410,19 @@ def _normalize_organization_context_payload(record: PersistedPolicyState) -> dic
     return {
         "organization_id": str(
             organization_context.get("organization_id") or record.organization_id
+        ),
+        "policy_status": str(organization_context.get("policy_status") or "pass"),
+        "contract_version": str(
+            organization_context.get("contract_version") or "2026-04-11"
+        ),
+        "compatible_with_planner_cache": organization_context.get(
+            "compatible_with_planner_cache", True
+        ),
+        "booking_requirements": _normalize_policy_requirements(
+            organization_context.get("booking_requirements")
+        ),
+        "blocking_issues": _normalize_policy_requirements(
+            organization_context.get("blocking_issues")
         ),
         "approved_channels": _normalize_string_list(organization_context.get("approved_channels")),
         "comparable_requirements": comparable_requirements,
@@ -550,6 +626,23 @@ def import_workspace_policy_constraints(
         raise
 
     imported = TPPPolicySyncService(_PassiveTPPClient(response)).import_policy_constraints(request)
+    if existing is not None and not imported.organization_context.compatible_with_planner_cache:
+        preserved = _build_workspace_policy_payload(
+            trip_record=trip_record,
+            policy_record=existing,
+        )
+        preserved["policy_evaluation"] = _policy_evaluation_from_import(
+            trip_record, imported
+        ).to_dict()
+        preserved["summary"] = {
+            **_summarize_policy_import(imported),
+            "status": "cache_incompatible",
+            "fallback_reason": (
+                "TPP rejected the planner cache version, so the stored policy state remains "
+                "unchanged until a compatible snapshot is available."
+            ),
+        }
+        return preserved
     imported_at = _isoformat(datetime.now(UTC))
     policy_state_id = (
         existing.policy_state_id if existing is not None else f"policy-state:{trip_id}"

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -37,6 +37,10 @@ class WorkspacePolicyNotFoundError(ValueError):
     """Raised when workspace policy state or trip ownership is missing."""
 
 
+class PersistedPolicyStateValidationError(ValueError):
+    """Raised when stored policy JSON can no longer satisfy the policy contract."""
+
+
 def _isoformat(value: datetime) -> str:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
@@ -161,6 +165,7 @@ def _summarize_policy_import(imported: PolicyConstraintImport) -> dict[str, Any]
         "contract_version": org.contract_version,
         "compatible_with_planner_cache": org.compatible_with_planner_cache,
         "booking_requirements": [requirement.to_dict() for requirement in org.booking_requirements],
+        "blocking_issues": [requirement.to_dict() for requirement in org.blocking_issues],
         "sync_status": freshness.status,
         "is_stale": stale,
         "required_booking_channels": list(constraint_set.required_booking_channels),
@@ -357,22 +362,30 @@ def _normalize_string_list(payload: object) -> list[str]:
     return [value for value in payload if isinstance(value, str) and value]
 
 
-def _normalize_policy_requirements(payload: object) -> list[TPPPolicyRequirement]:
+def _normalize_policy_requirements(
+    payload: object, *, field_name: str
+) -> list[TPPPolicyRequirement]:
     if not isinstance(payload, list):
-        return []
+        raise PersistedPolicyStateValidationError(f"{field_name} must be provided as a list")
     requirements: list[TPPPolicyRequirement] = []
-    for item in payload:
+    for index, item in enumerate(payload):
         if not isinstance(item, dict):
-            continue
+            raise PersistedPolicyStateValidationError(
+                f"{field_name}[{index}] must be provided as a mapping"
+            )
         code = item.get("code")
         summary = item.get("summary")
         severity = item.get("severity")
         if not isinstance(code, str) or not isinstance(summary, str) or not isinstance(severity, str):
-            continue
+            raise PersistedPolicyStateValidationError(
+                f"{field_name}[{index}] must include string code, summary, and severity values"
+            )
         try:
             requirements.append(TPPPolicyRequirement(code=code, summary=summary, severity=severity))
-        except ValueError:
-            continue
+        except ValueError as error:
+            raise PersistedPolicyStateValidationError(
+                f"{field_name}[{index}] is invalid: {error}"
+            ) from error
     return requirements
 
 
@@ -419,10 +432,12 @@ def _normalize_organization_context_payload(record: PersistedPolicyState) -> dic
             "compatible_with_planner_cache", True
         ),
         "booking_requirements": _normalize_policy_requirements(
-            organization_context.get("booking_requirements")
+            organization_context.get("booking_requirements"),
+            field_name="organization_context.booking_requirements",
         ),
         "blocking_issues": _normalize_policy_requirements(
-            organization_context.get("blocking_issues")
+            organization_context.get("blocking_issues"),
+            field_name="organization_context.blocking_issues",
         ),
         "approved_channels": _normalize_string_list(organization_context.get("approved_channels")),
         "comparable_requirements": comparable_requirements,
@@ -489,16 +504,23 @@ def _build_workspace_policy_payload(
     trip_record: PersistedTrip,
     policy_record: PersistedPolicyState,
 ) -> dict[str, Any]:
-    imported = PolicyConstraintImport(
-        constraint_set=PolicyConstraintSet(**_normalize_constraint_set_payload(policy_record)),
-        organization_context=OrganizationContextSnapshot(
-            **_normalize_organization_context_payload(policy_record)
-        ),
-        freshness=PolicyFreshness(**_normalize_freshness_payload(policy_record)),
-        source_request_id=policy_record.source_request_id,
-        source_correlation_id=policy_record.source_correlation_id,
-        raw_payload=_normalize_json_object(policy_record.raw_payload),
-    )
+    try:
+        imported = PolicyConstraintImport(
+            constraint_set=PolicyConstraintSet(**_normalize_constraint_set_payload(policy_record)),
+            organization_context=OrganizationContextSnapshot(
+                **_normalize_organization_context_payload(policy_record)
+            ),
+            freshness=PolicyFreshness(**_normalize_freshness_payload(policy_record)),
+            source_request_id=policy_record.source_request_id,
+            source_correlation_id=policy_record.source_correlation_id,
+            raw_payload=_normalize_json_object(policy_record.raw_payload),
+        )
+    except PersistedPolicyStateValidationError as error:
+        return _invalid_policy_state_payload(
+            trip_record=trip_record,
+            policy_record=policy_record,
+            error=error,
+        )
     proposal = _proposal_from_import(trip_record, imported)
     policy_evaluation = _policy_evaluation_from_import(trip_record, imported)
     return {
@@ -506,6 +528,52 @@ def _build_workspace_policy_payload(
         "proposal": proposal.to_dict(),
         "policy_evaluation": policy_evaluation.to_dict(),
         "summary": _summarize_policy_import(imported),
+    }
+
+
+def _invalid_policy_state_payload(
+    *,
+    trip_record: PersistedTrip,
+    policy_record: PersistedPolicyState,
+    error: PersistedPolicyStateValidationError,
+) -> dict[str, Any]:
+    """Expose invalid stored policy data as an explicit unavailable evaluation."""
+
+    failure = PolicyFailureReason(
+        code="invalid_persisted_policy_state",
+        message=(
+            "Stored TPP policy requirements are invalid and cannot be used for compliance "
+            f"evaluation: {error}"
+        ),
+        severity="blocking",
+        related_category="policy_sync",
+    )
+    evaluation = PolicyEvaluationResult(
+        evaluation_id=f"policy-eval:{trip_record.trip_id}:{policy_record.policy_id}",
+        proposal_id=f"proposal-preview:{trip_record.trip_id}",
+        status="policy_unavailable",
+        failure_reasons=[failure],
+        exception_guidance=["Refresh the policy import before preparing a final approval packet."],
+        notes=["The stored policy state failed validation and was not silently degraded."],
+        compliance_score=0.0,
+    )
+    return {
+        "policy_state": {
+            "policy_state_id": policy_record.policy_state_id,
+            "policy_id": policy_record.policy_id,
+            "organization_id": policy_record.organization_id,
+            "policy_version": policy_record.policy_version,
+            "sync_status": policy_record.sync_status,
+            "organization_context": _normalize_json_object(policy_record.organization_context),
+        },
+        "proposal": None,
+        "policy_evaluation": evaluation.to_dict(),
+        "summary": {
+            "policy_id": policy_record.policy_id,
+            "organization_id": policy_record.organization_id,
+            "status": "policy_state_invalid",
+            "validation_error": str(error),
+        },
     }
 
 

--- a/trip_planner/app/services/policy.py
+++ b/trip_planner/app/services/policy.py
@@ -432,11 +432,11 @@ def _normalize_organization_context_payload(record: PersistedPolicyState) -> dic
             "compatible_with_planner_cache", True
         ),
         "booking_requirements": _normalize_policy_requirements(
-            organization_context.get("booking_requirements"),
+            organization_context.get("booking_requirements") or [],
             field_name="organization_context.booking_requirements",
         ),
         "blocking_issues": _normalize_policy_requirements(
-            organization_context.get("blocking_issues"),
+            organization_context.get("blocking_issues") or [],
             field_name="organization_context.blocking_issues",
         ),
         "approved_channels": _normalize_string_list(organization_context.get("approved_channels")),

--- a/trip_planner/business/policy_contracts.py
+++ b/trip_planner/business/policy_contracts.py
@@ -20,6 +20,7 @@ POLICY_EVALUATION_STATUSES: tuple[str, ...] = (
     "compliant",
     "non_compliant",
     "exception_required",
+    "policy_unavailable",
 )
 FAILURE_SEVERITIES: tuple[str, ...] = ("warning", "blocking")
 

--- a/trip_planner/integrations/tpp/__init__.py
+++ b/trip_planner/integrations/tpp/__init__.py
@@ -26,6 +26,7 @@ from .policy_sync import (
     PolicyConstraintImport,
     PolicyFreshness,
     PolicySyncError,
+    TPPPolicyRequirement,
     TPPPolicySyncService,
     summarize_policy_import,
 )
@@ -56,6 +57,7 @@ __all__ = [
     "PersistedEvaluationResult",
     "PolicyConstraintImport",
     "PolicyFreshness",
+    "TPPPolicyRequirement",
     "PolicyReoptimizationContext",
     "PolicyReoptimizationPlan",
     "PolicySyncError",

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -896,6 +896,18 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             for item in payload.get("approval_triggers") or []
             if isinstance(item, dict) and str(item.get("code") or item.get("summary") or "").strip()
         ]
+        booking_requirements = self._adapt_policy_requirements(
+            payload.get("booking_requirements"),
+            field_name="booking_requirements",
+        )
+        blocking_issues = self._adapt_policy_requirements(
+            [
+                item
+                for item in payload.get("approval_triggers") or []
+                if isinstance(item, dict) and item.get("blocking") is True
+            ],
+            field_name="approval_triggers",
+        )
         freshness = str(payload.get("freshness") or "current").strip() or "current"
         result_payload = {
             "constraint_set": {
@@ -913,17 +925,18 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
             },
             "organization_context": {
                 "organization_id": organization_id,
+                "policy_status": str(payload.get("policy_status") or "").strip(),
+                "contract_version": str(versioning.get("contract_version") or "").strip(),
+                "compatible_with_planner_cache": versioning.get("compatible_with_planner_cache"),
+                "booking_requirements": booking_requirements,
+                "blocking_issues": blocking_issues,
                 "approved_channels": [],
                 "comparable_requirements": {},
                 "documentation_rules": documentation_rules,
                 "approval_triggers": approval_triggers,
                 "comfort_preferences": {},
                 "class_of_service_limits": {},
-                "metadata": {
-                    "policy_status": str(payload.get("policy_status") or ""),
-                    "contract_version": str(versioning.get("contract_version") or ""),
-                    "etag": str(versioning.get("etag") or ""),
-                },
+                "metadata": {"etag": str(versioning.get("etag") or "")},
             },
             "freshness": {
                 "snapshot_version": str(versioning.get("etag") or policy_version),
@@ -951,6 +964,24 @@ class HTTPTPPIntegrationClient(BaseTPPIntegrationClient):
                 "received_at": payload.get("generated_at"),
             }
         )
+
+    @staticmethod
+    def _adapt_policy_requirements(value: Any, *, field_name: str) -> list[dict[str, str]]:
+        if not isinstance(value, list):
+            raise TPPContractError(f"TPP {field_name} must be a list.")
+        requirements: list[dict[str, str]] = []
+        for index, item in enumerate(value):
+            if not isinstance(item, dict):
+                raise TPPContractError(f"TPP {field_name}[{index}] must be an object.")
+            code = str(item.get("code") or "").strip()
+            summary = str(item.get("summary") or "").strip()
+            if not code or not summary:
+                raise TPPContractError(
+                    f"TPP {field_name}[{index}] must include non-empty code and summary."
+                )
+            severity = "blocking" if item.get("blocking") is True or item.get("severity") == "error" else "warning"
+            requirements.append({"code": code, "summary": summary, "severity": severity})
+        return requirements
 
     def _submit_proposal(self, request: TPPRequestEnvelope) -> TPPResponseEnvelope:
         payload = self._request_json(

--- a/trip_planner/integrations/tpp/policy_sync.py
+++ b/trip_planner/integrations/tpp/policy_sync.py
@@ -94,6 +94,12 @@ def _require_string_field(value: Any, field_name: str) -> str:
     return value
 
 
+def _optional_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    return default
+
+
 def _parse_timestamp(value: str, field_name: str) -> datetime:
     require_non_empty(value, field_name)
     try:
@@ -340,7 +346,10 @@ class TPPPolicySyncService:
             contract_version=_require_string_field(
                 context_payload.get("contract_version"), "organization_context.contract_version"
             ),
-            compatible_with_planner_cache=context_payload.get("compatible_with_planner_cache"),
+            compatible_with_planner_cache=_optional_bool(
+                context_payload.get("compatible_with_planner_cache"),
+                default=True,
+            ),
             booking_requirements=_require_policy_requirements(
                 context_payload.get("booking_requirements"),
                 "organization_context.booking_requirements",

--- a/trip_planner/integrations/tpp/policy_sync.py
+++ b/trip_planner/integrations/tpp/policy_sync.py
@@ -18,6 +18,8 @@ from .client import TPPIntegrationClient
 from .contracts import TPPRequestEnvelope, TPPResponseEnvelope
 
 POLICY_SYNC_STATES: tuple[str, ...] = ("current", "stale", "invalidated")
+TPP_POLICY_STATUSES: tuple[str, ...] = ("pass", "fail")
+SUPPORTED_TPP_POLICY_CONTRACT_VERSIONS: tuple[str, ...] = ("2026-04-11",)
 
 
 def _require_mapping(value: Any, field_name: str) -> dict[str, Any]:
@@ -44,6 +46,45 @@ def _optional_string_list(value: Any, field_name: str) -> list[str]:
     if value is None:
         return []
     return _require_string_list(value, field_name)
+
+
+@dataclass(slots=True)
+class TPPPolicyRequirement:
+    """A planner-facing rule received from the TPP policy snapshot."""
+
+    code: str
+    summary: str
+    severity: str
+
+    def __post_init__(self) -> None:
+        require_non_empty(self.code, "code")
+        require_non_empty(self.summary, "summary")
+        if self.severity not in {"warning", "blocking"}:
+            raise ValueError("severity must be 'warning' or 'blocking'")
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def _require_policy_requirements(value: Any, field_name: str) -> list[TPPPolicyRequirement]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be provided as a list")
+    requirements: list[TPPPolicyRequirement] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"{field_name}[{index}] must be provided as a mapping")
+        requirements.append(
+            TPPPolicyRequirement(
+                code=_require_string_field(item.get("code"), f"{field_name}[{index}].code"),
+                summary=_require_string_field(
+                    item.get("summary"), f"{field_name}[{index}].summary"
+                ),
+                severity=_require_string_field(
+                    item.get("severity"), f"{field_name}[{index}].severity"
+                ),
+            )
+        )
+    return requirements
 
 
 def _require_string_field(value: Any, field_name: str) -> str:
@@ -124,6 +165,11 @@ class PolicyFreshness:
 @dataclass(slots=True)
 class OrganizationContextSnapshot:
     organization_id: str
+    policy_status: str
+    contract_version: str
+    compatible_with_planner_cache: bool
+    booking_requirements: list[TPPPolicyRequirement]
+    blocking_issues: list[TPPPolicyRequirement]
     approved_channels: list[str] = field(default_factory=list)
     comparable_requirements: dict[str, int] = field(default_factory=dict)
     documentation_rules: list[str] = field(default_factory=list)
@@ -134,6 +180,20 @@ class OrganizationContextSnapshot:
 
     def __post_init__(self) -> None:
         require_non_empty(self.organization_id, "organization_id")
+        if self.policy_status not in TPP_POLICY_STATUSES:
+            raise ValueError(f"policy_status must be one of {TPP_POLICY_STATUSES}")
+        if self.contract_version not in SUPPORTED_TPP_POLICY_CONTRACT_VERSIONS:
+            raise ValueError(
+                "Unsupported TPP policy contract version "
+                f"{self.contract_version!r}; expected one of "
+                f"{SUPPORTED_TPP_POLICY_CONTRACT_VERSIONS}"
+            )
+        if not isinstance(self.compatible_with_planner_cache, bool):
+            raise ValueError("compatible_with_planner_cache must be a boolean")
+        if any(not isinstance(item, TPPPolicyRequirement) for item in self.booking_requirements):
+            raise ValueError("booking_requirements must contain TPPPolicyRequirement instances")
+        if any(not isinstance(item, TPPPolicyRequirement) for item in self.blocking_issues):
+            raise ValueError("blocking_issues must contain TPPPolicyRequirement instances")
         require_strings(self.approved_channels, "approved_channels")
         require_strings(self.documentation_rules, "documentation_rules")
         require_strings(self.approval_triggers, "approval_triggers")
@@ -274,6 +334,21 @@ class TPPPolicySyncService:
 
         organization_context = OrganizationContextSnapshot(
             organization_id=organization_id,
+            policy_status=_require_string_field(
+                context_payload.get("policy_status"), "organization_context.policy_status"
+            ),
+            contract_version=_require_string_field(
+                context_payload.get("contract_version"), "organization_context.contract_version"
+            ),
+            compatible_with_planner_cache=context_payload.get("compatible_with_planner_cache"),
+            booking_requirements=_require_policy_requirements(
+                context_payload.get("booking_requirements"),
+                "organization_context.booking_requirements",
+            ),
+            blocking_issues=_require_policy_requirements(
+                context_payload.get("blocking_issues"),
+                "organization_context.blocking_issues",
+            ),
             approved_channels=_optional_string_list(
                 context_payload.get("approved_channels")
                 or constraint_payload.get("required_booking_channels"),
@@ -341,6 +416,12 @@ def summarize_policy_import(
         "organization_id": imported.organization_id,
         "policy_id": imported.constraint_set.policy_id,
         "policy_version": imported.constraint_set.policy_version,
+        "policy_status": imported.organization_context.policy_status,
+        "contract_version": imported.organization_context.contract_version,
+        "compatible_with_planner_cache": imported.organization_context.compatible_with_planner_cache,
+        "booking_requirements": [
+            requirement.to_dict() for requirement in imported.organization_context.booking_requirements
+        ],
         "approved_channels": list(imported.organization_context.approved_channels),
         "approval_triggers": list(imported.organization_context.approval_triggers),
         "documentation_rules": list(imported.constraint_set.documentation_rules),

--- a/trip_planner/integrations/tpp/policy_sync.py
+++ b/trip_planner/integrations/tpp/policy_sync.py
@@ -95,9 +95,11 @@ def _require_string_field(value: Any, field_name: str) -> str:
 
 
 def _optional_bool(value: Any, *, default: bool) -> bool:
+    if value is None:
+        return default
     if isinstance(value, bool):
         return value
-    return default
+    raise ValueError("compatible_with_planner_cache must be a boolean")
 
 
 def _parse_timestamp(value: str, field_name: str) -> datetime:

--- a/trip_planner/integrations/tpp/policy_sync.py
+++ b/trip_planner/integrations/tpp/policy_sync.py
@@ -422,6 +422,9 @@ def summarize_policy_import(
         "booking_requirements": [
             requirement.to_dict() for requirement in imported.organization_context.booking_requirements
         ],
+        "blocking_issues": [
+            requirement.to_dict() for requirement in imported.organization_context.blocking_issues
+        ],
         "approved_channels": list(imported.organization_context.approved_channels),
         "approval_triggers": list(imported.organization_context.approval_triggers),
         "documentation_rules": list(imported.constraint_set.documentation_rules),


### PR DESCRIPTION
Closes #1676

## Summary
- Preserve TPP policy verdicts, cache compatibility, and typed booking/blocking requirements through the import contract.
- Surface TPP denials as non-compliant workspace results with the original blocking rule codes.
- Keep the prior stored policy state when TPP rejects the planner cache version.

## Validation
- `uv run --extra dev pytest -q tests/integrations/test_policy_sync.py tests/app/test_policy.py`
- `uv run --extra dev pytest -q tests/app/test_workspace.py`
- `uv run --extra dev pytest -q tests/business/test_policy_contracts.py`
- `uv run --extra dev ruff check --select F,E9 trip_planner/integrations/tpp/client.py trip_planner/integrations/tpp/policy_sync.py trip_planner/app/services/policy.py tests/integrations/test_policy_sync.py tests/app/test_policy.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Policy summaries now display status, contract version, cache compatibility, booking requirements, and blocking issues.
  - Added validation for supported policy versions and requirement details.
  - Added clear handling for unavailable policies and incompatible planner-cache states.

- **Bug Fixes**
  - Workspace policy imports preserve existing policy data when incoming snapshots are incompatible.
  - Blocking policy issues now produce non-compliant results.
  - Malformed stored policy data is reported as unavailable instead of degraded output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->