### PR TITLE
Fix workspace refresh state loss

### DIFF
--- a/frontend/src/components/budget/WorkspaceBudgetPanel.test.tsx
+++ b/frontend/src/components/budget/WorkspaceBudgetPanel.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { BudgetWorkspaceState } from "../../api/workspace";
+import { WorkspaceBudgetPanel } from "./WorkspaceBudgetPanel";
+
+const budgetState: BudgetWorkspaceState = {
+  budget_plan: {
+    budget_plan_id: "budget:kyoto",
+    trip_id: "trip:kyoto",
+    owner_profile_id: "profile:traveler",
+    title: "Leisure trip budget",
+    mode: "leisure",
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    scenario_budgets: [
+      {
+        scenario_budget_id: "scenario-budget:kyoto",
+        saved_scenario_id: "saved-scenario:kyoto",
+        title: "Kyoto baseline",
+        summary: "Baseline budget",
+        tags: [],
+        notes: [],
+        allocations: [
+          {
+            category_key: "lodging",
+            label: "Lodging",
+            planned_amount: 1200,
+            currency: "USD",
+            flexibility: "flexible",
+            notes: [],
+          },
+        ],
+      },
+    ],
+    current_scenario_budget_id: "scenario-budget:kyoto",
+    currency: "USD",
+    schema_version: "1",
+    tags: [],
+    notes: [],
+  },
+  versions: [
+    {
+      version_id: "budget-version:1",
+      budget_plan_id: "budget:kyoto",
+      recorded_at: "2026-08-01T00:00:00Z",
+      summary: "Initial budget",
+    },
+  ],
+  spend_events: [],
+  summary: {
+    currency: "USD",
+    has_budget_plan: true,
+    current_scenario_budget_id: "scenario-budget:kyoto",
+    current_scenario_title: "Kyoto baseline",
+    planned_total: 1200,
+    actual_total: 0,
+    remaining_total: 1200,
+    spend_event_count: 0,
+    version_count: 1,
+    suggested_categories: ["lodging"],
+    category_summaries: [
+      {
+        category_key: "lodging",
+        label: "Lodging",
+        currency: "USD",
+        planned_amount: 1200,
+        actual_amount: 0,
+        remaining_amount: 1200,
+        flexibility: "flexible",
+      },
+    ],
+  },
+};
+
+describe("WorkspaceBudgetPanel", () => {
+  it("unsaved budget edits survive a refresh", async () => {
+    const user = userEvent.setup();
+    const onSaveBudget = vi.fn().mockResolvedValue(undefined);
+    const onRecordSpend = vi.fn().mockResolvedValue(undefined);
+    const props = {
+      tripMode: "leisure",
+      busyLabel: null,
+      errorMessage: null,
+      onSaveBudget,
+      onRecordSpend,
+    };
+    const view = render(<WorkspaceBudgetPanel budgetState={budgetState} {...props} />);
+
+    const title = screen.getByRole("textbox", { name: "Budget title" });
+    await user.clear(title);
+    await user.type(title, "Unsaved Kyoto edits");
+
+    view.rerender(
+      <WorkspaceBudgetPanel
+        budgetState={{ ...budgetState, budget_plan: { ...budgetState.budget_plan! } }}
+        {...props}
+      />
+    );
+
+    expect(title).toHaveValue("Unsaved Kyoto edits");
+  });
+});

--- a/frontend/src/components/budget/WorkspaceBudgetPanel.tsx
+++ b/frontend/src/components/budget/WorkspaceBudgetPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 
 import type {
   ActualSpendEventUpsertPayload,
@@ -117,6 +117,16 @@ function buildSpendFormState(budgetState: BudgetWorkspaceState): SpendFormState 
   };
 }
 
+function budgetRevision(budgetState: BudgetWorkspaceState, tripMode: string): string {
+  return [
+    budgetState.budget_plan?.budget_plan_id ?? "new-budget",
+    budgetState.budget_plan?.updated_at ?? "",
+    budgetState.versions[0]?.version_id ?? "",
+    budgetState.summary.current_scenario_budget_id ?? "",
+    tripMode,
+  ].join(":");
+}
+
 export function WorkspaceBudgetPanel({
   budgetState,
   tripMode,
@@ -139,13 +149,35 @@ export function WorkspaceBudgetPanel({
     buildSpendFormState(budgetState)
   );
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
+  const [refreshMessage, setRefreshMessage] = useState<string | null>(null);
+  const [budgetDirty, setBudgetDirty] = useState(false);
+  const [spendDirty, setSpendDirty] = useState(false);
+  const lastBudgetRevisionRef = useRef<string | null>(null);
   const activeScenario = getActiveScenario(budgetState);
+  const persistedRevision = budgetRevision(budgetState, tripMode);
 
   useEffect(() => {
-    setBudgetForm(buildBudgetFormState(budgetState, tripMode));
-    setSpendForm(buildSpendFormState(budgetState));
-    setValidationMessage(null);
-  }, [budgetState, tripMode]);
+    const previousRevision = lastBudgetRevisionRef.current;
+    if (previousRevision === persistedRevision) {
+      return;
+    }
+    lastBudgetRevisionRef.current = persistedRevision;
+
+    if (!budgetDirty) {
+      setBudgetForm(buildBudgetFormState(budgetState, tripMode));
+    }
+    if (!spendDirty) {
+      setSpendForm(buildSpendFormState(budgetState));
+    }
+    if (!budgetDirty && !spendDirty) {
+      setValidationMessage(null);
+      setRefreshMessage(null);
+    } else if (previousRevision !== null) {
+      setRefreshMessage(
+        "A newer saved budget is available. Your unsaved edits are still here; save them when you are ready."
+      );
+    }
+  }, [budgetDirty, budgetState, persistedRevision, spendDirty, tripMode]);
 
   async function handleBudgetSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -189,6 +221,8 @@ export function WorkspaceBudgetPanel({
       ],
       summary: budgetForm.summary.trim(),
     });
+    setBudgetDirty(false);
+    setRefreshMessage(null);
   }
 
   async function handleSpendSubmit(event: FormEvent<HTMLFormElement>) {
@@ -215,6 +249,8 @@ export function WorkspaceBudgetPanel({
       merchant_name: spendForm.merchant_name.trim(),
       notes: [],
     });
+    setSpendDirty(false);
+    setRefreshMessage(null);
   }
 
   return (
@@ -228,6 +264,7 @@ export function WorkspaceBudgetPanel({
       {busyLabel ? <p className="muted-copy">{busyLabel}</p> : null}
       {errorMessage ? <p className="planner-inline-error">{errorMessage}</p> : null}
       {validationMessage ? <p className="planner-inline-error">{validationMessage}</p> : null}
+      {refreshMessage ? <p className="planner-inline-notice">{refreshMessage}</p> : null}
 
       <dl className="budget-summary-grid">
         <div>
@@ -256,9 +293,10 @@ export function WorkspaceBudgetPanel({
               <input
                 aria-label="Budget title"
                 value={budgetForm.title}
-                onChange={(event) =>
-                  setBudgetForm((current) => ({ ...current, title: event.target.value }))
-                }
+                onChange={(event) => {
+                  setBudgetDirty(true);
+                  setBudgetForm((current) => ({ ...current, title: event.target.value }));
+                }}
               />
             </label>
 
@@ -268,9 +306,10 @@ export function WorkspaceBudgetPanel({
                 aria-label="Currency"
                 maxLength={3}
                 value={budgetForm.currency}
-                onChange={(event) =>
-                  setBudgetForm((current) => ({ ...current, currency: event.target.value.toUpperCase() }))
-                }
+                onChange={(event) => {
+                  setBudgetDirty(true);
+                  setBudgetForm((current) => ({ ...current, currency: event.target.value.toUpperCase() }));
+                }}
               />
             </label>
           </div>
@@ -280,9 +319,10 @@ export function WorkspaceBudgetPanel({
             <input
               aria-label="Scenario label"
               value={budgetForm.scenarioTitle}
-              onChange={(event) =>
-                setBudgetForm((current) => ({ ...current, scenarioTitle: event.target.value }))
-              }
+              onChange={(event) => {
+                setBudgetDirty(true);
+                setBudgetForm((current) => ({ ...current, scenarioTitle: event.target.value }));
+              }}
             />
           </label>
 
@@ -291,9 +331,10 @@ export function WorkspaceBudgetPanel({
             <input
               aria-label="Update summary"
               value={budgetForm.summary}
-              onChange={(event) =>
-                setBudgetForm((current) => ({ ...current, summary: event.target.value }))
-              }
+              onChange={(event) => {
+                setBudgetDirty(true);
+                setBudgetForm((current) => ({ ...current, summary: event.target.value }));
+              }}
             />
           </label>
 
@@ -308,7 +349,8 @@ export function WorkspaceBudgetPanel({
                   min="0"
                   step="0.01"
                   value={allocation.planned_amount}
-                  onChange={(event) =>
+                  onChange={(event) => {
+                    setBudgetDirty(true);
                     setBudgetForm((current) => ({
                       ...current,
                       allocations: current.allocations.map((item) =>
@@ -316,8 +358,8 @@ export function WorkspaceBudgetPanel({
                           ? { ...item, planned_amount: event.target.value }
                           : item
                       ),
-                    }))
-                  }
+                    }));
+                  }}
                 />
               </label>
             ))}
@@ -334,9 +376,10 @@ export function WorkspaceBudgetPanel({
             <select
               aria-label="Spend category"
               value={spendForm.category_key}
-              onChange={(event) =>
-                setSpendForm((current) => ({ ...current, category_key: event.target.value }))
-              }
+              onChange={(event) => {
+                setSpendDirty(true);
+                setSpendForm((current) => ({ ...current, category_key: event.target.value }));
+              }}
             >
               {budgetState.summary.category_summaries.map((summary) => (
                 <option key={summary.category_key} value={summary.category_key}>
@@ -355,9 +398,10 @@ export function WorkspaceBudgetPanel({
               min="0"
               step="0.01"
               value={spendForm.amount}
-              onChange={(event) =>
-                setSpendForm((current) => ({ ...current, amount: event.target.value }))
-              }
+              onChange={(event) => {
+                setSpendDirty(true);
+                setSpendForm((current) => ({ ...current, amount: event.target.value }));
+              }}
             />
           </label>
 
@@ -366,9 +410,10 @@ export function WorkspaceBudgetPanel({
             <input
               aria-label="Spend context"
               value={spendForm.source_context}
-              onChange={(event) =>
-                setSpendForm((current) => ({ ...current, source_context: event.target.value }))
-              }
+              onChange={(event) => {
+                setSpendDirty(true);
+                setSpendForm((current) => ({ ...current, source_context: event.target.value }));
+              }}
             />
           </label>
 
@@ -377,9 +422,10 @@ export function WorkspaceBudgetPanel({
             <input
               aria-label="Merchant"
               value={spendForm.merchant_name}
-              onChange={(event) =>
-                setSpendForm((current) => ({ ...current, merchant_name: event.target.value }))
-              }
+              onChange={(event) => {
+                setSpendDirty(true);
+                setSpendForm((current) => ({ ...current, merchant_name: event.target.value }));
+              }}
             />
           </label>
 

--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -292,6 +292,48 @@ describe("TripMap", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps a visible marker selected when refreshed scenario data has a new identity", () => {
+    function RefreshHarness({ refreshed }: { refreshed: boolean }) {
+      const [activeScope, setActiveScope] = useState<"global" | "regional" | "local">("regional");
+      const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(null);
+      const refreshedComparison = refreshed
+        ? { ...comparison, scenarios: comparison.scenarios.map((scenario) => ({ ...scenario })) }
+        : comparison;
+      return (
+        <TripMap
+          comparison={refreshedComparison}
+          scenarioComparisonSummary="Rail-first stays the easiest route to compare against."
+          scenarioFocusAreas={["route_pace"]}
+          activeScenarioId="route-option:rail-first"
+          onSelectScenario={vi.fn()}
+          bundles={bundles}
+          feasibilitySummary={feasibilitySummary}
+          tripPrimaryRegions={["Sweden", "Norway"]}
+          tripMode="business"
+          policyPosture="No approval packet yet"
+          activeScope={activeScope}
+          selectedSegmentId={selectedSegmentId}
+          onScopeChange={setActiveScope}
+          onSelectSegment={setSelectedSegmentId}
+          compactLayout={false}
+        />
+      );
+    }
+
+    const view = render(<RefreshHarness refreshed={false} />);
+    const markerButtons = screen.getAllByRole("button", { name: /marker:/i });
+    const selectedMarker = markerButtons[markerButtons.length - 1];
+    fireEvent.click(selectedMarker);
+    expect(selectedMarker).toHaveAttribute("aria-pressed", "true");
+
+    view.rerender(<RefreshHarness refreshed />);
+
+    expect(screen.getByRole("button", { name: selectedMarker.getAttribute("aria-label")! })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
   it("renders segment timing and confidence in traveler language", () => {
     renderTripMap();
 

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -149,6 +149,8 @@ function ActiveTripMap({
     mapSurface.visibleMarkers.find((marker) => marker.focusCues.length > 0)?.id ??
     mapSurface.visibleMarkers[0]?.id ??
     null;
+  const visibleMarkerIds = JSON.stringify(mapSurface.visibleMarkers.map((marker) => marker.id));
+  const visibleMarkerIdSet = useMemo(() => new Set(JSON.parse(visibleMarkerIds) as string[]), [visibleMarkerIds]);
   const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(initialMarkerId);
   const selectedMarker = useMemo(
     () =>
@@ -159,8 +161,12 @@ function ActiveTripMap({
   );
 
   useEffect(() => {
-    setSelectedMarkerId(initialMarkerId);
-  }, [activeScenario.scenario_id, initialMarkerId]);
+    setSelectedMarkerId((current) =>
+      current !== null && visibleMarkerIdSet.has(current)
+        ? current
+        : initialMarkerId
+    );
+  }, [activeScenario.scenario_id, initialMarkerId, visibleMarkerIdSet]);
 
   function handleScopeChange(nextScope: MapViewScope) {
     onScopeChange(nextScope);

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1156,10 +1156,20 @@ function WorkspacePageContent({
     const previousWorkspace = previousWorkspaceRef.current;
     previousWorkspaceRef.current = workspace;
     setCurrentWorkspace(workspace);
-    setSourceMixTarget(sourceMixTargetFromWorkspace(workspace));
-    setSelectedScenarioId(resolveMapScenarioId(workspace));
-    setSelectedMapScope("regional");
-    setSelectedSegmentId(null);
+    const tripChanged = previousWorkspace.trip_record.trip.trip_id !== workspace.trip_record.trip.trip_id;
+    if (tripChanged) {
+      setSourceMixTarget(sourceMixTargetFromWorkspace(workspace));
+      setSelectedScenarioId(resolveMapScenarioId(workspace));
+      setSelectedMapScope("regional");
+      setSelectedSegmentId(null);
+    } else {
+      const availableScenarioIds = new Set(
+        resolveRouteComparison(workspace).scenarios.map((scenario) => scenario.scenario_id)
+      );
+      setSelectedScenarioId((current) =>
+        current !== null && availableScenarioIds.has(current) ? current : resolveMapScenarioId(workspace)
+      );
+    }
     setPlannerConversationNotice(null);
     setRouteOptionSuccess(null);
     setNotebookSuccess(null);
@@ -1169,10 +1179,14 @@ function WorkspacePageContent({
   }, [workspace]);
 
   useEffect(() => {
-    setSelectedTripComparisonId(
-      trips.find((trip) => trip.trip_id !== workspace.trip_record.trip.trip_id)?.trip_id ?? null
-    );
-  }, [trips, workspace]);
+    setSelectedTripComparisonId((current) => {
+      const currentTripId = workspace.trip_record.trip.trip_id;
+      if (current !== null && current !== currentTripId && trips.some((trip) => trip.trip_id === current)) {
+        return current;
+      }
+      return trips.find((trip) => trip.trip_id !== currentTripId)?.trip_id ?? null;
+    });
+  }, [trips, workspace.trip_record.trip.trip_id]);
 
   useEffect(() => {
     let isCancelled = false;


### PR DESCRIPTION
## Summary

- Preserve dirty budget and spend drafts across equivalent workspace refreshes and explain the newer-saved-value conflict behavior.
- Retain valid scenario, map, comparison, and marker selections until their persisted identities change.
- Add focused regression coverage for draft and marker refresh behavior.

## Validation

- `npm test` (19 files, 119 tests passed)
- `npx tsc -b --pretty false`
- `npx vitest run src/components/budget/WorkspaceBudgetPanel.test.tsx -t "unsaved budget edits survive a refresh"`
- `npx vitest run src/routes/WorkspacePage.test.tsx` (52 passed)

## Live verification

The named UI regression tests rerender equivalent refreshed data after an unsaved edit or non-default marker selection and confirm the local state remains intact.

Closes #1686
