### PR TITLE
fix(policy): expose approval packet action in panel

### DIFF
--- a/frontend/src/components/workspace/panels/PolicyPanel.test.tsx
+++ b/frontend/src/components/workspace/panels/PolicyPanel.test.tsx
@@ -1,0 +1,19 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PolicyPanel } from "./PolicyPanel";
+
+describe("PolicyPanel", () => {
+  it("offers an enabled action when no approval packet exists", () => {
+    const onPrepare = vi.fn();
+
+    render(<PolicyPanel approvalPacketContent={null} noPacketAction={{ onPrepare }} />);
+
+    expect(screen.getByRole("heading", { name: "No approval packet yet" })).toBeInTheDocument();
+    const action = screen.getByRole("button", { name: "Prepare approval packet" });
+    expect(action).toBeEnabled();
+
+    fireEvent.click(action);
+    expect(onPrepare).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/workspace/panels/PolicyPanel.tsx
+++ b/frontend/src/components/workspace/panels/PolicyPanel.tsx
@@ -4,16 +4,34 @@ type PolicyPanelProps = {
   approvalPacketContent: ReactNode | null;
   approvalDetailsContent?: ReactNode | null;
   grid?: boolean;
+  noPacketAction?: {
+    onPrepare: () => void;
+  } | null;
 };
 
 export function PolicyPanel({
   approvalPacketContent,
   approvalDetailsContent = null,
   grid = false,
+  noPacketAction = null,
 }: PolicyPanelProps) {
   const content = (
     <>
-      {approvalPacketContent ? (
+      {noPacketAction ? (
+        <section className="status-card" data-testid="approval-packet">
+          <p className="status-label">Approval packet</p>
+          <h2>No approval packet yet</h2>
+          <p className="muted-copy">
+            Approval packet records have not been saved for this workspace yet.
+          </p>
+          <p className="muted-copy">
+            Start in Plan to prepare the trip details that policy review needs.
+          </p>
+          <button type="button" onClick={noPacketAction.onPrepare}>
+            Prepare approval packet
+          </button>
+        </section>
+      ) : approvalPacketContent ? (
         <section className="status-card" data-testid="approval-packet">
           {approvalPacketContent}
         </section>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -2429,27 +2429,19 @@ function WorkspacePageContent({
         <PolicyTabPanel labelledBy={workspaceTabButtonId("policy")}>
           <WorkspacePolicyPanel
             grid
+            noPacketAction={
+              currentWorkspace.proposal_state == null
+                ? { onPrepare: handlePrepareApprovalPacket }
+                : null
+            }
             approvalPacketContent={
-              panelVisibility.showApprovalReadinessPanel ? (
+              panelVisibility.showApprovalReadinessPanel && currentWorkspace.proposal_state != null ? (
                 <>
                 <p className="status-label">Approval packet</p>
                 <h2 data-testid="proposal-lifecycle">
                   {proposalLifecycle?.title ?? "Proposal lifecycle in progress"}
                 </h2>
-                {currentWorkspace.proposal_state == null ? (
-                  <>
-                    <p className="muted-copy">
-                      Approval packet records have not been saved for this workspace yet.
-                    </p>
-                    <p className="muted-copy">
-                      Start in Plan to prepare the trip details that policy review needs.
-                    </p>
-                    <button type="button" onClick={handlePrepareApprovalPacket}>
-                      Prepare approval packet
-                    </button>
-                  </>
-                ) : (
-                  <>
+                <>
                     <div aria-live="polite" role="status">
                       {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
                       {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
@@ -2497,8 +2489,7 @@ function WorkspacePageContent({
                         {proposalLifecycle?.state === "failed" ? "Retry policy check" : "Refresh live status"}
                       </button>
                     ) : null}
-                  </>
-                )}
+                </>
                 </>
               ) : null
             }


### PR DESCRIPTION
Follow-up for #1678; this does not close the source issue. It moves the no-packet action into PolicyPanel, preserves the accessible Plan handoff, and adds the named enabled-action regression test. Validation: npx vitest run src/components/workspace/panels/PolicyPanel.test.tsx src/routes/WorkspacePage.test.tsx -t 'offers a direct path to prepare an approval packet when none exists'; npm run build.