### PR TITLE
Merge the two-trip live canary: real Google Maps provider + browser canary (unmerged since 2026-07-13)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dist/
 # Runtime LangSmith fleet artifacts are regenerated and can contain local trace IDs.
 artifacts/langsmith/
 workloop-state.md
+.gitnexus

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test install runtime-backend runtime-frontend runtime-dev runtime-check runtime-smoke runtime-production-check runtime-preview-smoke runtime-full-product-check full-product-check
+.PHONY: test install runtime-backend runtime-frontend runtime-dev runtime-check runtime-smoke runtime-production-check runtime-preview-smoke runtime-full-product-check full-product-check two-trip-ui-canary two-trip-demo
 
 test:
 	python -m pytest
@@ -38,3 +38,9 @@ full-product-check:
 	python scripts/check_full_product_verification.py --live-tpp $(LIVE_TPP)
 
 runtime-full-product-check: full-product-check
+
+two-trip-ui-canary:
+	./scripts/run_two_trip_ui_canary.sh
+
+two-trip-demo:
+	TRIP_PLANNER_SEED_DEMO=1 uv run --extra dev python scripts/seed_demo_data.py

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The runtime baseline now treats the saved trip record as the durable planning container. New scenario, budget, workspace, and policy work should attach to a persisted trip instead of inventing a parallel root object.
 Saved scenarios and trip-level planning history now persist underneath that same trip container, so later comparison and workspace slices should consume those records instead of reintroducing fixture-only storage.
-The shipped full-stack MVP now includes authenticated trip creation, persisted trip and scenario routes, the workspace shell, planner session APIs, stored policy/proposal state, and a provider-backed map adapter seam with bounded fallback rendering. Live external policy transport remains a follow-on integration, so docs and checks in this repo should describe that gap explicitly instead of implying it already ships.
+The shipped full-stack MVP now includes authenticated trip creation, persisted trip and scenario routes, the workspace shell, planner session APIs, stored policy/proposal state, a live Google Maps JavaScript SDK path with bounded fallback rendering, and a review-only browser handoff into a sibling `Travel-Plan-Permission` portal.
 
 ## Current MVP Surfaces
 
@@ -16,9 +16,9 @@ The current runtime already ships these inspectable application surfaces:
 - authenticated sign-up, sign-in, sign-out, and session restore
 - persisted trip creation plus saved trip, scenario-history, and workspace routes
 - planner session APIs and workspace state hydration for the frontend app shell
-- stored proposal and policy posture state that later `Travel-Plan-Permission` work can consume
+- stored proposal and policy posture state plus a business-trip handoff that pre-fills the `Travel-Plan-Permission` workbook workflow
 
-The current runtime ships a Google Maps JavaScript adapter boundary for the workspace map surface, with CI-safe mocked rendering and fallback states for missing config, provider load errors, and sparse route data. Remote `Travel-Plan-Permission` execution remains an explicit follow-on integration, so local runtime checks and product docs should continue to call that out as deferred.
+When a browser API key is configured, the workspace loads Google's JavaScript SDK and renders native markers and a route polyline from saved trip coordinates. Browser geocoding is used only when those coordinates are unavailable. Missing credentials, SDK errors, and unresolved locations retain the schematic route as an explicitly labelled fallback. For business trips, the Policy tab can POST known trip details to the sibling `Travel-Plan-Permission` portal, where the traveler completes organization-specific fields and generates the organization's Excel workbook for review and download. That handoff deliberately cannot submit the request.
 
 ## Persisted Workspace Runtime Behavior
 
@@ -134,8 +134,11 @@ Run the full stack together from the repo root:
 make runtime-dev
 ```
 
-That starts the FastAPI runtime on `http://127.0.0.1:8000` and the Vite app on
-`http://127.0.0.1:5173` with the frontend proxying `/api` requests to the backend.
+That starts the FastAPI runtime on `http://127.0.0.1:8000`, the Vite app on
+`http://127.0.0.1:5173`, and the sibling `Travel-Plan-Permission` portal on
+`http://127.0.0.1:8766`. The frontend proxies `/api` requests to the backend and
+receives the TPP portal origin through `VITE_TPP_PORTAL_URL`. Set `TPP_REPO_PATH`
+or `TPP_BASE_URL` when the sibling checkout or portal uses a different location.
 
 Validate the runtime surfaces from the repo root:
 
@@ -155,6 +158,20 @@ For a full-product verification lane that first runs the backend/frontend runtim
 make full-product-check
 ```
 
+To prove the same flow through the actual browser UI, creating a Washington DC
+business trip and a Kyoto/Osaka leisure trip through the public forms and then
+opening each rendered scenario comparison, run:
+
+```bash
+make two-trip-ui-canary
+```
+
+This uses an isolated temporary database, performs no booking or purchase, and
+writes passing/failing browser evidence under the artifact directory printed by
+the command. To leave equivalent synthetic trips in your normal local app so
+you can explore them after the test, run `make two-trip-demo`, start the app with
+`make runtime-dev`, and sign in with the documented demo credentials below.
+
 `make runtime-full-product-check` is available as an equivalent runtime-prefixed alias.
 Use `python scripts/check_full_product_verification.py --skip-frontend-smoke` only when you need to isolate the product-journey assertions from frontend/runtime smoke prerequisites.
 
@@ -171,7 +188,7 @@ The verification path covers:
 - a smoke test that runs the frontend client against a live backend process
 - a separate full-product check for fresh leisure and business product journeys
 
-These checks validate the local full-stack MVP that already exists in this repo. They exercise the map adapter and fallback seam with mocked provider state. They do not prove live Google Maps rendering or remote Travel-Plan-Permission transport.
+These checks validate the local full-stack MVP that already exists in this repo. Unit tests exercise SDK loading, geocoding, native map construction, fallback behavior, and the scoped TPP handoff. Use the browser canary with a configured browser key to prove Google's live SDK path; the local business-trip flow proves TPP review and workbook generation without submitting anything externally.
 The production-focused testing plan in [docs/local-testing-plan.md](docs/local-testing-plan.md) adds the critical auth, trip, workspace, policy, proposal, and preview-verification journeys on top of that baseline.
 
 ## Demo Deploy (data-zoned)
@@ -211,8 +228,10 @@ seeded workspace (the script prints the exact `/workspace/<trip_id>` URLs):
 - email: `demo@trip-planner.local`
 - password: `demo-trip-planner-2026`
 
-Each `/workspace/<trip_id>` immediately shows ranked scenarios and the
-(schematic) map card. Do **not** run this seed against a production deployment;
+The seeded workspaces are a Washington DC client visit and a Kyoto/Osaka
+cultural week. Each immediately shows ranked scenarios and uses the live Google
+map when a browser key is configured, with the route sketch retained as a
+fallback. Do **not** run this seed against a production deployment;
 it exists for local and non-production evaluation only.
 
 ## Persistent Deployment
@@ -257,8 +276,10 @@ Use these env vars only when you are intentionally exercising an integration sea
 
 - `VITE_API_BASE_URL`: overrides the frontend API base URL when you are not using the local Vite proxy.
 - `VITE_GOOGLE_MAPS_BROWSER_API_KEY`: primary key for enabling the Google Maps JavaScript adapter path in the workspace.
+- `VITE_GOOGLE_MAPS_MAP_ID`: optional production map ID for advanced markers. Local development uses Google's demo map ID when this is unset.
 - `VITE_GOOGLE_MAPS_EMBED_API_KEY`: legacy key name still accepted as a compatibility fallback when `VITE_GOOGLE_MAPS_BROWSER_API_KEY` is not set.
 - `VITE_GOOGLE_MAPS_PROVIDER_STATE`: optional local/test override for the map adapter load state (`ready`, `loading`, or `error`).
+- `VITE_TPP_PORTAL_URL`: browser-visible TPP origin used by the business Policy-tab handoff. `make runtime-dev` supplies the sibling portal origin automatically.
 - `TRIP_PLANNER_DATA_ZONE`: explicit data-zone switch for integration seams. Use `synthetic` for local/demo data (the default) or `proprietary` for real traveler/company data inside the perimeter.
 - `TRIP_PLANNER_OPENAI_AUTHORIZED_ENDPOINT`: marker for an approved no-train OpenAI endpoint. In `TRIP_PLANNER_DATA_ZONE=proprietary`, the planner refuses the OpenAI path and stays in deterministic fallback unless this marker is set. The outbound planner prompt redaction hook still runs before model invocation when the OpenAI path is enabled.
 - `TPP_BASE_URL`, `TPP_ACCESS_TOKEN`, `TPP_OIDC_PROVIDER`: enable the live `Travel-Plan-Permission` transport client. If they are unset, the repo should continue to present stored-policy and passive/local TPP seams rather than implying a real remote policy round-trip. In `TRIP_PLANNER_DATA_ZONE=proprietary`, `TPP_BASE_URL` must point only at an in-perimeter service.
@@ -288,8 +309,10 @@ one service do not suppress a different host.
 
 That distinction matters for docs and verification messaging:
 
+Local verification checks are useful. They do not prove live Google Maps rendering or remote Travel-Plan-Permission transport.
+
 - missing local prerequisites such as `.venv` or `frontend/node_modules` are setup failures
 - missing live integration env vars are not setup failures for the shipped MVP
 - missing Google Maps configuration or a provider load error should preserve route context through the fallback map instead of blanking the workspace
 - fallback map behavior is intentionally bounded: route-context overlays, markers, route summaries, and detail panels stay visible, but live provider-only interactions do not
-- live remote `Travel-Plan-Permission` execution remains deferred unless you deliberately configure that seam
+- the TPP browser handoff is intentionally review-only: it can create a local draft and workbook but cannot submit a request or make an approval decision

--- a/frontend/e2e/two-trip-canary.spec.ts
+++ b/frontend/e2e/two-trip-canary.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+type TripInput = {
+  title: string;
+  summary: string;
+  mode: "business" | "leisure";
+  regions: string;
+  startDate: string;
+  endDate: string;
+  durationDays: string;
+  travelerKind: "solo" | "team";
+  travelerCount: string;
+  travelerNotes: string;
+  expectedLeadScenario: string;
+};
+
+function isoDate(daysFromToday: number): string {
+  const value = new Date();
+  value.setUTCDate(value.getUTCDate() + daysFromToday);
+  return value.toISOString().slice(0, 10);
+}
+
+async function createTripThroughApp(page: Page, input: TripInput): Promise<string> {
+  await page.goto("/trips/new");
+  await page.getByLabel("Title", { exact: true }).fill(input.title);
+  await page.getByLabel("Summary", { exact: true }).fill(input.summary);
+  await page.locator('select[name="mode"]').selectOption(input.mode);
+  await page.getByLabel("Primary regions", { exact: true }).fill(input.regions);
+  await page.getByLabel("Start date", { exact: true }).fill(input.startDate);
+  await page.getByLabel("End date", { exact: true }).fill(input.endDate);
+  await page.getByLabel("Duration days", { exact: true }).fill(input.durationDays);
+  await page.locator('select[name="travelerKind"]').selectOption(input.travelerKind);
+  await page.getByLabel("Traveler count", { exact: true }).fill(input.travelerCount);
+  await page.getByLabel("Traveler notes", { exact: true }).fill(input.travelerNotes);
+  await page.getByRole("button", { name: "Create trip", exact: true }).click();
+
+  await expect(page).toHaveURL(/\/workspace\/trip-/);
+  await expect(page.getByRole("heading", { name: input.title, exact: true }).first()).toBeVisible();
+  await page.getByRole("tab", { name: "Compare", exact: true }).click();
+  await expect(page.getByRole("tab", { name: "Compare", exact: true })).toHaveAttribute(
+    "aria-selected",
+    "true"
+  );
+  await expect(
+    page.getByRole("heading", { name: input.expectedLeadScenario, exact: true }).first()
+  ).toBeVisible();
+  await expect(page.getByText("3 runtime scenario(s)", { exact: false })).toBeVisible();
+  if (process.env.VITE_GOOGLE_MAPS_BROWSER_API_KEY?.trim()) {
+    await page.getByRole("tab", { name: "Map", exact: true }).click();
+    await expect(page.locator('[data-google-maps-live="true"]')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("Live Google Maps", { exact: true })).toBeVisible();
+    await page.getByRole("tab", { name: "Compare", exact: true }).click();
+  }
+  return page.url();
+}
+
+test("a traveler can create and inspect the two-trip canary in the real app", async ({ page }, testInfo: TestInfo) => {
+  const uniqueEmail = `two-trip-canary-${Date.now()}@example.com`;
+  await page.goto("/signup");
+  await page.getByLabel("Display name", { exact: true }).fill("Two Trip Canary");
+  await page.getByLabel("Email", { exact: true }).fill(uniqueEmail);
+  await page.getByLabel("Password", { exact: true }).fill("canary-password-2026");
+  await page.getByRole("button", { name: "Create account", exact: true }).click();
+  await expect(page).toHaveURL(/\/trips$/);
+
+  const businessUrl = await createTripThroughApp(page, {
+    title: "Canary Washington DC client visit",
+    summary: "Three travelers attending a two-day client meeting with an arrival buffer.",
+    mode: "business",
+    regions: "Washington DC",
+    startDate: isoDate(75),
+    endDate: isoDate(77),
+    durationDays: "3",
+    travelerKind: "team",
+    travelerCount: "3",
+    travelerNotes: "Economy travel, central lodging, explicit budget, and manager review.",
+    expectedLeadScenario: "Washington DC runtime bundle",
+  });
+  await testInfo.attach("business-workspace", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+
+  const leisureUrl = await createTripThroughApp(page, {
+    title: "Canary Kyoto cultural week",
+    summary: "Seven days focused on Kyoto culture, food, and low-transfer neighborhood exploration.",
+    mode: "leisure",
+    regions: "Kyoto, Osaka",
+    startDate: isoDate(90),
+    endDate: isoDate(96),
+    durationDays: "7",
+    travelerKind: "solo",
+    travelerCount: "1",
+    travelerNotes: "Moderate budget, cultural sites, local food, and simple transfers via Osaka.",
+    expectedLeadScenario: "Kyoto runtime bundle",
+  });
+  await testInfo.attach("leisure-workspace", {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: "image/png",
+  });
+
+  await page.goto("/trips");
+  await expect(
+    page.getByRole("heading", { name: "Canary Washington DC client visit", exact: true })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Canary Kyoto cultural week", exact: true })
+  ).toBeVisible();
+  await testInfo.attach("two-trip-canary-summary", {
+    body: Buffer.from(JSON.stringify({ businessUrl, leisureUrl }, null, 2)),
+    contentType: "application/json",
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,14 +8,17 @@
       "name": "trip-planner-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@googlemaps/js-api-loader": "^2.1.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "1.61.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/google.maps": "^3.65.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.0",
@@ -310,6 +313,15 @@
         }
       }
     },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.1.1.tgz",
+      "integrity": "sha512-yUpAwksbHrlZIWD49JmveNSfBG4oAK0AwMknfSaPMnP5N7UT8oFRVCqwjGb1XQovi//7KLbPQKZpbofiLGzpDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/google.maps": "^3.53.1"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -347,6 +359,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -770,6 +798,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/google.maps": {
+      "version": "3.65.4",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.65.4.tgz",
+      "integrity": "sha512-5mvL6keNtWL8jisY5ABjNCpczqGpP9SU9CgYYi7xK+rmy0PSVsDIS+4fM+q6HR1uihDj2k7F1KoHK7kSV5GBpQ==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -1992,6 +2026,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,18 +11,22 @@
     "prebuild": "python ../scripts/write_frontend_redirects.py && python ../scripts/check_deploy_origin.py",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run --exclude src/smoke/**",
+    "test": "vitest run --exclude src/smoke/** --exclude e2e/**",
+    "test:e2e:canary": "playwright test e2e/two-trip-canary.spec.ts",
     "test:smoke": "vitest run src/smoke/runtime.smoke.test.ts"
   },
   "dependencies": {
+    "@googlemaps/js-api-loader": "^2.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "1.61.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/google.maps": "^3.65.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test";
+
+const artifactDirectory =
+  process.env.TRIP_PLANNER_CANARY_ARTIFACT_DIR ?? "/tmp/trip-planner-two-trip-canary-artifacts";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  outputDir: artifactDirectory,
+  reporter: [["list"]],
+  use: {
+    baseURL: process.env.TRIP_PLANNER_CANARY_BASE_URL ?? "http://127.0.0.1:5173",
+    channel: process.env.PLAYWRIGHT_BROWSER_CHANNEL ?? "chrome",
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+});

--- a/frontend/src/api/costCoverage.ts
+++ b/frontend/src/api/costCoverage.ts
@@ -1,0 +1,117 @@
+import { fetchJson } from "../lib/api/client";
+
+export type CostCoverageStatus =
+  | "needs_input"
+  | "research_ready"
+  | "researched"
+  | "estimated"
+  | "evidenced"
+  | "complete"
+  | "not_applicable";
+
+export type ResearchSource = {
+  title: string;
+  url: string;
+};
+
+export type ResearchOption = {
+  name: string;
+  unit_rate: number | null;
+  unit: string;
+  estimated_total: number | null;
+  notes: string;
+  source_url: string;
+  details?: Record<string, string | number | boolean | null>;
+};
+
+export type CostCoverageRequirement = {
+  code: string;
+  category: string;
+  title: string;
+  summary: string;
+  collection_mode: "automatic" | "researchable" | "traveler";
+  evidence_kind: string;
+  required_inputs: string[];
+  output_fields: string[];
+  research_prompt?: string | null;
+  policy_reference?: string | null;
+  status: CostCoverageStatus;
+  inputs: Record<string, string>;
+  missing_inputs: string[];
+  estimate_amount: number | null;
+  currency: string;
+  note: string;
+  source_url: string;
+  research: {
+    status: string;
+    summary: string;
+    options: ResearchOption[];
+    sources: ResearchSource[];
+    researched_at: string;
+    model: string | null;
+  } | null;
+  selected_option: ResearchOption | null;
+  updated_at: string | null;
+};
+
+export type CostCoverageResponse = {
+  trip_id: string;
+  contract_version: string;
+  source_status: string;
+  summary: {
+    requirement_count: number;
+    resolved_count: number;
+    research_offer_count: number;
+    ready_for_handoff: boolean;
+    headline: string;
+  };
+  requirements: CostCoverageRequirement[];
+  research_notice?: {
+    status: string;
+    missing_inputs: string[];
+    message: string;
+  } | null;
+};
+
+export function fetchCostCoverage(tripId: string): Promise<CostCoverageResponse> {
+  return fetchJson<CostCoverageResponse>({
+    path: `/api/workspace/${tripId}/cost-coverage`,
+    credentials: "include",
+  });
+}
+
+export function researchCostCoverage(
+  tripId: string,
+  requirementCode: string,
+  inputs: Record<string, string>
+): Promise<CostCoverageResponse> {
+  return fetchJson<CostCoverageResponse>({
+    path: `/api/workspace/${tripId}/cost-coverage/${requirementCode}/research`,
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ inputs }),
+  });
+}
+
+export function updateCostCoverage(
+  tripId: string,
+  requirementCode: string,
+  payload: {
+    status?: CostCoverageStatus;
+    estimate_amount?: number;
+    currency?: string;
+    note?: string;
+    source_url?: string;
+    inputs?: Record<string, string>;
+    selected_option?: ResearchOption;
+  }
+): Promise<CostCoverageResponse> {
+  return fetchJson<CostCoverageResponse>({
+    path: `/api/workspace/${tripId}/cost-coverage/${requirementCode}`,
+    method: "PATCH",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -278,6 +278,8 @@ export type RuntimeScenarioComparison = {
         route_index: number;
         x: number;
         y: number;
+        latitude?: number;
+        longitude?: number;
       }>;
       rough_route_geometry: Array<{
         id: string;

--- a/frontend/src/components/costs/CostEvidencePanel.test.tsx
+++ b/frontend/src/components/costs/CostEvidencePanel.test.tsx
@@ -1,0 +1,141 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CostCoverageRequirement, CostCoverageResponse } from "../../api/costCoverage";
+import { CostEvidencePanel } from "./CostEvidencePanel";
+
+const { fetchCostCoverage, researchCostCoverage, updateCostCoverage } = vi.hoisted(() => ({
+  fetchCostCoverage: vi.fn(),
+  researchCostCoverage: vi.fn(),
+  updateCostCoverage: vi.fn(),
+}));
+
+vi.mock("../../api/costCoverage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/costCoverage")>()),
+  fetchCostCoverage,
+  researchCostCoverage,
+  updateCostCoverage,
+}));
+
+const airportParking: CostCoverageRequirement = {
+  code: "airport_parking",
+  category: "ground_transport",
+  title: "Airport parking",
+  summary: "Find an official parking option and calculate the total.",
+  collection_mode: "researchable" as const,
+  evidence_kind: "provider_rate",
+  required_inputs: ["departure_airport", "parking_days"],
+  output_fields: ["parking_estimate"],
+  research_prompt: "Find official airport parking rates.",
+  policy_reference: "driving_vs_flying",
+  status: "needs_input" as const,
+  inputs: { parking_days: "4" },
+  missing_inputs: ["departure_airport"],
+  estimate_amount: null,
+  currency: "USD",
+  note: "",
+  source_url: "",
+  research: null,
+  selected_option: null,
+  updated_at: null,
+};
+
+function responseWith(requirement: CostCoverageRequirement = airportParking): CostCoverageResponse {
+  return {
+    trip_id: "trip-nyc",
+    contract_version: "tpp-intake-requirements/v1",
+    source_status: "live_tpp",
+    summary: {
+      requirement_count: 1,
+      resolved_count: requirement.status === "evidenced" ? 1 : 0,
+      research_offer_count: requirement.status === "evidenced" ? 0 : 1,
+      ready_for_handoff: requirement.status === "evidenced",
+      headline: "The planner can research missing trip costs and evidence.",
+    },
+    requirements: [requirement],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  fetchCostCoverage.mockReset();
+  researchCostCoverage.mockReset();
+  updateCostCoverage.mockReset();
+});
+
+describe("CostEvidencePanel", () => {
+  it("asks only for the missing airport and offers to research the parking details", async () => {
+    fetchCostCoverage.mockResolvedValue(responseWith());
+    researchCostCoverage.mockResolvedValue(responseWith());
+
+    render(<CostEvidencePanel tripId="trip-nyc" />);
+
+    expect(await screen.findByRole("heading", { name: "Airport parking" })).toBeVisible();
+    expect(screen.getByLabelText("Departure Airport")).toBeVisible();
+    expect(screen.queryByLabelText("Parking Days")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Departure Airport"), { target: { value: "STL" } });
+    fireEvent.click(screen.getByRole("button", { name: "Research this for me" }));
+
+    await waitFor(() =>
+      expect(researchCostCoverage).toHaveBeenCalledWith("trip-nyc", "airport_parking", {
+        parking_days: "4",
+        departure_airport: "STL",
+      })
+    );
+  });
+
+  it("shows sourced options and saves the selected estimate for the workbook", async () => {
+    const option = {
+      name: "Official Lot D",
+      unit_rate: 11,
+      unit: "per day",
+      estimated_total: 44,
+      notes: "Official airport economy parking.",
+      source_url: "https://www.flystl.com/parking",
+    };
+    const researched = {
+      ...airportParking,
+      status: "researched" as const,
+      inputs: { parking_days: "4", departure_airport: "STL" },
+      missing_inputs: [],
+      research: {
+        status: "completed",
+        summary: "Official airport lots are available.",
+        options: [option],
+        sources: [{ title: "STL parking", url: option.source_url }],
+        researched_at: "2026-07-12T12:00:00Z",
+        model: "gpt-5.6-sol",
+      },
+    };
+    fetchCostCoverage.mockResolvedValue(responseWith(researched));
+    updateCostCoverage.mockResolvedValue(
+      responseWith({
+        ...researched,
+        status: "evidenced",
+        estimate_amount: 44,
+        source_url: option.source_url,
+        selected_option: option,
+      })
+    );
+
+    render(<CostEvidencePanel tripId="trip-nyc" />);
+
+    expect(await screen.findByText("$44.00 estimated total")).toBeVisible();
+    expect(screen.getByLabelText("Departure Airport")).toHaveValue("STL");
+    fireEvent.click(screen.getByRole("button", { name: "Use this estimate" }));
+
+    await waitFor(() =>
+      expect(updateCostCoverage).toHaveBeenCalledWith(
+        "trip-nyc",
+        "airport_parking",
+        expect.objectContaining({
+          estimate_amount: 44,
+          source_url: option.source_url,
+          selected_option: option,
+        })
+      )
+    );
+    expect(await screen.findByRole("button", { name: "Selected for workbook" })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/costs/CostEvidencePanel.tsx
+++ b/frontend/src/components/costs/CostEvidencePanel.tsx
@@ -1,0 +1,340 @@
+import { useEffect, useState } from "react";
+
+import {
+  fetchCostCoverage,
+  researchCostCoverage,
+  updateCostCoverage,
+  type CostCoverageRequirement,
+  type CostCoverageResponse,
+  type ResearchOption,
+} from "../../api/costCoverage";
+
+function labelFor(value: string): string {
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatMoney(value: number | null, currency = "USD"): string | null {
+  if (value == null || !Number.isFinite(value)) {
+    return null;
+  }
+  return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(value);
+}
+
+function modeMessage(requirement: CostCoverageRequirement): string {
+  if (requirement.collection_mode === "automatic") {
+    return "The planner calculates this once it has the few trip-specific details below.";
+  }
+  if (requirement.collection_mode === "researchable") {
+    return "The planner can find current options, calculate an estimate, and retain the sources.";
+  }
+  return "Only you or your organization can confirm this item.";
+}
+
+const AUTOMATIC_INPUTS = new Set([
+  "travel_dates",
+  "parking_days",
+  "trip_duration_days",
+  "destination",
+]);
+const REMEMBERED_PROFILE_INPUTS = new Set([
+  "traveler_residence_address",
+  "official_domicile_address",
+]);
+
+export function CostEvidencePanel({ tripId }: { tripId: string }) {
+  const [coverage, setCoverage] = useState<CostCoverageResponse | null>(null);
+  const [inputDrafts, setInputDrafts] = useState<Record<string, Record<string, string>>>({});
+  const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({});
+  const [busyCode, setBusyCode] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setError(null);
+    void fetchCostCoverage(tripId)
+      .then((result) => {
+        if (!active) return;
+        setCoverage(result);
+        setInputDrafts(
+          Object.fromEntries(result.requirements.map((item) => [item.code, { ...item.inputs }]))
+        );
+        setNoteDrafts(
+          Object.fromEntries(result.requirements.map((item) => [item.code, item.note ?? ""]))
+        );
+      })
+      .catch((caught: unknown) => {
+        if (active) setError(caught instanceof Error ? caught.message : "Cost coverage could not be loaded.");
+      });
+    return () => {
+      active = false;
+    };
+  }, [tripId]);
+
+  function adopt(result: CostCoverageResponse) {
+    setCoverage(result);
+    setInputDrafts((current) => ({
+      ...current,
+      ...Object.fromEntries(
+        result.requirements.map((item) => [item.code, { ...(current[item.code] ?? {}), ...item.inputs }])
+      ),
+    }));
+  }
+
+  async function runResearch(requirement: CostCoverageRequirement) {
+    setBusyCode(requirement.code);
+    setError(null);
+    try {
+      adopt(await researchCostCoverage(tripId, requirement.code, inputDrafts[requirement.code] ?? {}));
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "The planner could not finish this research.");
+    } finally {
+      setBusyCode(null);
+    }
+  }
+
+  async function chooseOption(requirement: CostCoverageRequirement, option: ResearchOption) {
+    setBusyCode(requirement.code);
+    setError(null);
+    try {
+      adopt(
+        await updateCostCoverage(tripId, requirement.code, {
+          estimate_amount: option.estimated_total ?? option.unit_rate ?? undefined,
+          source_url: option.source_url,
+          selected_option: option,
+          note: option.notes,
+          inputs: inputDrafts[requirement.code] ?? {},
+        })
+      );
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "The estimate could not be saved.");
+    } finally {
+      setBusyCode(null);
+    }
+  }
+
+  async function resolveTravelerItem(
+    requirement: CostCoverageRequirement,
+    status: "complete" | "not_applicable"
+  ) {
+    setBusyCode(requirement.code);
+    setError(null);
+    try {
+      adopt(
+        await updateCostCoverage(tripId, requirement.code, {
+          status,
+          note: noteDrafts[requirement.code] ?? "",
+          inputs: inputDrafts[requirement.code] ?? {},
+        })
+      );
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "The item could not be updated.");
+    } finally {
+      setBusyCode(null);
+    }
+  }
+
+  if (error && coverage == null) {
+    return (
+      <section className="status-card status-card-error">
+        <p className="status-label">Costs &amp; evidence</p>
+        <h2>Organization requirements are temporarily unavailable</h2>
+        <p role="alert">{error}</p>
+      </section>
+    );
+  }
+  if (coverage == null) {
+    return <p className="muted-copy">Loading organization cost and evidence requirements…</p>;
+  }
+
+  return (
+    <div className="cost-evidence-workspace">
+      <section className="status-card cost-evidence-summary">
+        <div>
+          <p className="status-label">Costs &amp; evidence</p>
+          <h2>{coverage.summary.headline}</h2>
+          <p>
+            The planner handles public research and calculations. It asks you only for details it
+            cannot reliably determine, then carries the selected estimates and sources into the
+            organization workbook.
+          </p>
+        </div>
+        <div className="cost-evidence-count" aria-label="Coverage progress">
+          <strong>{coverage.summary.resolved_count}</strong>
+          <span>of {coverage.summary.requirement_count} resolved</span>
+        </div>
+      </section>
+
+      {error ? <p className="planner-inline-error" role="alert">{error}</p> : null}
+
+      <div className="cost-evidence-list">
+        {coverage.requirements.map((requirement) => {
+          const isBusy = busyCode === requirement.code;
+          const canResearch = ["researchable", "automatic"].includes(requirement.collection_mode);
+          const inputNames = Array.from(
+            new Set([
+              ...requirement.missing_inputs,
+              ...(requirement.research
+                ? requirement.required_inputs.filter((name) => !AUTOMATIC_INPUTS.has(name))
+                : []),
+            ])
+          );
+          return (
+            <article className="status-card cost-evidence-card" key={requirement.code}>
+              <div className="cost-evidence-heading">
+                <div>
+                  <p className="status-label">{labelFor(requirement.category)}</p>
+                  <h3>{requirement.title}</h3>
+                </div>
+                <span className={`cost-evidence-status status-${requirement.status}`}>
+                  {labelFor(requirement.status)}
+                </span>
+              </div>
+              <p>{requirement.summary}</p>
+              <p className="cost-evidence-assistance">{modeMessage(requirement)}</p>
+
+              {inputNames.length > 0 ? (
+                <div className="cost-evidence-inputs">
+                  {inputNames.map((inputName) => (
+                    <label key={inputName}>
+                      <span>{labelFor(inputName)}</span>
+                      <input
+                        value={inputDrafts[requirement.code]?.[inputName] ?? ""}
+                        onChange={(event) =>
+                          setInputDrafts((current) => ({
+                            ...current,
+                            [requirement.code]: {
+                              ...(current[requirement.code] ?? {}),
+                              [inputName]: event.target.value,
+                            },
+                          }))
+                        }
+                        placeholder={`Add ${labelFor(inputName).toLowerCase()}`}
+                      />
+                      {REMEMBERED_PROFILE_INPUTS.has(inputName) ? (
+                        <small>Saved to your travel profile for future trips.</small>
+                      ) : null}
+                    </label>
+                  ))}
+                </div>
+              ) : null}
+
+              {canResearch ? (
+                <button
+                  type="button"
+                  className="primary-button"
+                  disabled={isBusy}
+                  onClick={() => void runResearch(requirement)}
+                >
+                  {isBusy
+                    ? "Working…"
+                    : requirement.research
+                      ? "Refresh current options"
+                      : requirement.collection_mode === "automatic"
+                        ? "Calculate this for me"
+                        : "Research this for me"}
+                </button>
+              ) : (
+                <div className="cost-evidence-traveler-input">
+                  <label>
+                    <span>What should TPP know?</span>
+                    <textarea
+                      value={noteDrafts[requirement.code] ?? ""}
+                      onChange={(event) =>
+                        setNoteDrafts((current) => ({
+                          ...current,
+                          [requirement.code]: event.target.value,
+                        }))
+                      }
+                      placeholder="Add the organization or traveler-only detail here."
+                    />
+                  </label>
+                  <div className="button-row">
+                    <button
+                      type="button"
+                      className="primary-button"
+                      disabled={isBusy}
+                      onClick={() => void resolveTravelerItem(requirement, "complete")}
+                    >
+                      Save as complete
+                    </button>
+                    {requirement.code !== "organization_attestations" ? (
+                      <button
+                        type="button"
+                        className="secondary-button"
+                        disabled={isBusy}
+                        onClick={() => void resolveTravelerItem(requirement, "not_applicable")}
+                      >
+                        Not applicable
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              )}
+
+              {requirement.research ? (
+                <div className="cost-evidence-results">
+                  <p className="status-label">Planner research</p>
+                  <p>{requirement.research.summary}</p>
+                  <div className="cost-evidence-options">
+                    {requirement.research.options.map((option, index) => {
+                      const total = formatMoney(option.estimated_total, requirement.currency);
+                      const rate = formatMoney(option.unit_rate, requirement.currency);
+                      const selected = requirement.selected_option?.name === option.name;
+                      return (
+                        <article className="decision-card" key={`${option.name}-${index}`}>
+                          <h4>{option.name}</h4>
+                          {total ? <strong>{total} estimated total</strong> : null}
+                          {!total && rate ? <strong>{rate}{option.unit ? ` ${option.unit}` : ""}</strong> : null}
+                          <p>{option.notes}</p>
+                          {option.details && Object.keys(option.details).length > 0 ? (
+                            <dl className="cost-evidence-facts">
+                              {Object.entries(option.details).map(([key, value]) => (
+                                <div key={key}>
+                                  <dt>{labelFor(key)}</dt>
+                                  <dd>{String(value)}</dd>
+                                </div>
+                              ))}
+                            </dl>
+                          ) : null}
+                          <div className="button-row">
+                            <button
+                              type="button"
+                              className={selected ? "secondary-button" : "primary-button"}
+                              disabled={isBusy || selected}
+                              onClick={() => void chooseOption(requirement, option)}
+                            >
+                              {selected ? "Selected for workbook" : "Use this estimate"}
+                            </button>
+                            {option.source_url ? (
+                              <a href={option.source_url} target="_blank" rel="noreferrer">
+                                View source
+                              </a>
+                            ) : null}
+                          </div>
+                        </article>
+                      );
+                    })}
+                  </div>
+                  {requirement.research.sources.length > 0 ? (
+                    <details>
+                      <summary>All sources ({requirement.research.sources.length})</summary>
+                      <ul>
+                        {requirement.research.sources.map((source) => (
+                          <li key={source.url}>
+                            <a href={source.url} target="_blank" rel="noreferrer">{source.title}</a>
+                          </li>
+                        ))}
+                      </ul>
+                    </details>
+                  ) : null}
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/maps/GoogleMapsProviderMap.test.tsx
+++ b/frontend/src/components/maps/GoogleMapsProviderMap.test.tsx
@@ -1,0 +1,157 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GoogleMapsProviderMap } from "./GoogleMapsProviderMap";
+import { loadGoogleMapsLibraries } from "./googleMapsLoader";
+import type { MapMarker, RouteStop } from "./mapSurface";
+
+vi.mock("./googleMapsLoader", () => ({
+  loadGoogleMapsLibraries: vi.fn(),
+}));
+
+const routeStops: RouteStop[] = [
+  { id: "stop-1", sourceId: "kyoto", label: "Kyoto", description: "Start", sourceRefs: [], x: 10, y: 20 },
+  { id: "stop-2", sourceId: "uji", label: "Uji", description: "End", sourceRefs: [], x: 80, y: 70 },
+];
+const markers: MapMarker[] = routeStops.map((stop) => ({
+  id: `${stop.id}-marker`,
+  sourceId: stop.sourceId,
+  kind: "stop",
+  label: stop.label,
+  summary: stop.description,
+  detail: stop.description,
+  x: stop.x,
+  y: stop.y,
+  emphasized: false,
+  focusCues: [],
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("GoogleMapsProviderMap", () => {
+  it("loads Google libraries, geocodes trip stops, and renders live provider state", async () => {
+    class LatLng {
+      constructor(public lat: number, public lng: number) {}
+    }
+    class LatLngBounds {
+      extend = vi.fn();
+    }
+    const geocode = vi
+      .fn()
+      .mockResolvedValueOnce({ results: [{ geometry: { location: new LatLng(35.01, 135.76) } }] })
+      .mockResolvedValueOnce({ results: [{ geometry: { location: new LatLng(34.89, 135.8) } }] });
+    const fitBounds = vi.fn();
+    class ProviderMap {
+      fitBounds = fitBounds;
+    }
+    const setMap = vi.fn();
+    class Polyline {
+      setMap = setMap;
+    }
+    class AdvancedMarkerElement {
+      map: unknown;
+      addEventListener = vi.fn();
+      constructor(options: { map: unknown }) {
+        this.map = options.map;
+      }
+    }
+    vi.mocked(loadGoogleMapsLibraries).mockResolvedValue({
+      core: { LatLngBounds } as unknown as google.maps.CoreLibrary,
+      geocoding: { Geocoder: class { geocode = geocode; } } as unknown as google.maps.GeocodingLibrary,
+      maps: { Map: ProviderMap, Polyline } as unknown as google.maps.MapsLibrary,
+      marker: { AdvancedMarkerElement } as unknown as google.maps.MarkerLibrary,
+    });
+
+    render(
+      <GoogleMapsProviderMap
+        apiKey="test-key"
+        title="Kyoto route"
+        markers={markers}
+        routeStops={routeStops}
+        destinationAnchors={["Kyoto", "Uji"]}
+        onSelectMarker={vi.fn()}
+        fallback={<div>fallback sketch</div>}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("Live Google Maps")).toBeInTheDocument());
+    const liveMap = screen.getByRole("application", { name: "Live Google map for Kyoto route" });
+    expect(liveMap).toBeInTheDocument();
+    expect(liveMap.closest("[data-google-maps-live]")).toHaveAttribute(
+      "data-google-maps-live",
+      "true"
+    );
+    expect(geocode).toHaveBeenCalledTimes(2);
+    expect(fitBounds).toHaveBeenCalled();
+  });
+
+  it("shows the route sketch when the SDK fails", async () => {
+    vi.mocked(loadGoogleMapsLibraries).mockRejectedValue(new Error("SDK blocked"));
+
+    render(
+      <GoogleMapsProviderMap
+        apiKey="test-key"
+        title="Kyoto route"
+        markers={markers}
+        routeStops={routeStops}
+        destinationAnchors={["Kyoto"]}
+        onSelectMarker={vi.fn()}
+        fallback={<div>fallback sketch</div>}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/SDK blocked/)).toBeInTheDocument());
+    expect(screen.getByText("fallback sketch")).toBeInTheDocument();
+  });
+
+  it("uses supplied trip coordinates without requiring Google geocoding", async () => {
+    const geocode = vi.fn().mockRejectedValue(new Error("Geocoding API disabled"));
+    const fitBounds = vi.fn();
+    class LatLngBounds {
+      extend = vi.fn();
+    }
+    class ProviderMap {
+      fitBounds = fitBounds;
+    }
+    class Polyline {
+      setMap = vi.fn();
+    }
+    class AdvancedMarkerElement {
+      map: unknown;
+      addEventListener = vi.fn();
+      constructor(options: { map: unknown }) {
+        this.map = options.map;
+      }
+    }
+    vi.mocked(loadGoogleMapsLibraries).mockResolvedValue({
+      core: { LatLngBounds } as unknown as google.maps.CoreLibrary,
+      geocoding: { Geocoder: class { geocode = geocode; } } as unknown as google.maps.GeocodingLibrary,
+      maps: { Map: ProviderMap, Polyline } as unknown as google.maps.MapsLibrary,
+      marker: { AdvancedMarkerElement } as unknown as google.maps.MarkerLibrary,
+    });
+    const locatedMarkers = markers.map((marker, index) => ({
+      ...marker,
+      latitude: 38.85 + index * 0.05,
+      longitude: -77.04,
+    }));
+
+    render(
+      <GoogleMapsProviderMap
+        apiKey="test-key"
+        title="Washington route"
+        markers={locatedMarkers}
+        routeStops={routeStops}
+        destinationAnchors={["Washington DC"]}
+        onSelectMarker={vi.fn()}
+        fallback={<div>fallback sketch</div>}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText("Live Google Maps")).toBeInTheDocument());
+    expect(geocode).not.toHaveBeenCalled();
+    expect(fitBounds).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/maps/GoogleMapsProviderMap.tsx
+++ b/frontend/src/components/maps/GoogleMapsProviderMap.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+
+import type { MapMarker, RouteStop } from "./mapSurface";
+import { loadGoogleMapsLibraries } from "./googleMapsLoader";
+
+type ProviderState = "loading" | "ready" | "error";
+
+type GeocodedMarker = {
+  marker: MapMarker;
+  position: google.maps.LatLng | google.maps.LatLngLiteral;
+};
+
+const geocodeCache = new Map<string, google.maps.LatLng | google.maps.LatLngLiteral>();
+
+function queryForMarker(marker: MapMarker, destinationAnchors: string[]): string {
+  const regionalContext = destinationAnchors.slice(0, 2).join(", ");
+  return regionalContext && !marker.label.toLowerCase().includes(regionalContext.toLowerCase())
+    ? `${marker.label}, ${regionalContext}`
+    : marker.label;
+}
+
+async function geocodeVisibleMarkers(
+  geocoder: google.maps.Geocoder,
+  markers: MapMarker[],
+  destinationAnchors: string[]
+): Promise<GeocodedMarker[]> {
+  const visibleMarkers = markers.slice(0, 10);
+  const suppliedCoordinates = visibleMarkers.flatMap((marker) =>
+    marker.latitude != null && marker.longitude != null
+      ? [{
+        marker,
+        position: { lat: marker.latitude, lng: marker.longitude },
+      }]
+      : []
+  );
+  if (suppliedCoordinates.length > 0) {
+    return suppliedCoordinates;
+  }
+
+  const resolved: GeocodedMarker[] = [];
+  for (const marker of visibleMarkers) {
+    const query = queryForMarker(marker, destinationAnchors);
+    let position = geocodeCache.get(query);
+    if (position == null) {
+      try {
+        const response = await geocoder.geocode({ address: query });
+        position = response.results[0]?.geometry.location;
+      } catch {
+        position = undefined;
+      }
+      if (position != null) {
+        geocodeCache.set(query, position);
+      }
+    }
+    if (position != null) {
+      resolved.push({ marker, position });
+    }
+  }
+  return resolved;
+}
+
+export function GoogleMapsProviderMap({
+  apiKey,
+  mapId,
+  title,
+  markers,
+  routeStops,
+  destinationAnchors,
+  onSelectMarker,
+  fallback,
+}: {
+  apiKey: string;
+  mapId?: string;
+  title: string;
+  markers: MapMarker[];
+  routeStops: RouteStop[];
+  destinationAnchors: string[];
+  onSelectMarker: (markerId: string) => void;
+  fallback: ReactNode;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [providerState, setProviderState] = useState<ProviderState>("loading");
+  const [providerError, setProviderError] = useState<string | null>(null);
+  const markerSignature = useMemo(
+    () => markers.map((marker) => `${marker.id}:${marker.label}`).join("|"),
+    [markers]
+  );
+  const routeStopSignature = useMemo(
+    () => routeStops.map((stop) => `${stop.id}:${stop.label}`).join("|"),
+    [routeStops]
+  );
+  const destinationSignature = destinationAnchors.join("|");
+  const stableMarkers = useMemo(() => markers, [markerSignature]);
+  const stableRouteStops = useMemo(() => routeStops, [routeStopSignature]);
+  const stableDestinationAnchors = useMemo(
+    () => destinationAnchors,
+    [destinationSignature]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    const advancedMarkers: google.maps.marker.AdvancedMarkerElement[] = [];
+    let routeLine: google.maps.Polyline | null = null;
+
+    setProviderState("loading");
+    setProviderError(null);
+
+    async function initialize() {
+      const container = containerRef.current;
+      if (container == null) {
+        return;
+      }
+      try {
+        const libraries = await loadGoogleMapsLibraries(apiKey);
+        if (cancelled) {
+          return;
+        }
+        const geocoder = new libraries.geocoding.Geocoder();
+        const geocoded = await geocodeVisibleMarkers(
+          geocoder,
+          stableMarkers,
+          stableDestinationAnchors
+        );
+        if (cancelled) {
+          return;
+        }
+        if (geocoded.length === 0) {
+          throw new Error("Google Maps could not resolve any visible trip locations.");
+        }
+
+        const bounds = new libraries.core.LatLngBounds();
+        const map = new libraries.maps.Map(container, {
+          center: geocoded[0].position,
+          zoom: 8,
+          mapId: mapId?.trim() || "DEMO_MAP_ID",
+          mapTypeControl: false,
+          streetViewControl: false,
+          fullscreenControl: true,
+        });
+        const positionByMarkerId = new Map(
+          geocoded.map(({ marker, position }) => [marker.id, position])
+        );
+        for (const { marker, position } of geocoded) {
+          bounds.extend(position);
+          const providerMarker = new libraries.marker.AdvancedMarkerElement({
+            map,
+            position,
+            title: marker.label,
+            gmpClickable: true,
+          });
+          providerMarker.addEventListener("gmp-click", () => onSelectMarker(marker.id));
+          advancedMarkers.push(providerMarker);
+        }
+        const routePath = stableRouteStops
+          .map((stop) => positionByMarkerId.get(`${stop.id}-marker`))
+          .filter(
+            (position): position is google.maps.LatLng | google.maps.LatLngLiteral =>
+              position != null
+          );
+        if (routePath.length > 1) {
+          routeLine = new libraries.maps.Polyline({
+            map,
+            path: routePath,
+            strokeColor: "#285d50",
+            strokeOpacity: 0.9,
+            strokeWeight: 4,
+          });
+        }
+        if (geocoded.length > 1) {
+          map.fitBounds(bounds, 48);
+        }
+        setProviderState("ready");
+      } catch (error) {
+        if (!cancelled) {
+          setProviderState("error");
+          setProviderError(
+            error instanceof Error ? error.message : "Google Maps failed to initialize."
+          );
+        }
+      }
+    }
+
+    void initialize();
+    return () => {
+      cancelled = true;
+      for (const marker of advancedMarkers) {
+        marker.map = null;
+      }
+      routeLine?.setMap(null);
+    };
+  }, [apiKey, mapId, onSelectMarker, stableDestinationAnchors, stableMarkers, stableRouteStops]);
+
+  if (providerState === "error") {
+    return (
+      <div className="map-provider-runtime" data-provider-state="error">
+        <p className="map-warning" role="status">
+          {providerError} Showing the route sketch instead.
+        </p>
+        {fallback}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="map-provider-runtime"
+      data-provider-state={providerState}
+      data-google-maps-live={providerState === "ready" ? "true" : "false"}
+    >
+      <div className="map-provider-live-status" role="status">
+        {providerState === "ready" ? "Live Google Maps" : "Loading Google Maps…"}
+      </div>
+      <div
+        ref={containerRef}
+        className="map-provider-canvas map-provider-canvas-google"
+        role="application"
+        aria-label={`Live Google map for ${title}`}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/maps/TripMap.test.tsx
+++ b/frontend/src/components/maps/TripMap.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { useState } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { FeasibilitySummary, RuntimeScenarioComparison, WorkspaceData } from "../../api/workspace";
 import { TripMap } from "./TripMap";
@@ -154,6 +154,11 @@ const planningLedger: WorkspaceData["planning_ledger"] = {
   },
 };
 
+beforeEach(() => {
+  vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "");
+  vi.stubEnv("VITE_GOOGLE_MAPS_EMBED_API_KEY", "");
+});
+
 afterEach(() => {
   cleanup();
   vi.unstubAllEnvs();
@@ -239,21 +244,22 @@ describe("TripMap", () => {
     expect(screen.queryByRole("img", { name: /route geometry overlay/i })).not.toBeInTheDocument();
   });
 
-  it("labels the keyed provider surface as a schematic preview", () => {
+  it("mounts the live SDK surface when a browser key is configured", () => {
     vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "test-key");
     vi.stubEnv("VITE_GOOGLE_MAPS_PROVIDER_STATE", "ready");
 
     renderTripMap();
 
     expect(screen.getByRole("heading", { name: "Map for Rail-first route" })).toBeInTheDocument();
-    expect(screen.getByText("Schematic preview — not a live map")).toBeInTheDocument();
+    expect(screen.queryByText("Schematic preview — not a live map")).not.toBeInTheDocument();
     expect(screen.queryByText("Route sketch mode")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass(
       "map-route-google-maps-js"
     );
     expect(
-      screen.getByRole("img", { name: "Route geometry overlay for Rail-first route" })
+      screen.getByRole("application", { name: "Live Google map for Rail-first route" })
     ).toBeInTheDocument();
+    expect(screen.getByText("Loading Google Maps…")).toBeInTheDocument();
     expect(screen.queryByText(/Google Maps JavaScript/i)).not.toBeInTheDocument();
   });
 

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -7,6 +7,7 @@ import {
   type MapProviderLoadState,
   type MapViewScope,
 } from "./mapSurface";
+import { GoogleMapsProviderMap } from "./GoogleMapsProviderMap";
 
 type InventoryBundle = WorkspaceData["inventory_summary"]["bundles"][number];
 type TripMapScenario = RuntimeScenarioComparison["scenarios"][number];
@@ -124,6 +125,7 @@ function ActiveTripMap({
   const googleMapsApiKey =
     import.meta.env.VITE_GOOGLE_MAPS_BROWSER_API_KEY ||
     import.meta.env.VITE_GOOGLE_MAPS_EMBED_API_KEY;
+  const googleMapsMapId = import.meta.env.VITE_GOOGLE_MAPS_MAP_ID;
   const providerLoadState =
     (import.meta.env.VITE_GOOGLE_MAPS_PROVIDER_STATE as MapProviderLoadState | undefined) ?? "ready";
   const mapSurface = buildTripMapSurfaceModel({
@@ -248,9 +250,11 @@ function ActiveTripMap({
         >
           <div className="map-provider-toolbar">
             <span className="map-provider-name">{mapSurface.scope.label}</span>
-            <span className="map-preview-badge" aria-label={SCHEMATIC_PREVIEW_BADGE_TEXT}>
-              {SCHEMATIC_PREVIEW_BADGE_TEXT}
-            </span>
+            {isFallbackSketch ? (
+              <span className="map-preview-badge" aria-label={SCHEMATIC_PREVIEW_BADGE_TEXT}>
+                {SCHEMATIC_PREVIEW_BADGE_TEXT}
+              </span>
+            ) : null}
             {isFallbackSketch ? (
               <span className="map-preview-badge map-preview-badge-warning">
                 Route sketch mode
@@ -263,12 +267,22 @@ function ActiveTripMap({
             ) : null}
           </div>
           {mapSurface.provider.kind === "google-maps-js" ? (
-            <InteractiveProviderMap
+            <GoogleMapsProviderMap
+              apiKey={mapSurface.provider.apiKey}
+              mapId={googleMapsMapId}
               title={activeScenario.title}
               markers={mapSurface.visibleMarkers}
-              selectedMarker={selectedMarker}
-              routeSegments={mapSurface.visibleRouteSegments}
+              routeStops={mapSurface.visibleRouteStops}
+              destinationAnchors={mapSurface.destinationContext}
               onSelectMarker={setSelectedMarkerId}
+              fallback={
+                <FallbackRouteSchematic
+                  markers={mapSurface.visibleMarkers}
+                  selectedMarker={selectedMarker}
+                  routeStops={mapSurface.visibleRouteStops}
+                  onSelectMarker={setSelectedMarkerId}
+                />
+              }
             />
           ) : (
             <FallbackRouteSchematic
@@ -439,59 +453,6 @@ function ActiveTripMap({
         </div>
       </div>
     </section>
-  );
-}
-
-function InteractiveProviderMap({
-  title,
-  markers,
-  selectedMarker,
-  routeSegments,
-  onSelectMarker,
-}: {
-  title: string;
-  markers: MapMarker[];
-  selectedMarker: MapMarker | null;
-  routeSegments: ReturnType<typeof buildTripMapSurfaceModel>["routeSegments"];
-  onSelectMarker: (markerId: string) => void;
-}) {
-  return (
-    <div className="map-provider-canvas" role="group" aria-label={`Interactive map for ${title}`}>
-      <svg
-        className="map-route-geometry"
-        viewBox="0 0 100 100"
-        role="img"
-        aria-label={`Route geometry overlay for ${title}`}
-      >
-        {routeSegments.map((segment) => (
-          <line
-            key={segment.id}
-            x1={segment.x1}
-            y1={segment.y1}
-            x2={segment.x2}
-            y2={segment.y2}
-            className={`map-route-line${segment.warning ? " map-route-line-warning" : ""}${
-              segment.focusCues.length > 0 ? " map-route-line-focused" : ""
-            }`}
-          />
-        ))}
-      </svg>
-      {markers.map((marker) => (
-        <button
-          key={marker.id}
-          type="button"
-          className={`map-marker map-marker-${marker.kind}${
-            selectedMarker?.id === marker.id ? " map-marker-selected" : ""
-          }${marker.emphasized ? " map-marker-emphasized" : ""}`}
-          style={{ left: `${marker.x}%`, top: `${marker.y}%` }}
-          aria-label={markerAccessibleLabel(marker)}
-          aria-pressed={selectedMarker?.id === marker.id}
-          onClick={() => onSelectMarker(marker.id)}
-        >
-          <span>{markerLabel(marker.kind)}</span>
-        </button>
-      ))}
-    </div>
   );
 }
 

--- a/frontend/src/components/maps/googleMapsLoader.ts
+++ b/frontend/src/components/maps/googleMapsLoader.ts
@@ -1,0 +1,43 @@
+import { importLibrary, setOptions } from "@googlemaps/js-api-loader";
+
+export type GoogleMapsLibraries = {
+  core: google.maps.CoreLibrary;
+  geocoding: google.maps.GeocodingLibrary;
+  maps: google.maps.MapsLibrary;
+  marker: google.maps.MarkerLibrary;
+};
+
+let configuredKey: string | null = null;
+let librariesPromise: Promise<GoogleMapsLibraries> | null = null;
+
+export function loadGoogleMapsLibraries(apiKey: string): Promise<GoogleMapsLibraries> {
+  const normalizedKey = apiKey.trim();
+  if (normalizedKey === "") {
+    return Promise.reject(new Error("Google Maps requires a browser API key."));
+  }
+  if (configuredKey != null && configuredKey !== normalizedKey) {
+    return Promise.reject(
+      new Error("Google Maps was already configured with a different browser API key.")
+    );
+  }
+  if (librariesPromise == null) {
+    configuredKey = normalizedKey;
+    setOptions({
+      key: normalizedKey,
+      v: "weekly",
+      authReferrerPolicy: "origin",
+    });
+    librariesPromise = Promise.all([
+      importLibrary("core"),
+      importLibrary("geocoding"),
+      importLibrary("maps"),
+      importLibrary("marker"),
+    ]).then(([core, geocoding, maps, marker]) => ({ core, geocoding, maps, marker }));
+  }
+  return librariesPromise;
+}
+
+export function resetGoogleMapsLoaderForTests() {
+  configuredKey = null;
+  librariesPromise = null;
+}

--- a/frontend/src/components/maps/mapSurface.ts
+++ b/frontend/src/components/maps/mapSurface.ts
@@ -14,8 +14,8 @@ export type MapProviderLoadState = "ready" | "loading" | "error";
 export type MapSurfaceProvider =
   | {
       kind: "google-maps-js";
-      label: "Google Maps JavaScript adapter";
-      status: "live";
+      label: "Google Maps configured";
+      status: "configured";
       apiKey: string;
       summary: string;
     }
@@ -34,6 +34,8 @@ export type RouteStop = {
   sourceRefs: string[];
   x: number;
   y: number;
+  latitude?: number;
+  longitude?: number;
 };
 
 export type MapMarkerKind = "stop" | "lodging" | "activity" | "transport" | "policy";
@@ -59,6 +61,8 @@ export type MapMarker = {
   detail: string;
   x: number;
   y: number;
+  latitude?: number;
+  longitude?: number;
   emphasized: boolean;
   focusCues: MapFocusCue[];
 };
@@ -301,6 +305,8 @@ function buildRouteStops(activeScenario: TripMapScenario): RouteStop[] {
       sourceRefs: marker.source_refs ?? [],
       x: marker.x * 100,
       y: marker.y * 100,
+      latitude: marker.latitude,
+      longitude: marker.longitude,
     }));
   }
 
@@ -398,6 +404,8 @@ function buildMarkers({
     detail: stop.description,
     x: stop.x,
     y: stop.y,
+    latitude: stop.latitude,
+    longitude: stop.longitude,
     emphasized: index === 0 || index === routeStops.length - 1,
     focusCues: [],
   }));
@@ -926,11 +934,11 @@ export function buildTripMapSurfaceModel({
   } else {
     provider = {
       kind: "google-maps-js",
-      label: "Google Maps JavaScript adapter",
-      status: "live",
+      label: "Google Maps configured",
+      status: "configured",
       apiKey: trimmedApiKey,
       summary:
-        "Google Maps JavaScript is the active presentation adapter; route, marker, and warning state still comes from workspace runtime data.",
+        "Google Maps JavaScript is configured and will be marked live only after the SDK and trip locations load successfully.",
     };
   }
   const visibleMapContent = visibleMapContentFor({

--- a/frontend/src/components/policy/TppWorkbookHandoff.test.tsx
+++ b/frontend/src/components/policy/TppWorkbookHandoff.test.tsx
@@ -1,0 +1,186 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { RuntimeScenarioComparison, WorkspaceData } from "../../api/workspace";
+import { TppWorkbookHandoff } from "./TppWorkbookHandoff";
+
+const { fetchCostCoverage } = vi.hoisted(() => ({ fetchCostCoverage: vi.fn() }));
+vi.mock("../../api/costCoverage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/costCoverage")>()),
+  fetchCostCoverage,
+}));
+
+const trip = {
+  trip_id: "trip-washington",
+  title: "Washington client visit",
+  summary: "Client strategy meetings",
+  status: "draft",
+  mode: "business",
+  trip_frame: {
+    start_date: "2026-10-14",
+    end_date: "2026-10-16",
+    duration_days: 3,
+    primary_regions: ["Washington DC"],
+  },
+} satisfies WorkspaceData["trip_record"]["trip"];
+
+const scenario = {
+  scenario_id: "scenario-washington",
+  title: "Washington runtime bundle",
+  route_summary: "DCA to downtown meetings",
+} as RuntimeScenarioComparison["scenarios"][number];
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  fetchCostCoverage.mockReset();
+});
+
+describe("TppWorkbookHandoff", () => {
+  it("posts trip details and sourced estimates to TPP without putting them in the URL", async () => {
+    vi.stubEnv("VITE_TPP_PORTAL_URL", "http://127.0.0.1:8765/");
+    fetchCostCoverage.mockResolvedValue({
+      trip_id: trip.trip_id,
+      contract_version: "tpp-intake-requirements/v1",
+      source_status: "live_tpp",
+      summary: {
+        requirement_count: 2,
+        resolved_count: 2,
+        research_offer_count: 0,
+        ready_for_handoff: true,
+        headline: "Complete",
+      },
+      requirements: [
+        {
+          code: "airport_parking",
+          title: "Airport parking",
+          inputs: { departure_airport: "STL", parking_days: "3" },
+          estimate_amount: 48,
+          source_url: "https://www.flystl.com/parking",
+          selected_option: {
+            name: "Lot C uncovered",
+            unit_rate: 12,
+            unit: "per day",
+            estimated_total: 48,
+            notes: "Official airport rate",
+            source_url: "https://www.flystl.com/parking",
+          },
+          research: { sources: [], options: [], summary: "Official parking rates" },
+        },
+        {
+          code: "airport_access",
+          title: "Airport access",
+          inputs: {
+            traveler_residence_address: "803 B Broadway, Jefferson City, MO",
+            official_domicile_address: "3236 W Edgewood Dr, Jefferson City, MO 65109",
+            departure_airport: "STL",
+          },
+          estimate_amount: 153.99,
+          source_url: "https://www.google.com/maps",
+          selected_option: {
+            name: "Personal vehicle from home",
+            unit_rate: 0.725,
+            unit: "mile",
+            estimated_total: 153.99,
+            notes: "Direct reimbursable route; ordinary commuting excluded.",
+            source_url: "https://www.google.com/maps",
+            details: {
+              reimbursable_miles: 212.4,
+              mileage_cost: 153.99,
+              route_rule: "Direct route with commuting excluded",
+            },
+          },
+          research: { sources: [], options: [], summary: "Mileage comparison" },
+        },
+        {
+          code: "local_mobility",
+          title: "Local transportation",
+          inputs: {},
+          estimate_amount: 35,
+          source_url: "https://new.mta.info/fares",
+          selected_option: {
+            name: "Subway plus bounded taxi allowance",
+            unit_rate: null,
+            unit: "trip",
+            estimated_total: 35,
+            notes: "Transit-first plan",
+            source_url: "https://new.mta.info/fares",
+          },
+          research: { sources: [], options: [], summary: "Transit-first plan" },
+        },
+        {
+          code: "meals_incidentals",
+          title: "Meals and incidental allowance",
+          inputs: { destination_zip: "20004" },
+          estimate_amount: 180,
+          source_url: "https://www.gsa.gov/travel/plan-book/per-diem-rates",
+          selected_option: {
+            name: "Eligible meal allowance",
+            unit_rate: null,
+            unit: "trip",
+            estimated_total: 180,
+            notes: "Conference lunches excluded.",
+            source_url: "https://www.gsa.gov/travel/plan-book/per-diem-rates",
+            details: {
+              eligible_breakfasts: 2,
+              eligible_lunches: 1,
+              eligible_dinners: 2,
+              meals_provided: true,
+              meal_per_diem_requested: true,
+            },
+          },
+          research: { sources: [], options: [], summary: "Policy meal calculation" },
+        },
+      ],
+    });
+    const submittedForms: HTMLFormElement[] = [];
+    vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(function submit(
+      this: HTMLFormElement
+    ) {
+      submittedForms.push(this);
+    });
+    render(<TppWorkbookHandoff trip={trip} scenario={scenario} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Prepare organization workbook" }));
+
+    await waitFor(() => expect(submittedForms).toHaveLength(1));
+
+    const submittedForm = submittedForms[0];
+    expect(submittedForm).toBeDefined();
+    if (submittedForm == null) {
+      throw new Error("Expected the handoff form to be submitted.");
+    }
+    expect(submittedForm.action).toBe("http://127.0.0.1:8765/portal/handoff");
+    expect(submittedForm.method).toBe("post");
+    const values = new FormData(submittedForm);
+    expect(values.get("business_purpose")).toBe("Client strategy meetings");
+    expect(values.get("city_state")).toBe("Washington DC");
+    expect(values.get("depart_date")).toBe("2026-10-14");
+    expect(values.get("departure_city_airport")).toBe("STL");
+    expect(values.get("parking_estimate")).toBe("48");
+    expect(values.get("ground_transport_estimate")).toBe("35");
+    expect(values.get("ground_transport.mileage_planned")).toBe("true");
+    expect(values.get("ground_transport.mileage_miles")).toBe("212.4");
+    expect(values.get("ground_transport.mileage_cost")).toBe("153.99");
+    expect(values.get("ground_transport.rideshare_cost")).toBe("35");
+    expect(values.get("destination_zip")).toBe("20004");
+    expect(values.get("meal_counts.breakfast")).toBe("2");
+    expect(values.get("meal_counts.lunch")).toBe("1");
+    expect(values.get("meal_counts.dinner")).toBe("2");
+    expect(values.get("meals_provided")).toBe("true");
+    expect(values.get("notes")).toContain("Washington runtime bundle");
+    expect(values.get("notes")).toContain("https://www.flystl.com/parking");
+    expect(submittedForm.action).not.toContain("Washington");
+  });
+
+  it("keeps the handoff disabled until the TPP portal is configured", () => {
+    vi.stubEnv("VITE_TPP_PORTAL_URL", "");
+    render(<TppWorkbookHandoff trip={trip} scenario={null} />);
+
+    expect(
+      screen.getByRole("button", { name: "Prepare organization workbook" })
+    ).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("not configured");
+  });
+});

--- a/frontend/src/components/policy/TppWorkbookHandoff.tsx
+++ b/frontend/src/components/policy/TppWorkbookHandoff.tsx
@@ -1,0 +1,221 @@
+import { useState } from "react";
+
+import {
+  fetchCostCoverage,
+  type CostCoverageRequirement,
+  type CostCoverageResponse,
+} from "../../api/costCoverage";
+import type { RuntimeScenarioComparison, WorkspaceData } from "../../api/workspace";
+
+type WorkspaceTrip = WorkspaceData["trip_record"]["trip"];
+type WorkspaceScenario = RuntimeScenarioComparison["scenarios"][number];
+
+export function buildTppHandoffAnswers(
+  trip: WorkspaceTrip,
+  scenario: WorkspaceScenario | null,
+  coverage: CostCoverageResponse | null = null
+): Record<string, string> {
+  const eventDates =
+    trip.trip_frame.start_date && trip.trip_frame.end_date
+      ? `${trip.trip_frame.start_date} - ${trip.trip_frame.end_date}`
+      : "";
+  const byCode = new Map(
+    (coverage?.requirements ?? []).map((requirement) => [requirement.code, requirement])
+  );
+  const selected = (code: string) => byCode.get(code)?.selected_option ?? null;
+  const amount = (requirement: CostCoverageRequirement | undefined) =>
+    requirement?.estimate_amount ?? requirement?.selected_option?.estimated_total ?? null;
+  const parking = byCode.get("airport_parking");
+  const intercity = byCode.get("intercity_transport");
+  const lodging = byCode.get("lodging");
+  const lodgingOption = selected("lodging");
+  const meals = byCode.get("meals_incidentals");
+  const mealOption = selected("meals_incidentals") ?? meals?.research?.options[0] ?? null;
+  const mealDetails = mealOption?.details ?? {};
+  const airportAccess = byCode.get("airport_access");
+  const airportAccessDetails = airportAccess?.selected_option?.details ?? {};
+  const groundRequirements = ["destination_transfers", "local_mobility"]
+    .map((code) => byCode.get(code))
+    .filter((item): item is CostCoverageRequirement => item != null);
+  const groundEstimate = groundRequirements.reduce(
+    (total, requirement) => total + (amount(requirement) ?? 0),
+    0
+  );
+  const detailNumber = (key: string) => {
+    const value = airportAccessDetails[key];
+    return typeof value === "number" ? value : Number.parseFloat(String(value ?? ""));
+  };
+  const mileageMiles = detailNumber("reimbursable_miles");
+  const mileageCost = detailNumber("mileage_cost");
+  const airportRideshare = detailNumber("rideshare_total");
+  const destinationGroundEstimate = groundEstimate;
+  const totalRideshare =
+    (Number.isFinite(airportRideshare) ? airportRideshare : 0) + destinationGroundEstimate;
+  const fareOptions = intercity?.research?.options ?? [];
+  const comparableLodging = (lodging?.research?.options ?? []).filter(
+    (option) => option.name !== lodgingOption?.name
+  );
+  const sourceNotes = (coverage?.requirements ?? [])
+    .filter((requirement) => requirement.source_url || requirement.research?.sources.length)
+    .map((requirement) => {
+      const urls = (
+        requirement.source_url
+          ? [requirement.source_url]
+          : requirement.research?.sources.slice(0, 3).map((source) => source.url) ?? []
+      ).filter((url, index, urls) => Boolean(url) && urls.indexOf(url) === index);
+      return `${requirement.title}: ${urls.join(", ")}`;
+    });
+  const notes = [
+    `Prepared from trip-planner trip ${trip.trip_id}.`,
+    scenario ? `Selected scenario: ${scenario.title}. ${scenario.route_summary}` : "",
+    sourceNotes.length > 0 ? `Planner evidence — ${sourceNotes.join(" | ")}` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return Object.fromEntries(
+    Object.entries({
+      business_purpose: trip.summary || trip.title,
+      city_state: trip.trip_frame.primary_regions.join(", "),
+      event_dates: eventDates,
+      depart_date: trip.trip_frame.start_date ?? "",
+      return_date: trip.trip_frame.end_date ?? "",
+      departure_city_airport:
+        parking?.inputs.departure_airport ?? intercity?.inputs.departure_airport ?? "",
+      return_city_airport: intercity?.inputs.destination_airport ?? "",
+      parking_estimate: amount(parking)?.toString() ?? "",
+      ground_transport_estimate: groundEstimate > 0 ? groundEstimate.toString() : "",
+      ground_transport_pref: [airportAccess, ...groundRequirements]
+        .map((requirement) => requirement?.selected_option?.name)
+        .filter(Boolean)
+        .join("; "),
+      "ground_transport.mileage_planned": Number.isFinite(mileageMiles) ? "true" : "",
+      "ground_transport.mileage_miles": Number.isFinite(mileageMiles)
+        ? mileageMiles.toString()
+        : "",
+      "ground_transport.mileage_cost": Number.isFinite(mileageCost)
+        ? mileageCost.toString()
+        : "",
+      "ground_transport.rideshare_planned": totalRideshare > 0 ? "true" : "",
+      "ground_transport.rideshare_cost": totalRideshare > 0 ? totalRideshare.toString() : "",
+      selected_fare: amount(intercity)?.toString() ?? "",
+      lowest_fare:
+        fareOptions
+          .map((option) => option.estimated_total)
+          .filter((value): value is number => value != null)
+          .sort((left, right) => left - right)[0]?.toString() ?? "",
+      fare_evidence_attached: intercity?.source_url ? "true" : "",
+      "hotel.name": lodgingOption?.name ?? "",
+      "hotel.address": lodgingOption?.details?.address?.toString() ?? "",
+      "hotel.nightly_rate": lodgingOption?.unit_rate?.toString() ?? "",
+      "hotel.nights": trip.trip_frame.duration_days
+        ? Math.max(trip.trip_frame.duration_days - 1, 1).toString()
+        : "",
+      "hotel.price_compare_notes": lodging?.research?.summary ?? "",
+      "comparable_hotels[0].name": comparableLodging[0]?.name ?? "",
+      "comparable_hotels[0].nightly_rate": comparableLodging[0]?.unit_rate?.toString() ?? "",
+      "comparable_hotels[1].name": comparableLodging[1]?.name ?? "",
+      "comparable_hotels[1].nightly_rate": comparableLodging[1]?.unit_rate?.toString() ?? "",
+      destination_zip: meals?.inputs.destination_zip ?? "",
+      "meal_counts.breakfast": mealDetails.eligible_breakfasts?.toString() ?? "",
+      "meal_counts.lunch": mealDetails.eligible_lunches?.toString() ?? "",
+      "meal_counts.dinner": mealDetails.eligible_dinners?.toString() ?? "",
+      meals_provided:
+        typeof mealDetails.meals_provided === "boolean"
+          ? String(mealDetails.meals_provided)
+          : "",
+      meal_per_diem_requested:
+        typeof mealDetails.meal_per_diem_requested === "boolean"
+          ? String(mealDetails.meal_per_diem_requested)
+          : "",
+      notes,
+    }).filter(([, value]) => value !== "")
+  );
+}
+
+export function submitTppHandoff(
+  portalUrl: string,
+  answers: Record<string, string>,
+  documentObject: Document = document
+) {
+  const normalizedBaseUrl = portalUrl.trim().replace(/\/$/, "");
+  const handoffUrl = new URL(`${normalizedBaseUrl}/portal/handoff`);
+  if (!(["http:", "https:"] as string[]).includes(handoffUrl.protocol)) {
+    throw new Error("The TPP portal URL must use HTTP or HTTPS.");
+  }
+  const form = documentObject.createElement("form");
+  form.method = "post";
+  form.action = handoffUrl.toString();
+  form.hidden = true;
+  for (const [name, value] of Object.entries(answers)) {
+    const input = documentObject.createElement("input");
+    input.type = "hidden";
+    input.name = name;
+    input.value = value;
+    form.append(input);
+  }
+  documentObject.body.append(form);
+  form.submit();
+  form.remove();
+}
+
+export function TppWorkbookHandoff({
+  trip,
+  scenario,
+}: {
+  trip: WorkspaceTrip;
+  scenario: WorkspaceScenario | null;
+}) {
+  const portalUrl = import.meta.env.VITE_TPP_PORTAL_URL?.trim() ?? "";
+  const configured = portalUrl !== "";
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleHandoff() {
+    setBusy(true);
+    setError(null);
+    try {
+      const coverage = await fetchCostCoverage(trip.trip_id);
+      submitTppHandoff(portalUrl, buildTppHandoffAnswers(trip, scenario, coverage));
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "The cost and evidence record could not be prepared for TPP."
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="status-card" data-testid="tpp-workbook-handoff">
+      <p className="status-label">Organization workbook</p>
+      <h2>Prepare the workplace travel request</h2>
+      <p>
+        Continue in Travel Plan Permission with this trip prefilled. TPP will collect the
+        organization-specific details, validate the request, and generate the Excel workbook.
+      </p>
+      <p className="muted-copy">
+        This handoff creates a review-only browser session. It does not submit the request.
+      </p>
+      <button
+        type="button"
+        className="primary-button"
+        disabled={!configured || busy}
+        onClick={() => void handleHandoff()}
+      >
+        {busy ? "Preparing evidence handoff…" : "Prepare organization workbook"}
+      </button>
+      {!configured ? (
+        <p className="planner-inline-error" role="status">
+          The TPP portal URL is not configured for this runtime.
+        </p>
+      ) : null}
+      {error ? (
+        <p className="planner-inline-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -900,6 +900,8 @@ describe("WorkspacePage", () => {
     // a prior test somehow leaks it, no later test can render the workspace into
     // the break hook with a stale `true` value.
     delete (window as WorkspaceTestWindow).__TRIP_PLANNER_WORKSPACE_BREAK__;
+    vi.stubEnv("VITE_GOOGLE_MAPS_BROWSER_API_KEY", "");
+    vi.stubEnv("VITE_GOOGLE_MAPS_EMBED_API_KEY", "");
     mockedFetchPlannerSession.mockResolvedValue(plannerSessionPayload);
     mockedSubmitPlannerTurn.mockResolvedValue(plannerSessionPayload);
     mockedSubmitRouteOptionAction.mockResolvedValue(workspacePayload);
@@ -1935,16 +1937,17 @@ describe("WorkspacePage", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByLabelText("Interactive map for Kyoto base with Uji day trip")
+        screen.getByRole("application", {
+          name: "Live Google map for Kyoto base with Uji day trip",
+        })
       ).toBeInTheDocument();
     });
 
-    expect(screen.getByLabelText("Route geometry overlay for Kyoto base with Uji day trip")).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: /stop marker:/ }).length).toBeGreaterThan(0);
     expect(container.querySelector("iframe")).toBeNull();
     expect(screen.queryByTitle(/google maps/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Fallback option markers")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Schematic preview — not a live map")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Schematic preview — not a live map")).not.toBeInTheDocument();
+    expect(screen.getByText("Loading Google Maps…")).toBeInTheDocument();
     expect(screen.getByLabelText("Selected route option route drawing")).toHaveClass(
       "map-route-google-maps-js"
     );
@@ -1954,17 +1957,15 @@ describe("WorkspacePage", () => {
         .length
     ).toBeGreaterThan(0);
     expect(screen.queryByText("Google Maps JavaScript adapter")).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /lodging marker: Osaka arrival buffer/ }));
-    expect(screen.getAllByRole("heading", { name: "Osaka arrival buffer" }).length).toBeGreaterThan(0);
-    await user.click(screen.getByRole("button", { name: /activity marker: Kyoto cultural anchor/ }));
-    expect(screen.getAllByRole("heading", { name: "Kyoto cultural anchor" }).length).toBeGreaterThan(0);
-    await user.click(screen.getByRole("button", { name: /policy marker: Route burden warning/ }));
-    expect(screen.getByRole("heading", { name: "Route burden warning" })).toBeInTheDocument();
     expect(screen.getAllByText("Feasibility warning active").length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
 
-    expect(screen.getByLabelText("Interactive map for Kyoto plus Osaka fallback")).toBeInTheDocument();
+    expect(
+      screen.getByRole("application", {
+        name: "Live Google map for Kyoto plus Osaka fallback",
+      })
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Osaka").length).toBeGreaterThan(0);
   });
 
@@ -1979,7 +1980,9 @@ describe("WorkspacePage", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByLabelText("Interactive map for Kyoto base with Uji day trip")
+        screen.getByRole("application", {
+          name: "Live Google map for Kyoto base with Uji day trip",
+        })
       ).toBeInTheDocument();
     });
 

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -35,9 +35,11 @@ import {
   type WorkspaceData,
 } from "../api/workspace";
 import { WorkspaceBudgetPanel } from "../components/budget/WorkspaceBudgetPanel";
+import { CostEvidencePanel } from "../components/costs/CostEvidencePanel";
 import { TripMap } from "../components/maps/TripMap";
 import type { MapViewScope } from "../components/maps/mapSurface";
 import { PlanningModeSelector } from "../components/planner/PlanningModeSelector";
+import { TppWorkbookHandoff } from "../components/policy/TppWorkbookHandoff";
 import { PlannerSidePanelSurface } from "../components/planner/PlannerSidePanelSurface";
 import { TripComparison } from "../components/trips/TripComparison";
 import { PlanningNotebookPanel } from "../components/workspace/PlanningNotebookPanel";
@@ -49,6 +51,7 @@ import { ScenarioComparison } from "../components/workspace/ScenarioComparison";
 import { AsyncRouteContent } from "../lib/routes/AsyncRouteContent";
 import { BudgetPanel } from "./workspace/BudgetPanel";
 import { ComparePanel } from "./workspace/ComparePanel";
+import { CostsPanel } from "./workspace/CostsPanel";
 import { MapPanel } from "./workspace/MapPanel";
 import { NotebookPanel } from "./workspace/NotebookPanel";
 import { PlanPanel } from "./workspace/PlanPanel";
@@ -103,7 +106,7 @@ type PlannerPromptSuggestion = {
   draft: string;
 };
 
-type WorkspaceTab = "plan" | "compare" | "map" | "budget" | "notebook" | "policy";
+type WorkspaceTab = "plan" | "compare" | "map" | "costs" | "budget" | "notebook" | "policy";
 
 type ProposalLifecycleState =
   | "pending"
@@ -189,6 +192,7 @@ const WORKSPACE_TABS: { id: WorkspaceTab; label: string }[] = [
   { id: "plan", label: "Plan" },
   { id: "compare", label: "Compare" },
   { id: "map", label: "Map" },
+  { id: "costs", label: "Costs & evidence" },
   { id: "budget", label: "Budget" },
   { id: "notebook", label: "Notebook" },
   { id: "policy", label: "Policy" },
@@ -2469,6 +2473,11 @@ function WorkspacePageContent({
           />
         </MapPanel>
       ) : null}
+      {activeTab === "costs" ? (
+        <CostsPanel labelledBy={workspaceTabButtonId("costs")}>
+          <CostEvidencePanel tripId={trip.trip_id} />
+        </CostsPanel>
+      ) : null}
       {activeTab === "budget" ? (
         <BudgetPanel labelledBy={workspaceTabButtonId("budget")}>
           {panelVisibility.showBudgetPanel ? (
@@ -2535,6 +2544,9 @@ function WorkspacePageContent({
       ) : null}
       {activeTab === "policy" ? (
         <PolicyTabPanel labelledBy={workspaceTabButtonId("policy")}>
+          {trip.mode === "business" ? (
+            <TppWorkbookHandoff trip={trip} scenario={selectedRuntimeScenario} />
+          ) : null}
           <WorkspacePolicyPanel
             grid
             approvalPacketContent={

--- a/frontend/src/routes/workspace/CostsPanel.tsx
+++ b/frontend/src/routes/workspace/CostsPanel.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export function CostsPanel({ children, labelledBy }: { children: ReactNode; labelledBy: string }) {
+  return (
+    <section
+      id="workspace-panel-costs"
+      role="tabpanel"
+      aria-labelledby={labelledBy}
+      data-testid="workspace-panel-costs"
+    >
+      {children}
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1156,6 +1156,30 @@ a {
   background-size: 34px 34px, 34px 34px, auto;
 }
 
+.map-provider-runtime {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.map-provider-live-status {
+  width: fit-content;
+  border: 1px solid rgba(40, 93, 80, 0.3);
+  border-radius: 999px;
+  background: rgba(222, 244, 235, 0.92);
+  color: #174a3f;
+  font-size: 0.82rem;
+  font-weight: 800;
+  padding: var(--space-1) var(--space-2);
+}
+
+.map-provider-runtime[data-provider-state="loading"] .map-provider-canvas-google {
+  opacity: 0.72;
+}
+
+.map-provider-canvas-google {
+  background: var(--color-surface);
+}
+
 .map-route-geometry {
   position: absolute;
   inset: 0;
@@ -1797,6 +1821,133 @@ a {
   font-weight: 600;
 }
 
+.cost-evidence-workspace,
+.cost-evidence-list {
+  display: grid;
+  gap: var(--space-5);
+}
+
+.cost-evidence-summary {
+  display: flex;
+  gap: var(--space-5);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cost-evidence-summary > div:first-child {
+  max-width: 760px;
+}
+
+.cost-evidence-count {
+  display: grid;
+  min-width: 130px;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  border-radius: 18px;
+  background: rgba(56, 117, 107, 0.1);
+  text-align: center;
+}
+
+.cost-evidence-count strong {
+  font-size: 2rem;
+}
+
+.cost-evidence-card {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.cost-evidence-card > p,
+.cost-evidence-card h3,
+.cost-evidence-card h4 {
+  margin: 0;
+}
+
+.cost-evidence-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.cost-evidence-status {
+  flex: none;
+  padding: 0.4rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(19, 33, 44, 0.08);
+  color: var(--color-ink-soft);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.cost-evidence-status.status-evidenced,
+.cost-evidence-status.status-complete,
+.cost-evidence-status.status-not_applicable {
+  background: rgba(56, 117, 107, 0.12);
+  color: var(--color-mint-deep);
+}
+
+.cost-evidence-assistance {
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--color-mint-ring);
+  background: rgba(56, 117, 107, 0.07);
+  color: var(--color-ink-soft);
+}
+
+.cost-evidence-inputs {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.cost-evidence-inputs label,
+.cost-evidence-traveler-input label {
+  display: grid;
+  gap: var(--space-2);
+  color: var(--color-ink-soft);
+  font-weight: 600;
+}
+
+.cost-evidence-inputs input,
+.cost-evidence-traveler-input textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border: 1px solid rgba(19, 33, 44, 0.18);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.84);
+  color: var(--color-ink);
+  font: inherit;
+}
+
+.cost-evidence-traveler-input,
+.cost-evidence-results {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.cost-evidence-traveler-input textarea {
+  min-height: 88px;
+  resize: vertical;
+}
+
+.cost-evidence-options {
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.cost-evidence-options .decision-card {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
 @media (max-width: 720px) {
   .app-shell {
     padding-inline: var(--space-4);
@@ -1808,5 +1959,10 @@ a {
 
   .timeline-stop {
     grid-template-columns: 1fr;
+  }
+
+  .cost-evidence-summary {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,10 +1,13 @@
 /// <reference types="vite/client" />
+/// <reference types="google.maps" />
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_GOOGLE_MAPS_BROWSER_API_KEY?: string;
   readonly VITE_GOOGLE_MAPS_EMBED_API_KEY?: string;
   readonly VITE_GOOGLE_MAPS_PROVIDER_STATE?: "ready" | "loading" | "error";
+  readonly VITE_GOOGLE_MAPS_MAP_ID?: string;
+  readonly VITE_TPP_PORTAL_URL?: string;
 }
 
 interface ImportMeta {

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -123,9 +123,17 @@ def _signup(client: TestClient) -> str:
     return response.json()["user"]["user_id"]
 
 
-def _create_trip(client: TestClient, *, mode: str, title: str, region: str) -> str:
+def _create_trip(
+    client: TestClient,
+    *,
+    mode: str,
+    title: str,
+    regions: list[str],
+    duration_days: int,
+    traveler_notes: str,
+) -> str:
     start_date = date.today() + timedelta(days=45)
-    end_date = start_date + timedelta(days=2)
+    end_date = start_date + timedelta(days=duration_days - 1)
     response = client.post(
         "/api/trips",
         json={
@@ -135,18 +143,47 @@ def _create_trip(client: TestClient, *, mode: str, title: str, region: str) -> s
             "trip_frame": {
                 "start_date": start_date.isoformat(),
                 "end_date": end_date.isoformat(),
-                "duration_days": 3,
-                "primary_regions": [region],
+                "duration_days": duration_days,
+                "primary_regions": regions,
                 "traveler_party": {
                     "kind": "team" if mode == "business" else "solo",
                     "traveler_count": 3 if mode == "business" else 1,
-                    "notes": "Created by full-product verification.",
+                    "notes": traveler_notes,
                 },
             },
         },
     )
     _require(response.status_code == 201, "trip creation failed", status=response.status_code)
     return response.json()["trip"]["trip_id"]
+
+
+def _assert_trip_scenario_identity(
+    payload: dict[str, Any],
+    *,
+    trip_id: str,
+    mode: str,
+    expected_regions: list[str],
+    expected_lead_title: str,
+) -> None:
+    trip = payload["trip_record"]["trip"]
+    _require(trip["mode"] == mode, "workspace mode did not match canary", trip_id=trip_id)
+    _require(
+        trip["trip_frame"]["primary_regions"] == expected_regions,
+        "workspace destinations did not match canary",
+        trip_id=trip_id,
+        expected_regions=expected_regions,
+        actual_regions=trip["trip_frame"]["primary_regions"],
+    )
+    scenario_titles = [
+        row.get("title") for row in payload["runtime_scenario_comparison"].get("scenarios", [])
+    ]
+    _require(
+        expected_lead_title in scenario_titles,
+        "workspace did not produce a destination-specific lead scenario",
+        trip_id=trip_id,
+        expected_title=expected_lead_title,
+        scenario_titles=scenario_titles,
+    )
 
 
 def _proposal_payload(trip_id: str) -> dict[str, Any]:
@@ -339,8 +376,15 @@ def classify_map_prerequisite(env: Mapping[str, str] | None = None) -> CheckResu
     if provider_state == "ready":
         return CheckResult(
             "map-provider",
-            "PASS",
-            {"provider_state": "provider-backed", "env": "VITE_GOOGLE_MAPS_*"},
+            "READY",
+            {
+                "provider_state": "credential-configured",
+                "env": "VITE_GOOGLE_MAPS_*",
+                "message": (
+                    "A browser API key is configured, but credential presence alone does not "
+                    "prove that the Google Maps SDK loaded or rendered provider-backed content."
+                ),
+            },
         )
     if provider_state == "loading":
         return CheckResult(
@@ -526,6 +570,62 @@ def _resolve_tpp_interpreter(repo_path: Path) -> list[str]:
     )
 
 
+def _run_tpp_workbook_canary(repo_path: Path) -> dict[str, Any]:
+    """Generate and structurally verify TPP's organization workbook without submitting it."""
+
+    fixture_path = repo_path / "tests" / "fixtures" / "washington_dc_business_trip.json"
+    _require(
+        fixture_path.is_file(),
+        "TPP organization workbook fixture is missing",
+        fixture_path=str(fixture_path),
+    )
+    interpreter = _resolve_tpp_interpreter(repo_path)
+    with tempfile.TemporaryDirectory(prefix="tpp-workbook-canary.") as tmpdir:
+        output_path = Path(tmpdir) / "washington-dc-business-trip.xlsx"
+        command = [
+            *interpreter,
+            "-m",
+            "travel_plan_permission.workbook_canary",
+            "--fixture",
+            str(fixture_path),
+            "--output",
+            str(output_path),
+        ]
+        completed = subprocess.run(
+            command,
+            cwd=repo_path,
+            env={**os.environ, "PYTHONPATH": str(repo_path / "src")},
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        _require(
+            completed.returncode == 0,
+            "TPP organization workbook canary failed",
+            command=shlex.join(command),
+            returncode=completed.returncode,
+            stdout_tail=completed.stdout[-1200:],
+            stderr_tail=completed.stderr[-1200:],
+        )
+        lines = [line for line in completed.stdout.splitlines() if line.strip()]
+        _require(bool(lines), "TPP organization workbook canary returned no JSON result")
+        try:
+            details = json.loads(lines[-1])
+        except json.JSONDecodeError as exc:
+            raise VerificationFailure(
+                "TPP organization workbook canary returned invalid JSON",
+                stdout_tail=completed.stdout[-1200:],
+            ) from exc
+        _require(
+            details.get("submission_performed") is False,
+            "TPP organization workbook canary unexpectedly reported submission",
+            details=details,
+        )
+        _require(output_path.is_file(), "TPP organization workbook artifact was not created")
+        return {**details, "repo_path": str(repo_path)}
+
+
 def _tail_file(path: Path, *, line_count: int = 50, max_bytes: int = 64 * 1024) -> str:
     if not path.exists():
         return ""
@@ -568,6 +668,7 @@ def _started_tpp_service(
     base_url = f"http://127.0.0.1:{port}"
     repo_root = Path(repo_path)
     interpreter = _resolve_tpp_interpreter(repo_root)
+    runtime_dir = Path(tempfile.mkdtemp(prefix="tpp-service-runtime."))
     service_env = {
         **os.environ,
         "PYTHONPATH": str(repo_root / "src"),
@@ -575,6 +676,8 @@ def _started_tpp_service(
         "TPP_AUTH_MODE": "static-token",
         "TPP_ACCESS_TOKEN": env["TPP_ACCESS_TOKEN"],
         "TPP_OIDC_PROVIDER": env["TPP_OIDC_PROVIDER"],
+        "TPP_PORTAL_STATE_PATH": str(runtime_dir / "portal-state.sqlite3"),
+        "TPP_AUDIT_STATE_PATH": str(runtime_dir / "audit-state.sqlite3"),
     }
     stdout_file = tempfile.NamedTemporaryFile(prefix="tpp-service-", suffix=".stdout", delete=False)
     stderr_file = tempfile.NamedTemporaryFile(prefix="tpp-service-", suffix=".stderr", delete=False)
@@ -602,6 +705,7 @@ def _started_tpp_service(
         stderr_file.close()
         stdout_path.unlink(missing_ok=True)
         stderr_path.unlink(missing_ok=True)
+        shutil.rmtree(runtime_dir, ignore_errors=True)
         raise
     else:
         stdout_file.close()
@@ -626,6 +730,7 @@ def _started_tpp_service(
         _stop_process(process)
         stdout_path.unlink(missing_ok=True)
         stderr_path.unlink(missing_ok=True)
+        shutil.rmtree(runtime_dir, ignore_errors=True)
 
 
 def _run_live_tpp_journey(client: TestClient, trip_id: str, env: dict[str, str]) -> dict[str, Any]:
@@ -708,6 +813,9 @@ def _run_live_tpp_journey(client: TestClient, trip_id: str, env: dict[str, str])
                 proposal_id=proposal["proposal_id"],
             )
             payload = evaluation_response.json()
+            evaluation_result = dict(
+                payload["proposal_state"]["evaluation"].get("evaluation_result") or {}
+            )
             return {
                 "base_url": base_url,
                 "trip_id": trip_id,
@@ -715,6 +823,7 @@ def _run_live_tpp_journey(client: TestClient, trip_id: str, env: dict[str, str])
                 "execution_id": payload["proposal_state"]["execution_id"],
                 "status_poll": status_response.json()["summary"]["submission_status"],
                 "evaluation_status": payload["summary"]["evaluation_result_status"],
+                "failure_reasons": list(evaluation_result.get("failure_reasons") or []),
             }
         finally:
             for key, value in previous.items():
@@ -736,6 +845,22 @@ def _temporary_database_url(database_url: str) -> Iterator[None]:
             os.environ.pop("TRIP_PLANNER_DATABASE_URL", None)
         else:
             os.environ["TRIP_PLANNER_DATABASE_URL"] = previous_database_url
+
+
+@contextmanager
+def _temporary_fleet_artifact(path: Path) -> Iterator[None]:
+    """Keep canary telemetry off the Dropbox-backed repository artifact."""
+
+    key = "TRIP_PLANNER_LANGSMITH_FLEET_PATH"
+    previous = os.environ.get(key)
+    os.environ[key] = str(path)
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = previous
 
 
 @contextmanager
@@ -766,6 +891,7 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
     with (
         tempfile.TemporaryDirectory(prefix="trip-planner-full-product.") as tmpdir,
         _temporary_database_url(f"sqlite:///{Path(tmpdir) / 'full_product.db'}"),
+        _temporary_fleet_artifact(Path(tmpdir) / "langsmith-fleet.ndjson"),
         _force_planner_fallback_runtime(),
     ):
         reset_database_state()
@@ -778,8 +904,12 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
             leisure_trip_id = _create_trip(
                 client,
                 mode="leisure",
-                title="Full-product leisure verification",
-                region="Seattle",
+                title="Canary Kyoto cultural week",
+                regions=["Kyoto", "Osaka"],
+                duration_days=7,
+                traveler_notes=(
+                    "Overseas leisure canary: culture, food, moderate budget, and low-transfer pacing."
+                ),
             )
             leisure_workspace = client.get(f"/api/workspace/{leisure_trip_id}")
             _require(
@@ -811,6 +941,13 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
             )
             _assert_runtime_inventory(leisure_payload, trip_id=leisure_trip_id)
             _assert_workspace_scenario_context(leisure_payload, trip_id=leisure_trip_id)
+            _assert_trip_scenario_identity(
+                leisure_payload,
+                trip_id=leisure_trip_id,
+                mode="leisure",
+                expected_regions=["Kyoto", "Osaka"],
+                expected_lead_title="Kyoto runtime bundle",
+            )
             planner_runtime = _assert_planner_runtime_response(
                 planner_turn.json(),
                 trip_id=leisure_trip_id,
@@ -830,6 +967,7 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
                         "route_contexts": len(
                             leisure_payload["runtime_scenario_comparison"]["scenarios"]
                         ),
+                        "destination": "Kyoto",
                     },
                 )
             )
@@ -837,8 +975,13 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
             business_trip_id = _create_trip(
                 client,
                 mode="business",
-                title="Full-product business verification",
-                region="Chicago",
+                title="Canary Washington DC client visit",
+                regions=["Washington DC"],
+                duration_days=3,
+                traveler_notes=(
+                    "US business canary: three travelers, economy policy, arrival buffer, "
+                    "central lodging, and explicit budget."
+                ),
             )
             business_workspace = client.get(f"/api/workspace/{business_trip_id}")
             _require(
@@ -850,6 +993,13 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
             business_payload = business_workspace.json()
             _assert_runtime_inventory(business_payload, trip_id=business_trip_id)
             _assert_workspace_scenario_context(business_payload, trip_id=business_trip_id)
+            _assert_trip_scenario_identity(
+                business_payload,
+                trip_id=business_trip_id,
+                mode="business",
+                expected_regions=["Washington DC"],
+                expected_lead_title="Washington DC runtime bundle",
+            )
             policy_request = _prepared_policy_request(business_trip_id)
             imported = client.put(
                 f"/api/workspace/{business_trip_id}/policy",
@@ -981,6 +1131,7 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
                         ],
                         "follow_up_status": evaluation_payload["summary"]["follow_up_status"],
                         "status_poll": refresh_payload["summary"]["submission_status"],
+                        "destination": "Washington DC",
                     },
                 )
             )
@@ -999,7 +1150,34 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
                     business_trip_id,
                     {key: str(value) for key, value in tpp_status.details.items()},
                 )
+                _require(
+                    live_details["evaluation_status"] == "compliant",
+                    "live TPP did not accept the business canary as policy compliant",
+                    trip_id=business_trip_id,
+                    evaluation_status=live_details["evaluation_status"],
+                    failure_reasons=live_details.get("failure_reasons", []),
+                )
                 results.append(CheckResult("live-tpp", "PASS", live_details))
+                local_tpp_path = tpp_status.details.get("TPP_REPO_PATH")
+                if isinstance(local_tpp_path, str) and local_tpp_path:
+                    workbook_details = _run_tpp_workbook_canary(Path(local_tpp_path))
+                    results.append(
+                        CheckResult("organization-workbook", "PASS", workbook_details)
+                    )
+                else:
+                    results.append(
+                        CheckResult(
+                            "organization-workbook",
+                            "SKIPPED",
+                            {
+                                "reason": "remote TPP verification has no local template checkout",
+                                "remediation": (
+                                    "Set TPP_REPO_PATH to run the no-submission organization "
+                                    "workbook canary."
+                                ),
+                            },
+                        )
+                    )
             else:
                 results.append(tpp_status)
                 if live_tpp == "required":

--- a/scripts/run_full_stack_dev.sh
+++ b/scripts/run_full_stack_dev.sh
@@ -7,9 +7,16 @@ backend_host="${BACKEND_HOST:-127.0.0.1}"
 backend_port="${BACKEND_PORT:-8000}"
 frontend_host="${FRONTEND_HOST:-127.0.0.1}"
 frontend_port="${FRONTEND_PORT:-5173}"
+tpp_repo_path="${TPP_REPO_PATH:-${repo_root}/../Travel-Plan-Permission}"
+tpp_host="${TPP_HOST:-127.0.0.1}"
+tpp_port="${TPP_PORT:-8766}"
+tpp_base_url_was_set="${TPP_BASE_URL:+true}"
+tpp_base_url="${TPP_BASE_URL:-http://${tpp_host}:${tpp_port}}"
+tpp_runtime_dir=""
 
 backend_pid=""
 frontend_pid=""
+tpp_pid=""
 
 cleanup() {
   if [ -n "${frontend_pid}" ] && kill -0 "${frontend_pid}" 2>/dev/null; then
@@ -20,14 +27,77 @@ cleanup() {
     kill "${backend_pid}" 2>/dev/null || true
     wait "${backend_pid}" 2>/dev/null || true
   fi
+  if [ -n "${tpp_pid}" ] && kill -0 "${tpp_pid}" 2>/dev/null; then
+    kill "${tpp_pid}" 2>/dev/null || true
+    wait "${tpp_pid}" 2>/dev/null || true
+  fi
+  if [ -n "${tpp_runtime_dir}" ]; then
+    rm -rf "${tpp_runtime_dir}"
+  fi
 }
 
 trap cleanup EXIT INT TERM
 
 cd "${repo_root}"
 
+if ! curl --fail --silent --show-error "${tpp_base_url}/readyz" >/dev/null 2>&1; then
+  if [ "${tpp_base_url_was_set}" = "true" ]; then
+    echo "Configured Travel-Plan-Permission service is not ready at ${tpp_base_url}." >&2
+    exit 1
+  fi
+  if [ ! -d "${tpp_repo_path}" ]; then
+    echo "Travel-Plan-Permission checkout not found at ${tpp_repo_path}." >&2
+    echo "Set TPP_REPO_PATH or start a service and set TPP_BASE_URL." >&2
+    exit 1
+  fi
+  if [ -x "${tpp_repo_path}/.venv/bin/python" ]; then
+    tpp_python="${tpp_repo_path}/.venv/bin/python"
+  else
+    echo "Travel-Plan-Permission needs ${tpp_repo_path}/.venv/bin/python for runtime-dev." >&2
+    exit 1
+  fi
+  tpp_runtime_dir="$(mktemp -d "${TMPDIR:-/tmp}/trip-planner-tpp-runtime.XXXXXX")"
+  env \
+    PYTHONPATH="${tpp_repo_path}/src" \
+    TPP_BASE_URL="${tpp_base_url}" \
+    TPP_AUTH_MODE="static-token" \
+    TPP_ACCESS_TOKEN="${TPP_ACCESS_TOKEN:-trip-planner-local-token-2026}" \
+    TPP_OIDC_PROVIDER="${TPP_OIDC_PROVIDER:-google}" \
+    TPP_HANDOFF_SIGNING_SECRET="${TPP_HANDOFF_SIGNING_SECRET:-trip-planner-handoff-secret-2026}" \
+    TPP_PORTAL_STATE_PATH="${tpp_runtime_dir}/portal-state.sqlite3" \
+    TPP_AUDIT_STATE_PATH="${tpp_runtime_dir}/audit-state.sqlite3" \
+    "${tpp_python}" -m travel_plan_permission.http_service \
+      --host "${tpp_host}" \
+      --port "${tpp_port}" \
+      >"${tpp_runtime_dir}/service.stdout" \
+      2>"${tpp_runtime_dir}/service.stderr" &
+  tpp_pid=$!
+  for _attempt in $(seq 1 80); do
+    if curl --fail --silent "${tpp_base_url}/readyz" >/dev/null 2>&1; then
+      break
+    fi
+    if ! kill -0 "${tpp_pid}" 2>/dev/null; then
+      echo "Travel-Plan-Permission exited during startup:" >&2
+      tail -40 "${tpp_runtime_dir}/service.stderr" >&2 || true
+      exit 1
+    fi
+    sleep 0.25
+  done
+  if ! curl --fail --silent "${tpp_base_url}/readyz" >/dev/null 2>&1; then
+    echo "Travel-Plan-Permission did not become ready at ${tpp_base_url}." >&2
+    tail -40 "${tpp_runtime_dir}/service.stderr" >&2 || true
+    exit 1
+  fi
+fi
+
+export VITE_TPP_PORTAL_URL="${VITE_TPP_PORTAL_URL:-${tpp_base_url}}"
+export TPP_BASE_URL="${tpp_base_url}"
+export TPP_ACCESS_TOKEN="${TPP_ACCESS_TOKEN:-trip-planner-local-token-2026}"
+export TPP_OIDC_PROVIDER="${TPP_OIDC_PROVIDER:-google}"
+
 python -m uvicorn trip_planner.app.main:app \
   --reload \
+  --reload-dir "${repo_root}/trip_planner" \
   --host "${backend_host}" \
   --port "${backend_port}" &
 backend_pid=$!
@@ -36,8 +106,9 @@ cat <<EOF
 Trip Planner runtime is starting.
 - Backend: http://${backend_host}:${backend_port}
 - Frontend: http://${frontend_host}:${frontend_port}
+- TPP portal: ${VITE_TPP_PORTAL_URL}/portal
 
-Press Ctrl+C to stop both processes.
+Press Ctrl+C to stop the local runtime.
 EOF
 
 npm --prefix "${repo_root}/frontend" run dev -- \

--- a/scripts/run_two_trip_ui_canary.sh
+++ b/scripts/run_two_trip_ui_canary.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+backend_port="${TRIP_PLANNER_CANARY_BACKEND_PORT:-8000}"
+frontend_port="${TRIP_PLANNER_CANARY_FRONTEND_PORT:-5173}"
+backend_url="http://127.0.0.1:${backend_port}"
+frontend_url="http://127.0.0.1:${frontend_port}"
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/trip-planner-two-trip-canary.XXXXXX")"
+artifact_dir="${TRIP_PLANNER_CANARY_ARTIFACT_DIR:-${run_dir}/artifacts}"
+backend_log="${run_dir}/backend.log"
+frontend_log="${run_dir}/frontend.log"
+backend_pid=""
+frontend_pid=""
+
+cleanup() {
+  if [ -n "${frontend_pid}" ] && kill -0 "${frontend_pid}" 2>/dev/null; then
+    kill "${frontend_pid}" 2>/dev/null || true
+    wait "${frontend_pid}" 2>/dev/null || true
+  fi
+  if [ -n "${backend_pid}" ] && kill -0 "${backend_pid}" 2>/dev/null; then
+    kill "${backend_pid}" 2>/dev/null || true
+    wait "${backend_pid}" 2>/dev/null || true
+  fi
+}
+
+show_failure_logs() {
+  echo "Two-trip UI canary failed. Backend log tail:"
+  tail -80 "${backend_log}" 2>/dev/null || true
+  echo "Frontend log tail:"
+  tail -80 "${frontend_log}" 2>/dev/null || true
+}
+
+wait_for_url() {
+  local url="$1"
+  local attempts=60
+  for ((attempt = 1; attempt <= attempts; attempt += 1)); do
+    if curl --fail --silent --show-error "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+trap cleanup EXIT INT TERM
+trap show_failure_logs ERR
+
+mkdir -p "${artifact_dir}"
+cd "${repo_root}"
+
+TRIP_PLANNER_DATABASE_URL="sqlite:///${run_dir}/canary.sqlite3" \
+TRIP_PLANNER_CORS_ORIGINS="${frontend_url}" \
+  uv run --extra dev python -m uvicorn trip_planner.app.main:app \
+  --host 127.0.0.1 --port "${backend_port}" >"${backend_log}" 2>&1 &
+backend_pid=$!
+wait_for_url "${backend_url}/api/health"
+
+VITE_API_BASE_URL="${backend_url}" frontend/node_modules/.bin/vite frontend \
+  --host 127.0.0.1 --port "${frontend_port}" --strictPort >"${frontend_log}" 2>&1 &
+frontend_pid=$!
+wait_for_url "${frontend_url}/signup"
+
+TRIP_PLANNER_CANARY_BASE_URL="${frontend_url}" \
+TRIP_PLANNER_CANARY_ARTIFACT_DIR="${artifact_dir}" \
+  npm --prefix frontend run test:e2e:canary
+
+echo "Two-trip UI canary PASS. Browser artifacts: ${artifact_dir}"

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -51,8 +51,8 @@ DEMO_PASSWORD = "demo-trip-planner-2026"  # synthetic; >= 8 chars
 DEMO_DISPLAY_NAME = "Demo Tester"
 
 #: Stable titles let the seed stay idempotent across re-runs.
-DEMO_LEISURE_TITLE = "Demo leisure getaway (synthetic)"
-DEMO_BUSINESS_TITLE = "Demo business summit (synthetic)"
+DEMO_LEISURE_TITLE = "Demo Kyoto cultural week (synthetic)"
+DEMO_BUSINESS_TITLE = "Demo Washington DC client visit (synthetic)"
 
 
 @dataclass(frozen=True)
@@ -110,6 +110,9 @@ def _ensure_trip(
     primary_regions: list[str],
     traveler_kind: str,
     traveler_count: int,
+    duration_days: int,
+    start_offset_days: int,
+    traveler_notes: str,
 ) -> str:
     """Create the demo trip if absent; otherwise reuse it (idempotent).
 
@@ -122,8 +125,8 @@ def _ensure_trip(
         return existing_by_title[title]
 
     # Future, deterministic-relative dates keep the demo trip "upcoming".
-    start = date.today() + timedelta(days=45)
-    end = start + timedelta(days=3)
+    start = date.today() + timedelta(days=start_offset_days)
+    end = start + timedelta(days=duration_days - 1)
     created = create_trip(
         db_session,
         user=user,
@@ -132,11 +135,11 @@ def _ensure_trip(
         mode=mode,
         start_date=start.isoformat(),
         end_date=end.isoformat(),
-        duration_days=(end - start).days,
+        duration_days=duration_days,
         primary_regions=primary_regions,
         traveler_kind=traveler_kind,
         traveler_count=traveler_count,
-        traveler_notes="Synthetic demo data -- safe to delete.",
+        traveler_notes=traveler_notes,
     )
     return created["trip_id"]
 
@@ -168,22 +171,34 @@ def seed_demo_data(*, force: bool = False) -> DemoSeedResult | None:
             user=user,
             existing_by_title=existing_by_title,
             title=DEMO_LEISURE_TITLE,
-            summary="A relaxed multi-day city break to explore the workspace.",
+            summary="Seven days of Kyoto culture, food, and low-transfer neighborhood exploration.",
             mode="leisure",
-            primary_regions=["Chicago"],
+            primary_regions=["Kyoto", "Osaka"],
             traveler_kind="solo",
             traveler_count=1,
+            duration_days=7,
+            start_offset_days=90,
+            traveler_notes=(
+                "Synthetic overseas leisure canary: moderate budget, cultural sites, food, "
+                "and simple transfers. Safe to delete."
+            ),
         )
         business_trip_id = _ensure_trip(
             session,
             user=user,
             existing_by_title=existing_by_title,
             title=DEMO_BUSINESS_TITLE,
-            summary="A short business summit with a small travelling team.",
+            summary="A three-person Washington DC client meeting with an arrival buffer.",
             mode="business",
-            primary_regions=["Chicago"],
+            primary_regions=["Washington DC"],
             traveler_kind="team",
             traveler_count=3,
+            duration_days=3,
+            start_offset_days=75,
+            traveler_notes=(
+                "Synthetic US business canary: economy travel, central lodging, explicit "
+                "budget, and manager-review posture. Safe to delete."
+            ),
         )
     finally:
         session.close()

--- a/tests/app/test_cost_coverage.py
+++ b/tests/app/test_cost_coverage.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trip_planner.app.main import create_app
+from trip_planner.persistence.db import reset_database_state
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("TRIP_PLANNER_DATABASE_URL", f"sqlite:///{tmp_path / 'coverage.db'}")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    reset_database_state()
+    with TestClient(create_app()) as test_client:
+        response = test_client.post(
+            "/api/auth/signup",
+            json={
+                "email": "coverage@example.com",
+                "password": "password123",
+                "display_name": "Coverage Tester",
+            },
+        )
+        assert response.status_code == 201
+        yield test_client
+    reset_database_state()
+
+
+def _catalog() -> dict[str, object]:
+    return {
+        "contract_version": "tpp-intake-requirements/v1",
+        "organization_id": "tpp",
+        "requirements": [
+            {
+                "code": "airport_parking",
+                "category": "ground_transport",
+                "title": "Airport parking",
+                "summary": "Research official parking rates.",
+                "collection_mode": "researchable",
+                "evidence_kind": "provider_rate",
+                "required_inputs": ["departure_airport", "parking_days"],
+                "output_fields": ["parking_estimate"],
+                "research_prompt": "Find current official airport parking options.",
+            },
+            {
+                "code": "organization_attestations",
+                "category": "administrative",
+                "title": "Organization details",
+                "summary": "Traveler-supplied fields.",
+                "collection_mode": "traveler",
+                "evidence_kind": "traveler_confirmation",
+                "required_inputs": [],
+                "output_fields": ["cost_center"],
+            },
+        ],
+    }
+
+
+def _create_trip(client: TestClient) -> str:
+    response = client.post(
+        "/api/trips",
+        json={
+            "title": "NYC meetings",
+            "summary": "Business meetings",
+            "mode": "business",
+            "trip_frame": {
+                "start_date": "2026-11-11",
+                "end_date": "2026-11-14",
+                "duration_days": 4,
+                "primary_regions": ["New York, NY 10282"],
+            },
+        },
+    )
+    assert response.status_code == 201
+    return response.json()["trip"]["trip_id"]
+
+
+def test_cost_coverage_derives_parking_days_and_requests_only_missing_airport(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "trip_planner.app.services.cost_coverage._load_tpp_catalog",
+        _catalog,
+    )
+    trip_id = _create_trip(client)
+
+    response = client.get(f"/api/workspace/{trip_id}/cost-coverage")
+
+    assert response.status_code == 200
+    parking = next(
+        item for item in response.json()["requirements"] if item["code"] == "airport_parking"
+    )
+    assert parking["inputs"]["parking_days"] == "4"
+    assert parking["missing_inputs"] == ["departure_airport"]
+    assert parking["status"] == "needs_input"
+    assert response.json()["summary"]["research_offer_count"] == 1
+
+
+def test_research_returns_missing_input_prompt_without_calling_provider(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "trip_planner.app.services.cost_coverage._load_tpp_catalog",
+        _catalog,
+    )
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/workspace/{trip_id}/cost-coverage/airport_parking/research",
+        json={"inputs": {}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["research_notice"]["status"] == "needs_input"
+    assert response.json()["research_notice"]["missing_inputs"] == ["departure_airport"]
+
+
+def test_live_research_persists_options_sources_and_timestamp(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "trip_planner.app.services.cost_coverage._load_tpp_catalog",
+        _catalog,
+    )
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "gpt-test")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key")
+    option = {
+        "name": "Official economy lot",
+        "unit_rate": 12,
+        "unit": "day",
+        "estimated_total": 48,
+        "notes": "Airport shuttle included.",
+        "source_url": "https://airport.example/parking",
+    }
+    response_payload = SimpleNamespace(
+        output_text=json.dumps({"summary": "Official parking researched.", "options": [option]}),
+        output=[
+            SimpleNamespace(
+                type="web_search_call",
+                action=SimpleNamespace(
+                    sources=[
+                        SimpleNamespace(
+                            title="Airport parking",
+                            url="https://airport.example/parking",
+                        )
+                    ]
+                ),
+            )
+        ],
+    )
+
+    class FakeResponses:
+        def create(self, **kwargs):
+            assert kwargs["tools"] == [{"type": "web_search"}]
+            return response_payload
+
+    class FakeOpenAI:
+        def __init__(self, **_kwargs) -> None:
+            self.responses = FakeResponses()
+
+    monkeypatch.setattr("openai.OpenAI", FakeOpenAI)
+    trip_id = _create_trip(client)
+
+    response = client.post(
+        f"/api/workspace/{trip_id}/cost-coverage/airport_parking/research",
+        json={"inputs": {"departure_airport": "STL"}},
+    )
+
+    assert response.status_code == 200
+    parking = next(
+        item for item in response.json()["requirements"] if item["code"] == "airport_parking"
+    )
+    assert parking["status"] == "researched"
+    assert parking["research"]["options"] == [option]
+    assert parking["research"]["sources"][0]["url"] == option["source_url"]
+    assert parking["research"]["researched_at"].endswith("Z")
+
+
+def test_selecting_researched_option_marks_requirement_evidenced(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "trip_planner.app.services.cost_coverage._load_tpp_catalog",
+        _catalog,
+    )
+    trip_id = _create_trip(client)
+
+    response = client.patch(
+        f"/api/workspace/{trip_id}/cost-coverage/airport_parking",
+        json={
+            "estimate_amount": 48,
+            "source_url": "https://airport.example/parking",
+            "selected_option": {"name": "Official economy lot", "estimated_total": 48},
+        },
+    )
+
+    assert response.status_code == 200
+    parking = next(
+        item for item in response.json()["requirements"] if item["code"] == "airport_parking"
+    )
+    assert parking["status"] == "evidenced"
+    assert parking["estimate_amount"] == 48
+
+
+def test_shared_inputs_are_reused_across_related_requirements(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = _catalog()
+    requirements = catalog["requirements"]
+    assert isinstance(requirements, list)
+    requirements.append(
+        {
+            "code": "intercity_transport",
+            "category": "airfare",
+            "title": "Intercity transportation",
+            "summary": "Research roundtrip options.",
+            "collection_mode": "researchable",
+            "evidence_kind": "fare_quote",
+            "required_inputs": [
+                "departure_airport",
+                "destination_airport",
+                "travel_dates",
+            ],
+            "output_fields": ["selected_fare"],
+            "research_prompt": "Find practical transportation options.",
+        }
+    )
+    monkeypatch.setattr(
+        "trip_planner.app.services.cost_coverage._load_tpp_catalog",
+        lambda: catalog,
+    )
+    trip_id = _create_trip(client)
+
+    response = client.patch(
+        f"/api/workspace/{trip_id}/cost-coverage/airport_parking",
+        json={"inputs": {"departure_airport": "STL"}},
+    )
+
+    assert response.status_code == 200
+    intercity = next(
+        item for item in response.json()["requirements"] if item["code"] == "intercity_transport"
+    )
+    assert intercity["inputs"]["departure_airport"] == "STL"
+    assert intercity["missing_inputs"] == ["destination_airport"]
+
+
+def test_residence_and_official_domicile_are_reused_for_future_trips(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = _catalog()
+    requirements = catalog["requirements"]
+    assert isinstance(requirements, list)
+    requirements.append(
+        {
+            "code": "airport_access",
+            "category": "ground_transport",
+            "title": "Airport access",
+            "summary": "Apply mileage and commuting rules.",
+            "collection_mode": "researchable",
+            "evidence_kind": "route_comparison",
+            "required_inputs": [
+                "traveler_residence_address",
+                "official_domicile_address",
+                "departure_airport",
+            ],
+            "output_fields": ["ground_transport.mileage_miles"],
+            "research_prompt": "Compare the residence and official domicile routes.",
+        }
+    )
+    monkeypatch.setattr(
+        "trip_planner.app.services.cost_coverage._load_tpp_catalog",
+        lambda: catalog,
+    )
+    first_trip_id = _create_trip(client)
+    addresses = {
+        "traveler_residence_address": "803 B Broadway, Jefferson City, MO",
+        "official_domicile_address": "3236 W Edgewood Dr, Jefferson City, MO 65109",
+        "departure_airport": "STL",
+    }
+
+    response = client.patch(
+        f"/api/workspace/{first_trip_id}/cost-coverage/airport_access",
+        json={"inputs": addresses},
+    )
+    assert response.status_code == 200
+
+    second_trip_id = _create_trip(client)
+    second_response = client.get(f"/api/workspace/{second_trip_id}/cost-coverage")
+    airport_access = next(
+        item for item in second_response.json()["requirements"] if item["code"] == "airport_access"
+    )
+    assert (
+        airport_access["inputs"]["traveler_residence_address"]
+        == addresses["traveler_residence_address"]
+    )
+    assert (
+        airport_access["inputs"]["official_domicile_address"]
+        == addresses["official_domicile_address"]
+    )
+    assert airport_access["missing_inputs"] == ["departure_airport"]
+
+
+def test_destination_zip_is_derived_from_saved_trip_region(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = _catalog()
+    requirements = catalog["requirements"]
+    assert isinstance(requirements, list)
+    requirements.append(
+        {
+            "code": "meals_incidentals",
+            "category": "meals",
+            "title": "Meals and incidental allowance",
+            "summary": "Calculate eligible meals.",
+            "collection_mode": "automatic",
+            "evidence_kind": "policy_rate",
+            "required_inputs": ["destination_zip"],
+            "output_fields": ["meal_counts"],
+            "research_prompt": "Apply the organization meal policy.",
+        }
+    )
+    monkeypatch.setattr(
+        "trip_planner.app.services.cost_coverage._load_tpp_catalog",
+        lambda: catalog,
+    )
+    trip_id = _create_trip(client)
+
+    response = client.get(f"/api/workspace/{trip_id}/cost-coverage")
+
+    assert response.status_code == 200
+    meals = next(
+        item for item in response.json()["requirements"] if item["code"] == "meals_incidentals"
+    )
+    assert meals["inputs"]["destination_zip"] == "10282"
+    assert meals["missing_inputs"] == []

--- a/tests/app/test_demo_seed.py
+++ b/tests/app/test_demo_seed.py
@@ -10,7 +10,9 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 from scripts.seed_demo_data import (
+    DEMO_BUSINESS_TITLE,
     DEMO_EMAIL,
+    DEMO_LEISURE_TITLE,
     DEMO_PASSWORD,
     SEED_ENV_FLAG,
     _ensure_demo_user,
@@ -50,9 +52,9 @@ def test_demo_seed_populates_workspace(temp_db: None, monkeypatch: pytest.Monkey
         )
         assert login.status_code == 200, login.text
 
-        response = client.get(f"/api/workspace/{result.leisure_trip_id}")
-        assert response.status_code == 200, response.text
-        payload = response.json()
+        leisure_response = client.get(f"/api/workspace/{result.leisure_trip_id}")
+        assert leisure_response.status_code == 200, leisure_response.text
+        payload = leisure_response.json()
 
         # Ranked scenario comparison must be populated, not a missing-* partial.
         comparison = payload["runtime_scenario_comparison"]
@@ -65,6 +67,27 @@ def test_demo_seed_populates_workspace(temp_db: None, monkeypatch: pytest.Monkey
 
         # Deterministic fallback planner -- no external LLM was invoked.
         assert payload["runtime_state"]["status"] == "ready"
+        leisure_trip = payload["trip_record"]["trip"]
+        assert leisure_trip["title"] == DEMO_LEISURE_TITLE
+        assert leisure_trip["trip_frame"]["primary_regions"] == ["Kyoto", "Osaka"]
+        assert leisure_trip["trip_frame"]["duration_days"] == 7
+        assert any(
+            scenario["title"] == "Kyoto runtime bundle"
+            for scenario in comparison["scenarios"]
+        )
+
+        business_response = client.get(f"/api/workspace/{result.business_trip_id}")
+        assert business_response.status_code == 200, business_response.text
+        business_payload = business_response.json()
+        business_trip = business_payload["trip_record"]["trip"]
+        assert business_trip["title"] == DEMO_BUSINESS_TITLE
+        assert business_trip["trip_frame"]["primary_regions"] == ["Washington DC"]
+        assert business_trip["trip_frame"]["duration_days"] == 3
+        assert business_payload["runtime_scenario_comparison"]["scenarios"]
+        assert any(
+            scenario["title"] == "Washington DC runtime bundle"
+            for scenario in business_payload["runtime_scenario_comparison"]["scenarios"]
+        )
 
 
 def test_demo_seed_is_noop_when_flag_unset(temp_db: None, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/app/test_full_product_verification.py
+++ b/tests/app/test_full_product_verification.py
@@ -1,5 +1,7 @@
+import json
 import os
 import subprocess
+from pathlib import Path
 
 from scripts import check_full_product_verification as verifier
 from scripts.check_full_product_verification import (
@@ -40,11 +42,13 @@ def test_full_product_local_journeys_cover_runtime_identifiers(monkeypatch) -> N
     assert by_name["local-leisure-journey"].details["trip_id"].startswith("trip-")
     assert by_name["local-leisure-journey"].details["scenario_id"].startswith("scenario:")
     assert by_name["local-leisure-journey"].details["route_contexts"] > 0
+    assert by_name["local-leisure-journey"].details["destination"] == "Kyoto"
     assert by_name["local-leisure-journey"].details["planner_runtime"] in {
         "fallback",
         "model",
     }
     assert by_name["local-business-journey"].details["proposal_id"].startswith("proposal:trip-")
+    assert by_name["local-business-journey"].details["destination"] == "Washington DC"
     assert by_name["local-business-journey"].details["evaluation_status"] == "compliant"
     assert by_name["local-business-journey"].details["follow_up_status"] == "resolved"
     assert by_name["local-business-journey"].details["status_poll"] in {
@@ -53,6 +57,7 @@ def test_full_product_local_journeys_cover_runtime_identifiers(monkeypatch) -> N
         "retry_scheduled",
     }
     assert "TRIP_PLANNER_DATABASE_URL" not in os.environ
+    assert "TRIP_PLANNER_LANGSMITH_FLEET_PATH" not in os.environ
 
 
 def test_map_provider_check_reports_missing_config_as_skipped(monkeypatch) -> None:
@@ -78,6 +83,19 @@ def test_map_provider_check_fails_when_configured_provider_errors(monkeypatch) -
 
     assert check.status == "FAIL"
     assert check.details["provider_state"] == "error"
+
+
+def test_map_provider_check_does_not_treat_credential_presence_as_live_pass() -> None:
+    check = classify_map_prerequisite(
+        env={
+            "VITE_GOOGLE_MAPS_BROWSER_API_KEY": "test-key",
+            "VITE_GOOGLE_MAPS_PROVIDER_STATE": "ready",
+        }
+    )
+
+    assert check.status == "READY"
+    assert check.details["provider_state"] == "credential-configured"
+    assert "does not prove" in check.details["message"]
 
 
 def test_planner_llm_check_blocks_openai_in_proprietary_zone_without_marker() -> None:
@@ -286,6 +304,44 @@ def test_tpp_interpreter_resolution_fails_with_actionable_message(monkeypatch, t
     assert "TPP_BASE_URL" in message
 
 
+def test_tpp_workbook_canary_runs_owned_tpp_module(monkeypatch, tmp_path) -> None:
+    repo_path = tmp_path / "Travel-Plan-Permission"
+    venv_python = repo_path / ".venv" / "bin" / "python"
+    fixture = repo_path / "tests" / "fixtures" / "washington_dc_business_trip.json"
+    venv_python.parent.mkdir(parents=True)
+    fixture.parent.mkdir(parents=True)
+    venv_python.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+    fixture.write_text("{}", encoding="utf-8")
+
+    def fake_run(command, **kwargs):
+        output_path = command[command.index("--output") + 1]
+        Path(output_path).write_bytes(b"workbook")
+        assert command[:3] == [
+            str(venv_python),
+            "-m",
+            "travel_plan_permission.workbook_canary",
+        ]
+        assert kwargs["cwd"] == repo_path
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "artifact": "washington-dc-business-trip.xlsx",
+                    "submission_performed": False,
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(verifier.subprocess, "run", fake_run)
+
+    result = verifier._run_tpp_workbook_canary(repo_path)
+
+    assert result["submission_performed"] is False
+    assert result["repo_path"] == str(repo_path)
+
+
 def test_started_tpp_service_captures_startup_stderr(monkeypatch, tmp_path) -> None:
     repo_path = tmp_path / "Travel-Plan-Permission"
     venv_python = repo_path / ".venv" / "bin" / "python"
@@ -295,6 +351,8 @@ def test_started_tpp_service_captures_startup_stderr(monkeypatch, tmp_path) -> N
     class FakeProcess:
         def __init__(self, *args, **kwargs):
             self.args = args[0]
+            assert kwargs["env"]["TPP_PORTAL_STATE_PATH"].endswith("portal-state.sqlite3")
+            assert kwargs["env"]["TPP_AUDIT_STATE_PATH"].endswith("audit-state.sqlite3")
             kwargs["stderr"].write(b"ModuleNotFoundError: No module named 'jinja2'\n")
             kwargs["stderr"].flush()
 

--- a/tests/app/test_inventory.py
+++ b/tests/app/test_inventory.py
@@ -10,6 +10,7 @@ from trip_planner.app.services.inventory import (
     _build_inventory_assembly_input,
     assemble_inventory_bundles_for_trip,
     build_inventory_summary_payload,
+    lookup_region_coordinates,
 )
 from trip_planner.persistence.db import reset_database_state
 from trip_planner.persistence.models.trip import PersistedTrip
@@ -23,6 +24,18 @@ _FIXTURE_ADAPTER_MARKERS = {
     "PersistedTripInventoryFixtureAdapter",
     "persisted-trip-fixture-inventory",
 }
+
+
+def test_known_region_coordinates_match_specific_route_aliases_first() -> None:
+    assert lookup_region_coordinates("dest-gateway-washington-dc") == (
+        38.8512,
+        -77.0402,
+    )
+    assert lookup_region_coordinates("dest-city-washington-dc") == (
+        38.9072,
+        -77.0369,
+    )
+    assert lookup_region_coordinates("unlisted-place") is None
 
 
 @pytest.fixture

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -10,10 +10,13 @@ from sqlalchemy import delete, select
 from trip_planner.app.main import create_app
 from trip_planner.app.services.auth import AuthenticatedUser
 from trip_planner.app.services.planner import (
+    _OpenAIPlannerChatModel,
+    _openai_response_text,
     set_intent_classifier_factory_for_tests,
     set_planner_chat_model_factory_for_tests,
     set_planner_prompt_redactor_for_tests,
 )
+from trip_planner.app.services.planner_runtime_config import PlannerRuntimeConfig
 from trip_planner.app.services.planner_tools import (
     execute_planner_tool_call,
     list_planner_tools,
@@ -92,6 +95,64 @@ class FailingPlannerChatModel:
     def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
         del payload
         raise RuntimeError("provider timeout")
+
+
+class SequencedPlannerChatModel:
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self.responses = list(responses)
+        self.requests: list[dict[str, Any]] = []
+
+    def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.requests.append(payload)
+        if payload.get("task") == "classify_planner_intent":
+            return {
+                "content": json.dumps(
+                    {"task_class": "planning_synthesis", "intent": "planning_synthesis"}
+                )
+            }
+        if not self.responses:
+            raise AssertionError("Planner model received an unexpected extra invocation.")
+        return self.responses.pop(0)
+
+
+def test_openai_planner_uses_responses_api_for_tool_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeChatOpenAI:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr("langchain_openai.ChatOpenAI", FakeChatOpenAI)
+
+    _OpenAIPlannerChatModel(
+        PlannerRuntimeConfig(
+            mode="model",
+            provider="openai",
+            model="gpt-test",
+            status="ready",
+            title="Model-backed planner",
+            summary="Planner turns use the configured model.",
+        )
+    )
+
+    assert captured == {
+        "model": "gpt-test",
+        "temperature": 0,
+        "use_responses_api": True,
+    }
+
+
+def test_openai_response_text_ignores_reasoning_and_function_blocks() -> None:
+    class ResponsesMessage:
+        content = [
+            {"type": "reasoning", "summary": []},
+            {"type": "function_call", "name": "read_workspace_state"},
+            {"type": "output_text", "text": "Traveler-facing answer."},
+        ]
+
+    assert _openai_response_text(ResponsesMessage()) == "Traveler-facing answer."
 
 
 def _create_trip(client: TestClient) -> str:
@@ -681,6 +742,77 @@ def test_planner_turn_uses_configured_model_and_persists_requested_tool_trace(
         assert checkpoint is not None
         assert checkpoint.metadata_payload["tool_call_count"] == 6
         assert checkpoint.metadata_payload["selected_planning_mode"] == "collaborative"
+
+
+def test_model_tool_loop_executes_reads_then_bounded_lodging_update(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    trip_id = _create_trip(client)
+    model = SequencedPlannerChatModel(
+        [
+            {
+                "content": "",
+                "tool_calls": [{"tool_name": "read_budget_state", "arguments": {}}],
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "tool_name": "update_budget_plan",
+                        "arguments": {
+                            "total_amount": 774,
+                            "title": "NYC lodging budget",
+                            "currency": "USD",
+                            "allocations": [
+                                {"category_key": "lodging", "planned_amount": 774}
+                            ],
+                        },
+                    }
+                ],
+            },
+            {"content": "Artezen is saved as the $774 lodging plan.", "tool_calls": []},
+        ]
+    )
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("TRIP_PLANNER_PLANNER_MODEL", "fake-planner-model")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-test-key")
+    set_planner_chat_model_factory_for_tests(lambda _: model)
+
+    response = client.post(
+        f"/api/planner/{trip_id}/turns",
+        json={"message": "Save a $774 lodging-only plan after reading the budget."},
+    )
+
+    assert response.status_code == 200
+    planner_reply = response.json()["messages"][-1]
+    assert planner_reply["content"] == "Artezen is saved as the $774 lodging plan."
+    completed_names = {
+        item["tool_name"]
+        for item in planner_reply["tool_calls"]
+        if item["status"] == "completed"
+    }
+    assert {"read_budget_state", "update_budget_plan"}.issubset(completed_names)
+    workspace = client.get(f"/api/workspace/{trip_id}")
+    category_summaries = workspace.json()["budget_state"]["summary"]["category_summaries"]
+    lodging = next(item for item in category_summaries if item["category_key"] == "lodging")
+    assert lodging["planned_amount"] == 774
+    followups = [
+        request
+        for request in model.requests
+        if request.get("completed_tool_results") is not None
+    ]
+    assert len(followups) == 2
+
+
+def test_planner_tool_catalog_exposes_budget_and_notebook_schemas() -> None:
+    tools = {item["tool_name"]: item for item in list_planner_tools()}
+
+    budget_schema = tools["update_budget_plan"]["input_schema"]
+    assert budget_schema["required"] == ["total_amount"]
+    assert "allocations" in budget_schema["properties"]
+    notebook_schema = tools["capture_notebook_item"]["input_schema"]
+    assert notebook_schema["required"] == ["title"]
 
 
 def test_planner_turn_emits_no_secret_langsmith_fleet_artifact(

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -1240,6 +1240,7 @@ def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
                 "expense_breakdown": {"airfare": 620.0},
                 "selected_fare": 620.0,
                 "flight_cost": 620.0,
+                "fare_evidence_attached": True,
                 "comparable_hotels": None,
                 "selected_providers": {"airfare": "United"},
                 "validation_results": [],

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -2508,6 +2508,18 @@ def test_runtime_route_options_hold_blocked_scenarios_for_research() -> None:
     assert "make_baseline" not in [action["action_type"] for action in blocked["available_actions"]]
 
 
+def test_runtime_map_markers_include_known_geographic_coordinates() -> None:
+    markers = workspace_service._build_runtime_map_place_markers(
+        ["dest-gateway-washington-dc", "dest-city-washington-dc"],
+        source_refs=["test"],
+    )
+
+    assert [(marker["latitude"], marker["longitude"]) for marker in markers] == [
+        (38.8512, -77.0402),
+        (38.9072, -77.0369),
+    ]
+
+
 def test_workspace_route_option_actions_update_comparison_and_ledger(
     client: TestClient,
 ) -> None:

--- a/tests/persistence/test_migration_compat.py
+++ b/tests/persistence/test_migration_compat.py
@@ -71,7 +71,7 @@ def test_current_migrations_repair_database_stamped_at_previous_20260510_02(
 
     with engine.connect() as connection:
         assert connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one() == (
-            "20260512_01"
+            "20260712_01"
         )
         assert (
             connection.execute(
@@ -82,5 +82,12 @@ def test_current_migrations_repair_database_stamped_at_previous_20260510_02(
             ).scalar_one()
             == "open_question"
         )
+    assert "cost_coverage_state" in {
+        column["name"] for column in inspector.get_columns("persisted_trips")
+    }
+    if inspector.has_table("user_accounts"):
+        assert "travel_profile_state" in {
+            column["name"] for column in inspector.get_columns("user_accounts")
+        }
 
     reset_database_state()

--- a/trip_planner/app/main.py
+++ b/trip_planner/app/main.py
@@ -8,6 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from trip_planner.app import APP_VERSION
 from trip_planner.app.routes.auth import router as auth_router
 from trip_planner.app.routes.budget import router as budget_router
+from trip_planner.app.routes.cost_coverage import router as cost_coverage_router
 from trip_planner.app.routes.health import router as health_router
 from trip_planner.app.routes.inventory import router as inventory_router
 from trip_planner.app.routes.planner import router as planner_router
@@ -84,6 +85,7 @@ def create_app() -> FastAPI:
     app.include_router(scenario_history_router, prefix="/api")
     app.include_router(workspace_router, prefix="/api")
     app.include_router(budget_router, prefix="/api")
+    app.include_router(cost_coverage_router, prefix="/api")
 
     @app.get("/")
     def read_root() -> dict[str, str]:

--- a/trip_planner/app/routes/cost_coverage.py
+++ b/trip_planner/app/routes/cost_coverage.py
@@ -1,0 +1,86 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from trip_planner.app.schemas.cost_coverage import (
+    CostCoverageResearchRequest,
+    CostCoverageResponse,
+    CostCoverageUpdateRequest,
+)
+from trip_planner.app.services.auth import AuthenticatedUser, require_authenticated_user
+from trip_planner.app.services.cost_coverage import (
+    CostCoverageUnavailableError,
+    get_cost_coverage_payload,
+    research_cost_coverage_item,
+    update_cost_coverage_item,
+)
+from trip_planner.app.services.workspace import WorkspaceTripNotFoundError
+from trip_planner.persistence.db import get_db_session
+
+router = APIRouter(tags=["cost-coverage"])
+
+
+@router.get("/workspace/{trip_id}/cost-coverage", response_model=CostCoverageResponse)
+def read_cost_coverage(
+    trip_id: str,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> CostCoverageResponse:
+    try:
+        result = get_cost_coverage_payload(db_session, user=user, trip_id=trip_id)
+    except WorkspaceTripNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    return CostCoverageResponse.model_validate(result)
+
+
+@router.patch(
+    "/workspace/{trip_id}/cost-coverage/{requirement_code}",
+    response_model=CostCoverageResponse,
+)
+def update_cost_coverage(
+    trip_id: str,
+    requirement_code: str,
+    payload: CostCoverageUpdateRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> CostCoverageResponse:
+    try:
+        result = update_cost_coverage_item(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            requirement_code=requirement_code,
+            updates=payload.model_dump(exclude_none=True),
+        )
+    except WorkspaceTripNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return CostCoverageResponse.model_validate(result)
+
+
+@router.post(
+    "/workspace/{trip_id}/cost-coverage/{requirement_code}/research",
+    response_model=CostCoverageResponse,
+)
+def research_cost_coverage(
+    trip_id: str,
+    requirement_code: str,
+    payload: CostCoverageResearchRequest,
+    user: AuthenticatedUser = Depends(require_authenticated_user),
+    db_session: Session = Depends(get_db_session),
+) -> CostCoverageResponse:
+    try:
+        result = research_cost_coverage_item(
+            db_session,
+            user=user,
+            trip_id=trip_id,
+            requirement_code=requirement_code,
+            inputs=payload.inputs,
+        )
+    except WorkspaceTripNotFoundError as error:
+        raise HTTPException(status_code=404, detail=str(error)) from error
+    except CostCoverageUnavailableError as error:
+        raise HTTPException(status_code=503, detail=str(error)) from error
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+    return CostCoverageResponse.model_validate(result)

--- a/trip_planner/app/schemas/cost_coverage.py
+++ b/trip_planner/app/schemas/cost_coverage.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+CoverageStatus = Literal[
+    "needs_input",
+    "research_ready",
+    "researched",
+    "estimated",
+    "evidenced",
+    "complete",
+    "not_applicable",
+]
+
+
+class CostCoverageUpdateRequest(BaseModel):
+    status: CoverageStatus | None = None
+    estimate_amount: float | None = Field(default=None, ge=0)
+    currency: str = Field(default="USD", min_length=3, max_length=3)
+    note: str | None = None
+    source_url: str | None = None
+    inputs: dict[str, str] = Field(default_factory=dict)
+    selected_option: dict[str, Any] | None = None
+
+
+class CostCoverageResearchRequest(BaseModel):
+    inputs: dict[str, str] = Field(default_factory=dict)
+
+
+class CostCoverageResponse(BaseModel):
+    trip_id: str
+    contract_version: str
+    source_status: str
+    summary: dict[str, Any]
+    requirements: list[dict[str, Any]]
+    research_notice: dict[str, Any] | None = None

--- a/trip_planner/app/services/cost_coverage.py
+++ b/trip_planner/app/services/cost_coverage.py
@@ -1,0 +1,413 @@
+"""Evidence-aware business-trip cost coverage and assisted research."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from trip_planner.app.services.auth import AuthenticatedUser
+from trip_planner.app.services.planner_runtime_config import get_planner_runtime_config
+from trip_planner.app.services.workspace import WorkspaceTripNotFoundError, _get_owned_trip_record
+from trip_planner.persistence.models.account import UserAccount
+
+_DEFAULT_CONTRACT_VERSION = "tpp-intake-requirements/v1"
+_COVERAGE_STATUSES = {
+    "needs_input",
+    "research_ready",
+    "researched",
+    "estimated",
+    "evidenced",
+    "complete",
+    "not_applicable",
+}
+_PROFILE_INPUT_KEYS = {
+    "traveler_residence_address",
+    "official_domicile_address",
+}
+
+
+class CostCoverageUnavailableError(RuntimeError):
+    """Raised when organization requirements cannot be loaded safely."""
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _load_tpp_catalog() -> dict[str, Any]:
+    base_url = os.getenv("TPP_BASE_URL", "").strip().rstrip("/")
+    token = os.getenv("TPP_ACCESS_TOKEN", "").strip()
+    if not base_url or not token:
+        raise CostCoverageUnavailableError(
+            "TPP intake requirements are unavailable because the planner transport is not configured."
+        )
+    request = urllib.request.Request(
+        f"{base_url}/api/planner/intake-requirements",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:  # noqa: S310
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+        raise CostCoverageUnavailableError(
+            "TPP intake requirements could not be loaded."
+        ) from error
+    if not isinstance(payload, dict) or not isinstance(payload.get("requirements"), list):
+        raise CostCoverageUnavailableError("TPP returned a malformed intake requirement catalog.")
+    return payload
+
+
+def _automatic_inputs(record: Any) -> dict[str, str]:
+    travel_dates = ""
+    if record.start_date and record.end_date:
+        travel_dates = f"{record.start_date} to {record.end_date}"
+    destination = ", ".join(record.primary_regions or [])
+    zip_match = re.search(r"\b\d{5}(?:-\d{4})?\b", destination)
+    return {
+        "travel_dates": travel_dates,
+        "parking_days": str(record.duration_days or ""),
+        "trip_duration_days": str(record.duration_days or ""),
+        "destination": destination,
+        "destination_zip": zip_match.group(0) if zip_match else "",
+    }
+
+
+def _merge_requirement_state(
+    requirement: dict[str, Any],
+    stored: dict[str, Any],
+    automatic_inputs: dict[str, str],
+) -> dict[str, Any]:
+    inputs = {
+        **{key: value for key, value in automatic_inputs.items() if value},
+        **{
+            str(key): str(value)
+            for key, value in dict(stored.get("inputs") or {}).items()
+            if str(value).strip()
+        },
+    }
+    required_inputs = [str(item) for item in requirement.get("required_inputs") or []]
+    missing_inputs = [item for item in required_inputs if not inputs.get(item, "").strip()]
+    collection_mode = str(requirement.get("collection_mode") or "traveler")
+    default_status = (
+        "needs_input"
+        if missing_inputs
+        else "research_ready" if collection_mode == "researchable" else "needs_input"
+    )
+    return {
+        **requirement,
+        "status": str(stored.get("status") or default_status),
+        "inputs": inputs,
+        "missing_inputs": missing_inputs,
+        "estimate_amount": stored.get("estimate_amount"),
+        "currency": str(stored.get("currency") or "USD"),
+        "note": str(stored.get("note") or ""),
+        "source_url": str(stored.get("source_url") or ""),
+        "research": stored.get("research"),
+        "selected_option": stored.get("selected_option"),
+        "updated_at": stored.get("updated_at"),
+    }
+
+
+def _summary(requirements: list[dict[str, Any]]) -> dict[str, Any]:
+    resolved = {"complete", "not_applicable", "evidenced"}
+    researchable = [
+        item
+        for item in requirements
+        if item.get("collection_mode") == "researchable" and item.get("status") not in resolved
+    ]
+    return {
+        "requirement_count": len(requirements),
+        "resolved_count": sum(item.get("status") in resolved for item in requirements),
+        "research_offer_count": len(researchable),
+        "ready_for_handoff": all(item.get("status") in resolved for item in requirements),
+        "headline": (
+            "Cost and evidence coverage is complete."
+            if requirements and all(item.get("status") in resolved for item in requirements)
+            else "The planner can research missing trip costs and evidence."
+        ),
+    }
+
+
+def get_cost_coverage_payload(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+) -> dict[str, Any]:
+    try:
+        record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    except ValueError as error:
+        raise WorkspaceTripNotFoundError(str(error)) from error
+    try:
+        catalog = _load_tpp_catalog()
+        source_status = "live_tpp"
+    except CostCoverageUnavailableError as error:
+        state = dict(record.cost_coverage_state or {})
+        cached = state.get("catalog")
+        if not isinstance(cached, dict):
+            return {
+                "trip_id": trip_id,
+                "contract_version": _DEFAULT_CONTRACT_VERSION,
+                "source_status": "unavailable",
+                "summary": {
+                    "requirement_count": 0,
+                    "resolved_count": 0,
+                    "research_offer_count": 0,
+                    "ready_for_handoff": False,
+                    "headline": str(error),
+                },
+                "requirements": [],
+            }
+        catalog = cached
+        source_status = "cached_tpp"
+
+    state = dict(record.cost_coverage_state or {})
+    account = db_session.get(UserAccount, user.user_id)
+    profile_inputs = (
+        {
+            str(key): str(value)
+            for key, value in dict(account.travel_profile_state or {}).items()
+            if str(value).strip()
+        }
+        if account is not None
+        else {}
+    )
+    stored_items = {
+        str(item.get("code")): item
+        for item in list(state.get("items") or [])
+        if isinstance(item, dict) and item.get("code")
+    }
+    item_inputs = {
+        str(key): str(value)
+        for item in stored_items.values()
+        for key, value in dict(item.get("inputs") or {}).items()
+        if str(value).strip()
+    }
+    shared_inputs = {
+        **profile_inputs,
+        **item_inputs,
+        **{
+            str(key): str(value)
+            for key, value in dict(state.get("shared_inputs") or {}).items()
+            if str(value).strip()
+        },
+    }
+    automatic_inputs = {**_automatic_inputs(record), **shared_inputs}
+    requirements = [
+        _merge_requirement_state(
+            item, stored_items.get(str(item.get("code")), {}), automatic_inputs
+        )
+        for item in catalog.get("requirements") or []
+        if isinstance(item, dict) and item.get("code")
+    ]
+    record.cost_coverage_state = {
+        **state,
+        "shared_inputs": shared_inputs,
+        "catalog": catalog,
+        "contract_version": catalog.get("contract_version", _DEFAULT_CONTRACT_VERSION),
+        "items": [
+            {key: value for key, value in item.items() if key not in {"missing_inputs"}}
+            for item in requirements
+        ],
+    }
+    db_session.commit()
+    return {
+        "trip_id": trip_id,
+        "contract_version": str(catalog.get("contract_version") or _DEFAULT_CONTRACT_VERSION),
+        "source_status": source_status,
+        "summary": _summary(requirements),
+        "requirements": requirements,
+    }
+
+
+def update_cost_coverage_item(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    requirement_code: str,
+    updates: dict[str, Any],
+) -> dict[str, Any]:
+    current = get_cost_coverage_payload(db_session, user=user, trip_id=trip_id)
+    record = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    requirements = list(current["requirements"])
+    target = next(
+        (item for item in requirements if item.get("code") == requirement_code),
+        None,
+    )
+    if target is None:
+        raise ValueError(f"Unknown cost coverage requirement '{requirement_code}'.")
+    status = updates.get("status")
+    if status is not None and status not in _COVERAGE_STATUSES:
+        raise ValueError(f"Unsupported cost coverage status '{status}'.")
+    merged = {
+        **target,
+        **{key: value for key, value in updates.items() if value is not None},
+        "inputs": {**dict(target.get("inputs") or {}), **dict(updates.get("inputs") or {})},
+        "updated_at": _iso_now(),
+    }
+    if merged.get("selected_option") and updates.get("status") is None:
+        merged["status"] = "evidenced" if merged.get("source_url") else "estimated"
+    requirements = [
+        merged if item.get("code") == requirement_code else item for item in requirements
+    ]
+    state = dict(record.cost_coverage_state or {})
+    shared_inputs = {
+        **dict(state.get("shared_inputs") or {}),
+        **{
+            str(key): str(value)
+            for key, value in dict(updates.get("inputs") or {}).items()
+            if str(value).strip()
+        },
+    }
+    account = db_session.get(UserAccount, user.user_id)
+    if account is not None:
+        profile_updates = {
+            str(key): str(value).strip()
+            for key, value in dict(updates.get("inputs") or {}).items()
+            if key in _PROFILE_INPUT_KEYS and str(value).strip()
+        }
+        if profile_updates:
+            account.travel_profile_state = {
+                **dict(account.travel_profile_state or {}),
+                **profile_updates,
+            }
+    record.cost_coverage_state = {
+        **state,
+        "shared_inputs": shared_inputs,
+        "items": requirements,
+    }
+    db_session.commit()
+    return get_cost_coverage_payload(db_session, user=user, trip_id=trip_id)
+
+
+def _response_sources(response: Any) -> list[dict[str, str]]:
+    sources: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) != "web_search_call":
+            continue
+        action = getattr(item, "action", None)
+        for source in getattr(action, "sources", []) or []:
+            url = str(getattr(source, "url", "") or "").strip()
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            sources.append(
+                {
+                    "title": str(getattr(source, "title", "") or "Source"),
+                    "url": url,
+                }
+            )
+    return sources[:12]
+
+
+def _parse_research_output(text: str) -> tuple[str, list[dict[str, Any]]]:
+    candidate = text.strip()
+    candidate = re.sub(r"^```(?:json)?\s*|\s*```$", "", candidate, flags=re.I)
+    try:
+        payload = json.loads(candidate)
+    except json.JSONDecodeError:
+        return text.strip(), []
+    if not isinstance(payload, dict):
+        return text.strip(), []
+    options = [item for item in payload.get("options") or [] if isinstance(item, dict)][:8]
+    return str(payload.get("summary") or "Research completed."), options
+
+
+def research_cost_coverage_item(
+    db_session: Session,
+    *,
+    user: AuthenticatedUser,
+    trip_id: str,
+    requirement_code: str,
+    inputs: dict[str, str],
+) -> dict[str, Any]:
+    current = update_cost_coverage_item(
+        db_session,
+        user=user,
+        trip_id=trip_id,
+        requirement_code=requirement_code,
+        updates={"inputs": inputs},
+    )
+    requirement = next(
+        item for item in current["requirements"] if item.get("code") == requirement_code
+    )
+    if requirement.get("collection_mode") not in {"researchable", "automatic"}:
+        raise ValueError("This requirement needs traveler or organization input.")
+    missing = list(requirement.get("missing_inputs") or [])
+    if missing:
+        return {
+            **current,
+            "research_notice": {
+                "status": "needs_input",
+                "missing_inputs": missing,
+                "message": "Add the highlighted trip details and the planner can research this.",
+            },
+        }
+
+    runtime = get_planner_runtime_config()
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    if runtime.mode != "model" or runtime.provider != "openai" or not api_key:
+        raise CostCoverageUnavailableError(
+            "Live evidence research requires the authorized OpenAI planner runtime."
+        )
+    from openai import OpenAI
+
+    trip = _get_owned_trip_record(db_session, user=user, trip_id=trip_id)
+    context = {
+        "trip_dates": f"{trip.start_date} to {trip.end_date}",
+        "destination": list(trip.primary_regions or []),
+        "duration_days": trip.duration_days,
+        "inputs": requirement.get("inputs") or {},
+    }
+    prompt = (
+        "You are researching one anticipated business-travel cost. Use current public web "
+        "sources, prefer official providers, never book or submit anything, and do not invent "
+        "missing rates. Return ONLY valid JSON with keys summary and options. options must be "
+        "an array of objects with name, unit_rate (number or null), unit, estimated_total "
+        "(number or null), notes, source_url, and a details object for structured facts needed "
+        "by the named output fields. For a meal allowance, return one option whose details "
+        "include eligible_breakfasts, eligible_lunches, eligible_dinners, meals_provided, and "
+        "meal_per_diem_requested. For airport access, include mode, reimbursable_miles, "
+        "mileage_cost, rideshare_total, home_to_airport_miles, office_to_airport_miles, and "
+        "route_rule; apply the organization's supplied 2026 workbook rate of $0.725 per "
+        "reimbursable mile and do not count ordinary home-to-office commuting. For airport "
+        "parking, compare airport-operated lots with reputable off-airport shuttle operators; "
+        "do not default to either category or to an operator the traveler used previously. "
+        "No markdown fences.\n\n"
+        f"Requirement: {requirement.get('title')}\n"
+        f"Research task: {requirement.get('research_prompt')}\n"
+        f"Trip context: {json.dumps(context, default=str)}"
+    )
+    response = OpenAI(api_key=api_key).responses.create(
+        model=runtime.model or "gpt-5.6-sol",
+        tools=[{"type": "web_search"}],
+        include=["web_search_call.action.sources"],
+        input=prompt,
+    )
+    summary, options = _parse_research_output(response.output_text)
+    sources = _response_sources(response)
+    research = {
+        "status": "completed",
+        "summary": summary,
+        "options": options,
+        "sources": sources,
+        "researched_at": _iso_now(),
+        "model": runtime.model,
+    }
+    return update_cost_coverage_item(
+        db_session,
+        user=user,
+        trip_id=trip_id,
+        requirement_code=requirement_code,
+        updates={"status": "researched", "research": research},
+    )

--- a/trip_planner/app/services/inventory.py
+++ b/trip_planner/app/services/inventory.py
@@ -62,6 +62,12 @@ _REGION_GEO_DEFAULTS: dict[str, dict[str, Any]] = {
         "country_code": "JP",
         "time_zone": "Asia/Tokyo",
     },
+    "gateway-kyoto": {
+        "latitude": 34.4342,
+        "longitude": 135.244,
+        "country_code": "JP",
+        "time_zone": "Asia/Tokyo",
+    },
     "lisbon": {
         "latitude": 38.7223,
         "longitude": -9.1393,
@@ -81,7 +87,44 @@ _REGION_GEO_DEFAULTS: dict[str, dict[str, Any]] = {
         "country_code": "JP",
         "time_zone": "Asia/Tokyo",
     },
+    "osaka": {
+        "latitude": 34.6937,
+        "longitude": 135.5023,
+        "country_code": "JP",
+        "time_zone": "Asia/Tokyo",
+    },
+    "uji": {
+        "latitude": 34.8845,
+        "longitude": 135.7997,
+        "country_code": "JP",
+        "time_zone": "Asia/Tokyo",
+    },
+    "gateway-washington-dc": {
+        "latitude": 38.8512,
+        "longitude": -77.0402,
+        "country_code": "US",
+        "region_code": "DC",
+        "time_zone": "America/New_York",
+    },
+    "washington-dc": {
+        "latitude": 38.9072,
+        "longitude": -77.0369,
+        "country_code": "US",
+        "region_code": "DC",
+        "time_zone": "America/New_York",
+    },
 }
+
+
+def lookup_region_coordinates(value: str) -> tuple[float, float] | None:
+    """Return a known regional centroid for map rendering without a geocoding call."""
+
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    matches = [key for key in _REGION_GEO_DEFAULTS if key in slug]
+    if not matches:
+        return None
+    geo = _REGION_GEO_DEFAULTS[max(matches, key=len)]
+    return float(geo["latitude"]), float(geo["longitude"])
 
 
 @dataclass(frozen=True)

--- a/trip_planner/app/services/planner.py
+++ b/trip_planner/app/services/planner.py
@@ -1292,7 +1292,11 @@ class _OpenAIPlannerChatModel:
             raise ValueError("Planner model name is required.")
         from langchain_openai import ChatOpenAI
 
-        self._model = ChatOpenAI(model=config.model, temperature=0)
+        self._model = ChatOpenAI(
+            model=config.model,
+            temperature=0,
+            use_responses_api=True,
+        )
 
     def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
         if payload.get("task") == "classify_planner_intent":
@@ -1309,31 +1313,54 @@ class _OpenAIPlannerChatModel:
             )
             return {"content": str(response.content)}
 
+        completed_tool_results = list(payload.get("completed_tool_results") or [])
+        completed_state_change = any(
+            bool(item.get("mutates_state"))
+            and str(item.get("status") or "") == "completed"
+            for item in completed_tool_results
+            if isinstance(item, dict)
+        )
+        available_tools = list(payload["available_tools"])
+        if completed_tool_results:
+            available_tools = [
+                tool for tool in available_tools if bool(tool.get("mutates_state"))
+            ]
         tools = [
             {
                 "type": "function",
                 "function": {
                     "name": tool["tool_name"],
                     "description": tool["description"],
-                    "parameters": {
-                        "type": "object",
-                        "properties": {},
-                        "additionalProperties": True,
-                    },
+                    "parameters": tool["input_schema"],
                 },
             }
-            for tool in payload["available_tools"]
+            for tool in available_tools
         ]
-        model = self._model.bind_tools(tools)
+        model = self._model if completed_state_change else self._model.bind_tools(tools)
         invoke_kwargs: dict[str, Any] = {}
         langsmith_run_config = payload.get("langsmith_run_config")
         if isinstance(langsmith_run_config, dict):
             invoke_kwargs["config"] = langsmith_run_config
+        system_prompt = _PLANNER_SYSTEM_PROMPT
+        if completed_tool_results:
+            if completed_state_change:
+                system_prompt += (
+                    "\n\nThe application executed the prior read and state-changing tool "
+                    "requests. Review completed_tool_results and return the final "
+                    "traveler-facing answer now."
+                )
+            else:
+                system_prompt += (
+                    "\n\nThe application executed your prior read-only tool requests. "
+                    "Review completed_tool_results. Only state-changing tools remain "
+                    "available; request the safe updates needed by the traveler, or return "
+                    "the final traveler-facing answer if no update is appropriate."
+                )
         response = model.invoke(
             [
                 (
                     "system",
-                    _PLANNER_SYSTEM_PROMPT,
+                    system_prompt,
                 ),
                 (
                     "human",
@@ -1341,6 +1368,7 @@ class _OpenAIPlannerChatModel:
                         {
                             "message": payload["message"],
                             "context": payload["runtime_context"],
+                            "completed_tool_results": completed_tool_results,
                         },
                         default=str,
                     ),
@@ -1356,7 +1384,30 @@ class _OpenAIPlannerChatModel:
                     "arguments": call.get("args") or call.get("arguments") or {},
                 }
             )
-        return {"content": str(response.content), "tool_calls": tool_calls}
+        return {
+            "content": _openai_response_text(response),
+            "tool_calls": tool_calls,
+        }
+
+
+def _openai_response_text(response: Any) -> str:
+    """Extract traveler-visible text without stringifying Responses API blocks."""
+    content = getattr(response, "content", "")
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    text_parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = str(block.get("type") or "")
+        if block_type not in {"text", "output_text"}:
+            continue
+        text = block.get("text") or block.get("content")
+        if isinstance(text, str) and text.strip():
+            text_parts.append(text.strip())
+    return "\n".join(text_parts)
 
 
 class ModelBackedPlannerConversationRunnable:
@@ -1894,6 +1945,67 @@ def _assemble_planner_reply(
         tool_calls=reply.requested_tool_calls,
     )
     executed_tool_calls = [*runtime.executed_tool_calls, *model_tool_calls]
+    empty_model_response = (
+        reply.content
+        == "Planner model returned an empty response after reading the current trip context."
+    )
+    followup_round = 0
+    pending_tool_calls = list(reply.requested_tool_calls or [])
+    while (
+        empty_model_response
+        and pending_tool_calls
+        and runtime.chat_model is not None
+        and followup_round < 4
+    ):
+        followup_round += 1
+        followup_payload = {
+            "message": runtime.normalized_message,
+            "trip_id": trip_id,
+            "available_tools": list_planner_tools(),
+            "runtime_context": runtime.runtime_context,
+            "provider": runtime.runtime_config.provider,
+            "model": runtime.runtime_config.model,
+            "data_zone": runtime.runtime_config.data_zone,
+            "completed_tool_results": executed_tool_calls,
+        }
+        if runtime.runtime_config.provider == "openai":
+            followup_payload = _redact_openai_planner_payload(followup_payload)
+        try:
+            raw_followup = runtime.chat_model.invoke(followup_payload)
+        except Exception as error:
+            reply = _planner_model_error_reply(
+                session_state_id=runtime.session.session_state_id,
+                error=error,
+            )
+            break
+        followup_content = str(raw_followup.get("content") or "").strip()
+        pending_tool_calls = [
+            {
+                "tool_name": str(item.get("tool_name") or item.get("name") or ""),
+                "arguments": item.get("arguments") or item.get("args") or {},
+            }
+            for item in list(raw_followup.get("tool_calls") or [])
+        ]
+        if pending_tool_calls:
+            executed_tool_calls.extend(
+                _execute_model_tool_calls(
+                    db_session,
+                    user=user,
+                    trip_id=trip_id,
+                    tool_calls=pending_tool_calls,
+                )
+            )
+        empty_model_response = not followup_content
+        if followup_content:
+            reply = PlannerConversationReply(
+                content=followup_content,
+                refs=reply.refs,
+                tool_calls=reply.tool_calls,
+                requested_tool_calls=pending_tool_calls,
+                structured_blocks=reply.structured_blocks,
+                turn_metadata=reply.turn_metadata,
+            )
+            break
     model_runtime_failed = any(
         item.get("tool_name") == "planner_model" and item.get("status") == "error"
         for item in reply.tool_calls

--- a/trip_planner/app/services/planner_tools.py
+++ b/trip_planner/app/services/planner_tools.py
@@ -39,6 +39,7 @@ class PlannerToolDefinition:
     tool_name: str
     description: str
     mutates_state: bool = False
+    input_schema: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,6 +117,31 @@ _TOOL_DEFINITIONS: tuple[PlannerToolDefinition, ...] = (
         tool_name="update_budget_plan",
         description="Create or update a bounded budget plan using persisted workspace state.",
         mutates_state=True,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "total_amount": {"type": "number", "exclusiveMinimum": 0},
+                "title": {"type": "string"},
+                "currency": {"type": "string", "minLength": 3, "maxLength": 3},
+                "allocations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "category_key": {"type": "string"},
+                            "planned_amount": {
+                                "type": "number",
+                                "minimum": 0,
+                            },
+                        },
+                        "required": ["category_key", "planned_amount"],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": ["total_amount"],
+            "additionalProperties": False,
+        },
     ),
     PlannerToolDefinition(
         tool_name="read_policy_state",
@@ -139,6 +165,31 @@ _TOOL_DEFINITIONS: tuple[PlannerToolDefinition, ...] = (
         tool_name="capture_notebook_item",
         description="Save a trip-scoped planning notebook item for later planner turns.",
         mutates_state=True,
+        input_schema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "note": {"type": "string"},
+                "category": {
+                    "type": "string",
+                    "enum": [
+                        "route",
+                        "lodging",
+                        "activities",
+                        "budget",
+                        "documents",
+                        "policy",
+                        "other",
+                    ],
+                },
+                "priority": {
+                    "type": "string",
+                    "enum": ["low", "normal", "high"],
+                },
+            },
+            "required": ["title"],
+            "additionalProperties": False,
+        },
     ),
     PlannerToolDefinition(
         tool_name="set_notebook_focus",
@@ -168,6 +219,12 @@ def list_planner_tools() -> list[dict[str, Any]]:
             "tool_name": item.tool_name,
             "description": item.description,
             "mutates_state": item.mutates_state,
+            "input_schema": item.input_schema
+            or {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": True,
+            },
         }
         for item in _TOOL_DEFINITIONS
     ]
@@ -291,6 +348,52 @@ def _category_allocations(
                 "flexibility": "flexible",
                 "notes": ["Planner-generated budget allocation."],
             }
+        )
+    return allocations
+
+
+def _requested_category_allocations(
+    *,
+    total_amount: float,
+    currency: str,
+    suggested_categories: list[str],
+    requested: Any,
+) -> list[dict[str, Any]]:
+    if requested is None:
+        return _category_allocations(total_amount, suggested_categories[:4], currency)
+    if not isinstance(requested, list) or not requested:
+        raise ValueError("allocations must be a non-empty list when provided.")
+
+    allocations: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in requested:
+        if not isinstance(item, dict):
+            raise ValueError("Each budget allocation must be an object.")
+        category = str(item.get("category_key") or "").strip()
+        if category not in suggested_categories:
+            raise ValueError(f"Unsupported budget category '{category}'.")
+        if category in seen:
+            raise ValueError(f"Duplicate budget category '{category}'.")
+        planned_amount = round(float(item.get("planned_amount", -1)), 2)
+        if planned_amount < 0:
+            raise ValueError("planned_amount must be greater than or equal to 0.")
+        seen.add(category)
+        allocations.append(
+            {
+                "category_key": category,
+                "label": category.replace("_", " ").title(),
+                "planned_amount": planned_amount,
+                "currency": currency,
+                "flexibility": "flexible",
+                "notes": ["Planner-generated budget allocation."],
+            }
+        )
+
+    allocated_total = round(sum(item["planned_amount"] for item in allocations), 2)
+    if allocated_total != round(total_amount, 2):
+        raise ValueError(
+            "Budget allocations must sum to total_amount; "
+            f"received {allocated_total:.2f} for {total_amount:.2f}."
         )
     return allocations
 
@@ -1035,7 +1138,6 @@ def _update_budget_plan(
     budget_payload = get_workspace_budget_payload(db_session, user=user, trip_id=trip_id)
     workspace_payload = _workspace_payload(db_session, user=user, trip_id=trip_id)
     summary = budget_payload["summary"]
-    categories = list(summary.get("suggested_categories") or [])[:4]
     raw_currency = arguments.get("currency") or summary["currency"] or "USD"
     currency = str(raw_currency).strip().upper()
     if len(currency) != 3 or not currency.isalpha():
@@ -1066,7 +1168,12 @@ def _update_budget_plan(
                 "summary": "Planner-generated budget baseline.",
                 "tags": ["planner-tool"],
                 "notes": ["Created from the explicit planner tool boundary."],
-                "allocations": _category_allocations(total_amount, categories, currency),
+                "allocations": _requested_category_allocations(
+                    total_amount=total_amount,
+                    currency=currency,
+                    suggested_categories=list(summary.get("suggested_categories") or []),
+                    requested=arguments.get("allocations"),
+                ),
             }
         ],
         summary=f"Planner set the working budget to {currency} {total_amount:.2f}.",

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -142,6 +142,10 @@ def _tpp_trip_plan_payload(
     airfare_cost = costs.get("airfare")
     lodging_cost = costs.get("lodging")
     transportation_mode = "air" if airfare_cost is not None else "mixed"
+    fare_evidence_attached = any(
+        _tpp_expense_category(option.category) == "airfare" and option.justification_refs
+        for option in proposal.selected_options
+    )
 
     return {
         "trip_id": proposal.trip_id,
@@ -162,6 +166,7 @@ def _tpp_trip_plan_payload(
         "expense_breakdown": costs,
         "selected_fare": airfare_cost,
         "flight_cost": airfare_cost,
+        "fare_evidence_attached": fare_evidence_attached,
         "comparable_hotels": comparable_hotels or ([lodging_cost] if lodging_cost else None),
         "selected_providers": selected_providers,
         "validation_results": [],

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -26,6 +26,7 @@ from trip_planner.app.services.inventory import (
     _build_inventory_assembly_input,
     assemble_inventory_bundles_for_trip,
     build_inventory_summary_payload,
+    lookup_region_coordinates,
 )
 from trip_planner.app.services.planner_memory import build_planner_memory_payload
 from trip_planner.app.services.planner_runtime_config import get_planner_runtime_config
@@ -913,8 +914,12 @@ def _build_runtime_map_place_markers(
     source_refs: list[str],
 ) -> list[dict[str, Any]]:
     stop_count = len([stop for stop in route_sequence if stop])
-    return [
-        {
+    markers: list[dict[str, Any]] = []
+    for index, stop in enumerate(route_sequence):
+        if not stop:
+            continue
+        coordinates = lookup_region_coordinates(stop)
+        marker = {
             "id": f"route-stop:{index + 1}",
             "source_id": stop,
             "label": _humanize_route_stop(stop),
@@ -926,9 +931,10 @@ def _build_runtime_map_place_markers(
             "route_index": index,
             **_map_coordinate_for_route_index(index, len(route_sequence)),
         }
-        for index, stop in enumerate(route_sequence)
-        if stop
-    ]
+        if coordinates is not None:
+            marker["latitude"], marker["longitude"] = coordinates
+        markers.append(marker)
+    return markers
 
 
 def _build_runtime_map_route_geometry(

--- a/trip_planner/persistence/alembic/versions/20260712_01_cost_coverage.py
+++ b/trip_planner/persistence/alembic/versions/20260712_01_cost_coverage.py
@@ -1,0 +1,49 @@
+"""add persisted trip cost and evidence coverage state
+
+Revision ID: 20260712_01
+Revises: 20260512_01
+Create Date: 2026-07-12 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260712_01"
+down_revision = "20260512_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    table_names = set(inspector.get_table_names())
+    if "user_accounts" in table_names:
+        account_columns = {column["name"] for column in inspector.get_columns("user_accounts")}
+        if "travel_profile_state" not in account_columns:
+            op.add_column(
+                "user_accounts",
+                sa.Column(
+                    "travel_profile_state",
+                    sa.JSON(),
+                    nullable=False,
+                    server_default=sa.text("'{}'"),
+                ),
+            )
+    trip_columns = {column["name"] for column in inspector.get_columns("persisted_trips")}
+    if "cost_coverage_state" not in trip_columns:
+        op.add_column(
+            "persisted_trips",
+            sa.Column(
+                "cost_coverage_state",
+                sa.JSON(),
+                nullable=False,
+                server_default=sa.text("'{}'"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("persisted_trips", "cost_coverage_state")
+    op.drop_column("user_accounts", "travel_profile_state")

--- a/trip_planner/persistence/models/account.py
+++ b/trip_planner/persistence/models/account.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, String
+from sqlalchemy import JSON, DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from trip_planner.persistence.db import Base
@@ -27,6 +27,7 @@ class UserAccount(Base):
     display_name: Mapped[str] = mapped_column(String(120))
     password_hash: Mapped[str] = mapped_column(String(512))
     status: Mapped[str] = mapped_column(String(32), default="active")
+    travel_profile_state: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=_utcnow,

--- a/trip_planner/persistence/models/trip.py
+++ b/trip_planner/persistence/models/trip.py
@@ -44,6 +44,7 @@ class PersistedTrip(Base):
     itinerary_state_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
     budget_state_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
     policy_state_id: Mapped[str | None] = mapped_column(String(96), nullable=True)
+    cost_coverage_state: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),


### PR DESCRIPTION
## Why

This branch has been complete and unmerged since **2026-07-13**. No pull request was ever opened for
it — there was no failed review and no red gate, it simply never got proposed. This PR proposes it.

It merges **cleanly with zero conflicts** against the current tip (verified by a trial merge).

## What it carries

- `frontend/src/components/maps/googleMapsLoader.ts` — real Google Maps SDK loading via
  `@googlemaps/js-api-loader`, with `importLibrary` calls for the core, geocoding, maps and marker
  libraries, rejecting when no browser key is present.
- `frontend/src/components/maps/GoogleMapsProviderMap.tsx` and its test — an actual provider map
  component.
- Provider-state handling that reports `configured` rather than `live` for a key that is present but
  unproven. `grep -c 'status: "live"' frontend/src/components/maps/mapSurface.ts` returns **0** on this
  branch.
- `frontend/playwright.config.ts`, `frontend/e2e/two-trip-canary.spec.ts` and
  `scripts/run_two_trip_ui_canary.sh` — a two-trip browser canary covering signup through the real
  interface, a domestic business trip, an overseas leisure trip, and a Saved Trips revisit.

48 files changed.

## Issues this addresses

- Addresses #1685 — a configured Maps key currently makes the interface claim
  `status: "live"` and the "Google Maps JavaScript adapter" label with high confidence while loading no
  SDK at all. This branch is the fix: it loads the provider for real and renames the unproven state to
  `configured`.
- Addresses #1694 — `main` currently has no browser test of any kind, so signup, trip creation and the
  end-to-end journey are uncovered. This branch supplies the canary.

Deliberately **not** using closing keywords. Both issues carry acceptance criteria including
deliberate-break demonstrations that this branch predates, so a human should confirm those before
closing them.

## What still needs doing after merge

- Run the canary against the current tip and paste the output; the branch predates 11 commits of `main`.
- Wire the canary into `.github/workflows/ci.yml`, which #1694 asks for and this branch does not do.
- Re-check the keyed Map tab and confirm the interface no longer reports `live` without a rendered
  provider surface, which is #1685's acceptance gate.
- Re-run `scripts/check_full_product_verification.py --live-tpp required`, since the branch touches the
  planner side of the cross-repo seam.

## Verification performed before opening this

Trial merge into the current tip: **0 conflicts**, 48 files. Confirmed on the branch that
`googleMapsLoader.ts` and `GoogleMapsProviderMap.tsx` exist and that `mapSurface.ts` contains no
`status: "live"` occurrence. The branch's own tests were not run at the merged tip — see above.
