### PR TITLE
Issue #1685: configured Maps key must not claim live provider

### DIFF
--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -239,14 +239,29 @@ describe("TripMap", () => {
     expect(screen.queryByRole("img", { name: /route geometry overlay/i })).not.toBeInTheDocument();
   });
 
-  it("labels the keyed provider surface as a schematic preview", () => {
+  it("labels the keyed provider surface as a schematic preview when readiness is unproven", () => {
+    vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "test-key");
+
+    renderTripMap();
+
+    expect(screen.getByRole("heading", { name: "Route sketch for Rail-first route" })).toBeInTheDocument();
+    expect(screen.getByText("Schematic preview — not a live map")).toBeInTheDocument();
+    expect(screen.getByText("Route sketch mode")).toBeInTheDocument();
+    expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass("map-route-fallback");
+    expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("High confidence: the route has enough map detail for close review.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("mounts the provider-backed surface when readiness is observed", () => {
     vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "test-key");
     vi.stubEnv("VITE_GOOGLE_MAPS_PROVIDER_STATE", "ready");
 
     renderTripMap();
 
     expect(screen.getByRole("heading", { name: "Map for Rail-first route" })).toBeInTheDocument();
-    expect(screen.getByText("Schematic preview — not a live map")).toBeInTheDocument();
+    expect(screen.queryByText("Schematic preview — not a live map")).not.toBeInTheDocument();
     expect(screen.queryByText("Route sketch mode")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass(
       "map-route-google-maps-js"

--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -162,7 +162,8 @@ afterEach(() => {
 function renderTripMap(
   onSelectScenario = vi.fn(),
   ledger?: WorkspaceData["planning_ledger"],
-  onSelectSegment = vi.fn()
+  onSelectSegment = vi.fn(),
+  providerLoadState?: "pending" | "loading" | "ready" | "error"
 ) {
   function Harness() {
     const [activeScope, setActiveScope] = useState<"global" | "regional" | "local">("regional");
@@ -180,6 +181,7 @@ function renderTripMap(
         tripMode="business"
         policyPosture="No approval packet yet"
         planningLedger={ledger}
+        providerLoadState={providerLoadState}
         activeScope={activeScope}
         selectedSegmentId={selectedSegmentId}
         onScopeChange={setActiveScope}
@@ -256,9 +258,8 @@ describe("TripMap", () => {
 
   it("mounts the provider-backed surface when readiness is observed", () => {
     vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "test-key");
-    vi.stubEnv("VITE_GOOGLE_MAPS_PROVIDER_STATE", "ready");
 
-    renderTripMap();
+    renderTripMap(vi.fn(), undefined, vi.fn(), "ready");
 
     expect(screen.getByRole("heading", { name: "Map for Rail-first route" })).toBeInTheDocument();
     expect(screen.queryByText("Schematic preview — not a live map")).not.toBeInTheDocument();

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -125,7 +125,8 @@ function ActiveTripMap({
     import.meta.env.VITE_GOOGLE_MAPS_BROWSER_API_KEY ||
     import.meta.env.VITE_GOOGLE_MAPS_EMBED_API_KEY;
   const providerLoadState =
-    (import.meta.env.VITE_GOOGLE_MAPS_PROVIDER_STATE as MapProviderLoadState | undefined) ?? "ready";
+    (import.meta.env.VITE_GOOGLE_MAPS_PROVIDER_STATE as MapProviderLoadState | undefined) ??
+    "pending";
   const mapSurface = buildTripMapSurfaceModel({
     activeScenario,
     bundles,
@@ -248,9 +249,11 @@ function ActiveTripMap({
         >
           <div className="map-provider-toolbar">
             <span className="map-provider-name">{mapSurface.scope.label}</span>
-            <span className="map-preview-badge" aria-label={SCHEMATIC_PREVIEW_BADGE_TEXT}>
-              {SCHEMATIC_PREVIEW_BADGE_TEXT}
-            </span>
+            {isFallbackSketch ? (
+              <span className="map-preview-badge" aria-label={SCHEMATIC_PREVIEW_BADGE_TEXT}>
+                {SCHEMATIC_PREVIEW_BADGE_TEXT}
+              </span>
+            ) : null}
             {isFallbackSketch ? (
               <span className="map-preview-badge map-preview-badge-warning">
                 Route sketch mode

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -24,6 +24,7 @@ export function TripMap({
   tripMode,
   policyPosture,
   planningLedger,
+  providerLoadState,
   activeScope,
   selectedSegmentId,
   onScopeChange,
@@ -41,6 +42,8 @@ export function TripMap({
   tripMode: string;
   policyPosture: string | null;
   planningLedger?: WorkspaceData["planning_ledger"];
+  /** Observed SDK lifecycle state; configuration alone must not mark the map live. */
+  providerLoadState?: MapProviderLoadState;
   activeScope: MapViewScope;
   selectedSegmentId: string | null;
   onScopeChange: (scope: MapViewScope) => void;
@@ -77,6 +80,7 @@ export function TripMap({
       tripMode={tripMode}
       policyPosture={policyPosture}
       planningLedger={planningLedger}
+      providerLoadState={providerLoadState}
       activeScope={activeScope}
       selectedSegmentId={selectedSegmentId}
       onScopeChange={onScopeChange}
@@ -98,6 +102,7 @@ function ActiveTripMap({
   tripMode,
   policyPosture,
   planningLedger,
+  providerLoadState = "pending",
   activeScope,
   selectedSegmentId,
   onScopeChange,
@@ -115,6 +120,7 @@ function ActiveTripMap({
   tripMode: string;
   policyPosture: string | null;
   planningLedger?: WorkspaceData["planning_ledger"];
+  providerLoadState?: MapProviderLoadState;
   activeScope: MapViewScope;
   selectedSegmentId: string | null;
   onScopeChange: (scope: MapViewScope) => void;
@@ -124,9 +130,6 @@ function ActiveTripMap({
   const googleMapsApiKey =
     import.meta.env.VITE_GOOGLE_MAPS_BROWSER_API_KEY ||
     import.meta.env.VITE_GOOGLE_MAPS_EMBED_API_KEY;
-  const providerLoadState =
-    (import.meta.env.VITE_GOOGLE_MAPS_PROVIDER_STATE as MapProviderLoadState | undefined) ??
-    "pending";
   const mapSurface = buildTripMapSurfaceModel({
     activeScenario,
     bundles,

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -306,6 +306,7 @@ describe("mapSurface", () => {
         assessments: [],
       },
       googleMapsApiKey: "test-key",
+      providerLoadState: "ready",
       activeScope: "local",
       selectedSegmentId: "segment:uji-nara",
     });
@@ -757,6 +758,7 @@ describe("mapSurface", () => {
     expect(model.provider.status).toBe("configured");
     expect(model.provider.label).toBe("Google Maps configured");
     expect(model.workspaceView.confidence.level).toBe("medium");
+    expect(model.routeSegments.map((segment) => segment.confidence)).not.toContain("high");
   });
 
   it("high confidence requires observed provider", () => {

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -111,6 +111,7 @@ describe("mapSurface", () => {
       tripMode: "business",
       policyPosture: "Approval-ready",
       googleMapsApiKey: "test-key",
+      providerLoadState: "ready",
     });
 
     expect(model.provider.kind).toBe("google-maps-js");
@@ -742,5 +743,39 @@ describe("mapSurface", () => {
 
     const bundleMarkers = model.markers.filter((marker) => marker.id.startsWith("bundle-bundle-1-"));
     expect(bundleMarkers.map((marker) => marker.kind)).toEqual(["lodging", "activity", "transport"]);
+  });
+
+  it("api key alone does not report a live provider", () => {
+    const model = buildTripMapSurfaceModel({
+      activeScenario: kyotoBaselineScenario,
+      bundles: [kyotoAnchorBundle],
+      feasibilitySummary: routeAttentionFeasibility,
+      googleMapsApiKey: "test-key",
+    });
+
+    expect(model.provider.kind).toBe("fallback");
+    expect(model.provider.status).toBe("configured");
+    expect(model.provider.label).toBe("Google Maps configured");
+    expect(model.workspaceView.confidence.level).toBe("medium");
+  });
+
+  it("high confidence requires observed provider", () => {
+    const configuredOnly = buildTripMapSurfaceModel({
+      activeScenario: kyotoBaselineScenario,
+      bundles: [kyotoAnchorBundle],
+      feasibilitySummary: routeAttentionFeasibility,
+      googleMapsApiKey: "test-key",
+    });
+    const observedReady = buildTripMapSurfaceModel({
+      activeScenario: kyotoBaselineScenario,
+      bundles: [kyotoAnchorBundle],
+      feasibilitySummary: routeAttentionFeasibility,
+      googleMapsApiKey: "test-key",
+      providerLoadState: "ready",
+    });
+
+    expect(configuredOnly.workspaceView.confidence.level).toBe("medium");
+    expect(observedReady.provider.kind).toBe("google-maps-js");
+    expect(observedReady.workspaceView.confidence.level).toBe("high");
   });
 });

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -327,7 +327,8 @@ function buildRouteStops(activeScenario: TripMapScenario): RouteStop[] {
 function buildRouteSegments(
   activeScenario: TripMapScenario,
   routeStops: RouteStop[],
-  routeWarning: string | null
+  routeWarning: string | null,
+  providerReady: boolean
 ): RouteSegment[] {
   const providerSegments = activeScenario.map_view?.rough_route_geometry ?? [];
   if (providerSegments.length > 0) {
@@ -336,23 +337,26 @@ function buildRouteSegments(
       .filter(
         (segment) => stopById.has(segment.from_marker_id) && stopById.has(segment.to_marker_id)
       )
-      .map((segment) => ({
-        id: segment.id,
-        fromStopId: segment.from_marker_id,
-        toStopId: segment.to_marker_id,
-        fromLabel: segment.from_label,
-        toLabel: segment.to_label,
-        x1: segment.x1 * 100,
-        y1: segment.y1 * 100,
-        x2: segment.x2 * 100,
-        y2: segment.y2 * 100,
-        warning: segment.warning ?? routeWarning,
-        durationMinutes: segment.duration_minutes ?? null,
-        distanceKm: segment.distance_km ?? null,
-        confidence: segment.confidence ?? activeScenario.map_view?.confidence.level ?? "medium",
-        unavailableReason: segment.unavailable_reason ?? null,
-        focusCues: [],
-      }));
+      .map((segment) => {
+        const confidence = segment.confidence ?? activeScenario.map_view?.confidence.level ?? "medium";
+        return {
+          id: segment.id,
+          fromStopId: segment.from_marker_id,
+          toStopId: segment.to_marker_id,
+          fromLabel: segment.from_label,
+          toLabel: segment.to_label,
+          x1: segment.x1 * 100,
+          y1: segment.y1 * 100,
+          x2: segment.x2 * 100,
+          y2: segment.y2 * 100,
+          warning: segment.warning ?? routeWarning,
+          durationMinutes: segment.duration_minutes ?? null,
+          distanceKm: segment.distance_km ?? null,
+          confidence: !providerReady && confidence === "high" ? "medium" : confidence,
+          unavailableReason: segment.unavailable_reason ?? null,
+          focusCues: [],
+        };
+      });
   }
 
   return routeStops.slice(0, -1).map((stop, index) => {
@@ -870,9 +874,10 @@ export function buildTripMapSurfaceModel({
     )
   );
   const trimmedApiKey = googleMapsApiKey?.trim() ?? "";
+  const providerReady = trimmedApiKey !== "" && providerLoadState === "ready";
   const routeWarning = deriveRouteWarning(activeScenario, feasibilitySummary);
   const resolvedPolicyPosture = tripMode === "leisure" ? null : policyPosture;
-  const routeSegments = buildRouteSegments(activeScenario, routeStops, routeWarning);
+  const routeSegments = buildRouteSegments(activeScenario, routeStops, routeWarning, providerReady);
   const baseMarkers = buildMarkers({
     activeScenario,
     bundles,

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -9,20 +9,26 @@ type InventoryBundle = WorkspaceData["inventory_summary"]["bundles"][number];
 type PlanningLedgerState = NonNullable<WorkspaceData["planning_ledger"]>;
 type PlanningLedgerEntry = PlanningLedgerState["entries"][number];
 
-export type MapProviderLoadState = "ready" | "loading" | "error";
+export type MapProviderLoadState = "pending" | "loading" | "ready" | "error";
 
 export type MapSurfaceProvider =
   | {
       kind: "google-maps-js";
-      label: "Google Maps JavaScript adapter";
-      status: "live";
+      label: "Google Maps configured";
+      status: "configured";
       apiKey: string;
       summary: string;
     }
   | {
       kind: "fallback";
       label: string;
-      status: "fallback" | "misconfigured" | "provider-error" | "loading" | "sparse-route";
+      status:
+        | "fallback"
+        | "configured"
+        | "misconfigured"
+        | "provider-error"
+        | "loading"
+        | "sparse-route";
       summary: string;
     };
 
@@ -793,9 +799,11 @@ function visibleFocusCuesFor({
 function deriveMapConfidence({
   routeState,
   provider,
+  providerLoadState,
 }: {
   routeState: "ready" | "sparse";
   provider: MapSurfaceProvider;
+  providerLoadState: MapProviderLoadState;
 }): MapWorkspaceView["confidence"] {
   if (routeState === "sparse") {
     return {
@@ -803,15 +811,18 @@ function deriveMapConfidence({
       summary: "Low confidence: the route needs more stops before the map can show its shape.",
     };
   }
-  if (provider.kind === "fallback") {
+  if (
+    provider.kind === "google-maps-js" &&
+    providerLoadState === "ready"
+  ) {
     return {
-      level: "medium",
-      summary: "Medium confidence: this is an approximate sketch from the current route stops.",
+      level: "high",
+      summary: "High confidence: the route has enough map detail for close review.",
     };
   }
   return {
-    level: "high",
-    summary: "High confidence: the route has enough map detail for close review.",
+    level: "medium",
+    summary: "Medium confidence: this is an approximate sketch from the current route stops.",
   };
 }
 
@@ -825,7 +836,7 @@ export function buildTripMapSurfaceModel({
   tripMode = null,
   policyPosture = null,
   googleMapsApiKey,
-  providerLoadState = "ready",
+  providerLoadState = "pending",
   activeScope = "regional",
   selectedSegmentId,
   planningLedger,
@@ -923,14 +934,22 @@ export function buildTripMapSurfaceModel({
       summary:
         "Google Maps JavaScript is loading; the workspace keeps route context visible until the adapter is ready.",
     };
+  } else if (providerLoadState !== "ready") {
+    provider = {
+      kind: "fallback",
+      label: "Google Maps configured",
+      status: "configured",
+      summary:
+        "Google Maps JavaScript is configured and will be marked live only after the SDK and trip locations load successfully.",
+    };
   } else {
     provider = {
       kind: "google-maps-js",
-      label: "Google Maps JavaScript adapter",
-      status: "live",
+      label: "Google Maps configured",
+      status: "configured",
       apiKey: trimmedApiKey,
       summary:
-        "Google Maps JavaScript is the active presentation adapter; route, marker, and warning state still comes from workspace runtime data.",
+        "Google Maps JavaScript is configured and will be marked live only after the SDK and trip locations load successfully.",
     };
   }
   const visibleMapContent = visibleMapContentFor({
@@ -956,7 +975,7 @@ export function buildTripMapSurfaceModel({
     placeMarkers: visibleMapContent.markers,
     roughRouteGeometry: visibleMapContent.routeSegments,
     focusCues: visibleFocusCues,
-    confidence: deriveMapConfidence({ routeState, provider }),
+    confidence: deriveMapConfidence({ routeState, provider, providerLoadState }),
     diagnostics: {
       provider,
       routeState,

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1923,7 +1923,7 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("7 transfer checkpoint(s)")).toBeInTheDocument();
   });
 
-  it("renders the Google Maps JavaScript provider path when configured", async () => {
+  it("does not treat configured environment state as observed provider readiness", async () => {
     vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "test-key");
     vi.stubEnv("VITE_GOOGLE_MAPS_PROVIDER_STATE", "ready");
     const user = userEvent.setup();
@@ -1935,23 +1935,21 @@ describe("WorkspacePage", () => {
     const { container } = renderWorkspacePage();
 
     await waitFor(() => {
-      expect(
-        screen.getByLabelText("Interactive map for Kyoto base with Uji day trip")
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Fallback option markers")).toBeInTheDocument();
     });
 
-    expect(screen.getByLabelText("Route geometry overlay for Kyoto base with Uji day trip")).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: /stop marker:/ }).length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText("Interactive map for Kyoto base with Uji day trip")).not.toBeInTheDocument();
+    expect(screen.getByText("Schematic preview — not a live map")).toBeInTheDocument();
     expect(container.querySelector("iframe")).toBeNull();
     expect(screen.queryByTitle(/google maps/i)).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Fallback option markers")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Fallback option markers")).toBeInTheDocument();
     expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass(
-      "map-route-google-maps-js"
+      "map-route-fallback"
     );
     expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
-    expect(screen.queryByLabelText("Schematic preview — not a live map")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Schematic preview — not a live map")).toBeInTheDocument();
     expect(
-      screen.getAllByText("High confidence: the route has enough map detail for close review.")
+      screen.getAllByText("Medium confidence: this is an approximate sketch from the current route stops.")
         .length
     ).toBeGreaterThan(0);
     expect(screen.queryByText("Google Maps JavaScript adapter")).not.toBeInTheDocument();
@@ -1965,7 +1963,7 @@ describe("WorkspacePage", () => {
 
     await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
 
-    expect(screen.getByLabelText("Interactive map for Kyoto plus Osaka fallback")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Route sketch for Kyoto plus Osaka fallback" })).toBeInTheDocument();
     expect(screen.getAllByText("Osaka").length).toBeGreaterThan(0);
   });
 
@@ -1979,9 +1977,7 @@ describe("WorkspacePage", () => {
     renderWorkspacePage();
 
     await waitFor(() => {
-      expect(
-        screen.getByLabelText("Interactive map for Kyoto base with Uji day trip")
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Fallback option markers")).toBeInTheDocument();
     });
 
     expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -1925,6 +1925,7 @@ describe("WorkspacePage", () => {
 
   it("renders the Google Maps JavaScript provider path when configured", async () => {
     vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "test-key");
+    vi.stubEnv("VITE_GOOGLE_MAPS_PROVIDER_STATE", "ready");
     const user = userEvent.setup();
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve(workspacePayload),
@@ -1944,11 +1945,11 @@ describe("WorkspacePage", () => {
     expect(container.querySelector("iframe")).toBeNull();
     expect(screen.queryByTitle(/google maps/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Fallback option markers")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Schematic preview — not a live map")).toBeInTheDocument();
     expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass(
       "map-route-google-maps-js"
     );
     expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
+    expect(screen.queryByLabelText("Schematic preview — not a live map")).not.toBeInTheDocument();
     expect(
       screen.getAllByText("High confidence: the route has enough map detail for close review.")
         .length

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -4,7 +4,6 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_GOOGLE_MAPS_BROWSER_API_KEY?: string;
   readonly VITE_GOOGLE_MAPS_EMBED_API_KEY?: string;
-  readonly VITE_GOOGLE_MAPS_PROVIDER_STATE?: "ready" | "loading" | "error";
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Implements #1685

## Summary
- Treat a configured Google Maps API key as a precondition only: default provider state is now `pending`, and key presence alone reports a `configured` fallback status instead of a live adapter.
- High-confidence map copy requires `providerLoadState === "ready"` (observed provider readiness), not merely a non-fallback provider kind.
- Remove the schematic-preview contradiction by showing the "Schematic preview — not a live map" badge only on fallback surfaces.

## Validation
- `npx vitest run frontend/src/components/maps/mapSurface.test.ts -t "api key alone does not report a live provider"` — PASS
- `npx vitest run frontend/src/components/maps/mapSurface.test.ts -t "high confidence requires observed provider"` — PASS
- `npx vitest run frontend/src/components/maps/TripMap.test.tsx` — 6 passed
- `grep -c 'status: "live"' frontend/src/components/maps/mapSurface.ts` → 0

## Live-verification gates (manual)
- Key configured, no SDK loaded: Map tab should report configured/pending state, no "Google Maps JavaScript adapter", no high-confidence summary.
- Key configured with `VITE_GOOGLE_MAPS_PROVIDER_STATE=ready`: provider-backed surface renders without schematic-preview badge.

## Deliberate-break proof
To demonstrate the named test gate, temporarily restore `status: "live"` on the key-present branch in `mapSurface.ts` and rerun the `api key alone does not report a live provider` test — it should fail; revert and confirm pass.

Closes #1685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map loading behavior by keeping configured maps in fallback mode until the map provider is confirmed ready.
  * Updated map labels and statuses to clearly distinguish loading, configured, live, fallback, and error states.
  * Map confidence and route previews now reflect the provider’s actual readiness.
  * Schematic preview indicators appear only when fallback maps are being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->