### PR TITLE
fix(maps): expose observed provider readiness

### DIFF
--- a/frontend/e2e/two-trip-canary.spec.ts
+++ b/frontend/e2e/two-trip-canary.spec.ts
@@ -48,6 +48,7 @@ async function createTripThroughApp(page: Page, input: TripInput): Promise<strin
   if (process.env.VITE_GOOGLE_MAPS_BROWSER_API_KEY?.trim()) {
     await page.getByRole("tab", { name: "Map", exact: true }).click();
     await expect(page.locator('[data-google-maps-live="true"]')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('[data-provider-surface="rendered"]')).toBeVisible();
     await expect(page.getByText("Live Google Maps", { exact: true })).toBeVisible();
     await page.getByRole("tab", { name: "Compare", exact: true }).click();
   }

--- a/frontend/src/components/maps/TripMap.tsx
+++ b/frontend/src/components/maps/TripMap.tsx
@@ -634,6 +634,7 @@ function GoogleMapsProviderMap({
               ? "error"
               : "loading"
         }
+        data-google-maps-live={providerSurfaceState === "ready" ? "true" : "false"}
       />
       {showLiveCanvas ? null : children}
     </>

--- a/frontend/src/components/maps/mapSurface.test.ts
+++ b/frontend/src/components/maps/mapSurface.test.ts
@@ -746,7 +746,7 @@ describe("mapSurface", () => {
     expect(bundleMarkers.map((marker) => marker.kind)).toEqual(["lodging", "activity", "transport"]);
   });
 
-  it("treats a configured key as not observed ready", () => {
+  it("configured is not observed ready", () => {
     const model = buildTripMapSurfaceModel({
       activeScenario: kyotoBaselineScenario,
       bundles: [kyotoAnchorBundle],


### PR DESCRIPTION
Closes #1699.

This bounded verifier follow-up exposes the live Google Maps marker only after the provider canvas renders, and the gated browser canary now also requires a rendered provider surface.

Validation: focused map-surface regression and TripMap tests pass. Deliberately treating a configured key as observed-ready makes the named regression fail; restoration passes.