### PR TITLE
fix: unify ingestion confidence semantics

### DIFF
--- a/tests/ingestion/test_common_helpers.py
+++ b/tests/ingestion/test_common_helpers.py
@@ -1,6 +1,13 @@
+from trip_planner.ingestion import (
+    activity_pipeline,
+    destination_pipeline,
+    lodging_pipeline,
+    transport_pipeline,
+)
 from trip_planner.ingestion._common import (
     IngestionSummary,
     IngestionWarning,
+    _lowest_match_confidence,
     _record_ids_for_decision,
     _records_for_decision,
     make_handoff,
@@ -13,6 +20,7 @@ from trip_planner.sources import (
     DeduplicationDecision,
     EntityResolution,
     MatchCandidate,
+    MergedEntityProvenance,
     ProvenanceReference,
     RawSnapshot,
     RawSourceRecord,
@@ -132,6 +140,63 @@ def test_unresolved_conflicts_excludes_selected_status() -> None:
     unresolved = unresolved_conflicts([selected, needs_review, preserved])
 
     assert unresolved == [needs_review, preserved]
+
+
+def test_lowest_match_confidence_is_status_aware() -> None:
+    match = EntityResolution(
+        resolution_id="resolution-match",
+        entity_scope="lodging",
+        option_kind="lodging",
+        status="match",
+        canonical_entity_id="lodging-match",
+        summary="Matched records retain their lowest candidate confidence.",
+        match_candidates=[
+            MatchCandidate(
+                candidate_id="candidate-high",
+                entity_scope="lodging",
+                option_kind="lodging",
+                match_strategy="provider_id",
+                confidence=0.9,
+            ),
+            MatchCandidate(
+                candidate_id="candidate-low",
+                entity_scope="lodging",
+                option_kind="lodging",
+                match_strategy="provider_id",
+                confidence=0.8,
+            ),
+        ],
+    )
+    ambiguous = EntityResolution(
+        resolution_id="resolution-ambiguous",
+        entity_scope="lodging",
+        option_kind="lodging",
+        status="ambiguous",
+        canonical_entity_id="lodging-ambiguous",
+        summary="Unresolved identity remains low confidence without candidates.",
+        conflicts=[_sample_conflict(status="preserved")],
+        review_required=True,
+    )
+    distinct = EntityResolution(
+        resolution_id="resolution-distinct",
+        entity_scope="lodging",
+        option_kind="lodging",
+        status="distinct",
+        canonical_entity_id="lodging-distinct",
+        summary="Confirmed distinct records have no candidate match.",
+        merged_provenance=MergedEntityProvenance(
+            canonical_entity_id="lodging-distinct",
+            entity_scope="lodging",
+        ),
+    )
+
+    assert _lowest_match_confidence(match) == 0.8
+    assert _lowest_match_confidence(ambiguous) == 0.0
+    assert _lowest_match_confidence(distinct) == 1.0
+    assert activity_pipeline._lowest_match_confidence is _lowest_match_confidence
+    assert destination_pipeline._lowest_match_confidence is _lowest_match_confidence
+    assert lodging_pipeline._lowest_match_confidence is _lowest_match_confidence
+    assert transport_pipeline._lowest_match_confidence is _lowest_match_confidence
 
 
 def test_record_ids_for_decision_collects_unique_ids_in_resolution_order() -> None:

--- a/trip_planner/ingestion/_common.py
+++ b/trip_planner/ingestion/_common.py
@@ -155,6 +155,22 @@ def _resolution_for_record(
     return None
 
 
+def _lowest_match_confidence(resolution: EntityResolution) -> float:
+    """Return the least candidate confidence with explicit empty-set semantics.
+
+    A ``distinct`` resolution records a confirmed non-match, so an empty candidate
+    set is fully confident.  An empty ``ambiguous`` resolution remains unproven and
+    must be treated as low confidence.  ``match`` resolutions are contractually
+    required to include candidates; returning ``0.0`` is the safe fallback if an
+    invalid instance reaches this helper.
+    """
+    if resolution.match_candidates:
+        return min(candidate.confidence for candidate in resolution.match_candidates)
+    if resolution.status == "distinct":
+        return 1.0
+    return 0.0
+
+
 def _dedupe_conflicts(conflicts: list[AttributeConflict]) -> list[AttributeConflict]:
     deduped: list[AttributeConflict] = []
     seen: set[tuple[str, str, str]] = set()

--- a/trip_planner/ingestion/activity_pipeline.py
+++ b/trip_planner/ingestion/activity_pipeline.py
@@ -22,6 +22,7 @@ from ._common import (
     IngestionWarning,
     _contribution_kind,
     _dedupe_conflicts,
+    _lowest_match_confidence,
     _record_ids_for_decision,
     _records_for_decision,
     _resolution_for_record,
@@ -306,12 +307,6 @@ def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution |
 
 def _separate_option_id(canonical_entity_id: str, record: RawSourceRecord) -> str:
     return f"{canonical_entity_id}-{record.record_id}"
-
-
-def _lowest_match_confidence(resolution: EntityResolution) -> float:
-    if not resolution.match_candidates:
-        return 0.0
-    return min(candidate.confidence for candidate in resolution.match_candidates)
 
 
 def _merge_string_lists(*lists: Any) -> list[str]:

--- a/trip_planner/ingestion/destination_pipeline.py
+++ b/trip_planner/ingestion/destination_pipeline.py
@@ -22,6 +22,7 @@ from ._common import (
     IngestionWarning,
     _contribution_kind,
     _dedupe_conflicts,
+    _lowest_match_confidence,
     _record_ids_for_decision,
     _records_for_decision,
     _resolution_for_record,
@@ -405,12 +406,6 @@ def _canonical_destination_id(record: RawSourceRecord, resolution: EntityResolut
 
 def _separate_destination_id(canonical_entity_id: str, record: RawSourceRecord) -> str:
     return f"{canonical_entity_id}-{record.record_id}"
-
-
-def _lowest_match_confidence(resolution: EntityResolution) -> float:
-    if not resolution.match_candidates:
-        return 0.0
-    return min(candidate.confidence for candidate in resolution.match_candidates)
 
 
 def _merge_sequence(existing: Any, incoming: Any) -> list[Any]:

--- a/trip_planner/ingestion/lodging_pipeline.py
+++ b/trip_planner/ingestion/lodging_pipeline.py
@@ -21,6 +21,7 @@ from ._common import (
     IngestionSummary,
     IngestionWarning,
     _dedupe_conflicts,
+    _lowest_match_confidence,
     _record_ids_for_decision,
     _records_for_decision,
     _resolution_for_record,
@@ -289,9 +290,3 @@ def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution |
 
 def _separate_option_id(canonical_entity_id: str, record: RawSourceRecord) -> str:
     return f"{canonical_entity_id}-{record.record_id}"
-
-
-def _lowest_match_confidence(resolution: EntityResolution) -> float:
-    if not resolution.match_candidates:
-        return 1.0
-    return min(candidate.confidence for candidate in resolution.match_candidates)

--- a/trip_planner/ingestion/transport_pipeline.py
+++ b/trip_planner/ingestion/transport_pipeline.py
@@ -20,6 +20,7 @@ from ._common import (
     IngestionSummary,
     IngestionWarning,
     _dedupe_conflicts,
+    _lowest_match_confidence,
     _record_ids_for_decision,
     _records_for_decision,
     _resolution_for_record,
@@ -283,9 +284,3 @@ def _canonical_option_id(record: RawSourceRecord, resolution: EntityResolution |
 
 def _separate_option_id(canonical_entity_id: str, record: RawSourceRecord) -> str:
     return f"{canonical_entity_id}-{record.record_id}"
-
-
-def _lowest_match_confidence(resolution: EntityResolution) -> float:
-    if not resolution.match_candidates:
-        return 1.0
-    return min(candidate.confidence for candidate in resolution.match_candidates)


### PR DESCRIPTION
Closes #1689

## Summary
- Consolidate `_lowest_match_confidence` in the ingestion common helpers.
- Define empty-candidate confidence by resolution status: confirmed distinct is `1.0`; ambiguous is `0.0`.
- Route all four ingestion pipelines to the shared helper and assert import identity.

## Validation
- `uv run pytest tests/ingestion/test_common_helpers.py::test_lowest_match_confidence_is_status_aware -q` (passed)
- `uv run pytest tests/ingestion/ -q` (29 passed)
- `uv run ruff check --select I trip_planner/ingestion/_common.py trip_planner/ingestion/activity_pipeline.py trip_planner/ingestion/destination_pipeline.py trip_planner/ingestion/lodging_pipeline.py trip_planner/ingestion/transport_pipeline.py tests/ingestion/test_common_helpers.py` (passed)
- `git diff --check` (passed)

## Deliberate-break evidence
Temporarily reinstating a local lodging `_lowest_match_confidence` made the named shared-helper test fail on the identity assertion; removing it restored the passing test.