### PR TITLE
feat: add workspace complexity guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  complexity-guard:
+    name: Complexity guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Reject changed functions above the recorded complexity ceiling
+        run: python scripts/measure_complexity.py --changed-from origin/main --max-complexity 59
+
   python:
     name: Python CI
     uses: stranske/Workflows/.github/workflows/reusable-10-ci-python.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,13 @@ jobs:
     name: Complexity guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
 
       - name: Reject changed functions above the recorded complexity ceiling
         run: python scripts/measure_complexity.py --changed-from origin/main --max-complexity 59

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -85,9 +85,13 @@ jobs:
     if: ${{ needs.detect.outputs.is_python_code == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.14'
 
       - name: Reject changed functions above the recorded complexity ceiling
         run: >-

--- a/.github/workflows/pr-00-gate.yml
+++ b/.github/workflows/pr-00-gate.yml
@@ -79,6 +79,22 @@ jobs:
       cache: false
     secrets: inherit
 
+  complexity-guard:
+    name: Complexity guard
+    needs: detect
+    if: ${{ needs.detect.outputs.is_python_code == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Reject changed functions above the recorded complexity ceiling
+        run: >-
+          python scripts/measure_complexity.py
+          --changed-from ${{ github.event.pull_request.base.sha || 'origin/main' }}
+          --max-complexity 59
+
   cross-repo-smoke:
     name: Cross-Repo Smoke
     needs: detect
@@ -117,7 +133,7 @@ jobs:
 
   summary:
     name: gate-summary
-    needs: [detect, python-ci, runtime-ci, cross-repo-smoke]
+    needs: [detect, python-ci, complexity-guard, runtime-ci, cross-repo-smoke]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
@@ -140,12 +156,14 @@ jobs:
         env:
           DETECT_RESULT: ${{ needs.detect.result || 'skipped' }}
           PYTHON_RESULT: ${{ needs.python-ci.result || 'skipped' }}
+          COMPLEXITY_RESULT: ${{ needs.complexity-guard.result || 'skipped' }}
           RUNTIME_RESULT: ${{ needs.runtime-ci.result || 'skipped' }}
           CROSS_REPO_RESULT: ${{ needs.cross-repo-smoke.result || 'skipped' }}
         run: |
           set -euo pipefail
 
           python_result="${PYTHON_RESULT:-skipped}"
+          complexity_result="${COMPLEXITY_RESULT:-skipped}"
           runtime_result="${RUNTIME_RESULT:-skipped}"
           cross_repo_result="${CROSS_REPO_RESULT:-skipped}"
           state="success"
@@ -161,20 +179,23 @@ jobs:
           if [ "$python_result" = "failure" ]; then
             state="failure"
             description="Python CI failed"
+          elif [ "$complexity_result" = "failure" ]; then
+            state="failure"
+            description="Complexity guard failed"
           elif [ "$runtime_result" = "failure" ]; then
             state="failure"
             description="Runtime CI failed"
           elif [ "$cross_repo_result" = "failure" ]; then
             state="failure"
             description="Cross-repo smoke check failed"
-          elif [ "$python_result" = "cancelled" ] || [ "$runtime_result" = "cancelled" ] || [ "$cross_repo_result" = "cancelled" ]; then
+          elif [ "$python_result" = "cancelled" ] || [ "$complexity_result" = "cancelled" ] || [ "$runtime_result" = "cancelled" ] || [ "$cross_repo_result" = "cancelled" ]; then
             state="error"
             description="Checks were cancelled"
-          elif is_terminal_ok "$python_result" && is_terminal_ok "$runtime_result" && is_terminal_ok "$cross_repo_result"; then
+          elif is_terminal_ok "$python_result" && is_terminal_ok "$complexity_result" && is_terminal_ok "$runtime_result" && is_terminal_ok "$cross_repo_result"; then
             state="success"
             ran=()
             skipped=()
-            for pair in "Python CI:$python_result" "runtime CI:$runtime_result" "cross-repo smoke:$cross_repo_result"; do
+            for pair in "Python CI:$python_result" "complexity guard:$complexity_result" "runtime CI:$runtime_result" "cross-repo smoke:$cross_repo_result"; do
               name="${pair%%:*}"
               result="${pair#*:}"
               if [ "$result" = "success" ]; then

--- a/langsmith-fleet-worker-attempt.json
+++ b/langsmith-fleet-worker-attempt.json
@@ -1,13 +1,13 @@
 {
   "agent": "codex",
   "cli_version": "0.144.1",
-  "emitted_at": "2026-08-12T14:05:45.697012Z",
+  "emitted_at": "2026-08-12T22:05:04.954466Z",
   "execution_profile": "codex-default",
   "fallback_models": [
     "gpt-5.5"
   ],
   "operation_role": "worker",
-  "pr_number": "1706",
+  "pr_number": "1710",
   "requested_model": "gpt-5.6-terra",
   "runner": "reusable-codex-run",
   "schema": "langsmith-fleet/v1",

--- a/scripts/measure_complexity.py
+++ b/scripts/measure_complexity.py
@@ -32,15 +32,30 @@ class FunctionMetric:
     complexity: int
 
 
-def _complexity(node: ast.AST) -> int:
+def _nodes_in_function_scope(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[ast.AST]:
+    pending = list(node.body)
+    nodes: list[ast.AST] = []
+    nested_scopes = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+    while pending:
+        child = pending.pop()
+        if isinstance(child, nested_scopes):
+            continue
+        nodes.append(child)
+        pending.extend(ast.iter_child_nodes(child))
+    return nodes
+
+
+def _complexity(node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
     decisions = 1
-    for child in ast.walk(node):
+    for child in _nodes_in_function_scope(node):
         if isinstance(child, _DECISION_NODES):
             decisions += 1
         elif isinstance(child, ast.BoolOp):
             decisions += len(child.values) - 1
         elif isinstance(child, ast.comprehension):
-            decisions += len(child.ifs)
+            decisions += 1 + len(child.ifs)
         elif isinstance(child, ast.Match):
             decisions += max(0, len(child.cases) - 1)
     return decisions

--- a/scripts/measure_complexity.py
+++ b/scripts/measure_complexity.py
@@ -1,0 +1,167 @@
+"""Measure function size and cyclomatic complexity for changed product code.
+
+The guard intentionally evaluates only functions that overlap the pull-request
+diff. Existing debt stays visible in the report without blocking unrelated
+maintenance; a changed function may not exceed the recorded complexity ceiling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+_DECISION_NODES = (
+    ast.If,
+    ast.For,
+    ast.AsyncFor,
+    ast.While,
+    ast.ExceptHandler,
+    ast.IfExp,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionMetric:
+    path: Path
+    name: str
+    start_line: int
+    end_line: int
+    complexity: int
+
+
+def _complexity(node: ast.AST) -> int:
+    decisions = 1
+    for child in ast.walk(node):
+        if isinstance(child, _DECISION_NODES):
+            decisions += 1
+        elif isinstance(child, ast.BoolOp):
+            decisions += len(child.values) - 1
+        elif isinstance(child, ast.comprehension):
+            decisions += len(child.ifs)
+        elif isinstance(child, ast.Match):
+            decisions += max(0, len(child.cases) - 1)
+    return decisions
+
+
+def measure_file(path: Path) -> list[FunctionMetric]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    metrics: list[FunctionMetric] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            metrics.append(
+                FunctionMetric(
+                    path=path,
+                    name=node.name,
+                    start_line=node.lineno,
+                    end_line=node.end_lineno,
+                    complexity=_complexity(node),
+                )
+            )
+    return sorted(
+        metrics, key=lambda metric: (metric.path, metric.start_line, metric.name)
+    )
+
+
+def changed_line_ranges(diff: str) -> dict[Path, list[range]]:
+    """Return new-file line ranges from a ``git diff --unified=0`` payload."""
+
+    result: dict[Path, list[range]] = {}
+    current_path: Path | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current_path = Path(line.removeprefix("+++ b/"))
+            continue
+        if not line.startswith("@@ ") or current_path is None:
+            continue
+        new_span = line.split(" +", maxsplit=1)[1].split(" ", maxsplit=1)[0]
+        start_and_count = new_span.removeprefix("+").split(",", maxsplit=1)
+        start = int(start_and_count[0])
+        count = int(start_and_count[1]) if len(start_and_count) == 2 else 1
+        if count:
+            result.setdefault(current_path, []).append(range(start, start + count))
+    return result
+
+
+def changed_functions(
+    metrics: list[FunctionMetric], ranges: list[range]
+) -> list[FunctionMetric]:
+    return [
+        metric
+        for metric in metrics
+        if any(
+            metric.start_line < changed_range.stop
+            and changed_range.start <= metric.end_line
+            for changed_range in ranges
+        )
+    ]
+
+
+def _git_diff(base_ref: str, root: Path) -> str:
+    return subprocess.run(
+        ["git", "diff", "--unified=0", f"{base_ref}...HEAD", "--", str(root)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path("trip_planner"))
+    parser.add_argument(
+        "--changed-from", help="Git ref used to limit enforcement to changed functions"
+    )
+    parser.add_argument("--max-complexity", type=int, default=59)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    source_files = sorted(args.root.rglob("*.py"))
+    all_metrics = [metric for path in source_files for metric in measure_file(path)]
+
+    if not args.changed_from:
+        for metric in all_metrics:
+            print(
+                f"{metric.path}:{metric.start_line}-{metric.end_line} "
+                f"{metric.name} complexity={metric.complexity}"
+            )
+        return 0
+
+    ranges_by_path = changed_line_ranges(_git_diff(args.changed_from, args.root))
+    guarded = [
+        metric
+        for metric in all_metrics
+        if metric.path in ranges_by_path
+        for metric in changed_functions([metric], ranges_by_path[metric.path])
+    ]
+    violations = [
+        metric for metric in guarded if metric.complexity > args.max_complexity
+    ]
+    if violations:
+        for metric in violations:
+            print(
+                f"ERROR: {metric.path}:{metric.start_line} {metric.name} has complexity "
+                f"{metric.complexity}; the changed-function ceiling is {args.max_complexity}.",
+            )
+        return 1
+
+    for metric in guarded:
+        print(
+            f"{metric.path}:{metric.start_line}-{metric.end_line} "
+            f"{metric.name} complexity={metric.complexity}",
+        )
+
+    print(
+        f"Changed-function complexity guard passed: {len(guarded)} function(s) at or below "
+        f"{args.max_complexity}.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/measure_complexity.py
+++ b/scripts/measure_complexity.py
@@ -35,7 +35,7 @@ class FunctionMetric:
 def _nodes_in_function_scope(
     node: ast.FunctionDef | ast.AsyncFunctionDef,
 ) -> list[ast.AST]:
-    pending = list(node.body)
+    pending: list[ast.AST] = list(node.body)
     nodes: list[ast.AST] = []
     nested_scopes = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
     while pending:
@@ -72,7 +72,7 @@ def measure_file(path: Path) -> list[FunctionMetric]:
                     path=path,
                     name=node.name,
                     start_line=node.lineno,
-                    end_line=node.end_lineno,
+                    end_line=node.end_lineno if node.end_lineno is not None else node.lineno,
                     complexity=_complexity(node),
                 )
             )

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -45,6 +45,13 @@ _FIXTURE_ADAPTER_MARKERS = {
     "Kyoto ranked scenario workspace",
     "Client summit ranked scenarios",
 }
+_WORKSPACE_MODULE_LINE_CEILING = 4350
+
+
+def test_workspace_module_stays_under_size_ceiling() -> None:
+    workspace_path = Path(workspace_service.__file__)
+
+    assert len(workspace_path.read_text(encoding="utf-8").splitlines()) <= _WORKSPACE_MODULE_LINE_CEILING
 
 
 def _assert_payload_avoids_fixture_or_default_inventory_data(payload: dict[str, Any]) -> None:

--- a/tests/app/test_workspace.py
+++ b/tests/app/test_workspace.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from trip_planner.app.main import create_app
 from trip_planner.app.services import proposal as proposal_service
 from trip_planner.app.services import workspace as workspace_service
+from trip_planner.app.services import workspace_fixtures
 from trip_planner.app.services.auth import AuthenticatedUser, create_account
 from trip_planner.app.services.feasibility import (
     build_feasibility_planner_outputs,
@@ -52,6 +53,18 @@ def test_workspace_module_stays_under_size_ceiling() -> None:
     workspace_path = Path(workspace_service.__file__)
 
     assert len(workspace_path.read_text(encoding="utf-8").splitlines()) <= _WORKSPACE_MODULE_LINE_CEILING
+
+
+def test_load_saved_scenarios_allows_entries_without_a_comparison(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "no-comparison.json").write_text('{"records": []}', encoding="utf-8")
+    monkeypatch.setattr(workspace_fixtures, "_state_fixture_dir", lambda _kind: tmp_path)
+
+    records, comparison = workspace_fixtures.load_saved_scenarios("no-comparison.json")
+
+    assert records == []
+    assert comparison is None
 
 
 def _assert_payload_avoids_fixture_or_default_inventory_data(payload: dict[str, Any]) -> None:

--- a/tests/test_measure_complexity.py
+++ b/tests/test_measure_complexity.py
@@ -1,0 +1,94 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.measure_complexity import (
+    changed_functions,
+    changed_line_ranges,
+    measure_file,
+)
+
+
+def test_measure_complexity_counts_boolean_and_branch_decisions(tmp_path: Path) -> None:
+    source = tmp_path / "sample.py"
+    source.write_text(
+        "def guarded(value):\n"
+        "    if value and value > 1:\n"
+        "        return value\n"
+        "    return 0\n",
+        encoding="utf-8",
+    )
+
+    metric = measure_file(source)[0]
+
+    assert metric.complexity == 3
+
+
+def test_changed_function_guard_selects_only_functions_touched_by_diff(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "sample.py"
+    source.write_text(
+        "def unchanged():\n"
+        "    return 1\n\n"
+        "def changed(value):\n"
+        "    if value:\n"
+        "        return 1\n"
+        "    return 0\n",
+        encoding="utf-8",
+    )
+    diff = "+++ b/sample.py\n@@ -4,0 +5,1 @@\n+    if value:\n"
+
+    selected = changed_functions(
+        measure_file(source), changed_line_ranges(diff)[Path("sample.py")]
+    )
+
+    assert [metric.name for metric in selected] == ["changed"]
+
+
+def test_complexity_cli_rejects_a_changed_function_over_the_ceiling(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "trip_planner"
+    source_root.mkdir()
+    source = source_root / "sample.py"
+    source.write_text("def guarded():\n    return 0\n", encoding="utf-8")
+    for command in (
+        ["git", "init", "--quiet"],
+        ["git", "config", "user.email", "tests@example.com"],
+        ["git", "config", "user.name", "Complexity tests"],
+        ["git", "add", "trip_planner/sample.py"],
+        ["git", "commit", "--quiet", "-m", "baseline"],
+    ):
+        subprocess.run(command, cwd=tmp_path, check=True)
+
+    source.write_text(
+        "def guarded(value):\n"
+        "    if value == 0:\n        return 0\n"
+        "    if value == 1:\n        return 1\n"
+        "    if value == 2:\n        return 2\n"
+        "    return 3\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", "trip_planner/sample.py"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "--quiet", "-m", "deliberate break"], cwd=tmp_path, check=True
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parents[1] / "scripts" / "measure_complexity.py"),
+            "--changed-from",
+            "HEAD~1",
+            "--max-complexity",
+            "3",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "changed-function ceiling is 3" in result.stdout

--- a/tests/test_measure_complexity.py
+++ b/tests/test_measure_complexity.py
@@ -24,6 +24,26 @@ def test_measure_complexity_counts_boolean_and_branch_decisions(tmp_path: Path) 
     assert metric.complexity == 3
 
 
+def test_measure_complexity_excludes_nested_scopes_and_counts_generators(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "sample.py"
+    source.write_text(
+        "def guarded(items):\n"
+        "    def nested(value):\n"
+        "        if value:\n"
+        "            return value\n"
+        "        return 0\n"
+        "    return [item for item in items for _ in range(2) if item]\n",
+        encoding="utf-8",
+    )
+
+    metric = measure_file(source)[0]
+
+    assert metric.name == "guarded"
+    assert metric.complexity == 4
+
+
 def test_changed_function_guard_selects_only_functions_touched_by_diff(
     tmp_path: Path,
 ) -> None:

--- a/trip_planner/app/services/workspace.py
+++ b/trip_planner/app/services/workspace.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import secrets
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
 
 from sqlalchemy import select
@@ -35,6 +33,12 @@ from trip_planner.app.services.scenarios import (
     build_scenario_ranking_outputs,
     build_scenario_ranking_payload,
     build_workspace_scenario_search,
+)
+from trip_planner.app.services.workspace_fixtures import (
+    FIXTURES,
+    load_saved_scenarios,
+    load_session,
+    load_trip_record,
 )
 from trip_planner.contracts import MoneyRange
 from trip_planner.contracts.trip import Trip
@@ -68,17 +72,8 @@ from trip_planner.state import (
     PersistedTripRecord,
     PlanningSessionState,
     SavedScenarioRecord,
-    ScenarioComparison,
     TripLifecycle,
 )
-
-
-@dataclass(frozen=True, slots=True)
-class WorkspaceFixture:
-    trip_fixture: str
-    scenarios_fixture: str
-    session_fixture: str
-    scenario_search_variant: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -152,52 +147,6 @@ _BOOTSTRAP_SCENARIO_SCORE_BY_LABEL = {
 
 class WorkspaceTripNotFoundError(ValueError):
     """Raised when a workspace trip does not exist for the authenticated user."""
-
-
-_FIXTURES: dict[str, WorkspaceFixture] = {
-    "trip-leisure-kyoto-draft": WorkspaceFixture(
-        trip_fixture="leisure_draft_trip.json",
-        scenarios_fixture="leisure_baseline_vs_fallback.json",
-        session_fixture="active_leisure_session.json",
-        scenario_search_variant="leisure",
-    ),
-    "trip-business-client-summit": WorkspaceFixture(
-        trip_fixture="business_active_trip.json",
-        scenarios_fixture="business_compliant_vs_exception.json",
-        session_fixture="business_review_session.json",
-        scenario_search_variant="business",
-    ),
-}
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[3]
-
-
-def _state_fixture_dir(kind: str) -> Path:
-    return _repo_root() / "tests" / "fixtures" / "state" / kind
-
-
-def _load_json(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _load_trip_record(name: str) -> PersistedTripRecord:
-    return PersistedTripRecord.from_dict(_load_json(_state_fixture_dir("trips") / name))
-
-
-def _load_saved_scenarios(
-    name: str,
-) -> tuple[list[SavedScenarioRecord], ScenarioComparison | None]:
-    payload = _load_json(_state_fixture_dir("scenarios") / name)
-    records = [SavedScenarioRecord.from_dict(item) for item in payload["records"]]
-    comparison = payload.get("comparison")
-    return records, (ScenarioComparison.from_dict(comparison) if comparison is not None else None)
-
-
-def _load_session(name: str) -> PlanningSessionState:
-    payload = _load_json(_state_fixture_dir("sessions") / name)
-    return PlanningSessionState.from_dict(payload["session"])
 
 
 def _canonicalize_saved_scenario_ids(
@@ -2528,7 +2477,7 @@ def _build_runtime_scenario_comparison_payload(
     user: AuthenticatedUser,
     trip_id: str,
 ) -> dict[str, Any] | None:
-    fixture = _FIXTURES.get(trip_id)
+    fixture = FIXTURES.get(trip_id)
     if fixture is not None:
         _db_record = db_session.scalar(
             select(PersistedTrip)
@@ -2538,8 +2487,8 @@ def _build_runtime_scenario_comparison_payload(
         if _db_record is not None:
             fixture = None
     if fixture is not None:
-        trip_record = _load_trip_record(fixture.trip_fixture)
-        session = _load_session(fixture.session_fixture)
+        trip_record = load_trip_record(fixture.trip_fixture)
+        session = load_session(fixture.session_fixture)
         inventory_bundles = assemble_inventory_bundles_for_trip(
             trip_id=trip_id,
             trip_mode=trip_record.trip.mode,
@@ -3287,10 +3236,10 @@ def _build_fixture_workspace_payload(
     trip_id: str,
     include_debug: bool,
 ) -> dict[str, Any]:
-    fixture = _FIXTURES[trip_id]
-    trip_record = _load_trip_record(fixture.trip_fixture)
-    saved_scenarios, scenario_comparison = _load_saved_scenarios(fixture.scenarios_fixture)
-    session = _load_session(fixture.session_fixture)
+    fixture = FIXTURES[trip_id]
+    trip_record = load_trip_record(fixture.trip_fixture)
+    saved_scenarios, scenario_comparison = load_saved_scenarios(fixture.scenarios_fixture)
+    session = load_session(fixture.session_fixture)
     _canonicalize_saved_scenario_ids(session, saved_scenarios)
     inventory_assembly_input = _build_inventory_assembly_input(
         trip_id=trip_id,
@@ -3534,7 +3483,7 @@ def get_workspace_payload(
     trip_id: str,
     include_debug: bool = True,
 ) -> dict[str, Any] | None:
-    fixture = _FIXTURES.get(trip_id)
+    fixture = FIXTURES.get(trip_id)
     if fixture is not None:
         db_record = db_session.scalar(
             select(PersistedTrip)

--- a/trip_planner/app/services/workspace_fixtures.py
+++ b/trip_planner/app/services/workspace_fixtures.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from trip_planner.state import (
+    PersistedTripRecord,
+    PlanningSessionState,
+    SavedScenarioRecord,
+    ScenarioComparison,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceFixture:
+    trip_fixture: str
+    scenarios_fixture: str
+    session_fixture: str
+    scenario_search_variant: str
+
+
+FIXTURES: dict[str, WorkspaceFixture] = {
+    "trip-leisure-kyoto-draft": WorkspaceFixture(
+        trip_fixture="leisure_draft_trip.json",
+        scenarios_fixture="leisure_baseline_vs_fallback.json",
+        session_fixture="active_leisure_session.json",
+        scenario_search_variant="leisure",
+    ),
+    "trip-business-client-summit": WorkspaceFixture(
+        trip_fixture="business_active_trip.json",
+        scenarios_fixture="business_compliant_vs_exception.json",
+        session_fixture="business_review_session.json",
+        scenario_search_variant="business",
+    ),
+}
+
+
+def _state_fixture_dir(kind: str) -> Path:
+    return Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "state" / kind
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_trip_record(name: str) -> PersistedTripRecord:
+    return PersistedTripRecord.from_dict(_load_json(_state_fixture_dir("trips") / name))
+
+
+def load_saved_scenarios(
+    name: str,
+) -> tuple[list[SavedScenarioRecord], ScenarioComparison | None]:
+    payload = _load_json(_state_fixture_dir("scenarios") / name)
+    records = [SavedScenarioRecord.from_dict(item) for item in payload["records"]]
+    comparison = payload.get("comparison")
+    return records, (
+        ScenarioComparison.from_dict(comparison) if comparison is not None else None
+    )
+
+
+def load_session(name: str) -> PlanningSessionState:
+    payload = _load_json(_state_fixture_dir("sessions") / name)
+    return PlanningSessionState.from_dict(payload["session"])


### PR DESCRIPTION
## Summary

Part of #1690: establish the guard-first baseline before further workspace decomposition.

- add a changed-function cyclomatic-complexity guard to CI and Gate aggregation
- add a 4,350-line ceiling for the workspace service
- extract fixture loading into a focused service module, reducing workspace.py from 4,399 to 4,348 lines

## Validation

- `python -m pytest tests/test_measure_complexity.py tests/app/test_workspace.py -q` (70 passed)
- `ruff check scripts/measure_complexity.py tests/test_measure_complexity.py trip_planner/app/services/workspace.py trip_planner/app/services/workspace_fixtures.py --ignore SIM117`
- `git diff --check`

## Deliberate break

`test_complexity_cli_rejects_a_changed_function_over_the_ceiling` commits a temporary over-ceiling function and confirms the CLI fails before restoring the passing baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks to detect excessive complexity in changed Python functions.
  * Added complexity status reporting to pull request validation.
* **Bug Fixes**
  * Improved loading of workspace fixtures and saved scenario comparisons.
* **Tests**
  * Expanded coverage for complexity analysis, enforcement, and workspace scenarios.
  * Added safeguards against excessive workspace module growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->