### PR TITLE
test(policy): add TPP denial contract proof

### DIFF
--- a/tests/integrations/test_tpp_policy_import.py
+++ b/tests/integrations/test_tpp_policy_import.py
@@ -34,7 +34,7 @@ def workspace_client(
     )
     reset_database_state()
     with TestClient(create_app()) as client:
-        client.post(
+        signup = client.post(
             "/api/auth/signup",
             json={
                 "email": "policy-import@example.test",
@@ -42,6 +42,7 @@ def workspace_client(
                 "display_name": "TPP policy import",
             },
         )
+        assert signup.status_code == 201, signup.text
         yield client
     reset_database_state()
 
@@ -63,6 +64,7 @@ def test_failing_policy_status_is_not_compliant(workspace_client: TestClient) ->
             },
         },
     )
+    assert trip.status_code == 201, trip.text
     trip_id = trip.json()["trip"]["trip_id"]
     fixture = _load_policy_fixture("standard_policy_sync.json")
     response = fixture["response"]

--- a/tests/integrations/test_tpp_policy_import.py
+++ b/tests/integrations/test_tpp_policy_import.py
@@ -1,0 +1,98 @@
+"""End-to-end contract checks for importing authoritative TPP policy verdicts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trip_planner.app.main import create_app
+from trip_planner.persistence.db import reset_database_state
+
+
+def _load_policy_fixture(name: str) -> dict[str, object]:
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "integrations"
+        / "tpp"
+        / "policy"
+        / name
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def workspace_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[TestClient]:
+    monkeypatch.setenv(
+        "TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'policy-import.db'}"
+    )
+    reset_database_state()
+    with TestClient(create_app()) as client:
+        client.post(
+            "/api/auth/signup",
+            json={
+                "email": "policy-import@example.test",
+                "password": "password123",
+                "display_name": "TPP policy import",
+            },
+        )
+        yield client
+    reset_database_state()
+
+
+def test_failing_policy_status_is_not_compliant(workspace_client: TestClient) -> None:
+    """A current TPP denial remains non-compliant with its rule-level explanation."""
+
+    trip = workspace_client.post(
+        "/api/trips",
+        json={
+            "title": "Denied TPP policy import",
+            "summary": "Verify the authoritative TPP denial is preserved.",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-05-04",
+                "end_date": "2026-05-06",
+                "duration_days": 2,
+                "primary_regions": ["Chicago"],
+            },
+        },
+    )
+    trip_id = trip.json()["trip"]["trip_id"]
+    fixture = _load_policy_fixture("standard_policy_sync.json")
+    response = fixture["response"]
+    assert isinstance(response, dict)
+    result_payload = response["result_payload"]
+    assert isinstance(result_payload, dict)
+    context = result_payload["organization_context"]
+    assert isinstance(context, dict)
+    context["policy_status"] = "fail"
+    context["blocking_issues"] = [
+        {
+            "code": "BUD-001",
+            "summary": "Trip cost exceeds the approved budget cap.",
+            "severity": "blocking",
+        }
+    ]
+
+    imported = workspace_client.put(
+        f"/api/workspace/{trip_id}/policy",
+        json={"request": fixture["request"], "response": response},
+    )
+
+    assert imported.status_code == 200
+    evaluation = imported.json()["policy_evaluation"]
+    assert evaluation["status"] == "non_compliant"
+    assert evaluation["failure_reasons"] == [
+        {
+            "code": "BUD-001",
+            "message": "Trip cost exceeds the approved budget cap.",
+            "severity": "blocking",
+            "related_category": "policy_sync",
+        }
+    ]


### PR DESCRIPTION
## Follow-up for #1676

Addresses the verifier completion-evidence gap on merged #1682.

- Adds the required `tests/integrations/test_tpp_policy_import.py::test_failing_policy_status_is_not_compliant` contract test.
- Exercises a current TPP `policy_status=fail` snapshot through the workspace import API and asserts the preserved `BUD-001` blocking reason.
- Deliberate-break proof: with the `policy_status == fail` branch temporarily disabled, this exact test fails (`compliant` instead of `non_compliant`); restoring the mapping makes the focused suite pass.

## Validation

- `uv run ruff check tests/integrations/test_tpp_policy_import.py`
- `uv run ruff format --check tests/integrations/test_tpp_policy_import.py`
- `uv run --extra dev pytest -q tests/integrations/test_tpp_policy_import.py::test_failing_policy_status_is_not_compliant tests/app/test_policy.py::test_workspace_policy_import_maps_tpp_failure_to_blocking_reasons tests/app/test_policy.py::test_workspace_policy_import_surfaces_live_tpp_unavailable_errors`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for importing policies with failing verdicts.
  * Verifies that blocked budget conditions produce a non-compliant evaluation with the expected failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->