### PR TITLE
fix: sanitize workspace error responses

### DIFF
--- a/tests/app/test_budget_routes.py
+++ b/tests/app/test_budget_routes.py
@@ -208,9 +208,7 @@ def test_budget_spend_routes_reject_non_finite_amounts_without_mutating_state(
         },
     )
     spend_event_id = recorded.json()["spend_events"][0]["spend_event_id"]
-    original_event = client.get(
-        f"/api/workspace/{trip_id}/budget"
-    ).json()["spend_events"][0]
+    original_event = client.get(f"/api/workspace/{trip_id}/budget").json()["spend_events"][0]
     rejected_update = client.patch(
         f"/api/workspace/{trip_id}/budget/spend-events/{spend_event_id}",
         content=json.dumps(
@@ -225,8 +223,7 @@ def test_budget_spend_routes_reject_non_finite_amounts_without_mutating_state(
     )
     assert rejected_update.status_code == 422
     assert (
-        client.get(f"/api/workspace/{trip_id}/budget").json()["spend_events"][0]
-        == original_event
+        client.get(f"/api/workspace/{trip_id}/budget").json()["spend_events"][0] == original_event
     )
 
 
@@ -345,7 +342,7 @@ def test_workspace_budget_spend_event_rejects_currency_drift(client: TestClient)
     )
 
     assert recorded.status_code == 400
-    assert recorded.json()["detail"] == "currency must match the persisted budget plan currency"
+    assert recorded.json()["detail"].startswith("The workspace budget request was invalid.")
 
 
 def test_workspace_budget_spend_event_updates_session_timestamp(client: TestClient) -> None:

--- a/tests/app/test_planner_routes.py
+++ b/tests/app/test_planner_routes.py
@@ -1290,7 +1290,7 @@ def test_planner_turn_rejects_invalid_tool_calls(client: TestClient) -> None:
     )
 
     assert response.status_code == 400
-    assert "not supported" in response.json()["detail"]
+    assert response.json()["detail"].startswith("The planner request was invalid.")
 
 
 def test_planner_turn_normalizes_lowercase_budget_currency(client: TestClient) -> None:

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Literal
@@ -8,8 +9,11 @@ import pytest
 from fastapi.testclient import TestClient
 
 from trip_planner.app.main import create_app
+from trip_planner.app.routes import errors as route_errors
+from trip_planner.app.routes import policy as policy_routes
 from trip_planner.app.services.auth import AuthenticatedUser
 from trip_planner.app.services.policy import _tpp_trip_plan_payload
+from trip_planner.integrations.tpp import TPPTransportError
 from trip_planner.integrations.tpp import client as tpp_client_module
 from trip_planner.persistence.db import get_session_factory, reset_database_state
 from trip_planner.persistence.models.policy import PersistedPolicyState
@@ -361,7 +365,7 @@ def test_workspace_policy_import_rejects_leisure_trip(client: TestClient) -> Non
     )
 
     assert response.status_code == 400
-    assert "business trips" in response.json()["detail"]
+    assert response.json()["detail"].startswith("The workspace policy request was invalid.")
 
 
 def test_workspace_policy_import_uses_live_tpp_transport_when_response_is_omitted(
@@ -522,7 +526,45 @@ def test_workspace_policy_import_surfaces_live_tpp_unavailable_errors(
     )
 
     assert response.status_code == 503
-    assert "failed" in response.json()["detail"]
+    assert response.json()["detail"].startswith(
+        "The policy service could not complete the request."
+    )
+
+
+def test_route_does_not_disclose_upstream_exception_text(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = "upstream-secret-7da6e2"
+    logged: dict[str, object] = {}
+
+    def _capture_log(*args: object, **kwargs: object) -> None:
+        logged["args"] = args
+        logged["exc_info"] = kwargs["exc_info"]
+
+    monkeypatch.setattr(route_errors.logger, "error", _capture_log)
+
+    def _raise_transport_error(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise TPPTransportError(sentinel, status_code=503)
+
+    monkeypatch.setattr(
+        policy_routes, "import_workspace_policy_constraints", _raise_transport_error
+    )
+    fixture = _load_fixture("standard_policy_sync.json")
+
+    response = client.put(
+        "/api/workspace/trip-secret/policy",
+        json={"request": fixture["request"], "response": fixture["response"]},
+    )
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert sentinel not in response.text
+    match = re.search(r"Reference ID: ([0-9a-f]{32}).", detail)
+    assert match is not None
+    assert str(logged["exc_info"]) == sentinel
+    assert match.group(1) in logged["args"]
 
 
 def test_workspace_policy_import_uses_stored_policy_fallback_on_live_timeout(

--- a/tests/app/test_policy.py
+++ b/tests/app/test_policy.py
@@ -536,6 +536,7 @@ def test_route_does_not_disclose_upstream_exception_text(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sentinel = "upstream-secret-7da6e2"
+    reference_id = "a" * 32
     logged: dict[str, object] = {}
 
     def _capture_log(*args: object, **kwargs: object) -> None:
@@ -546,7 +547,7 @@ def test_route_does_not_disclose_upstream_exception_text(
 
     def _raise_transport_error(*args: object, **kwargs: object) -> None:
         del args, kwargs
-        raise TPPTransportError(sentinel, status_code=503)
+        raise TPPTransportError(sentinel, status_code=503, reference_id=reference_id)
 
     monkeypatch.setattr(
         policy_routes, "import_workspace_policy_constraints", _raise_transport_error
@@ -564,7 +565,10 @@ def test_route_does_not_disclose_upstream_exception_text(
     match = re.search(r"Reference ID: ([0-9a-f]{32}).", detail)
     assert match is not None
     assert str(logged["exc_info"]) == sentinel
-    assert match.group(1) in logged["args"]
+    logged_args = logged["args"]
+    assert isinstance(logged_args, tuple)
+    assert match.group(1) == reference_id
+    assert reference_id in logged_args
 
 
 def test_workspace_policy_import_uses_stored_policy_fallback_on_live_timeout(

--- a/tests/app/test_proposal.py
+++ b/tests/app/test_proposal.py
@@ -601,7 +601,7 @@ def test_workspace_proposal_evaluation_rejects_mismatched_submission_linkage(
         },
     )
     assert evaluated.status_code == 400
-    assert "persisted proposal" in evaluated.json()["detail"]
+    assert evaluated.json()["detail"].startswith("The workspace proposal request was invalid.")
 
 
 def test_workspace_proposal_evaluation_normalizes_stale_request_linkage(
@@ -731,7 +731,9 @@ def test_workspace_proposal_evaluation_rejects_mismatched_scenario_and_organizat
         },
     )
     assert scenario_response.status_code == 400
-    assert "scenario_id" in scenario_response.json()["detail"]
+    assert scenario_response.json()["detail"].startswith(
+        "The workspace proposal request was invalid."
+    )
 
     organization_fixture = _load_fixture("results", "approved_evaluation.json")
     organization_fixture["request"]["trip_id"] = trip_id
@@ -1090,7 +1092,7 @@ def test_workspace_proposal_submission_rejects_leisure_trip(client: TestClient) 
     )
 
     assert response.status_code == 400
-    assert "business trips" in response.json()["detail"]
+    assert response.json()["detail"].startswith("The workspace proposal request was invalid.")
 
 
 def test_workspace_proposal_submission_and_evaluation_use_live_tpp_transport(
@@ -1327,10 +1329,7 @@ def test_workspace_proposal_live_transport_rejects_invalid_upstream_contract(
     )
 
     assert response.status_code == 400
-    assert (
-        response.json()["detail"]
-        == "result_payload.execution_id is required for non-terminal submissions"
-    )
+    assert response.json()["detail"].startswith("The workspace proposal request was invalid.")
 
 
 def test_workspace_proposal_submission_persists_stored_policy_when_live_tpp_times_out(

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -341,7 +341,7 @@ def test_workspace_planning_notebook_api_persists_items_and_focus_across_reload(
         json={"category": "lodging", "notebook_item_id": route_item["notebook_item_id"]},
     )
     assert mismatched_focus.status_code == 400
-    assert "does not match notebook item category" in mismatched_focus.json()["detail"]
+    assert mismatched_focus.json()["detail"].startswith("The workspace request was invalid.")
 
     focus_to_route = client.put(
         f"/api/workspace/{trip_id}/planning-notebook/focus",
@@ -477,21 +477,21 @@ def test_workspace_planning_ledger_rejects_supersedes_cycles(
         json={"supersedes_entry_id": first_id},
     )
     assert self_cycle.status_code == 400
-    assert "same ledger entry" in self_cycle.json()["detail"]
+    assert self_cycle.json()["detail"].startswith("The workspace request was invalid.")
 
     indirect_cycle = client.patch(
         f"/api/workspace/{trip_id}/planning-ledger/{first_id}",
         json={"supersedes_entry_id": second_id},
     )
     assert indirect_cycle.status_code == 400
-    assert "cycle" in indirect_cycle.json()["detail"]
+    assert indirect_cycle.json()["detail"].startswith("The workspace request was invalid.")
 
     missing_target = client.patch(
         f"/api/workspace/{trip_id}/planning-ledger/{first_id}",
         json={"supersedes_entry_id": "ledger:does-not-exist"},
     )
     assert missing_target.status_code == 400
-    assert "existing ledger entry" in missing_target.json()["detail"]
+    assert missing_target.json()["detail"].startswith("The workspace request was invalid.")
 
     other_trip = client.post(
         "/api/trips",
@@ -524,7 +524,7 @@ def test_workspace_planning_ledger_rejects_supersedes_cycles(
         json={"supersedes_entry_id": other_entry.json()["ledger_entry_id"]},
     )
     assert other_trip_target.status_code == 400
-    assert "existing ledger entry" in other_trip_target.json()["detail"]
+    assert other_trip_target.json()["detail"].startswith("The workspace request was invalid.")
 
     blank_target = client.patch(
         f"/api/workspace/{trip_id}/planning-ledger/{second_id}",
@@ -2646,7 +2646,7 @@ def test_workspace_option_feedback_rejects_unknown_option_id(client: TestClient)
     )
 
     assert invalid.status_code == 400
-    assert "not available in the current workspace option set" in invalid.json()["detail"]
+    assert invalid.json()["detail"].startswith("The workspace request was invalid.")
 
 
 def test_workspace_activity_log_is_capped_for_persisted_trips(client: TestClient) -> None:

--- a/trip_planner/app/routes/budget.py
+++ b/trip_planner/app/routes/budget.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from trip_planner.app.routes.errors import public_http_error
 from trip_planner.app.schemas.budget import (
     ActualSpendEventUpsertRequest,
     BudgetPlanUpsertRequest,
@@ -28,7 +29,9 @@ def read_workspace_budget(
     try:
         payload = get_workspace_budget_payload(db_session, user=user, trip_id=trip_id)
     except WorkspaceBudgetNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace budget was not found."
+        ) from error
     return BudgetWorkspaceResponse.model_validate(payload)
 
 
@@ -53,10 +56,14 @@ def save_workspace_budget(
             summary=payload.summary,
         )
     except WorkspaceBudgetNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace budget was not found."
+        ) from error
     except ValueError as error:
         status_code = 422 if "must be finite" in str(error) else 400
-        raise HTTPException(status_code=status_code, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=status_code, message="The workspace budget request was invalid."
+        ) from error
     return BudgetWorkspaceResponse.model_validate(result)
 
 
@@ -85,10 +92,14 @@ def create_workspace_spend_event(
             notes=payload.notes,
         )
     except WorkspaceBudgetNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace budget was not found."
+        ) from error
     except ValueError as error:
         status_code = 422 if "must be finite" in str(error) else 400
-        raise HTTPException(status_code=status_code, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=status_code, message="The workspace budget request was invalid."
+        ) from error
     return BudgetWorkspaceResponse.model_validate(result)
 
 
@@ -122,8 +133,12 @@ def patch_workspace_spend_event(
             notes=payload.notes,
         )
     except WorkspaceBudgetNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace budget was not found."
+        ) from error
     except ValueError as error:
         status_code = 422 if "must be finite" in str(error) else 400
-        raise HTTPException(status_code=status_code, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=status_code, message="The workspace budget request was invalid."
+        ) from error
     return BudgetWorkspaceResponse.model_validate(result)

--- a/trip_planner/app/routes/errors.py
+++ b/trip_planner/app/routes/errors.py
@@ -1,0 +1,30 @@
+"""Stable public HTTP errors for workspace routes."""
+
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+from fastapi import HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+def public_http_error(
+    error: Exception,
+    *,
+    status_code: int,
+    message: str,
+) -> HTTPException:
+    """Log the internal error and return a correlation-safe public response."""
+    reference_id = uuid4().hex
+    logger.error(
+        "%s (reference_id=%s)",
+        message,
+        reference_id,
+        exc_info=error,
+    )
+    return HTTPException(
+        status_code=status_code,
+        detail=f"{message} Reference ID: {reference_id}.",
+    )

--- a/trip_planner/app/routes/errors.py
+++ b/trip_planner/app/routes/errors.py
@@ -17,7 +17,9 @@ def public_http_error(
     message: str,
 ) -> HTTPException:
     """Log the internal error and return a correlation-safe public response."""
-    reference_id = uuid4().hex
+    reference_id = getattr(error, "reference_id", None)
+    if not isinstance(reference_id, str):
+        reference_id = uuid4().hex
     logger.error(
         "%s (reference_id=%s)",
         message,

--- a/trip_planner/app/routes/planner.py
+++ b/trip_planner/app/routes/planner.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from trip_planner.app.routes.errors import public_http_error
 from trip_planner.app.schemas.planner import PlannerSessionResponse, PlannerTurnRequest
 from trip_planner.app.services.auth import AuthenticatedUser, require_authenticated_user
 from trip_planner.app.services.planner import (
@@ -23,7 +24,9 @@ def read_planner_session(
     try:
         payload = get_planner_session_payload(db_session, user=user, trip_id=trip_id)
     except WorkspacePlannerTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested planner session was not found."
+        ) from error
     return PlannerSessionResponse.model_validate(payload)
 
 
@@ -36,7 +39,9 @@ def resume_planner_session(
     try:
         payload = resume_planner_session_payload(db_session, user=user, trip_id=trip_id)
     except WorkspacePlannerTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested planner session was not found."
+        ) from error
     return PlannerSessionResponse.model_validate(payload)
 
 
@@ -56,7 +61,11 @@ def create_planner_turn(
             tool_calls=[item.model_dump() for item in payload.tool_calls],
         )
     except WorkspacePlannerTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested planner session was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The planner request was invalid."
+        ) from error
     return PlannerSessionResponse.model_validate(result)

--- a/trip_planner/app/routes/policy.py
+++ b/trip_planner/app/routes/policy.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from trip_planner.app.routes.errors import public_http_error
 from trip_planner.app.schemas.policy import (
     PolicySyncImportRequest,
     WorkspacePolicyResponse,
@@ -26,7 +27,11 @@ def read_workspace_policy(
     try:
         payload = get_workspace_policy_payload(db_session, user=user, trip_id=trip_id)
     except WorkspacePolicyNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=404,
+            message="The requested workspace policy was not found.",
+        ) from error
     return WorkspacePolicyResponse.model_validate(payload)
 
 
@@ -49,9 +54,21 @@ def save_workspace_policy(
             notes=payload.notes,
         )
     except WorkspacePolicyNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=404,
+            message="The requested workspace policy was not found.",
+        ) from error
     except TPPTransportError as error:
-        raise HTTPException(status_code=error.status_code, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=error.status_code,
+            message="The policy service could not complete the request.",
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=400,
+            message="The workspace policy request was invalid.",
+        ) from error
     return WorkspacePolicyResponse.model_validate(result)

--- a/trip_planner/app/routes/proposal.py
+++ b/trip_planner/app/routes/proposal.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from trip_planner.app.routes.errors import public_http_error
 from trip_planner.app.schemas.proposal import (
     WorkspaceProposalEvaluationRequest,
     WorkspaceProposalFollowUpRequest,
@@ -33,7 +34,11 @@ def read_workspace_proposal(
     try:
         payload = get_workspace_proposal_payload(db_session, user=user, trip_id=trip_id)
     except WorkspaceProposalNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=404,
+            message="The requested workspace proposal was not found.",
+        ) from error
     return WorkspaceProposalResponse.model_validate(payload)
 
 
@@ -56,11 +61,23 @@ def save_workspace_proposal(
             scenario_id=payload.scenario_id,
         )
     except WorkspaceProposalNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=404,
+            message="The requested workspace proposal was not found.",
+        ) from error
     except TPPTransportError as error:
-        raise HTTPException(status_code=error.status_code, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=error.status_code,
+            message="The proposal service could not complete the request.",
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=400,
+            message="The workspace proposal request was invalid.",
+        ) from error
     return WorkspaceProposalResponse.model_validate(result)
 
 
@@ -82,11 +99,23 @@ def save_workspace_proposal_result(
             scenario_id=payload.scenario_id,
         )
     except WorkspaceProposalNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=404,
+            message="The requested workspace proposal was not found.",
+        ) from error
     except TPPTransportError as error:
-        raise HTTPException(status_code=error.status_code, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=error.status_code,
+            message="The proposal service could not complete the request.",
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=400,
+            message="The workspace proposal request was invalid.",
+        ) from error
     return WorkspaceProposalResponse.model_validate(result)
 
 
@@ -118,9 +147,17 @@ def save_workspace_proposal_follow_up_state(
             ),
         )
     except WorkspaceProposalNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=404,
+            message="The requested workspace proposal was not found.",
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=400,
+            message="The workspace proposal request was invalid.",
+        ) from error
     return WorkspaceProposalResponse.model_validate(result)
 
 
@@ -137,11 +174,23 @@ def refresh_workspace_proposal(
             trip_id=trip_id,
         )
     except WorkspaceProposalNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=404,
+            message="The requested workspace proposal was not found.",
+        ) from error
     except TPPTransportError as error:
-        raise HTTPException(status_code=error.status_code, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=error.status_code,
+            message="The proposal service could not complete the request.",
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=400,
+            message="The workspace proposal request was invalid.",
+        ) from error
     return WorkspaceProposalResponse.model_validate(result)
 
 
@@ -161,7 +210,15 @@ def reoptimize_workspace_proposal(
             justification_refs=payload.justification_refs,
         )
     except WorkspaceProposalNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=404,
+            message="The requested workspace proposal was not found.",
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error,
+            status_code=400,
+            message="The workspace proposal request was invalid.",
+        ) from error
     return WorkspaceProposalResponse.model_validate(result)

--- a/trip_planner/app/routes/workspace.py
+++ b/trip_planner/app/routes/workspace.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from trip_planner.app.routes.errors import public_http_error
 from trip_planner.app.schemas.workspace import (
     PlannerDecisionAnswerRequest,
     PlannerOptionFeedbackRequest,
@@ -98,9 +99,13 @@ def update_planning_mode(
             include_debug=False,
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return WorkspaceResponse.model_validate(result)
 
 
@@ -130,9 +135,13 @@ def create_workspace_planning_ledger_entry(
             related_decision_id=payload.related_decision_id,
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return PlanningLedgerEntry.model_validate(result)
 
 
@@ -156,9 +165,13 @@ def patch_workspace_planning_ledger_entry(
             updates=payload.model_dump(exclude_unset=True),
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return PlanningLedgerEntry.model_validate(result)
 
 
@@ -188,9 +201,13 @@ def create_workspace_planning_notebook_item(
             tags=payload.tags,
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return PlanningNotebookItem.model_validate(result)
 
 
@@ -214,9 +231,13 @@ def patch_workspace_planning_notebook_item(
             updates=payload.model_dump(exclude_unset=True),
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return PlanningNotebookItem.model_validate(result)
 
 
@@ -238,7 +259,9 @@ def delete_workspace_planning_notebook_item(
             notebook_item_id=notebook_item_id,
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
 
 
 @router.put(
@@ -260,9 +283,13 @@ def update_workspace_planning_notebook_focus(
             notebook_item_id=payload.notebook_item_id,
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return PlanningNotebookFocus.model_validate(result)
 
 
@@ -287,9 +314,13 @@ def answer_planner_decision(
             include_debug=False,
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return WorkspaceResponse.model_validate(result)
 
 
@@ -315,9 +346,13 @@ def record_planner_option_feedback(
             include_debug=False,
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return WorkspaceResponse.model_validate(result)
 
 
@@ -342,7 +377,11 @@ def record_route_option_action(
             include_debug=False,
         )
     except WorkspaceTripNotFoundError as error:
-        raise HTTPException(status_code=404, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=404, message="The requested workspace was not found."
+        ) from error
     except ValueError as error:
-        raise HTTPException(status_code=400, detail=str(error)) from error
+        raise public_http_error(
+            error, status_code=400, message="The workspace request was invalid."
+        ) from error
     return WorkspaceResponse.model_validate(result)

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -402,6 +402,7 @@ def _resolve_evaluation_response(
                 error_code="unknown",
                 status_code=502,
                 retryable=False,
+                reference_id=reference_id,
             )
         raise transport_error from exc
 

--- a/trip_planner/app/services/proposal.py
+++ b/trip_planner/app/services/proposal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
@@ -35,6 +36,8 @@ from trip_planner.integrations.tpp import (
 from trip_planner.persistence.models.proposal import PersistedProposalState
 from trip_planner.persistence.models.trip import PersistedTrip
 from trip_planner.state import ScenarioVersion
+
+logger = logging.getLogger(__name__)
 
 
 class WorkspaceProposalNotFoundError(ValueError):
@@ -388,8 +391,14 @@ def _resolve_evaluation_response(
             operation="fetch_evaluation_result",
         )
         if transport_error is None:
+            reference_id = uuid4().hex
+            logger.exception(
+                "TPP evaluation transport failed unexpectedly (reference_id=%s)",
+                reference_id,
+            )
             transport_error = TPPTransportError(
-                f"TPP fetch_evaluation_result transport failed unexpectedly: {exc}.",
+                "TPP fetch_evaluation_result transport failed unexpectedly. "
+                f"Reference ID: {reference_id}.",
                 error_code="unknown",
                 status_code=502,
                 retryable=False,

--- a/trip_planner/integrations/tpp/client.py
+++ b/trip_planner/integrations/tpp/client.py
@@ -92,6 +92,7 @@ class TPPTransportError(RuntimeError):
         ] = "unknown",
         status_code: int = 502,
         retryable: bool = False,
+        reference_id: str | None = None,
     ) -> None:
         if error_code not in self.VALID_ERROR_CODES:
             raise ValueError(
@@ -102,6 +103,7 @@ class TPPTransportError(RuntimeError):
         self.error_code = error_code
         self.status_code = status_code
         self.retryable = retryable
+        self.reference_id = reference_id
 
 
 class TPPConfigurationError(TPPTransportError):


### PR DESCRIPTION
Closes #1687

## Summary
- Replace raw exception interpolation across workspace-facing API routes with stable public messages and correlation references.
- Log original exceptions server-side, including the response reference ID, so sensitive upstream details stay out of HTTP bodies.
- Preserve existing HTTP status codes and add a named disclosure regression test.

## Validation
- `uv run pytest tests/app/test_policy.py::test_route_does_not_disclose_upstream_exception_text -q` (passed)
- `uv run pytest tests/app/test_policy.py tests/app/test_proposal.py tests/app/test_budget_routes.py tests/app/test_planner_routes.py tests/app/test_workspace.py -q` (154 passed)
- `uv run ruff check --select F,I ...` and `uv run black --check ...` (passed)
- `grep -rn "detail=str(" trip_planner/app/routes/` returned no matches.

## Deliberate-break evidence
Temporarily restoring `detail=str(error)` in `trip_planner/app/routes/policy.py` made `test_route_does_not_disclose_upstream_exception_text` fail because the sentinel secret appeared in the HTTP response. The safe handler was restored and the named test passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized error messages across budget, planner, policy, proposal, and workspace operations.
  - Preserved appropriate HTTP status codes for validation, missing-resource, and service failures.
  - Prevented internal exception details from appearing in responses while providing a reference ID for troubleshooting.
  - Improved consistency and reliability of API error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->