### PR TITLE
fix: reject non-finite budget values

### DIFF
--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-12T03:05:54.295481Z",
+  "emitted_at": "2026-08-12T04:05:25.905464Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "1700",
+  "pr_number": "1701",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/tests/app/test_budget_routes.py
+++ b/tests/app/test_budget_routes.py
@@ -149,6 +149,83 @@ def test_budget_route_rejects_non_finite_amounts(client: TestClient, amount: flo
     assert client.get(f"/api/workspace/{trip_id}/budget").json()["budget_plan"] is None
 
 
+@pytest.mark.parametrize("amount", [float("nan"), float("inf"), float("-inf")])
+def test_budget_spend_routes_reject_non_finite_amounts_without_mutating_state(
+    client: TestClient, amount: float
+) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Finite spend guard",
+            "summary": "Reject non-finite spend inputs before persistence.",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 4, "primary_regions": ["Kyoto"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+    client.put(
+        f"/api/workspace/{trip_id}/budget",
+        json={
+            "title": "Finite spend plan",
+            "currency": "USD",
+            "scenario_budgets": [
+                {
+                    "title": "Baseline",
+                    "allocations": [
+                        {
+                            "category_key": "food",
+                            "label": "Food",
+                            "planned_amount": 150,
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+    rejected_create = client.post(
+        f"/api/workspace/{trip_id}/budget/spend-events",
+        content=json.dumps(
+            {
+                "category_key": "food",
+                "amount": amount,
+                "source_kind": "manual",
+                "source_context": "Invalid spend",
+            }
+        ),
+        headers={"content-type": "application/json"},
+    )
+    assert rejected_create.status_code == 422
+    assert client.get(f"/api/workspace/{trip_id}/budget").json()["spend_events"] == []
+
+    recorded = client.post(
+        f"/api/workspace/{trip_id}/budget/spend-events",
+        json={
+            "category_key": "food",
+            "amount": 25,
+            "source_kind": "manual",
+            "source_context": "Valid spend",
+        },
+    )
+    spend_event_id = recorded.json()["spend_events"][0]["spend_event_id"]
+    rejected_update = client.patch(
+        f"/api/workspace/{trip_id}/budget/spend-events/{spend_event_id}",
+        content=json.dumps(
+            {
+                "category_key": "food",
+                "amount": amount,
+                "source_kind": "manual",
+                "source_context": "Invalid replacement",
+            }
+        ),
+        headers={"content-type": "application/json"},
+    )
+    assert rejected_update.status_code == 422
+    assert client.get(f"/api/workspace/{trip_id}/budget").json()["spend_events"][0][
+        "amount"
+    ] == 25
+
+
 def test_workspace_budget_spend_event_can_be_updated(client: TestClient) -> None:
     created = client.post(
         "/api/trips",

--- a/tests/app/test_budget_routes.py
+++ b/tests/app/test_budget_routes.py
@@ -208,6 +208,9 @@ def test_budget_spend_routes_reject_non_finite_amounts_without_mutating_state(
         },
     )
     spend_event_id = recorded.json()["spend_events"][0]["spend_event_id"]
+    original_event = client.get(
+        f"/api/workspace/{trip_id}/budget"
+    ).json()["spend_events"][0]
     rejected_update = client.patch(
         f"/api/workspace/{trip_id}/budget/spend-events/{spend_event_id}",
         content=json.dumps(
@@ -221,9 +224,10 @@ def test_budget_spend_routes_reject_non_finite_amounts_without_mutating_state(
         headers={"content-type": "application/json"},
     )
     assert rejected_update.status_code == 422
-    assert client.get(f"/api/workspace/{trip_id}/budget").json()["spend_events"][0][
-        "amount"
-    ] == 25
+    assert (
+        client.get(f"/api/workspace/{trip_id}/budget").json()["spend_events"][0]
+        == original_event
+    )
 
 
 def test_workspace_budget_spend_event_can_be_updated(client: TestClient) -> None:

--- a/tests/app/test_budget_routes.py
+++ b/tests/app/test_budget_routes.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -106,6 +107,46 @@ def test_workspace_budget_route_persists_plan_and_spend_events(client: TestClien
         == "budget-plan:" + trip_id
     )
     assert workspace_payload["session"]["active_budget_plan_id"] == "budget-plan:" + trip_id
+
+
+@pytest.mark.parametrize("amount", [float("nan"), float("inf"), float("-inf")])
+def test_budget_route_rejects_non_finite_amounts(client: TestClient, amount: float) -> None:
+    created = client.post(
+        "/api/trips",
+        json={
+            "title": "Finite budget guard",
+            "summary": "Reject non-finite budget inputs before persistence.",
+            "mode": "leisure",
+            "trip_frame": {"duration_days": 4, "primary_regions": ["Kyoto"]},
+        },
+    )
+    trip_id = created.json()["trip"]["trip_id"]
+
+    saved_budget = client.put(
+        f"/api/workspace/{trip_id}/budget",
+        content=json.dumps(
+            {
+                "title": "Invalid budget",
+                "currency": "USD",
+                "scenario_budgets": [
+                    {
+                        "title": "Non-finite allocation",
+                        "allocations": [
+                            {
+                                "category_key": "food",
+                                "label": "Food",
+                                "planned_amount": amount,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        headers={"content-type": "application/json"},
+    )
+
+    assert saved_budget.status_code == 422
+    assert client.get(f"/api/workspace/{trip_id}/budget").json()["budget_plan"] is None
 
 
 def test_workspace_budget_spend_event_can_be_updated(client: TestClient) -> None:

--- a/tests/app/test_trip_routes.py
+++ b/tests/app/test_trip_routes.py
@@ -455,6 +455,9 @@ def test_trip_scenario_history_rejects_invalid_domain_payloads_with_422(
         },
     )
     assert invalid_scenario.status_code == 422
+    assert invalid_scenario.json()["detail"][0]["ctx"]["error"].startswith(
+        "label must be one of"
+    )
 
     invalid_history = client.post(
         f"/api/trips/{trip_id}/planning-history",

--- a/tests/contracts/test_trip.py
+++ b/tests/contracts/test_trip.py
@@ -115,10 +115,10 @@ def test_trip_rejects_policy_state_for_leisure_mode() -> None:
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
 def test_traveler_party_rejects_non_finite_traveler_count(value: float) -> None:
     with pytest.raises(ValueError, match="traveler_count must be finite"):
-        TravelerPartySummary(traveler_count=value)
+        TravelerPartySummary(traveler_count=value)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
 def test_trip_frame_rejects_non_finite_duration_days(value: float) -> None:
     with pytest.raises(ValueError, match="duration_days must be finite"):
-        TripFrameSummary(duration_days=value)
+        TripFrameSummary(duration_days=value)  # type: ignore[arg-type]

--- a/tests/contracts/test_trip.py
+++ b/tests/contracts/test_trip.py
@@ -1,3 +1,5 @@
+import pytest
+
 from trip_planner.contracts import (
     ProfileRefs,
     TravelerPartySummary,
@@ -108,3 +110,15 @@ def test_trip_rejects_policy_state_for_leisure_mode() -> None:
         assert "policy_state_id" in str(exc)
     else:
         raise AssertionError("Leisure trip should reject business-only policy state references")
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_traveler_party_rejects_non_finite_traveler_count(value: float) -> None:
+    with pytest.raises(ValueError, match="traveler_count must be finite"):
+        TravelerPartySummary(traveler_count=value)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_trip_frame_rejects_non_finite_duration_days(value: float) -> None:
+    with pytest.raises(ValueError, match="duration_days must be finite"):
+        TripFrameSummary(duration_days=value)

--- a/tests/state/test_budget.py
+++ b/tests/state/test_budget.py
@@ -102,6 +102,29 @@ def test_budget_category_allocation_rejects_invalid_currency_and_category() -> N
         )
 
 
+@pytest.mark.parametrize("amount", [float("nan"), float("inf"), float("-inf")])
+def test_budget_records_reject_non_finite_amounts(amount: float) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        BudgetCategoryAllocation(
+            category_key="lodging",
+            label="Hotel",
+            planned_amount=amount,
+            currency="USD",
+        )
+    with pytest.raises(ValueError, match="must be finite"):
+        ActualSpendEvent(
+            spend_event_id="spend:non-finite",
+            trip_id="trip-1",
+            budget_plan_id="budget-plan:1",
+            category_key="food",
+            amount=amount,
+            currency="USD",
+            occurred_at="2026-04-02T07:00:00Z",
+            source_kind="manual",
+            source_context="Non-finite test",
+        )
+
+
 def test_actual_spend_event_rejects_invalid_source_or_amount() -> None:
     with pytest.raises(ValueError, match="amount must be positive"):
         ActualSpendEvent(

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,16 @@
+import pytest
+
+from trip_planner._validators import require_finite, require_non_negative
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_validators_reject_non_finite_values(value: float) -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        require_finite(value, "amount")
+    with pytest.raises(ValueError, match="must be finite"):
+        require_non_negative(value, "amount")
+
+
+def test_non_negative_validator_accepts_zero_and_positive_finite_values() -> None:
+    require_non_negative(0.0, "amount")
+    require_non_negative(10.5, "amount")

--- a/trip_planner/_validators.py
+++ b/trip_planner/_validators.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 
@@ -21,8 +22,14 @@ def require_probability(value: float, field_name: str) -> None:
 
 
 def require_non_negative(value: float, field_name: str) -> None:
+    require_finite(value, field_name)
     if value < 0:
         raise ValueError(f"{field_name} cannot be negative")
+
+
+def require_finite(value: float, field_name: str) -> None:
+    if not math.isfinite(value):
+        raise ValueError(f"{field_name} must be finite")
 
 
 def require_strings(values: list[str], field_name: str) -> None:

--- a/trip_planner/app/main.py
+++ b/trip_planner/app/main.py
@@ -47,6 +47,8 @@ def get_allowed_cors_origin_regex() -> str | None:
 def _json_safe_validation_value(value: Any) -> Any:
     if isinstance(value, float) and not math.isfinite(value):
         return str(value)
+    if isinstance(value, Exception):
+        return str(value)
     if isinstance(value, list):
         return [_json_safe_validation_value(item) for item in value]
     if isinstance(value, dict):

--- a/trip_planner/app/main.py
+++ b/trip_planner/app/main.py
@@ -1,9 +1,13 @@
 import logging
+import math
 import os
 from contextlib import asynccontextmanager
+from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from trip_planner.app import APP_VERSION
 from trip_planner.app.routes.auth import router as auth_router
@@ -40,6 +44,16 @@ def get_allowed_cors_origin_regex() -> str | None:
     return configured_regex or None
 
 
+def _json_safe_validation_value(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        return str(value)
+    if isinstance(value, list):
+        return [_json_safe_validation_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _json_safe_validation_value(item) for key, item in value.items()}
+    return value
+
+
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     # Resilient startup: a transient or expired database must not crash the whole
@@ -64,6 +78,15 @@ def create_app() -> FastAPI:
         description="Initial FastAPI runtime for the Trip Planner full-stack application.",
         lifespan=lifespan,
     )
+
+    @app.exception_handler(RequestValidationError)
+    async def request_validation_error_response(
+        _: Request, error: RequestValidationError
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": _json_safe_validation_value(error.errors())},
+        )
 
     app.add_middleware(
         CORSMiddleware,

--- a/trip_planner/app/routes/budget.py
+++ b/trip_planner/app/routes/budget.py
@@ -55,7 +55,8 @@ def save_workspace_budget(
     except WorkspaceBudgetNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        status_code = 422 if "must be finite" in str(error) else 400
+        raise HTTPException(status_code=status_code, detail=str(error)) from error
     return BudgetWorkspaceResponse.model_validate(result)
 
 
@@ -86,7 +87,8 @@ def create_workspace_spend_event(
     except WorkspaceBudgetNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        status_code = 422 if "must be finite" in str(error) else 400
+        raise HTTPException(status_code=status_code, detail=str(error)) from error
     return BudgetWorkspaceResponse.model_validate(result)
 
 
@@ -122,5 +124,6 @@ def patch_workspace_spend_event(
     except WorkspaceBudgetNotFoundError as error:
         raise HTTPException(status_code=404, detail=str(error)) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        status_code = 422 if "must be finite" in str(error) else 400
+        raise HTTPException(status_code=status_code, detail=str(error)) from error
     return BudgetWorkspaceResponse.model_validate(result)

--- a/trip_planner/app/services/budget.py
+++ b/trip_planner/app/services/budget.py
@@ -594,17 +594,33 @@ def update_workspace_spend_event(
             raise ValueError("currency cannot be changed for an existing spend event")
         updated_currency = normalized_currency
     now = _next_session_timestamp(None)
-    event_record.category_key = category_key
-    event_record.amount = _to_decimal_amount(amount)
-    event_record.currency = updated_currency
-    event_record.occurred_at = occurred_at or event_record.occurred_at
-    event_record.source_kind = source_kind
-    event_record.source_context = source_context
-    event_record.scenario_budget_id = scenario_budget_id
-    event_record.saved_scenario_id = saved_scenario_id
-    event_record.merchant_name = merchant_name
-    event_record.source_ref = source_ref
-    event_record.notes = list(notes)
+    updated_event = ActualSpendEvent(
+        spend_event_id=event_record.spend_event_id,
+        trip_id=record.trip_id,
+        budget_plan_id=event_record.budget_plan_id,
+        category_key=category_key,
+        amount=amount,
+        currency=updated_currency,
+        occurred_at=occurred_at or event_record.occurred_at,
+        source_kind=source_kind,
+        source_context=source_context,
+        scenario_budget_id=scenario_budget_id,
+        saved_scenario_id=saved_scenario_id,
+        merchant_name=merchant_name,
+        source_ref=source_ref,
+        notes=notes,
+    )
+    event_record.category_key = updated_event.category_key
+    event_record.amount = _to_decimal_amount(updated_event.amount)
+    event_record.currency = updated_event.currency
+    event_record.occurred_at = updated_event.occurred_at
+    event_record.source_kind = updated_event.source_kind
+    event_record.source_context = updated_event.source_context
+    event_record.scenario_budget_id = updated_event.scenario_budget_id
+    event_record.saved_scenario_id = updated_event.saved_scenario_id
+    event_record.merchant_name = updated_event.merchant_name
+    event_record.source_ref = updated_event.source_ref
+    event_record.notes = list(updated_event.notes)
     session_record = _ensure_session_record(db_session, record=record, timestamp=now)
     session_record.active_budget_plan_id = event_record.budget_plan_id
     session_record.last_updated_at = _next_session_timestamp(session_record.last_updated_at)

--- a/trip_planner/contracts/trip.py
+++ b/trip_planner/contracts/trip.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from trip_planner._validators import require_finite
+
 from ._validators import require_non_empty, require_strings
 
 TRIP_MODES: tuple[str, ...] = ("leisure", "business")
@@ -35,6 +37,7 @@ class TravelerPartySummary:
     def __post_init__(self) -> None:
         if self.kind not in TRAVELER_PARTY_KINDS:
             raise ValueError(f"kind must be one of {TRAVELER_PARTY_KINDS}")
+        require_finite(self.traveler_count, "traveler_count")
         if self.traveler_count <= 0:
             raise ValueError("traveler_count must be positive")
 
@@ -59,6 +62,8 @@ class TripFrameSummary:
             raise ValueError("start_date must be non-empty when provided")
         if self.end_date is not None and not self.end_date:
             raise ValueError("end_date must be non-empty when provided")
+        if self.duration_days is not None:
+            require_finite(self.duration_days, "duration_days")
         if self.duration_days is not None and self.duration_days <= 0:
             raise ValueError("duration_days must be positive when provided")
         require_strings(self.primary_regions, "primary_regions")

--- a/trip_planner/state/budget.py
+++ b/trip_planner/state/budget.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from trip_planner._validators import require_finite
 from trip_planner.contracts._validators import (
     require_non_empty,
     require_optional_non_empty,
@@ -82,6 +83,7 @@ class BudgetCategoryAllocation:
             raise ValueError(f"category_key must be one of {BUDGET_CATEGORY_KEYS}")
         require_non_empty(self.label, "label")
         _require_currency(self.currency, "currency")
+        require_finite(self.planned_amount, "planned_amount")
         if self.planned_amount <= 0:
             raise ValueError("planned_amount must be positive")
         if self.flexibility not in BUDGET_FLEXIBILITY_LEVELS:
@@ -262,6 +264,7 @@ class ActualSpendEvent:
         require_non_empty(self.budget_plan_id, "budget_plan_id")
         if self.category_key not in BUDGET_CATEGORY_KEYS:
             raise ValueError(f"category_key must be one of {BUDGET_CATEGORY_KEYS}")
+        require_finite(self.amount, "amount")
         if self.amount <= 0:
             raise ValueError("amount must be positive")
         _require_currency(self.currency, "currency")


### PR DESCRIPTION
Closes #1693

## Summary

- Reject NaN and infinities in shared numeric validation plus budget, trip, and spend-state boundaries.
- Return a serializable 422 response for malformed non-finite JSON values, without persisting a budget plan.
- Cover finite validation, state records, and the real workspace budget route.

## Validation

- uv run --extra dev python -m pytest -q tests/test_validators.py tests/state/test_budget.py tests/app/test_budget_routes.py — 23 passed.
- uv run --extra dev ruff check --select I,F on the changed files — passed.
- uv run --extra dev mypy on the changed application modules — passed.

## Deliberate-break evidence

Temporarily restoring the old one-sided non-negative comparison made the non-finite validator regression fail for NaN, Infinity, and -Infinity; restoring the finite guard made the focused suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Budget amounts, traveler counts, trip durations, and spending values now reject invalid non-finite numbers such as `NaN` and infinity.
  * Invalid budget requests return clear HTTP 422 validation responses without saving incomplete or invalid data.
  * Validation errors are safely formatted as JSON.
  * Spend-event updates now consistently preserve validated and normalized values.

* **Tests**
  * Added coverage for non-finite values across budget routes, trip data, and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->