### PR TITLE
fix: enforce cross-layer verifier outcomes

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-11T15:05:57.810320Z",
+  "emitted_at": "2026-08-12T03:05:54.295481Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "1682",
+  "pr_number": "1700",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -35,6 +35,25 @@ from trip_planner.persistence.db import ensure_database_ready, reset_database_st
 DEFAULT_TPP_REPO_PATH = REPO_ROOT.parent / "Travel-Plan-Permission"
 TPP_PORT = 8765
 EXPECTED_BUSINESS_EVALUATION_STATUS = "non_compliant"
+_EVALUATION_FIXTURE_BY_STATUS = {
+    "compliant": "approved_evaluation.json",
+    "non_compliant": "non_compliant_evaluation.json",
+}
+
+
+def _evaluation_fixture_name(expected_status: str) -> str:
+    fixture_name = _EVALUATION_FIXTURE_BY_STATUS.get(expected_status)
+    if fixture_name is None:
+        raise VerificationFailure(
+            json.dumps(
+                {
+                    "expected_status": expected_status,
+                    "supported_statuses": sorted(_EVALUATION_FIXTURE_BY_STATUS),
+                },
+                sort_keys=True,
+            )
+        )
+    return fixture_name
 
 
 class VerificationFailure(AssertionError):
@@ -691,7 +710,14 @@ def _started_tpp_service(
         stderr_path.unlink(missing_ok=True)
 
 
-def _run_live_tpp_journey(client: TestClient, trip_id: str, env: dict[str, str]) -> dict[str, Any]:
+def _run_live_tpp_journey(
+    client: TestClient,
+    trip_id: str,
+    env: dict[str, str],
+    *,
+    expected_evaluation_status: str = EXPECTED_BUSINESS_EVALUATION_STATUS,
+) -> dict[str, Any]:
+    evaluation_fixture_name = _evaluation_fixture_name(expected_evaluation_status)
     with _started_tpp_service(env) as (base_url, _process):
         with _temporary_tpp_client_environment(base_url, env):
             policy_request = _prepared_policy_request(trip_id)
@@ -745,6 +771,7 @@ def _run_live_tpp_journey(client: TestClient, trip_id: str, env: dict[str, str])
                 trip_id,
                 proposal["proposal_id"],
                 execution_id,
+                fixture_name=evaluation_fixture_name,
             )
             evaluation_response = client.put(
                 f"/api/workspace/{trip_id}/proposal/evaluation",
@@ -998,17 +1025,18 @@ def run_product_journeys(
                 proposal_id=proposal["proposal_id"],
                 summary=refresh_payload["summary"],
             )
+            evaluation_fixture_name = _evaluation_fixture_name(expected_business_evaluation_status)
             evaluation_request = _prepared_evaluation_request(
                 business_trip_id,
                 proposal["proposal_id"],
                 execution_id,
-                fixture_name="non_compliant_evaluation.json",
+                fixture_name=evaluation_fixture_name,
             )
             evaluation_response = _prepared_evaluation_response(
                 business_trip_id,
                 proposal["proposal_id"],
                 execution_id,
-                fixture_name="non_compliant_evaluation.json",
+                fixture_name=evaluation_fixture_name,
             )
             evaluated = client.put(
                 f"/api/workspace/{business_trip_id}/proposal/evaluation",
@@ -1085,6 +1113,7 @@ def run_product_journeys(
                     client,
                     business_trip_id,
                     {key: str(value) for key, value in tpp_status.details.items()},
+                    expected_evaluation_status=expected_business_evaluation_status,
                 )
                 _assert_business_verification_outcomes(
                     local_business_details,

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -34,6 +34,7 @@ from trip_planner.persistence.db import ensure_database_ready, reset_database_st
 
 DEFAULT_TPP_REPO_PATH = REPO_ROOT.parent / "Travel-Plan-Permission"
 TPP_PORT = 8765
+EXPECTED_BUSINESS_EVALUATION_STATUS = "compliant"
 
 
 class VerificationFailure(AssertionError):
@@ -54,6 +55,67 @@ class CheckResult:
 def _require(condition: bool, message: str, **details: Any) -> None:
     if not condition:
         raise VerificationFailure(message, **details)
+
+
+def _assert_business_verification_outcomes(
+    local_details: Mapping[str, Any],
+    *,
+    expected_evaluation_status: str,
+    live_details: Mapping[str, Any] | None = None,
+    require_status_poll: bool = True,
+) -> None:
+    """Assert the business journey's semantic, not merely transport, contract."""
+
+    local_status = local_details["evaluation_status"]
+    _require(
+        local_status == expected_evaluation_status,
+        "local business evaluation did not match the expected outcome",
+        expected_evaluation_status=expected_evaluation_status,
+        actual_evaluation_status=local_status,
+        trip_id=local_details.get("trip_id"),
+        proposal_id=local_details.get("proposal_id"),
+    )
+    if require_status_poll:
+        _require(
+            local_details["status_poll"] != "failed",
+            "local business proposal status poll reported failure",
+            status_poll=local_details["status_poll"],
+            trip_id=local_details.get("trip_id"),
+            proposal_id=local_details.get("proposal_id"),
+        )
+    if live_details is None:
+        return
+
+    live_status = live_details["evaluation_status"]
+    _require(
+        live_details["status_poll"] != "failed",
+        "live TPP proposal status poll reported failure",
+        status_poll=live_details["status_poll"],
+        trip_id=live_details.get("trip_id"),
+        proposal_id=live_details.get("proposal_id"),
+    )
+    _require(
+        local_details["proposal_id"] == live_details["proposal_id"],
+        "local and live policy checks used different proposals",
+        local_proposal_id=local_details["proposal_id"],
+        live_proposal_id=live_details["proposal_id"],
+    )
+    _require(
+        local_status == live_status,
+        "local and live policy evaluation statuses disagree",
+        local_evaluation_status=local_status,
+        live_evaluation_status=live_status,
+        trip_id=local_details.get("trip_id"),
+        proposal_id=local_details["proposal_id"],
+    )
+    _require(
+        live_status == expected_evaluation_status,
+        "live TPP evaluation did not match the expected outcome",
+        expected_evaluation_status=expected_evaluation_status,
+        actual_evaluation_status=live_status,
+        trip_id=live_details.get("trip_id"),
+        proposal_id=live_details.get("proposal_id"),
+    )
 
 
 def _fixture(*parts: str) -> dict[str, Any]:
@@ -756,7 +818,11 @@ def _force_planner_fallback_runtime() -> Iterator[None]:
                 os.environ[key] = value
 
 
-def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
+def run_product_journeys(
+    *,
+    live_tpp: str,
+    expected_business_evaluation_status: str = EXPECTED_BUSINESS_EVALUATION_STATUS,
+) -> list[CheckResult]:
     planner_llm_env = dict(os.environ)
     with (
         tempfile.TemporaryDirectory(prefix="trip-planner-full-product.") as tmpdir,
@@ -905,8 +971,8 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
             refresh_payload = refresh.json()
             _require(
                 refresh_payload["summary"]["submission_status"]
-                in {"deferred", "failed", "retry_scheduled"},
-                "local proposal status poll did not preserve workspace-visible submission state",
+                in {"deferred", "failed", "retry_scheduled", "succeeded"},
+                "local proposal status poll did not preserve a recognizable state",
                 trip_id=business_trip_id,
                 proposal_id=proposal["proposal_id"],
                 summary=refresh_payload["summary"],
@@ -961,24 +1027,20 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
                 proposal_id=proposal["proposal_id"],
                 follow_up=reloaded_proposal["summary"].get("follow_up"),
             )
-            results.append(
-                CheckResult(
-                    "local-business-journey",
-                    "PASS",
-                    {
-                        "trip_id": business_trip_id,
-                        "proposal_id": proposal["proposal_id"],
-                        "evaluation_status": evaluation_payload["summary"][
-                            "evaluation_result_status"
-                        ],
-                        "planning_mode": reloaded_business_workspace.json()["session"][
-                            "selected_planning_mode"
-                        ],
-                        "follow_up_status": evaluation_payload["summary"]["follow_up_status"],
-                        "status_poll": refresh_payload["summary"]["submission_status"],
-                    },
-                )
+            local_business_details = {
+                "trip_id": business_trip_id,
+                "proposal_id": proposal["proposal_id"],
+                "evaluation_status": evaluation_payload["summary"]["evaluation_result_status"],
+                "planning_mode": reloaded_business_workspace.json()["session"]["selected_planning_mode"],
+                "follow_up_status": evaluation_payload["summary"]["follow_up_status"],
+                "status_poll": refresh_payload["summary"]["submission_status"],
+            }
+            _assert_business_verification_outcomes(
+                local_business_details,
+                expected_evaluation_status=expected_business_evaluation_status,
+                require_status_poll=live_tpp != "off",
             )
+            results.append(CheckResult("local-business-journey", "PASS", local_business_details))
 
             map_result = classify_map_prerequisite()
             results.append(map_result)
@@ -993,6 +1055,11 @@ def run_product_journeys(*, live_tpp: str) -> list[CheckResult]:
                     client,
                     business_trip_id,
                     {key: str(value) for key, value in tpp_status.details.items()},
+                )
+                _assert_business_verification_outcomes(
+                    local_business_details,
+                    expected_evaluation_status=expected_business_evaluation_status,
+                    live_details=live_details,
                 )
                 results.append(CheckResult("live-tpp", "PASS", live_details))
             else:
@@ -1015,6 +1082,9 @@ def _print_results(results: list[CheckResult]) -> None:
             f"- {result.status} {result.name}: "
             f"{json.dumps(result.details, sort_keys=True)}{remediation}"
         )
+    for result in results:
+        if result.status == "SKIPPED":
+            print(f"- WARNING uncovered surface: {result.name}")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/check_full_product_verification.py
+++ b/scripts/check_full_product_verification.py
@@ -34,7 +34,7 @@ from trip_planner.persistence.db import ensure_database_ready, reset_database_st
 
 DEFAULT_TPP_REPO_PATH = REPO_ROOT.parent / "Travel-Plan-Permission"
 TPP_PORT = 8765
-EXPECTED_BUSINESS_EVALUATION_STATUS = "compliant"
+EXPECTED_BUSINESS_EVALUATION_STATUS = "non_compliant"
 
 
 class VerificationFailure(AssertionError):
@@ -275,9 +275,13 @@ def _prepared_submission_request(trip_id: str, proposal_id: str) -> dict[str, An
 
 
 def _prepared_evaluation_request(
-    trip_id: str, proposal_id: str, execution_id: str
+    trip_id: str,
+    proposal_id: str,
+    execution_id: str,
+    *,
+    fixture_name: str = "approved_evaluation.json",
 ) -> dict[str, Any]:
-    request_payload = copy.deepcopy(_fixture("results", "approved_evaluation.json")["request"])
+    request_payload = copy.deepcopy(_fixture("results", fixture_name)["request"])
     request_payload["trip_id"] = trip_id
     request_payload["proposal_id"] = proposal_id
     request_payload["payload"]["execution_id"] = execution_id
@@ -288,8 +292,10 @@ def _prepared_evaluation_response(
     trip_id: str,
     proposal_id: str,
     execution_id: str,
+    *,
+    fixture_name: str = "approved_evaluation.json",
 ) -> dict[str, Any]:
-    response_payload = copy.deepcopy(_fixture("results", "approved_evaluation.json")["response"])
+    response_payload = copy.deepcopy(_fixture("results", fixture_name)["response"])
     result_payload = response_payload["result_payload"]
     result_payload["execution_id"] = execution_id
     result_payload["trip_id"] = trip_id
@@ -687,14 +693,7 @@ def _started_tpp_service(
 
 def _run_live_tpp_journey(client: TestClient, trip_id: str, env: dict[str, str]) -> dict[str, Any]:
     with _started_tpp_service(env) as (base_url, _process):
-        tpp_env = {
-            "TPP_BASE_URL": base_url,
-            "TPP_ACCESS_TOKEN": env["TPP_ACCESS_TOKEN"],
-            "TPP_OIDC_PROVIDER": env["TPP_OIDC_PROVIDER"],
-        }
-        previous = {key: os.environ.get(key) for key in tpp_env}
-        os.environ.update(tpp_env)
-        try:
+        with _temporary_tpp_client_environment(base_url, env):
             policy_request = _prepared_policy_request(trip_id)
             policy_response = client.put(
                 f"/api/workspace/{trip_id}/policy",
@@ -773,12 +772,6 @@ def _run_live_tpp_journey(client: TestClient, trip_id: str, env: dict[str, str])
                 "status_poll": status_response.json()["summary"]["submission_status"],
                 "evaluation_status": payload["summary"]["evaluation_result_status"],
             }
-        finally:
-            for key, value in previous.items():
-                if value is None:
-                    os.environ.pop(key, None)
-                else:
-                    os.environ[key] = value
 
 
 @contextmanager
@@ -793,6 +786,27 @@ def _temporary_database_url(database_url: str) -> Iterator[None]:
             os.environ.pop("TRIP_PLANNER_DATABASE_URL", None)
         else:
             os.environ["TRIP_PLANNER_DATABASE_URL"] = previous_database_url
+
+
+@contextmanager
+def _temporary_tpp_client_environment(base_url: str, env: Mapping[str, str]) -> Iterator[None]:
+    """Route a planner request to the live TPP process for one verification step."""
+
+    tpp_env = {
+        "TPP_BASE_URL": base_url,
+        "TPP_ACCESS_TOKEN": env["TPP_ACCESS_TOKEN"],
+        "TPP_OIDC_PROVIDER": env["TPP_OIDC_PROVIDER"],
+    }
+    previous = {key: os.environ.get(key) for key in tpp_env}
+    os.environ.update(tpp_env)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 @contextmanager
@@ -833,6 +847,7 @@ def run_product_journeys(
         ensure_database_ready()
         app = create_app()
         results: list[CheckResult] = []
+        tpp_status = tpp_prerequisite_status(live_tpp=live_tpp)
 
         with TestClient(app) as client:
             user_id = _signup(client)
@@ -957,7 +972,13 @@ def run_product_journeys(
             )
             execution_id = submitted.json()["proposal_state"]["execution_id"]
 
-            refresh = client.post(f"/api/workspace/{business_trip_id}/proposal/refresh")
+            if tpp_status.status == "READY":
+                live_tpp_env = {key: str(value) for key, value in tpp_status.details.items()}
+                with _started_tpp_service(live_tpp_env) as (base_url, _process):
+                    with _temporary_tpp_client_environment(base_url, live_tpp_env):
+                        refresh = client.post(f"/api/workspace/{business_trip_id}/proposal/refresh")
+            else:
+                refresh = client.post(f"/api/workspace/{business_trip_id}/proposal/refresh")
             _require(
                 refresh.status_code == 200,
                 "local proposal status poll failed",
@@ -981,11 +1002,13 @@ def run_product_journeys(
                 business_trip_id,
                 proposal["proposal_id"],
                 execution_id,
+                fixture_name="non_compliant_evaluation.json",
             )
             evaluation_response = _prepared_evaluation_response(
                 business_trip_id,
                 proposal["proposal_id"],
                 execution_id,
+                fixture_name="non_compliant_evaluation.json",
             )
             evaluated = client.put(
                 f"/api/workspace/{business_trip_id}/proposal/evaluation",
@@ -1006,11 +1029,14 @@ def run_product_journeys(
                 route=f"/api/workspace/{business_trip_id}/proposal/evaluation",
             )
             evaluation_payload = evaluated.json()
+            expected_approval_ready = expected_business_evaluation_status == "compliant"
             _require(
-                evaluation_payload["summary"]["approval_ready"] is True,
-                "business evaluation did not produce approval-ready follow-up state",
+                evaluation_payload["summary"]["approval_ready"] is expected_approval_ready,
+                "business evaluation approval state did not match the expected outcome",
                 trip_id=business_trip_id,
                 proposal_id=proposal["proposal_id"],
+                expected_evaluation_status=expected_business_evaluation_status,
+                approval_ready=evaluation_payload["summary"]["approval_ready"],
             )
             reloaded_business_workspace = client.get(f"/api/workspace/{business_trip_id}")
             _require(
@@ -1020,11 +1046,16 @@ def run_product_journeys(
                 trip_id=business_trip_id,
             )
             reloaded_proposal = reloaded_business_workspace.json()["proposal_state"]
+            expected_follow_up_status = (
+                "resolved" if expected_business_evaluation_status == "compliant" else "reoptimization_required"
+            )
             _require(
-                reloaded_proposal["summary"]["follow_up_status"] == "resolved",
-                "business workspace did not expose reloaded follow-up state",
+                reloaded_proposal["summary"]["follow_up_status"] == expected_follow_up_status,
+                "business workspace follow-up state did not match the expected outcome",
                 trip_id=business_trip_id,
                 proposal_id=proposal["proposal_id"],
+                expected_evaluation_status=expected_business_evaluation_status,
+                expected_follow_up_status=expected_follow_up_status,
                 follow_up=reloaded_proposal["summary"].get("follow_up"),
             )
             local_business_details = {
@@ -1049,7 +1080,6 @@ def run_product_journeys(
 
             results.append(classify_planner_llm_prerequisite(env=planner_llm_env))
 
-            tpp_status = tpp_prerequisite_status(live_tpp=live_tpp)
             if tpp_status.status == "READY":
                 live_details = _run_live_tpp_journey(
                     client,

--- a/tests/app/test_full_product_verification.py
+++ b/tests/app/test_full_product_verification.py
@@ -45,8 +45,8 @@ def test_full_product_local_journeys_cover_runtime_identifiers(monkeypatch) -> N
         "model",
     }
     assert by_name["local-business-journey"].details["proposal_id"].startswith("proposal:trip-")
-    assert by_name["local-business-journey"].details["evaluation_status"] == "compliant"
-    assert by_name["local-business-journey"].details["follow_up_status"] == "resolved"
+    assert by_name["local-business-journey"].details["evaluation_status"] == "non_compliant"
+    assert by_name["local-business-journey"].details["follow_up_status"] == "reoptimization_required"
     assert by_name["local-business-journey"].details["status_poll"] in {
         "deferred",
         "failed",
@@ -351,7 +351,7 @@ def test_required_live_tpp_accepts_ready_prerequisite_after_success(monkeypatch)
             "proposal_id": f"proposal:{trip_id}",
             "execution_id": "exec-test",
             "status_poll": "succeeded",
-            "evaluation_status": "compliant",
+            "evaluation_status": "non_compliant",
         }
 
     monkeypatch.setattr(verifier, "_run_live_tpp_journey", fake_live_journey)

--- a/tests/app/test_full_product_verification.py
+++ b/tests/app/test_full_product_verification.py
@@ -344,7 +344,9 @@ def test_required_live_tpp_accepts_ready_prerequisite_after_success(monkeypatch)
     monkeypatch.setenv("TPP_ACCESS_TOKEN", "token")
     monkeypatch.setenv("TPP_OIDC_PROVIDER", "google")
 
-    def fake_live_journey(_client, trip_id: str, _env: dict[str, str]) -> dict[str, str]:
+    def fake_live_journey(
+        _client, trip_id: str, _env: dict[str, str], **_: object
+    ) -> dict[str, str]:
         return {
             "base_url": "https://tpp.example.test",
             "trip_id": trip_id,

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -404,8 +404,9 @@ def test_verifier_fails_on_failed_live_status_poll() -> None:
         )
 
 
-def test_temporary_tpp_client_environment_restores_missing_keys() -> None:
+def test_temporary_tpp_client_environment_restores_missing_keys(monkeypatch) -> None:
     for key in ("TPP_BASE_URL", "TPP_ACCESS_TOKEN", "TPP_OIDC_PROVIDER"):
+        monkeypatch.delenv(key, raising=False)
         assert key not in os.environ
 
     with verifier._temporary_tpp_client_environment(
@@ -423,9 +424,10 @@ def test_temporary_tpp_client_environment_restores_missing_keys() -> None:
         assert key not in os.environ
 
 
-def test_temporary_tpp_client_environment_restores_prior_values_on_exception() -> None:
-    os.environ["TPP_BASE_URL"] = "http://prior.example"
-    os.environ["TPP_ACCESS_TOKEN"] = "prior-token"
+def test_temporary_tpp_client_environment_restores_prior_values_on_exception(monkeypatch) -> None:
+    monkeypatch.setenv("TPP_BASE_URL", "http://prior.example")
+    monkeypatch.setenv("TPP_ACCESS_TOKEN", "prior-token")
+    monkeypatch.delenv("TPP_OIDC_PROVIDER", raising=False)
 
     with pytest.raises(RuntimeError):
         with verifier._temporary_tpp_client_environment(
@@ -442,8 +444,6 @@ def test_temporary_tpp_client_environment_restores_prior_values_on_exception() -
     assert os.environ["TPP_BASE_URL"] == "http://prior.example"
     assert os.environ["TPP_ACCESS_TOKEN"] == "prior-token"
     assert "TPP_OIDC_PROVIDER" not in os.environ
-    os.environ.pop("TPP_BASE_URL", None)
-    os.environ.pop("TPP_ACCESS_TOKEN", None)
 
 
 def test_evaluation_fixture_name_maps_expected_status() -> None:

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -1,3 +1,4 @@
+import os
 import stat
 import time
 from pathlib import Path
@@ -392,6 +393,62 @@ def test_verifier_fails_on_failed_status_poll() -> None:
             _business_details(status_poll="failed"),
             expected_evaluation_status="compliant",
         )
+
+
+def test_verifier_fails_on_failed_live_status_poll() -> None:
+    with pytest.raises(verifier.VerificationFailure, match="status poll reported failure"):
+        verifier._assert_business_verification_outcomes(
+            _business_details(),
+            expected_evaluation_status="compliant",
+            live_details=_business_details(status_poll="failed"),
+        )
+
+
+def test_temporary_tpp_client_environment_restores_missing_keys() -> None:
+    for key in ("TPP_BASE_URL", "TPP_ACCESS_TOKEN", "TPP_OIDC_PROVIDER"):
+        assert key not in os.environ
+
+    with verifier._temporary_tpp_client_environment(
+        "http://127.0.0.1:9",
+        {
+            "TPP_ACCESS_TOKEN": "token",
+            "TPP_OIDC_PROVIDER": "google",
+        },
+    ):
+        assert os.environ["TPP_BASE_URL"] == "http://127.0.0.1:9"
+        assert os.environ["TPP_ACCESS_TOKEN"] == "token"
+        assert os.environ["TPP_OIDC_PROVIDER"] == "google"
+
+    for key in ("TPP_BASE_URL", "TPP_ACCESS_TOKEN", "TPP_OIDC_PROVIDER"):
+        assert key not in os.environ
+
+
+def test_temporary_tpp_client_environment_restores_prior_values_on_exception() -> None:
+    os.environ["TPP_BASE_URL"] = "http://prior.example"
+    os.environ["TPP_ACCESS_TOKEN"] = "prior-token"
+
+    with pytest.raises(RuntimeError):
+        with verifier._temporary_tpp_client_environment(
+            "http://127.0.0.1:9",
+            {
+                "TPP_ACCESS_TOKEN": "token",
+                "TPP_OIDC_PROVIDER": "google",
+            },
+        ):
+            assert os.environ["TPP_BASE_URL"] == "http://127.0.0.1:9"
+            assert os.environ["TPP_ACCESS_TOKEN"] == "token"
+            raise RuntimeError("boom")
+
+    assert os.environ["TPP_BASE_URL"] == "http://prior.example"
+    assert os.environ["TPP_ACCESS_TOKEN"] == "prior-token"
+    assert "TPP_OIDC_PROVIDER" not in os.environ
+    os.environ.pop("TPP_BASE_URL", None)
+    os.environ.pop("TPP_ACCESS_TOKEN", None)
+
+
+def test_evaluation_fixture_name_maps_expected_status() -> None:
+    assert verifier._evaluation_fixture_name("compliant") == "approved_evaluation.json"
+    assert verifier._evaluation_fixture_name("non_compliant") == "non_compliant_evaluation.json"
 
 
 def test_verifier_requires_the_declared_expected_business_outcome() -> None:

--- a/tests/scripts/test_check_full_product_verification.py
+++ b/tests/scripts/test_check_full_product_verification.py
@@ -364,3 +364,50 @@ def test_resolve_tpp_interpreter_fails_fast_when_no_venv_or_uv(monkeypatch, tmp_
     message = str(exc_info.value)
     assert str(repo_path / ".venv" / "bin" / "python") in message
     assert f"uv run --directory {repo_path} python" in message
+
+
+def _business_details(
+    *, evaluation_status: str = "compliant", status_poll: str = "deferred"
+) -> dict[str, str]:
+    return {
+        "trip_id": "trip-business",
+        "proposal_id": "proposal:trip-business",
+        "evaluation_status": evaluation_status,
+        "status_poll": status_poll,
+    }
+
+
+def test_verifier_fails_when_local_and_live_verdicts_disagree() -> None:
+    with pytest.raises(verifier.VerificationFailure, match="statuses disagree"):
+        verifier._assert_business_verification_outcomes(
+            _business_details(),
+            expected_evaluation_status="compliant",
+            live_details=_business_details(evaluation_status="non_compliant"),
+        )
+
+
+def test_verifier_fails_on_failed_status_poll() -> None:
+    with pytest.raises(verifier.VerificationFailure, match="status poll reported failure"):
+        verifier._assert_business_verification_outcomes(
+            _business_details(status_poll="failed"),
+            expected_evaluation_status="compliant",
+        )
+
+
+def test_verifier_requires_the_declared_expected_business_outcome() -> None:
+    with pytest.raises(verifier.VerificationFailure, match="expected outcome"):
+        verifier._assert_business_verification_outcomes(
+            _business_details(evaluation_status="non_compliant"),
+            expected_evaluation_status="compliant",
+        )
+
+
+def test_verifier_summary_marks_skipped_surfaces_as_uncovered(capsys) -> None:
+    verifier._print_results(
+        [
+            verifier.CheckResult("local-business-journey", "PASS", _business_details()),
+            verifier.CheckResult("planner-llm", "SKIPPED", {"reason": "not configured"}),
+        ]
+    )
+
+    assert "WARNING uncovered surface: planner-llm" in capsys.readouterr().out


### PR DESCRIPTION
Closes #1692

## Summary

- Declares `non_compliant` as the expected outcome for the current evidence-less business fixture and requires local/live TPP agreement on that result.
- Fails verification when either policy status poll reports `failed`; a real required-mode poll now uses the started TPP service.
- Keeps skipped planner-LLM and map-provider surfaces explicitly uncovered.

## Validation

- `uv run --extra dev pytest -q tests/app/test_full_product_verification.py tests/scripts/test_check_full_product_verification.py` — 38 passed.
- `TPP_REPO_PATH=/Users/teacher/Library/CloudStorage/Dropbox/Learning/Code/Travel-Plan-Permission TPP_ACCESS_TOKEN=ci-cross-repo-smoke-token TPP_OIDC_PROVIDER=google uv run --extra dev python -c ...run_product_journeys(live_tpp="required")...` — local and live results PASS with `non_compliant`; the poll states were `retry_scheduled` and `deferred`.
- Ruff F/E9, `py_compile`, and `git diff --check` passed.

## Deliberate-break evidence

Temporarily replacing the local/live agreement condition with `True` makes the disagreement regression fail; restoring the assertion makes it pass. A failed status poll also raises the focused regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved business verification checks to validate evaluation outcomes, approvals, follow-up states, and local-to-live result consistency.
  * Added clearer warnings when verification checks are skipped.
  * Updated verification journeys to correctly handle non-compliant outcomes and required reoptimization.

* **Tests**
  * Added coverage for status mismatches, polling failures, unexpected outcomes, environment restoration, and uncovered verification areas.
  * Added support for validating configurable expected business evaluation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->