### PR TITLE
fix: partition workspace tab content

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -951,6 +951,14 @@ describe("WorkspacePage", () => {
 
     await user.click(screen.getByRole("tab", { name: "Plan" }));
     expect(screen.queryByRole("heading", { name: "Budget vs actual" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Trip rhythm and day sequence" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Review route tradeoffs" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Map" }));
+    expect(screen.getByRole("heading", { name: "Trip rhythm and day sequence" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Compare" }));
+    expect(screen.getByRole("heading", { name: "Review route tradeoffs" })).toBeInTheDocument();
   });
 
   it("keeps approval details in Policy and expands older activity on request", async () => {
@@ -1275,7 +1283,7 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
-    await selectWorkspaceTab("Plan");
+    await selectWorkspaceTab("Compare");
 
     await waitFor(() => {
       expect(
@@ -1334,6 +1342,8 @@ describe("WorkspacePage", () => {
     });
     expect(screen.getByRole("button", { name: "Compare routes" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Planner tools available")).not.toBeInTheDocument();
+
+    await selectWorkspaceTab("Map");
     expect(screen.getByRole("heading", { name: "Trip rhythm and day sequence" })).toBeInTheDocument();
     expect(screen.getByLabelText("Timeline summary")).toBeInTheDocument();
     expect(
@@ -1348,10 +1358,16 @@ describe("WorkspacePage", () => {
     expect(
       screen.queryByText("Days 1-5 keep this stop visible in the selected route review path.")
     ).not.toBeInTheDocument();
+
+    await selectWorkspaceTab("Compare");
     expect(screen.getByRole("heading", { name: "Review route tradeoffs" })).toBeInTheDocument();
     expect(screen.getByLabelText("Scenario review board")).toBeInTheDocument();
-
     expect(screen.getAllByText("Approval posture").length).toBeGreaterThan(0);
+
+    await selectWorkspaceTab("Plan");
+    expect(screen.queryByRole("heading", { name: "Trip rhythm and day sequence" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Review route tradeoffs" })).not.toBeInTheDocument();
+
     expect(screen.getByRole("heading", { name: "Places and options to review" })).toBeInTheDocument();
     expect(screen.getAllByText("Osaka arrival buffer").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Kyoto cultural anchor").length).toBeGreaterThan(0);
@@ -1528,9 +1544,15 @@ describe("WorkspacePage", () => {
     expect(screen.getAllByText("Business trip").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Review approval packet" })).toBeInTheDocument();
     expect(screen.getByText("Approval readiness is available for this trip.")).toBeInTheDocument();
-    expect(screen.getAllByText("Ready for approval").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Advance to approval").length).toBeGreaterThan(0);
+
+    await selectWorkspaceTab("Policy");
+    expect(screen.getAllByText("Ready for approval").length).toBeGreaterThan(0);
+
+    await selectWorkspaceTab("Compare");
     expect(screen.getAllByText("Approval posture").length).toBeGreaterThan(0);
+
+    await selectWorkspaceTab("Plan");
     expect(screen.getByText("Advanced diagnostics")).toBeInTheDocument();
     expect(document.body.textContent ?? "").not.toContain("proposal_state_id");
 
@@ -1980,13 +2002,9 @@ describe("WorkspacePage", () => {
     expect(screen.getAllByText("kyoto -> osaka -> kyoto").length).toBeGreaterThan(0);
     expect(within(screen.getByLabelText("Route context map")).getAllByText("Osaka").length).toBeGreaterThan(0);
 
-    await selectWorkspaceTab("Plan");
-
     expect(screen.getByText("88 / 100 planner score")).toBeInTheDocument();
     expect(screen.getAllByText("Higher-energy fallback with extra transfers").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Higher transfer load to preserve nightlife breadth.").length).toBeGreaterThan(0);
-
-    await selectWorkspaceTab("Map");
 
     expect(screen.getByRole("heading", { name: "Selected scenario affordances" })).toBeInTheDocument();
     expect(screen.getByText("Alternative scenario")).toBeInTheDocument();
@@ -2252,6 +2270,7 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Map");
     await waitFor(() => {
       expect(screen.getByText("Day plan is not ready yet")).toBeInTheDocument();
     });
@@ -2260,6 +2279,7 @@ describe("WorkspacePage", () => {
         "Ask the planner to compare routes or draft a first sequence of stops."
       )
     ).toBeInTheDocument();
+    await selectWorkspaceTab("Plan");
     await waitFor(() => {
       expect(getPlannerHost().shadowRoot?.querySelector('[aria-label="Planner side panel"]')).toBeTruthy();
     });
@@ -2277,6 +2297,7 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Compare");
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Compact route tradeoffs" })).toBeInTheDocument();
     });
@@ -2291,7 +2312,6 @@ describe("WorkspacePage", () => {
         .length
     ).toBeGreaterThan(0);
     expect(screen.queryByText(/Google Maps JavaScript is not configured in this environment/)).not.toBeInTheDocument();
-    await selectWorkspaceTab("Plan");
     expect(screen.getByRole("heading", { name: "Compact day-by-day review" })).toBeInTheDocument();
   });
 
@@ -2405,6 +2425,7 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Compare");
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Review route tradeoffs" })).toBeInTheDocument();
     });

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -930,6 +930,23 @@ describe("WorkspacePage", () => {
     mockedSetNotebookFocus.mockReset();
   });
 
+  it("does not render a panel from two tabs", async () => {
+    mockedUseLoaderData.mockReturnValue({ workspace: Promise.resolve(workspacePayload) });
+    renderWorkspacePage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Plan" })).toHaveAttribute("aria-selected", "true");
+    });
+    expect(screen.queryByRole("heading", { name: "Budget vs actual" })).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("tab", { name: "Budget" }));
+    expect(screen.getByRole("heading", { name: "Budget vs actual" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Plan" }));
+    expect(screen.queryByRole("heading", { name: "Budget vs actual" })).not.toBeInTheDocument();
+  });
+
   it("throws only when the workspace deliberate-break hook is enabled", async () => {
     mockedUseLoaderData.mockReturnValue({ workspace: Promise.resolve(workspacePayload) });
     const workspaceWindow = window as WorkspaceTestWindow;

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -766,6 +766,12 @@ function renderWorkspacePage() {
   );
 }
 
+async function selectWorkspaceTab(
+  label: "Plan" | "Compare" | "Map" | "Budget" | "Notebook" | "Policy"
+) {
+  await userEvent.setup().click(await screen.findByRole("tab", { name: label }));
+}
+
 function getPlannerHost() {
   const plannerHost = document.querySelector(".planner-panel-host");
   expect(plannerHost).toBeTruthy();
@@ -1244,6 +1250,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Plan");
+
     await waitFor(() => {
       expect(
         screen.getAllByRole("heading", { name: "Spring Kyoto anniversary draft" }).length
@@ -1251,6 +1259,8 @@ describe("WorkspacePage", () => {
     });
 
     expect(screen.getAllByTestId("policy-posture")[0]).toHaveTextContent("Approval-ready");
+
+    await selectWorkspaceTab("Policy");
     expect(screen.getByTestId("proposal-lifecycle")).toHaveTextContent(
       "Approval packet is ready"
     );
@@ -1273,13 +1283,18 @@ describe("WorkspacePage", () => {
       expect(screen.getAllByRole("heading", { name: "Spring Kyoto anniversary draft" }).length).toBeGreaterThan(0);
     });
 
+    await selectWorkspaceTab("Map");
     const routeContextMap = screen.getByLabelText("Route context map");
 
     expect(screen.getAllByRole("heading", { name: "Kyoto base with Uji day trip" }).length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Route sketch for Kyoto base with Uji day trip" })).toBeInTheDocument();
     expect(within(routeContextMap).getAllByText("Kyoto").length).toBeGreaterThan(0);
     expect(within(routeContextMap).getAllByText("Uji").length).toBeGreaterThan(0);
+
+    await selectWorkspaceTab("Plan");
     expect(screen.getByText("Save baseline scenario")).toBeInTheDocument();
+
+    await selectWorkspaceTab("Plan");
     expect(screen.getByRole("heading", { name: "Traveler planning workspace" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "How should the planner work?" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: /Collaborative/ })).toBeChecked();
@@ -1294,8 +1309,6 @@ describe("WorkspacePage", () => {
     });
     expect(screen.getByRole("button", { name: "Compare routes" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Planner tools available")).not.toBeInTheDocument();
-    expect(routeContextMap).toBeInTheDocument();
-    expect(screen.getByText("Destination context")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Trip rhythm and day sequence" })).toBeInTheDocument();
     expect(screen.getByLabelText("Timeline summary")).toBeInTheDocument();
     expect(
@@ -1312,21 +1325,30 @@ describe("WorkspacePage", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Review route tradeoffs" })).toBeInTheDocument();
     expect(screen.getByLabelText("Scenario review board")).toBeInTheDocument();
+
     expect(screen.getAllByText("Approval posture").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Places and options to review" })).toBeInTheDocument();
     expect(screen.getAllByText("Osaka arrival buffer").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Kyoto cultural anchor").length).toBeGreaterThan(0);
+
+    await selectWorkspaceTab("Policy");
     expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();
     expect(screen.getByText("Ready for approval")).toBeInTheDocument();
     expect(screen.getAllByText("Advance to approval").length).toBeGreaterThan(0);
     expect(screen.getByRole("heading", { name: "Options and readiness signals" })).toBeInTheDocument();
     expect(screen.queryByText("Conference Hotel")).not.toBeInTheDocument();
     expect(screen.queryByText("proposal-state:trip-leisure-kyoto-draft")).not.toBeInTheDocument();
+
+    await selectWorkspaceTab("Notebook");
     expect(screen.getByRole("heading", { name: "Planner notes to keep" })).toBeInTheDocument();
     expect(screen.getByText("Planner checkpoint 1")).toBeInTheDocument();
+
+    await selectWorkspaceTab("Compare");
     expect(screen.getByRole("heading", { name: "Compare this workspace with other saved trips" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Compare 2. Kyoto plus Osaka fallback" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Compare with Tokyo client summit" })).toBeInTheDocument();
+
+    await selectWorkspaceTab("Plan");
     await waitFor(() => {
       const plannerPanel = getPlannerHost().shadowRoot?.querySelector(
         '[aria-label="Planner side panel"]'
@@ -1915,6 +1937,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Map");
+
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" })).toBeInTheDocument();
     });
@@ -1923,18 +1947,22 @@ describe("WorkspacePage", () => {
       screen.getByRole("heading", { name: "Route sketch for Kyoto base with Uji day trip" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("kyoto -> uji -> kyoto").length).toBeGreaterThan(0);
-    expect(screen.getByText("93 / 100 planner score")).toBeInTheDocument();
-    expect(screen.getAllByText("Balanced Kyoto culture baseline").length).toBeGreaterThan(0);
     await user.click(screen.getByRole("button", { name: "2. Kyoto plus Osaka fallback" }));
 
     expect(
       screen.getByRole("heading", { name: "Route sketch for Kyoto plus Osaka fallback" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("kyoto -> osaka -> kyoto").length).toBeGreaterThan(0);
+    expect(within(screen.getByLabelText("Route context map")).getAllByText("Osaka").length).toBeGreaterThan(0);
+
+    await selectWorkspaceTab("Plan");
+
     expect(screen.getByText("88 / 100 planner score")).toBeInTheDocument();
     expect(screen.getAllByText("Higher-energy fallback with extra transfers").length).toBeGreaterThan(0);
-    expect(within(screen.getByLabelText("Route context map")).getAllByText("Osaka").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Higher transfer load to preserve nightlife breadth.").length).toBeGreaterThan(0);
+
+    await selectWorkspaceTab("Map");
+
     expect(screen.getByRole("heading", { name: "Selected scenario affordances" })).toBeInTheDocument();
     expect(screen.getByText("Alternative scenario")).toBeInTheDocument();
     expect(screen.getByText("7 transfer checkpoint(s)")).toBeInTheDocument();
@@ -1950,6 +1978,8 @@ describe("WorkspacePage", () => {
     });
 
     const { container } = renderWorkspacePage();
+
+    await selectWorkspaceTab("Map");
 
     await waitFor(() => {
       expect(screen.getByLabelText("Fallback option markers")).toBeInTheDocument();
@@ -1993,6 +2023,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Map");
+
     await waitFor(() => {
       expect(screen.getByLabelText("Fallback option markers")).toBeInTheDocument();
     });
@@ -2010,15 +2042,21 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Compare");
+
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Compare 2. Kyoto plus Osaka fallback" })).toBeInTheDocument();
     });
 
     expect(screen.getAllByText("Moderate travel friction with a clear cultural center of gravity.").length).toBeGreaterThan(0);
     await user.click(screen.getByRole("button", { name: "Compare 2. Kyoto plus Osaka fallback" }));
+
+    await selectWorkspaceTab("Map");
     expect(
       screen.getByRole("heading", { name: "Route sketch for Kyoto plus Osaka fallback" })
     ).toBeInTheDocument();
+
+    await selectWorkspaceTab("Compare");
     expect(screen.getAllByText("Osaka rainy-day fallback").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Higher transfer load to preserve nightlife breadth.").length).toBeGreaterThan(0);
 
@@ -2218,6 +2256,7 @@ describe("WorkspacePage", () => {
     });
 
     expect(screen.getByText("Compact review keeps route, day plan, and next choices close together.")).toBeInTheDocument();
+    await selectWorkspaceTab("Map");
     await waitFor(() => {
       expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
     });
@@ -2226,6 +2265,7 @@ describe("WorkspacePage", () => {
         .length
     ).toBeGreaterThan(0);
     expect(screen.queryByText(/Google Maps JavaScript is not configured in this environment/)).not.toBeInTheDocument();
+    await selectWorkspaceTab("Plan");
     expect(screen.getByRole("heading", { name: "Compact day-by-day review" })).toBeInTheDocument();
   });
 
@@ -2238,6 +2278,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Map");
 
     await waitFor(() => {
       expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
@@ -2256,6 +2298,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Map");
 
     await waitFor(() => {
       expect(screen.getByLabelText("Map view confidence")).toHaveTextContent("Regional route review");
@@ -2300,6 +2344,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Map");
 
     await waitFor(() => {
       expect(
@@ -2504,6 +2550,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Policy");
+
     await waitFor(() => {
       expect(
         screen.getByText(
@@ -2542,6 +2590,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Policy");
+
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Policy review is deferred" })).toBeInTheDocument();
     });
@@ -2576,6 +2626,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Policy");
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Policy review is running" })).toBeInTheDocument();
@@ -2618,6 +2670,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Policy");
+
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Awaiting policy evaluation result" })).toBeInTheDocument();
     });
@@ -2653,6 +2707,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Policy");
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Awaiting policy evaluation result" })).toBeInTheDocument();
@@ -2732,6 +2788,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Policy");
+
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Refresh live status" })).toBeInTheDocument();
     });
@@ -2776,6 +2834,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Policy");
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Live policy execution needs attention" })).toBeInTheDocument();
@@ -2846,6 +2906,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Policy");
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Policy review finished with follow-up" })).toBeInTheDocument();
@@ -2926,6 +2988,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Policy");
+
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Policy review finished with follow-up" })).toBeInTheDocument();
     });
@@ -2963,12 +3027,14 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Policy");
+
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Approval packet is ready" })).toBeInTheDocument();
     });
 
     expect(screen.queryByRole("heading", { name: "Approval-ready proposal" })).not.toBeInTheDocument();
-    expect(screen.getByText("resolved")).toBeInTheDocument();
+    expect(screen.getByText("Ready for approval")).toBeInTheDocument();
     expect(screen.queryByText("undefined")).not.toBeInTheDocument();
     expect(screen.queryByText(/Selected alternative:/)).not.toBeInTheDocument();
   });
@@ -3064,6 +3130,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Budget");
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Budget vs actual" })).toBeInTheDocument();
@@ -3240,6 +3308,8 @@ describe("WorkspacePage", () => {
     });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Budget");
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Record spend event" })).toBeInTheDocument();
@@ -3444,6 +3514,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Notebook");
+
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Planning notebook" })).toBeInTheDocument();
     });
@@ -3495,6 +3567,8 @@ describe("WorkspacePage", () => {
     mockedCreateNotebookItem.mockResolvedValue(newItem);
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Notebook");
 
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Planning notebook" })).toBeInTheDocument();
@@ -3557,6 +3631,8 @@ describe("WorkspacePage", () => {
     mockedUpdateNotebookItem.mockResolvedValue(completedItem);
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Notebook");
 
     await waitFor(() => {
       expect(screen.getByText("Research tea ceremony venues")).toBeInTheDocument();
@@ -3621,6 +3697,8 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Notebook");
+
     await waitFor(() => {
       expect(screen.getByText("Draft lodging short-list")).toBeInTheDocument();
     });
@@ -3682,6 +3760,8 @@ describe("WorkspacePage", () => {
     mockedSetNotebookFocus.mockResolvedValue({ category: null, notebook_item_id: "nb-item:focus-target" });
 
     renderWorkspacePage();
+
+    await selectWorkspaceTab("Notebook");
 
     await waitFor(() => {
       expect(screen.getByText("Map out Arashiyama day hike")).toBeInTheDocument();

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -953,6 +953,31 @@ describe("WorkspacePage", () => {
     expect(screen.queryByRole("heading", { name: "Budget vs actual" })).not.toBeInTheDocument();
   });
 
+  it("keeps approval details in Policy and expands older activity on request", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        activity_log: [
+          { activity_event_id: "activity:1", occurred_at: "2026-04-10T00:00:00Z", event_kind: "first", summary: "First activity" },
+          { activity_event_id: "activity:2", occurred_at: "2026-04-11T00:00:00Z", event_kind: "second", summary: "Second activity" },
+          { activity_event_id: "activity:3", occurred_at: "2026-04-12T00:00:00Z", event_kind: "older", summary: "Older activity" },
+        ],
+      }),
+    });
+    renderWorkspacePage();
+
+    await waitFor(() => expect(screen.getByText("Latest trip planning actions")).toBeInTheDocument());
+    expect(screen.queryByText("Options and readiness signals")).not.toBeInTheDocument();
+    expect(screen.queryByText("Older activity")).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "View all activity" }));
+    expect(screen.getByText("Older activity")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Policy" }));
+    expect(screen.getByText("Options and readiness signals")).toBeInTheDocument();
+  });
+
   it("throws only when the workspace deliberate-break hook is enabled", async () => {
     mockedUseLoaderData.mockReturnValue({ workspace: Promise.resolve(workspacePayload) });
     const workspaceWindow = window as WorkspaceTestWindow;
@@ -2112,6 +2137,7 @@ describe("WorkspacePage", () => {
 
     renderWorkspacePage();
 
+    await selectWorkspaceTab("Policy");
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Options and readiness signals" })).toBeInTheDocument();
     });

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1980,132 +1980,6 @@ function WorkspacePageContent({
         </section>
 
         <section className={STATUS_CARD_CLASS}>
-          <p className="status-label">Day plan</p>
-          {timelineStops.length === 0 || activeScenario.scenario === null ? (
-            <>
-              <h2>Day plan is not ready yet</h2>
-              <p>
-                Choose or build a route idea before reviewing day-by-day pacing.
-              </p>
-              <p className="muted-copy">
-                Ask the planner to compare routes or draft a first sequence of stops.
-              </p>
-            </>
-          ) : (
-            <>
-              <h2>{isCompactLayout ? "Compact day-by-day review" : "Trip rhythm and day sequence"}</h2>
-              <p>{selectedRuntimeScenario?.summary ?? activeScenario.scenario.scenario_summary.headline}</p>
-              <div className="timeline-summary-grid" aria-label="Timeline summary">
-                <article className="timeline-summary-card">
-                  <p className="scenario-kicker">Duration</p>
-                  <h3>
-                    {trip.trip_frame.duration_days == null
-                      ? "Trip length pending"
-                      : `${trip.trip_frame.duration_days} days planned`}
-                  </h3>
-                  <p>Dates: {formatDateRange(trip.trip_frame.start_date, trip.trip_frame.end_date)}</p>
-                </article>
-                <article className="timeline-summary-card">
-                  <p className="scenario-kicker">Route shape</p>
-                  <h3>{timelineStops.length} review checkpoints</h3>
-                  <p>
-                    {selectedRuntimeScenario?.route_summary ??
-                      activeScenario.scenario.scenario_summary.route_sequence.join(" -> ")}
-                  </p>
-                </article>
-                <article className="timeline-summary-card">
-                  <p className="scenario-kicker">Segment focus</p>
-                  <h3>
-                    {selectedRouteSegment
-                      ? `${selectedRouteSegment.fromLabel} to ${selectedRouteSegment.toLabel}`
-                      : "No segment selected"}
-                  </h3>
-                  <p>
-                    {selectedRouteSegment?.durationMinutes != null
-                      ? `${selectedRouteSegment.durationMinutes} minutes in the selected route option.`
-                      : "Segment timing will appear when route geometry is available."}
-                  </p>
-                </article>
-                <article className="timeline-summary-card">
-                  <p className="scenario-kicker">Pacing</p>
-                  <h3>
-                    {selectedRuntimeScenario == null
-                      ? "Planner score pending"
-                      : `${formatScenarioScore(selectedRuntimeScenario.metrics.score)} planner score`}
-                  </h3>
-                  <p>
-                    {panelVisibility.showPolicyPosture
-                      ? `${scenarioPolicyPosture} approval posture for the current workspace.`
-                      : "Pacing and route burden stay visible without approval details."}
-                  </p>
-                </article>
-                <article className="timeline-summary-card">
-                  <p className="scenario-kicker">Options</p>
-                  <h3>
-                    {selectedRuntimeScenario == null
-                      ? "Option count pending"
-                      : `${selectedRuntimeScenario.option_count} mapped options`}
-                  </h3>
-                  <p>
-                    {selectedRuntimeScenario?.comparison_note ??
-                      "Details update as route ideas become clearer."}
-                  </p>
-                </article>
-              </div>
-              {selectedTimelineNotes.length > 0 ? (
-                <div className="timeline-focus-notes" aria-label="Timeline linked planning notes">
-                  {selectedTimelineNotes.map((note) => (
-                    <span key={note}>{note}</span>
-                  ))}
-                </div>
-              ) : null}
-              <ol className="timeline-list" aria-label="Trip timeline sequence">
-                {timelineStops.map((stop) => {
-                  const isSegmentFocus =
-                    selectedRouteSegment != null &&
-                    (stop.routeIndex === selectedRouteSegment.fromIndex ||
-                      stop.routeIndex === selectedRouteSegment.toIndex);
-                  return (
-                  <li
-                    key={stop.key}
-                    className={`timeline-stop${isSegmentFocus ? " timeline-stop-focused" : ""}`}
-                  >
-                    <div className="timeline-dayband">
-                      <span>Day {stop.startDay}</span>
-                      <span>Day {stop.endDay}</span>
-                    </div>
-                    <div>
-                      <h3>{stop.label}</h3>
-                      <p>
-                        Days {stop.startDay}-{stop.endDay} keep this stop visible in the selected
-                        route review path.
-                      </p>
-                      {isSegmentFocus ? (
-                        <p className="muted-copy">
-                          Highlighted for the selected segment-level review.
-                        </p>
-                      ) : null}
-                    </div>
-                  </li>
-                  );
-                })}
-              </ol>
-            </>
-          )}
-        </section>
-
-        <RouteTradeoffsPanel
-          compactLayout={isCompactLayout}
-          showPolicyPosture={panelVisibility.showPolicyPosture}
-          scenarios={routeTradeoffCards}
-          emptyMessage={
-            currentWorkspace.runtime_state.status === "partial"
-              ? "Add a little more trip detail before route comparison can start."
-              : "No route ideas are available yet, so there is nothing to compare."
-          }
-        />
-
-        <section className={STATUS_CARD_CLASS}>
           <p className="status-label">Saved ideas</p>
           <h2>{currentWorkspace.scenario_search.title}</h2>
           <div className="scenario-stack">
@@ -2248,6 +2122,17 @@ function WorkspacePageContent({
       {activeTab === "compare" ? (
         <ComparePanel labelledBy={workspaceTabButtonId("compare")}>
           <div className="workspace-grid">
+            <RouteTradeoffsPanel
+              compactLayout={isCompactLayout}
+              showPolicyPosture={panelVisibility.showPolicyPosture}
+              scenarios={routeTradeoffCards}
+              emptyMessage={
+                currentWorkspace.runtime_state.status === "partial"
+                  ? "Add a little more trip detail before route comparison can start."
+                  : "No route ideas are available yet, so there is nothing to compare."
+              }
+            />
+
             <ScenarioComparison
               comparison={routeComparison}
               savedScenarios={currentWorkspace.saved_scenarios}
@@ -2276,24 +2161,141 @@ function WorkspacePageContent({
       ) : null}
       {activeTab === "map" ? (
         <MapPanel labelledBy={workspaceTabButtonId("map")}>
-          <TripMap
-            comparison={routeComparison}
-            scenarioComparisonSummary={currentWorkspace.scenario_comparison?.summary}
-            scenarioFocusAreas={currentWorkspace.scenario_comparison?.focus_areas ?? []}
-            activeScenarioId={selectedScenarioId}
-            onSelectScenario={handleScenarioSelection}
-            bundles={currentWorkspace.inventory_summary.bundles}
-            feasibilitySummary={currentWorkspace.feasibility_summary}
-            tripPrimaryRegions={trip.trip_frame.primary_regions}
-            tripMode={trip.mode}
-            policyPosture={panelVisibility.showPolicyPosture ? scenarioPolicyPosture : null}
-            planningLedger={currentWorkspace.planning_ledger}
-            activeScope={selectedMapScope}
-            selectedSegmentId={selectedRouteSegment?.id ?? null}
-            onScopeChange={setSelectedMapScope}
-            onSelectSegment={setSelectedSegmentId}
-            compactLayout={isCompactLayout}
-          />
+          <div className="workspace-grid">
+            <TripMap
+              comparison={routeComparison}
+              scenarioComparisonSummary={currentWorkspace.scenario_comparison?.summary}
+              scenarioFocusAreas={currentWorkspace.scenario_comparison?.focus_areas ?? []}
+              activeScenarioId={selectedScenarioId}
+              onSelectScenario={handleScenarioSelection}
+              bundles={currentWorkspace.inventory_summary.bundles}
+              feasibilitySummary={currentWorkspace.feasibility_summary}
+              tripPrimaryRegions={trip.trip_frame.primary_regions}
+              tripMode={trip.mode}
+              policyPosture={panelVisibility.showPolicyPosture ? scenarioPolicyPosture : null}
+              planningLedger={currentWorkspace.planning_ledger}
+              activeScope={selectedMapScope}
+              selectedSegmentId={selectedRouteSegment?.id ?? null}
+              onScopeChange={setSelectedMapScope}
+              onSelectSegment={setSelectedSegmentId}
+              compactLayout={isCompactLayout}
+            />
+
+            <section className={STATUS_CARD_CLASS}>
+              <p className="status-label">Day plan</p>
+              {timelineStops.length === 0 || activeScenario.scenario === null ? (
+                <>
+                  <h2>Day plan is not ready yet</h2>
+                  <p>
+                    Choose or build a route idea before reviewing day-by-day pacing.
+                  </p>
+                  <p className="muted-copy">
+                    Ask the planner to compare routes or draft a first sequence of stops.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <h2>{isCompactLayout ? "Compact day-by-day review" : "Trip rhythm and day sequence"}</h2>
+                  <p>{selectedRuntimeScenario?.summary ?? activeScenario.scenario.scenario_summary.headline}</p>
+                  <div className="timeline-summary-grid" aria-label="Timeline summary">
+                    <article className="timeline-summary-card">
+                      <p className="scenario-kicker">Duration</p>
+                      <h3>
+                        {trip.trip_frame.duration_days == null
+                          ? "Trip length pending"
+                          : `${trip.trip_frame.duration_days} days planned`}
+                      </h3>
+                      <p>Dates: {formatDateRange(trip.trip_frame.start_date, trip.trip_frame.end_date)}</p>
+                    </article>
+                    <article className="timeline-summary-card">
+                      <p className="scenario-kicker">Route shape</p>
+                      <h3>{timelineStops.length} review checkpoints</h3>
+                      <p>
+                        {selectedRuntimeScenario?.route_summary ??
+                          activeScenario.scenario.scenario_summary.route_sequence.join(" -> ")}
+                      </p>
+                    </article>
+                    <article className="timeline-summary-card">
+                      <p className="scenario-kicker">Segment focus</p>
+                      <h3>
+                        {selectedRouteSegment
+                          ? `${selectedRouteSegment.fromLabel} to ${selectedRouteSegment.toLabel}`
+                          : "No segment selected"}
+                      </h3>
+                      <p>
+                        {selectedRouteSegment?.durationMinutes != null
+                          ? `${selectedRouteSegment.durationMinutes} minutes in the selected route option.`
+                          : "Segment timing will appear when route geometry is available."}
+                      </p>
+                    </article>
+                    <article className="timeline-summary-card">
+                      <p className="scenario-kicker">Pacing</p>
+                      <h3>
+                        {selectedRuntimeScenario == null
+                          ? "Planner score pending"
+                          : `${formatScenarioScore(selectedRuntimeScenario.metrics.score)} planner score`}
+                      </h3>
+                      <p>
+                        {panelVisibility.showPolicyPosture
+                          ? `${scenarioPolicyPosture} approval posture for the current workspace.`
+                          : "Pacing and route burden stay visible without approval details."}
+                      </p>
+                    </article>
+                    <article className="timeline-summary-card">
+                      <p className="scenario-kicker">Options</p>
+                      <h3>
+                        {selectedRuntimeScenario == null
+                          ? "Option count pending"
+                          : `${selectedRuntimeScenario.option_count} mapped options`}
+                      </h3>
+                      <p>
+                        {selectedRuntimeScenario?.comparison_note ??
+                          "Details update as route ideas become clearer."}
+                      </p>
+                    </article>
+                  </div>
+                  {selectedTimelineNotes.length > 0 ? (
+                    <div className="timeline-focus-notes" aria-label="Timeline linked planning notes">
+                      {selectedTimelineNotes.map((note) => (
+                        <span key={note}>{note}</span>
+                      ))}
+                    </div>
+                  ) : null}
+                  <ol className="timeline-list" aria-label="Trip timeline sequence">
+                    {timelineStops.map((stop) => {
+                      const isSegmentFocus =
+                        selectedRouteSegment != null &&
+                        (stop.routeIndex === selectedRouteSegment.fromIndex ||
+                          stop.routeIndex === selectedRouteSegment.toIndex);
+                      return (
+                      <li
+                        key={stop.key}
+                        className={`timeline-stop${isSegmentFocus ? " timeline-stop-focused" : ""}`}
+                      >
+                        <div className="timeline-dayband">
+                          <span>Day {stop.startDay}</span>
+                          <span>Day {stop.endDay}</span>
+                        </div>
+                        <div>
+                          <h3>{stop.label}</h3>
+                          <p>
+                            Days {stop.startDay}-{stop.endDay} keep this stop visible in the selected
+                            route review path.
+                          </p>
+                          {isSegmentFocus ? (
+                            <p className="muted-copy">
+                              Highlighted for the selected segment-level review.
+                            </p>
+                          ) : null}
+                        </div>
+                      </li>
+                      );
+                    })}
+                  </ol>
+                </>
+              )}
+            </section>
+          </div>
         </MapPanel>
       ) : null}
       {activeTab === "budget" ? (

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -2410,6 +2410,34 @@ function WorkspacePageContent({
                   <>
                     {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
                     {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
+                    <dl className="workspace-meta">
+                      <div>
+                        <dt>Approval readiness</dt>
+                        <dd>
+                          {currentWorkspace.view_model?.policy_presentation.approval_status_label ??
+                            proposalLifecycle?.readinessLabel ??
+                            "Waiting for policy review"}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Packet status</dt>
+                        <dd>{currentWorkspace.proposal_state.summary.submission_status ?? "unknown"}</dd>
+                      </div>
+                      <div>
+                        <dt>Comparables</dt>
+                        <dd>{currentWorkspace.proposal_state.summary.comparable_count ?? 0}</dd>
+                      </div>
+                      <div>
+                        <dt>Next step</dt>
+                        <dd>
+                          {currentWorkspace.view_model?.policy_presentation.next_step_label ??
+                            formatFollowUpStatus(
+                              renderableProposalFollowUp?.status ??
+                                currentWorkspace.proposal_state.summary.follow_up_status
+                            )}
+                        </dd>
+                      </div>
+                    </dl>
                     <p>{proposalLifecycle?.summary ?? "Submission stored for later review."}</p>
                     {shouldShowProposalRefresh(
                       currentWorkspace.proposal_state,
@@ -2437,12 +2465,51 @@ function WorkspacePageContent({
                       <article className="decision-card">
                         <h3>{renderableProposalFollowUp.recommended_label ?? renderableProposalFollowUp.title}</h3>
                         <p>{renderableProposalFollowUp.summary}</p>
+                        {renderableProposalFollowUp.guidance?.length ? (
+                          <p className="muted-copy">{renderableProposalFollowUp.guidance[0]}</p>
+                        ) : null}
+                        {renderableProposalFollowUp.selected_alternative?.summary ? (
+                          <p className="muted-copy">
+                            Selected alternative: {renderableProposalFollowUp.selected_alternative.summary}
+                          </p>
+                        ) : null}
+                        {renderableProposalFollowUp.requested_exception?.reason ? (
+                          <p className="muted-copy">
+                            Exception rationale: {renderableProposalFollowUp.requested_exception.reason}
+                          </p>
+                        ) : null}
+                      </article>
+                    ) : null}
+                    {proposalLifecycle?.state === "running" || proposalLifecycle?.state === "deferred" ? (
+                      <article className="decision-card">
+                        <h3>Keep the workspace open for remote results</h3>
+                        <p>
+                          Reloading the workspace preserves the latest stored execution state, so you can safely return
+                          after the remote policy service posts a new verdict.
+                        </p>
+                      </article>
+                    ) : proposalLifecycle?.state === "failed" ? (
+                      <article className="decision-card">
+                        <h3>Review the live transport failure</h3>
+                        <p>
+                          Validate the remote TPP configuration and retry posture before asking travelers to treat this
+                          workspace as approval-ready.
+                        </p>
                       </article>
                     ) : null}
                     {(renderableProposalFollowUp?.guidance ?? []).map((guidance) => (
                       <article key={guidance} className="decision-card">
                         <h3>Guidance</h3>
                         <p>{guidance}</p>
+                      </article>
+                    ))}
+                    {(renderableProposalFollowUp?.alternatives ?? []).map((alternative) => (
+                      <article
+                        key={`${alternative.category}-${alternative.summary}`}
+                        className="decision-card"
+                      >
+                        <h3>{alternative.summary}</h3>
+                        <p>{alternative.rationale}</p>
                       </article>
                     ))}
                   </div>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1132,6 +1132,7 @@ function WorkspacePageContent({
     null
   );
   const [showPlannerDiagnostics, setShowPlannerDiagnostics] = useState(false);
+  const [showAllActivity, setShowAllActivity] = useState(false);
   const [plannerError, setPlannerError] = useState<string | null>(null);
   const [plannerBusyLabel, setPlannerBusyLabel] = useState<string | null>(null);
   const [planningModeBusy, setPlanningModeBusy] = useState(false);
@@ -2186,50 +2187,6 @@ function WorkspacePageContent({
           )}
         </section>
 
-        {panelVisibility.showProposalPanel ? (
-          <section className={STATUS_CARD_CLASS} data-testid="tpp-label">
-            <p className="status-label">Approval details</p>
-            <h2>Options and readiness signals</h2>
-          {currentWorkspace.proposal_state == null ? (
-            <p className="muted-copy">Approval-packet details will render here once the packet is saved.</p>
-          ) : (
-            <div className="decision-stack">
-              {renderableProposalFollowUp ? (
-                <article className="decision-card">
-                  <h3>{renderableProposalFollowUp.recommended_label ?? renderableProposalFollowUp.title}</h3>
-                  <p>{renderableProposalFollowUp.summary}</p>
-                  {renderableProposalFollowUp.selected_alternative?.summary ? (
-                    <p className="muted-copy">
-                      Selected alternative: {renderableProposalFollowUp.selected_alternative.summary}
-                    </p>
-                  ) : null}
-                  {renderableProposalFollowUp.requested_exception?.reason ? (
-                    <p className="muted-copy">
-                      Exception rationale: {renderableProposalFollowUp.requested_exception.reason}
-                    </p>
-                  ) : null}
-                </article>
-              ) : null}
-              {(renderableProposalFollowUp?.guidance ?? []).map((guidance) => (
-                <article key={guidance} className="decision-card">
-                  <h3>Guidance</h3>
-                  <p>{guidance}</p>
-                </article>
-              ))}
-              {(renderableProposalFollowUp?.alternatives ?? []).map((alternative) => (
-                <article
-                  key={`${alternative.category}-${alternative.summary}`}
-                  className="decision-card"
-                >
-                  <h3>{alternative.summary}</h3>
-                  <p>{alternative.rationale}</p>
-                </article>
-              ))}
-            </div>
-          )}
-          </section>
-        ) : null}
-
         <section className={STATUS_CARD_CLASS}>
           <p className="status-label">Planning notes</p>
           <h2>
@@ -2262,14 +2219,26 @@ function WorkspacePageContent({
             {currentWorkspace.activity_log.length === 0 ? (
               <p className="muted-copy">Planner actions will appear here after the first decision or feedback event.</p>
             ) : (
-              currentWorkspace.activity_log.slice(0, 2).map((entry) => (
+              currentWorkspace.activity_log
+                .slice(0, showAllActivity ? undefined : 2)
+                .map((entry) => (
                 <article key={entry.activity_event_id} className="decision-card">
                   <h3>{entry.event_kind.replace(/_/g, " ")}</h3>
                   <p>{entry.summary}</p>
                 </article>
-              ))
+                ))
             )}
           </div>
+          {currentWorkspace.activity_log.length > 2 ? (
+            <button
+              type="button"
+              className="secondary-button"
+              aria-expanded={showAllActivity}
+              onClick={() => setShowAllActivity((current) => !current)}
+            >
+              {showAllActivity ? "Show recent activity" : "View all activity"}
+            </button>
+          ) : null}
         </section>
       </div>
       </details>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1912,169 +1912,9 @@ function WorkspacePageContent({
           }
         />
 
-        {panelVisibility.showBudgetPanel ? (
-          <WorkspaceBudgetPanel
-            budgetState={currentWorkspace.budget_state}
-            tripMode={trip.mode}
-            busyLabel={budgetBusyLabel}
-            errorMessage={budgetError}
-            onSaveBudget={handleBudgetSave}
-            onRecordSpend={handleSpendRecord}
-          />
-        ) : null}
-
-        <TripMap
-          comparison={routeComparison}
-          scenarioComparisonSummary={currentWorkspace.scenario_comparison?.summary}
-          scenarioFocusAreas={currentWorkspace.scenario_comparison?.focus_areas ?? []}
-          activeScenarioId={selectedScenarioId}
-          onSelectScenario={handleScenarioSelection}
-          bundles={currentWorkspace.inventory_summary.bundles}
-          feasibilitySummary={currentWorkspace.feasibility_summary}
-          tripPrimaryRegions={trip.trip_frame.primary_regions}
-          tripMode={trip.mode}
-          policyPosture={panelVisibility.showPolicyPosture ? scenarioPolicyPosture : null}
-          planningLedger={currentWorkspace.planning_ledger}
-          activeScope={selectedMapScope}
-          selectedSegmentId={selectedRouteSegment?.id ?? null}
-          onScopeChange={setSelectedMapScope}
-          onSelectSegment={setSelectedSegmentId}
-          compactLayout={isCompactLayout}
-        />
-
-        <ScenarioComparison
-          comparison={routeComparison}
-          savedScenarios={currentWorkspace.saved_scenarios}
-          selectedScenarioId={selectedScenarioId}
-          onSelectScenario={handleScenarioSelection}
-        />
-
-        <RouteOptionWorkbench
-          comparison={routeComparison}
-          selectedScenarioId={selectedScenarioId}
-          busyLabel={routeOptionBusyLabel}
-          successMessage={routeOptionSuccess}
-          errorMessage={routeOptionError}
-          onSelectScenario={handleScenarioSelection}
-          onRouteOptionAction={handleRouteOptionAction}
-        />
-
+        <details className="workspace-plan-disclosure">
+          <summary>Planning details</summary>
         <PlanningLedgerPanel ledger={currentWorkspace.planning_ledger} />
-
-        {currentWorkspace.planning_notebook ? (
-          <PlanningNotebookPanel
-            notebookState={currentWorkspace.planning_notebook}
-            busyLabel={notebookBusyLabel}
-            successMessage={notebookSuccess}
-            errorMessage={notebookError}
-            onCreateItem={handleNotebookCreate}
-            onCompleteItem={handleNotebookComplete}
-            onReopenItem={handleNotebookReopen}
-            onDeleteItem={handleNotebookDelete}
-            onSetFocus={handleNotebookSetFocus}
-          />
-        ) : null}
-
-        <TripComparison
-          currentTrip={currentWorkspace.trip_record.trip}
-          trips={trips}
-          selectedTripId={selectedTripComparisonId}
-          onSelectTrip={setSelectedTripComparisonId}
-        />
-
-        {panelVisibility.showApprovalReadinessPanel ? (
-          <WorkspacePolicyPanel
-            approvalPacketContent={
-              <>
-            <p className="status-label">Approval packet</p>
-            <h2 data-testid="proposal-lifecycle">
-              {proposalLifecycle?.title ?? "Proposal lifecycle in progress"}
-            </h2>
-          {currentWorkspace.proposal_state == null ? (
-            <p className="muted-copy">
-              Approval packet records have not been saved for this workspace yet.
-            </p>
-          ) : (
-            <>
-              {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
-              {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
-              <dl className="workspace-meta">
-                <div>
-                  <dt>Approval readiness</dt>
-                  <dd>
-                    {currentWorkspace.view_model?.policy_presentation.approval_status_label ??
-                      proposalLifecycle?.readinessLabel ??
-                      "Waiting for policy review"}
-                  </dd>
-                </div>
-                <div>
-                  <dt>Packet status</dt>
-                  <dd>{currentWorkspace.proposal_state.summary.submission_status ?? "unknown"}</dd>
-                </div>
-                <div>
-                  <dt>Comparables</dt>
-                  <dd>{currentWorkspace.proposal_state.summary.comparable_count ?? 0}</dd>
-                </div>
-                <div>
-                  <dt>Next step</dt>
-                  <dd>
-                    {currentWorkspace.view_model?.policy_presentation.next_step_label ??
-                      formatFollowUpStatus(
-                        renderableProposalFollowUp?.status ??
-                          currentWorkspace.proposal_state.summary.follow_up_status
-                      )}
-                  </dd>
-                </div>
-              </dl>
-              <p>{proposalLifecycle?.summary ?? "Submission stored for later review."}</p>
-              {shouldShowProposalRefresh(
-                currentWorkspace.proposal_state,
-                renderableProposalFollowUp
-              ) ? (
-                <button type="button" className="secondary-button" onClick={handleProposalRefresh}>
-                  Refresh live status
-                </button>
-              ) : null}
-              {renderableProposalFollowUp ? (
-                <article className="decision-card">
-                  <h3>{renderableProposalFollowUp.recommended_label ?? renderableProposalFollowUp.title}</h3>
-                  <p>{renderableProposalFollowUp.summary}</p>
-                  {renderableProposalFollowUp.guidance &&
-                  renderableProposalFollowUp.guidance.length > 0 ? (
-                    <p className="muted-copy">{renderableProposalFollowUp.guidance[0]}</p>
-                  ) : null}
-                </article>
-              ) : proposalLifecycle?.state === "running" || proposalLifecycle?.state === "deferred" ? (
-                <article className="decision-card">
-                  <h3>Keep the workspace open for remote results</h3>
-                  <p>
-                    Reloading the workspace preserves the latest stored execution state, so you can safely return
-                    after the remote policy service posts a new verdict.
-                  </p>
-                </article>
-              ) : proposalLifecycle?.state === "failed" ? (
-                <article className="decision-card">
-                  <h3>Review the live transport failure</h3>
-                  <p>
-                    Validate the remote TPP configuration and retry posture before asking travelers to treat this
-                    workspace as approval-ready.
-                  </p>
-                </article>
-              ) : null}
-              <div className="decision-stack">
-                {(currentWorkspace.proposal_state.summary.highlights ?? []).map((highlight) => (
-                  <article key={highlight} className="decision-card">
-                    <p>{highlight}</p>
-                  </article>
-                ))}
-              </div>
-            </>
-          )}
-              </>
-            }
-          />
-        ) : null}
-
         <section className={STATUS_CARD_CLASS}>
           <p className="status-label">Things to consider</p>
           <h2>
@@ -2292,8 +2132,11 @@ function WorkspacePageContent({
             ) : null}
           </div>
         </section>
+        </details>
       </div>
 
+      <details className="workspace-plan-disclosure">
+        <summary>More planning context</summary>
       <div className="workspace-grid">
         <section className={STATUS_CARD_CLASS}>
           <p className="status-label">Planning settings</p>
@@ -2419,7 +2262,7 @@ function WorkspacePageContent({
             {currentWorkspace.activity_log.length === 0 ? (
               <p className="muted-copy">Planner actions will appear here after the first decision or feedback event.</p>
             ) : (
-              currentWorkspace.activity_log.slice(0, 4).map((entry) => (
+              currentWorkspace.activity_log.slice(0, 2).map((entry) => (
                 <article key={entry.activity_event_id} className="decision-card">
                   <h3>{entry.event_kind.replace(/_/g, " ")}</h3>
                   <p>{entry.summary}</p>
@@ -2429,6 +2272,7 @@ function WorkspacePageContent({
           </div>
         </section>
       </div>
+      </details>
         </PlanPanel>
       ) : null}
 


### PR DESCRIPTION
Closes #1677

## Summary

- Make Budget, Policy, Compare, Map, Notebook, and trip comparison surfaces single-tab owned.
- Collapse the remaining Plan context and limit recent activity to two entries.
- Add a regression proving the Budget panel disappears when Plan is active.

## Validation

- `npx tsc -b --pretty false`
- `npx vitest run src/routes/WorkspacePage.test.tsx -t 'does not render a panel from two tabs'`
- `grep -c '<WorkspaceBudgetPanel' src/routes/WorkspacePage.tsx` -> `1`
- `grep -c '<WorkspacePolicyPanel' src/routes/WorkspacePage.tsx` -> `1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible sections to organize planning details and supporting context.
  * Policy approval information now includes readiness, packet status, comparable counts, and next steps.
  * Follow-up cards provide clearer guidance, alternative recommendations, status updates, and exception details.
* **Improvements**
  * Recent activity now highlights the two latest entries.
  * Workspace navigation and tab content display more consistently, with only the selected panel shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->