### PR TITLE
fix: make policy packet states actionable

### DIFF
--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -2610,6 +2610,28 @@ describe("WorkspacePage", () => {
     expect(screen.queryByRole("button", { name: "Refresh live status" })).not.toBeInTheDocument();
   });
 
+  it("offers a direct path to prepare an approval packet when none exists", async () => {
+    mockedUseLoaderData.mockReturnValue({
+      workspace: Promise.resolve({
+        ...workspacePayload,
+        trip_record: {
+          ...workspacePayload.trip_record,
+          trip: tripComparisonPayload[1],
+        },
+        proposal_state: null,
+      }),
+      trips: Promise.resolve(tripComparisonPayload),
+    });
+
+    renderWorkspacePage();
+
+    await selectWorkspaceTab("Policy");
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: "Prepare approval packet" }));
+
+    expect(screen.getByRole("tab", { name: "Plan" })).toHaveAttribute("aria-selected", "true");
+  });
+
   it("surfaces a deferred execution state while the remote verdict is queued", async () => {
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({
@@ -2890,6 +2912,7 @@ describe("WorkspacePage", () => {
     expect(screen.getByText("Needs policy retry")).toBeInTheDocument();
     expect(screen.getByText("TPP gateway returned a 502 response for the proposal submission.")).toBeInTheDocument();
     expect(screen.getByText("Review the live transport failure")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry policy check" })).toBeInTheDocument();
   });
 
   it("surfaces reoptimization follow-up guidance for non-compliant policy results", async () => {

--- a/frontend/src/routes/WorkspacePage.test.tsx
+++ b/frontend/src/routes/WorkspacePage.test.tsx
@@ -2611,6 +2611,21 @@ describe("WorkspacePage", () => {
   });
 
   it("offers a direct path to prepare an approval packet when none exists", async () => {
+    mockedFetchPlannerSession.mockImplementation(async (tripId) => ({
+      ...plannerSessionPayload,
+      trip_id: tripId,
+      planner_panel_state: {
+        ...plannerSessionPayload.planner_panel_state,
+        trip: {
+          ...plannerSessionPayload.planner_panel_state.trip,
+          trip_id: tripId,
+        },
+        option_set: {
+          ...plannerSessionPayload.planner_panel_state.option_set,
+          trip_id: tripId,
+        },
+      },
+    }));
     mockedUseLoaderData.mockReturnValue({
       workspace: Promise.resolve({
         ...workspacePayload,
@@ -2630,6 +2645,10 @@ describe("WorkspacePage", () => {
     await user.click(await screen.findByRole("button", { name: "Prepare approval packet" }));
 
     expect(screen.getByRole("tab", { name: "Plan" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Plan" })).toHaveFocus();
+    await waitFor(() => {
+      expect(mockedFetchPlannerSession).toHaveBeenCalledWith("trip-business-tokyo-summit");
+    });
   });
 
   it("surfaces a deferred execution state while the remote verdict is queued", async () => {
@@ -2874,6 +2893,9 @@ describe("WorkspacePage", () => {
     expect(
       screen.getAllByText("Use a compliant downtown property before resubmitting the approval packet.").length
     ).toBeGreaterThan(0);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Policy status refreshed: Use a compliant downtown property before resubmitting the approval packet."
+    );
     expect(screen.queryByRole("button", { name: "Refresh live status" })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1661,6 +1661,10 @@ function WorkspacePageContent({
     }
   }
 
+  function handlePrepareApprovalPacket() {
+    setActiveTab("plan");
+  }
+
   if (
     typeof window !== "undefined" &&
     (window as WorkspaceTestWindow).__TRIP_PLANNER_WORKSPACE_BREAK__
@@ -2401,13 +2405,23 @@ function WorkspacePageContent({
                   {proposalLifecycle?.title ?? "Proposal lifecycle in progress"}
                 </h2>
                 {currentWorkspace.proposal_state == null ? (
-                  <p className="muted-copy">
-                    Approval packet records have not been saved for this workspace yet.
-                  </p>
+                  <>
+                    <p className="muted-copy">
+                      Approval packet records have not been saved for this workspace yet.
+                    </p>
+                    <p className="muted-copy">
+                      Start in Plan to prepare the trip details that policy review needs.
+                    </p>
+                    <button type="button" onClick={handlePrepareApprovalPacket}>
+                      Prepare approval packet
+                    </button>
+                  </>
                 ) : (
                   <>
-                    {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
-                    {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
+                    <div aria-live="polite" role="status">
+                      {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
+                      {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
+                    </div>
                     <dl className="workspace-meta">
                       <div>
                         <dt>Approval readiness</dt>
@@ -2440,9 +2454,9 @@ function WorkspacePageContent({
                     {shouldShowProposalRefresh(
                       currentWorkspace.proposal_state,
                       renderableProposalFollowUp
-                    ) ? (
+                    ) || proposalLifecycle?.state === "failed" ? (
                       <button type="button" className="secondary-button" onClick={handleProposalRefresh}>
-                        Refresh live status
+                        {proposalLifecycle?.state === "failed" ? "Retry policy check" : "Refresh live status"}
                       </button>
                     ) : null}
                   </>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -1145,6 +1145,7 @@ function WorkspacePageContent({
   const [notebookSuccess, setNotebookSuccess] = useState<string | null>(null);
   const [proposalError, setProposalError] = useState<string | null>(null);
   const [proposalBusyLabel, setProposalBusyLabel] = useState<string | null>(null);
+  const [proposalStatusMessage, setProposalStatusMessage] = useState<string | null>(null);
   const [routeOptionError, setRouteOptionError] = useState<string | null>(null);
   const [routeOptionBusyLabel, setRouteOptionBusyLabel] = useState<string | null>(null);
   const [routeOptionSuccess, setRouteOptionSuccess] = useState<string | null>(null);
@@ -1158,6 +1159,7 @@ function WorkspacePageContent({
     policy: null,
   });
   const plannerSessionLoadVersion = useRef(0);
+  const proposalRefreshVersion = useRef(0);
   const plannerConversationTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const previousWorkspaceRef = useRef(workspace);
   const isCompactLayout = useCompactWorkspaceLayout();
@@ -1644,25 +1646,55 @@ function WorkspacePageContent({
   }
 
   async function handleProposalRefresh() {
+    const refreshVersion = proposalRefreshVersion.current + 1;
+    proposalRefreshVersion.current = refreshVersion;
     setProposalError(null);
+    setProposalStatusMessage(null);
     setProposalBusyLabel("Refreshing live policy status...");
     try {
       const nextProposalState = await refreshWorkspaceProposalStatus(trip.trip_id);
+      if (refreshVersion !== proposalRefreshVersion.current) {
+        return;
+      }
+      if (nextProposalState == null) {
+        startTransition(() => {
+          setCurrentWorkspace((current) => ({
+            ...current,
+            proposal_state: null,
+          }));
+        });
+        setProposalStatusMessage("Policy status refreshed: no approval packet is currently saved.");
+        return;
+      }
+      const nextLifecycle = deriveProposalLifecyclePresentation(
+        nextProposalState,
+        nextProposalState.follow_up
+      );
       startTransition(() => {
         setCurrentWorkspace((current) => ({
           ...current,
           proposal_state: nextProposalState,
         }));
       });
+      setProposalStatusMessage(
+        nextLifecycle.state === "failed"
+          ? `Policy refresh completed with a policy failure: ${nextLifecycle.summary}`
+          : `Policy status refreshed: ${nextLifecycle.summary}`
+      );
     } catch (error) {
-      setProposalError(error instanceof Error ? error.message : "Proposal status refresh failed.");
+      if (refreshVersion === proposalRefreshVersion.current) {
+        setProposalError(error instanceof Error ? error.message : "Proposal status refresh failed.");
+      }
     } finally {
-      setProposalBusyLabel(null);
+      if (refreshVersion === proposalRefreshVersion.current) {
+        setProposalBusyLabel(null);
+      }
     }
   }
 
   function handlePrepareApprovalPacket() {
     setActiveTab("plan");
+    workspaceTabRefs.current.plan?.focus();
   }
 
   if (
@@ -2421,6 +2453,7 @@ function WorkspacePageContent({
                     <div aria-live="polite" role="status">
                       {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
                       {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
+                      {proposalStatusMessage ? <p className="muted-copy">{proposalStatusMessage}</p> : null}
                     </div>
                     <dl className="workspace-meta">
                       <div>
@@ -2455,7 +2488,12 @@ function WorkspacePageContent({
                       currentWorkspace.proposal_state,
                       renderableProposalFollowUp
                     ) || proposalLifecycle?.state === "failed" ? (
-                      <button type="button" className="secondary-button" onClick={handleProposalRefresh}>
+                      <button
+                        type="button"
+                        className="secondary-button"
+                        disabled={Boolean(proposalBusyLabel)}
+                        onClick={handleProposalRefresh}
+                      >
                         {proposalLifecycle?.state === "failed" ? "Retry policy check" : "Refresh live status"}
                       </button>
                     ) : null}


### PR DESCRIPTION
Closes #1678

## Summary
- Route an empty policy panel to Plan so travelers can prepare the approval packet.
- Present a retry control and live status updates when the policy service fails.

## Validation
- `npx vitest run src/routes/WorkspacePage.test.tsx` (58 passed)
- `npm run build`
- `git diff --check`

## Deliberate-break evidence
Temporarily removing the `Prepare approval packet` click handler made `WorkspacePage.test.tsx -t "offers a direct path to prepare an approval packet when none exists"` fail because the Plan tab remained unselected; the handler was restored and the test passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear action to return to the Plan tab when preparing an approval packet without an existing proposal.
  * Added a retry option when a policy check fails.
* **Accessibility & Usability**
  * Improved empty-state guidance and status announcements for proposal activity and errors.
  * Updated button labels to better reflect available actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->