### PR TITLE
fix(policy): four-state PolicyPanel follow-up for #1678

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -818,6 +818,27 @@ export async function refreshWorkspaceProposalStatus(tripId: string): Promise<Wo
   return response.proposal_state;
 }
 
+export type PrepareApprovalPacketHandlers = {
+  focusPlanTab: () => void;
+  preloadPlannerSession?: (tripId: string) => Promise<unknown>;
+};
+
+/** Policy-tab entry point before an approval packet exists. */
+export function prepareApprovalPacketFromPolicyTab(
+  tripId: string,
+  handlers: PrepareApprovalPacketHandlers
+): void {
+  handlers.focusPlanTab();
+  void handlers.preloadPlannerSession?.(tripId);
+}
+
+/** Retry hook used by the service-unavailable policy state. */
+export async function retryPolicyServiceCheck(
+  tripId: string
+): Promise<WorkspaceData["proposal_state"]> {
+  return refreshWorkspaceProposalStatus(tripId);
+}
+
 export async function answerPlannerDecision(
   tripId: string,
   decisionId: string,

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -829,7 +829,9 @@ export function prepareApprovalPacketFromPolicyTab(
   handlers: PrepareApprovalPacketHandlers
 ): void {
   handlers.focusPlanTab();
-  void handlers.preloadPlannerSession?.(tripId);
+  handlers.preloadPlannerSession?.(tripId).catch(() => {
+    // Preloading the planner session is best-effort; the Plan tab reloads it.
+  });
 }
 
 /** Retry hook used by the service-unavailable policy state. */

--- a/frontend/src/components/workspace/panels/PolicyPanel.test.tsx
+++ b/frontend/src/components/workspace/panels/PolicyPanel.test.tsx
@@ -64,4 +64,79 @@ describe("PolicyPanel", () => {
       unmount();
     }
   });
+
+  it("service-unavailable retry invokes onRetry", () => {
+    const onRetry = vi.fn();
+
+    render(
+      <PolicyPanel
+        view={{
+          kind: "service-unavailable",
+          message: "The travel policy service did not respond.",
+          onRetry,
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry policy check" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("not-evaluated blocking precondition replaces prepare action", () => {
+    const onPrepare = vi.fn();
+    const onSatisfy = vi.fn();
+
+    render(
+      <PolicyPanel
+        view={{
+          kind: "not-evaluated",
+          onPrepare,
+          blockingPrecondition: {
+            message: "Approval packets are only available for business trips.",
+            actionLabel: "Open Plan to review trip mode",
+            onSatisfy,
+          },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByText("Approval packets are only available for business trips.")
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Prepare approval packet" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open Plan to review trip mode" }));
+    expect(onSatisfy).toHaveBeenCalledOnce();
+    expect(onPrepare).not.toHaveBeenCalled();
+  });
+
+  it("announces statusMessage in the live region", () => {
+    render(
+      <PolicyPanel
+        view={{
+          kind: "compliant",
+          summary: "Trip meets policy requirements.",
+        }}
+        statusMessage="Policy check completed."
+      />
+    );
+
+    const liveRegion = screen.getByTestId("policy-status-live-region");
+    expect(liveRegion).toHaveTextContent("Policy check completed.");
+  });
+
+  it("lists all non-compliant issue codes", () => {
+    render(
+      <PolicyPanel
+        view={{
+          kind: "non-compliant",
+          issueCodes: ["hotel-cap-exceeded", "missing-receipt-policy"],
+          summary: "Blocking policy issues were found.",
+        }}
+      />
+    );
+
+    const issueList = screen.getByTestId("policy-issue-codes");
+    expect(issueList).toHaveTextContent("hotel-cap-exceeded");
+    expect(issueList).toHaveTextContent("missing-receipt-policy");
+  });
 });

--- a/frontend/src/components/workspace/panels/PolicyPanel.test.tsx
+++ b/frontend/src/components/workspace/panels/PolicyPanel.test.tsx
@@ -1,19 +1,67 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { PolicyPanel } from "./PolicyPanel";
+import { PolicyPanel, type PolicyPanelView } from "./PolicyPanel";
 
 describe("PolicyPanel", () => {
-  it("offers an enabled action when no approval packet exists", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("empty state offers an action", () => {
     const onPrepare = vi.fn();
 
-    render(<PolicyPanel approvalPacketContent={null} noPacketAction={{ onPrepare }} />);
+    render(
+      <PolicyPanel
+        view={{
+          kind: "not-evaluated",
+          onPrepare,
+        }}
+      />
+    );
 
-    expect(screen.getByRole("heading", { name: "No approval packet yet" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Policy not yet evaluated" })).toBeInTheDocument();
     const action = screen.getByRole("button", { name: "Prepare approval packet" });
     expect(action).toBeEnabled();
 
     fireEvent.click(action);
     expect(onPrepare).toHaveBeenCalledOnce();
+  });
+
+  it("renders four distinct policy states", () => {
+    const views: PolicyPanelView[] = [
+      {
+        kind: "not-evaluated",
+        onPrepare: vi.fn(),
+      },
+      {
+        kind: "compliant",
+        summary: "Trip meets policy requirements.",
+      },
+      {
+        kind: "non-compliant",
+        issueCodes: ["hotel-cap-exceeded", "missing-receipt-policy"],
+        summary: "Blocking policy issues were found.",
+      },
+      {
+        kind: "service-unavailable",
+        message: "The travel policy service did not respond.",
+        onRetry: vi.fn(),
+      },
+    ];
+
+    const headings = [
+      "Policy not yet evaluated",
+      "Policy compliant",
+      "Policy non-compliant",
+      "Policy service unavailable",
+    ];
+
+    for (const [index, view] of views.entries()) {
+      const { unmount } = render(<PolicyPanel view={view} />);
+      expect(screen.getByRole("heading", { name: headings[index] })).toBeInTheDocument();
+      expect(screen.getByTestId(`policy-state-${view.kind}`)).toBeInTheDocument();
+      unmount();
+    }
   });
 });

--- a/frontend/src/components/workspace/panels/PolicyPanel.tsx
+++ b/frontend/src/components/workspace/panels/PolicyPanel.tsx
@@ -1,41 +1,193 @@
 import type { ReactNode } from "react";
 
-type PolicyPanelProps = {
-  approvalPacketContent: ReactNode | null;
-  approvalDetailsContent?: ReactNode | null;
-  grid?: boolean;
-  noPacketAction?: {
-    onPrepare: () => void;
-  } | null;
+import type { WorkspaceData } from "../../../api/workspace";
+
+export type PolicyPanelBlockingPrecondition = {
+  message: string;
+  actionLabel: string;
+  onSatisfy: () => void;
 };
 
+export type PolicyPanelView =
+  | {
+      kind: "not-evaluated";
+      onPrepare: () => void;
+      blockingPrecondition?: PolicyPanelBlockingPrecondition;
+    }
+  | {
+      kind: "compliant";
+      summary: string;
+    }
+  | {
+      kind: "non-compliant";
+      issueCodes: string[];
+      summary: string;
+    }
+  | {
+      kind: "service-unavailable";
+      message: string;
+      onRetry: () => void;
+    };
+
+type PolicyPanelProps = {
+  view: PolicyPanelView;
+  approvalDetailsContent?: ReactNode | null;
+  grid?: boolean;
+  statusMessage?: string | null;
+};
+
+function isFailedTransportStatus(status: string | null | undefined): boolean {
+  return status != null && ["failed", "error", "errored", "rejected", "invalid"].includes(status);
+}
+
+export function derivePolicyPanelView(
+  workspace: WorkspaceData,
+  handlers: {
+    onPrepare: () => void;
+    onRetry: () => void;
+    onSatisfyPrecondition: () => void;
+  }
+): PolicyPanelView {
+  const proposal = workspace.proposal_state;
+  if (proposal == null) {
+    return {
+      kind: "not-evaluated",
+      onPrepare: handlers.onPrepare,
+      blockingPrecondition:
+        workspace.trip_record.trip.mode !== "business"
+          ? {
+              message: "Approval packets are only available for business trips.",
+              actionLabel: "Open Plan to review trip mode",
+              onSatisfy: handlers.onSatisfyPrecondition,
+            }
+          : undefined,
+    };
+  }
+
+  const summary = proposal.summary;
+  const submissionStatus = summary.submission_status ?? proposal.submission_status;
+  const transportStatus = summary.evaluation_transport_status ?? proposal.evaluation_status;
+
+  if (isFailedTransportStatus(submissionStatus) || isFailedTransportStatus(transportStatus)) {
+    return {
+      kind: "service-unavailable",
+      message:
+        summary.submission_summary ??
+        "The travel policy service is unavailable. Retry after confirming connectivity.",
+      onRetry: handlers.onRetry,
+    };
+  }
+
+  if (summary.approval_ready || summary.evaluation_result_status === "compliant") {
+    return {
+      kind: "compliant",
+      summary:
+        summary.follow_up_summary ??
+        summary.submission_summary ??
+        "This workspace complies with the configured travel policy.",
+    };
+  }
+
+  if (summary.evaluation_result_status === "non_compliant") {
+    const issueCodes =
+      proposal.evaluation?.evaluation_result?.failure_reasons?.map((reason) => reason.code) ??
+      summary.highlights ??
+      [];
+    return {
+      kind: "non-compliant",
+      issueCodes: issueCodes.length > 0 ? issueCodes : ["policy-review-required"],
+      summary:
+        summary.follow_up_summary ??
+        summary.submission_summary ??
+        "Policy review found blocking issues that must be resolved.",
+    };
+  }
+
+  return {
+    kind: "not-evaluated",
+    onPrepare: handlers.onPrepare,
+  };
+}
+
+function renderPolicyState(view: PolicyPanelView, statusMessage?: string | null) {
+  const liveRegion = (
+    <div aria-live="polite" role="status" data-testid="policy-status-live-region">
+      {statusMessage ? <p className="muted-copy">{statusMessage}</p> : null}
+    </div>
+  );
+
+  switch (view.kind) {
+    case "not-evaluated":
+      return (
+        <section className="status-card" data-testid="policy-state-not-evaluated">
+          <p className="status-label">Approval packet</p>
+          <h2>Policy not yet evaluated</h2>
+          <p className="muted-copy">
+            Approval packet records have not been saved for this workspace yet, or evaluation is still
+            pending.
+          </p>
+          {view.blockingPrecondition ? (
+            <p className="planner-inline-error">{view.blockingPrecondition.message}</p>
+          ) : null}
+          {liveRegion}
+          {view.blockingPrecondition ? (
+            <button type="button" onClick={view.blockingPrecondition.onSatisfy}>
+              {view.blockingPrecondition.actionLabel}
+            </button>
+          ) : (
+            <button type="button" onClick={view.onPrepare}>
+              Prepare approval packet
+            </button>
+          )}
+        </section>
+      );
+    case "compliant":
+      return (
+        <section className="status-card" data-testid="policy-state-compliant">
+          <p className="status-label">Approval packet</p>
+          <h2>Policy compliant</h2>
+          <p className="muted-copy">{view.summary}</p>
+          {liveRegion}
+        </section>
+      );
+    case "non-compliant":
+      return (
+        <section className="status-card" data-testid="policy-state-non-compliant">
+          <p className="status-label">Approval packet</p>
+          <h2>Policy non-compliant</h2>
+          <p className="muted-copy">{view.summary}</p>
+          <ul data-testid="policy-issue-codes">
+            {view.issueCodes.map((code) => (
+              <li key={code}>{code}</li>
+            ))}
+          </ul>
+          {liveRegion}
+        </section>
+      );
+    case "service-unavailable":
+      return (
+        <section className="status-card" data-testid="policy-state-service-unavailable">
+          <p className="status-label">Approval packet</p>
+          <h2>Policy service unavailable</h2>
+          <p className="muted-copy">{view.message}</p>
+          {liveRegion}
+          <button type="button" onClick={view.onRetry}>
+            Retry policy check
+          </button>
+        </section>
+      );
+  }
+}
+
 export function PolicyPanel({
-  approvalPacketContent,
+  view,
   approvalDetailsContent = null,
   grid = false,
-  noPacketAction = null,
+  statusMessage = null,
 }: PolicyPanelProps) {
   const content = (
     <>
-      {noPacketAction ? (
-        <section className="status-card" data-testid="approval-packet">
-          <p className="status-label">Approval packet</p>
-          <h2>No approval packet yet</h2>
-          <p className="muted-copy">
-            Approval packet records have not been saved for this workspace yet.
-          </p>
-          <p className="muted-copy">
-            Start in Plan to prepare the trip details that policy review needs.
-          </p>
-          <button type="button" onClick={noPacketAction.onPrepare}>
-            Prepare approval packet
-          </button>
-        </section>
-      ) : approvalPacketContent ? (
-        <section className="status-card" data-testid="approval-packet">
-          {approvalPacketContent}
-        </section>
-      ) : null}
+      {renderPolicyState(view, statusMessage)}
       {approvalDetailsContent ? (
         <section className="status-card" data-testid="tpp-label">
           {approvalDetailsContent}

--- a/frontend/src/components/workspace/panels/PolicyPanel.tsx
+++ b/frontend/src/components/workspace/panels/PolicyPanel.tsx
@@ -31,6 +31,7 @@ export type PolicyPanelView =
 
 type PolicyPanelProps = {
   view: PolicyPanelView;
+  lifecycleContent?: ReactNode | null;
   approvalDetailsContent?: ReactNode | null;
   grid?: boolean;
   statusMessage?: string | null;
@@ -109,7 +110,11 @@ export function derivePolicyPanelView(
   };
 }
 
-function renderPolicyState(view: PolicyPanelView, statusMessage?: string | null) {
+function renderPolicyState(
+  view: PolicyPanelView,
+  statusMessage?: string | null,
+  compact = false
+) {
   const liveRegion = (
     <div aria-live="polite" role="status" data-testid="policy-status-live-region">
       {statusMessage ? <p className="muted-copy">{statusMessage}</p> : null}
@@ -122,23 +127,25 @@ function renderPolicyState(view: PolicyPanelView, statusMessage?: string | null)
         <section className="status-card" data-testid="policy-state-not-evaluated">
           <p className="status-label">Approval packet</p>
           <h2>Policy not yet evaluated</h2>
-          <p className="muted-copy">
-            Approval packet records have not been saved for this workspace yet, or evaluation is still
-            pending.
-          </p>
+          {!compact ? (
+            <p className="muted-copy">
+              Approval packet records have not been saved for this workspace yet, or evaluation is still
+              pending.
+            </p>
+          ) : null}
           {view.blockingPrecondition ? (
             <p className="planner-inline-error">{view.blockingPrecondition.message}</p>
           ) : null}
-          {liveRegion}
-          {view.blockingPrecondition ? (
+          {!compact ? liveRegion : null}
+          {!compact && view.blockingPrecondition ? (
             <button type="button" onClick={view.blockingPrecondition.onSatisfy}>
               {view.blockingPrecondition.actionLabel}
             </button>
-          ) : (
+          ) : !compact ? (
             <button type="button" onClick={view.onPrepare}>
               Prepare approval packet
             </button>
-          )}
+          ) : null}
         </section>
       );
     case "compliant":
@@ -146,8 +153,8 @@ function renderPolicyState(view: PolicyPanelView, statusMessage?: string | null)
         <section className="status-card" data-testid="policy-state-compliant">
           <p className="status-label">Approval packet</p>
           <h2>Policy compliant</h2>
-          <p className="muted-copy">{view.summary}</p>
-          {liveRegion}
+          {!compact ? <p className="muted-copy">{view.summary}</p> : null}
+          {!compact ? liveRegion : null}
         </section>
       );
     case "non-compliant":
@@ -155,13 +162,13 @@ function renderPolicyState(view: PolicyPanelView, statusMessage?: string | null)
         <section className="status-card" data-testid="policy-state-non-compliant">
           <p className="status-label">Approval packet</p>
           <h2>Policy non-compliant</h2>
-          <p className="muted-copy">{view.summary}</p>
+          {!compact ? <p className="muted-copy">{view.summary}</p> : null}
           <ul data-testid="policy-issue-codes">
             {view.issueCodes.map((code) => (
               <li key={code}>{code}</li>
             ))}
           </ul>
-          {liveRegion}
+          {!compact ? liveRegion : null}
         </section>
       );
     case "service-unavailable":
@@ -169,11 +176,13 @@ function renderPolicyState(view: PolicyPanelView, statusMessage?: string | null)
         <section className="status-card" data-testid="policy-state-service-unavailable">
           <p className="status-label">Approval packet</p>
           <h2>Policy service unavailable</h2>
-          <p className="muted-copy">{view.message}</p>
-          {liveRegion}
-          <button type="button" onClick={view.onRetry}>
-            Retry policy check
-          </button>
+          {!compact ? <p className="muted-copy">{view.message}</p> : null}
+          {!compact ? liveRegion : null}
+          {!compact ? (
+            <button type="button" onClick={view.onRetry}>
+              Retry policy check
+            </button>
+          ) : null}
         </section>
       );
   }
@@ -181,13 +190,19 @@ function renderPolicyState(view: PolicyPanelView, statusMessage?: string | null)
 
 export function PolicyPanel({
   view,
+  lifecycleContent = null,
   approvalDetailsContent = null,
   grid = false,
   statusMessage = null,
 }: PolicyPanelProps) {
   const content = (
     <>
-      {renderPolicyState(view, statusMessage)}
+      {renderPolicyState(view, statusMessage, lifecycleContent != null)}
+      {lifecycleContent ? (
+        <section className="status-card" data-testid="approval-packet">
+          {lifecycleContent}
+        </section>
+      ) : null}
       {approvalDetailsContent ? (
         <section className="status-card" data-testid="tpp-label">
           {approvalDetailsContent}

--- a/frontend/src/components/workspace/panels/PolicyPanel.tsx
+++ b/frontend/src/components/workspace/panels/PolicyPanel.tsx
@@ -79,7 +79,7 @@ export function derivePolicyPanelView(
     };
   }
 
-  if (summary.approval_ready || summary.evaluation_result_status === "compliant") {
+  if (summary.evaluation_result_status === "compliant") {
     return {
       kind: "compliant",
       summary:
@@ -90,10 +90,9 @@ export function derivePolicyPanelView(
   }
 
   if (summary.evaluation_result_status === "non_compliant") {
-    const issueCodes =
-      proposal.evaluation?.evaluation_result?.failure_reasons?.map((reason) => reason.code) ??
-      summary.highlights ??
-      [];
+    const failureCodes =
+      proposal.evaluation?.evaluation_result?.failure_reasons?.map((reason) => reason.code) ?? [];
+    const issueCodes = failureCodes.length > 0 ? failureCodes : (summary.highlights ?? []);
     return {
       kind: "non-compliant",
       issueCodes: issueCodes.length > 0 ? issueCodes : ["policy-review-required"],
@@ -104,23 +103,23 @@ export function derivePolicyPanelView(
     };
   }
 
+  if (summary.approval_ready) {
+    return {
+      kind: "compliant",
+      summary:
+        summary.follow_up_summary ??
+        summary.submission_summary ??
+        "This workspace complies with the configured travel policy.",
+    };
+  }
+
   return {
     kind: "not-evaluated",
     onPrepare: handlers.onPrepare,
   };
 }
 
-function renderPolicyState(
-  view: PolicyPanelView,
-  statusMessage?: string | null,
-  compact = false
-) {
-  const liveRegion = (
-    <div aria-live="polite" role="status" data-testid="policy-status-live-region">
-      {statusMessage ? <p className="muted-copy">{statusMessage}</p> : null}
-    </div>
-  );
-
+function renderPolicyState(view: PolicyPanelView, compact = false) {
   switch (view.kind) {
     case "not-evaluated":
       return (
@@ -136,7 +135,6 @@ function renderPolicyState(
           {view.blockingPrecondition ? (
             <p className="planner-inline-error">{view.blockingPrecondition.message}</p>
           ) : null}
-          {!compact ? liveRegion : null}
           {!compact && view.blockingPrecondition ? (
             <button type="button" onClick={view.blockingPrecondition.onSatisfy}>
               {view.blockingPrecondition.actionLabel}
@@ -154,7 +152,6 @@ function renderPolicyState(
           <p className="status-label">Approval packet</p>
           <h2>Policy compliant</h2>
           {!compact ? <p className="muted-copy">{view.summary}</p> : null}
-          {!compact ? liveRegion : null}
         </section>
       );
     case "non-compliant":
@@ -168,7 +165,6 @@ function renderPolicyState(
               <li key={code}>{code}</li>
             ))}
           </ul>
-          {!compact ? liveRegion : null}
         </section>
       );
     case "service-unavailable":
@@ -177,7 +173,6 @@ function renderPolicyState(
           <p className="status-label">Approval packet</p>
           <h2>Policy service unavailable</h2>
           {!compact ? <p className="muted-copy">{view.message}</p> : null}
-          {!compact ? liveRegion : null}
           {!compact ? (
             <button type="button" onClick={view.onRetry}>
               Retry policy check
@@ -195,9 +190,15 @@ export function PolicyPanel({
   grid = false,
   statusMessage = null,
 }: PolicyPanelProps) {
+  const compact = lifecycleContent != null;
   const content = (
     <>
-      {renderPolicyState(view, statusMessage, lifecycleContent != null)}
+      {!compact ? (
+        <div aria-live="polite" role="status" data-testid="policy-status-live-region">
+          {statusMessage ? <p className="muted-copy">{statusMessage}</p> : null}
+        </div>
+      ) : null}
+      {renderPolicyState(view, compact)}
       {lifecycleContent ? (
         <section className="status-card" data-testid="approval-packet">
           {lifecycleContent}

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -2482,6 +2482,61 @@ function WorkspacePageContent({
             grid
             view={policyPanelView}
             statusMessage={proposalStatusMessage ?? proposalBusyLabel ?? proposalError}
+            lifecycleContent={
+              panelVisibility.showApprovalReadinessPanel && currentWorkspace.proposal_state != null ? (
+                <>
+                  <p className="status-label">Approval packet</p>
+                  <h2 data-testid="proposal-lifecycle">
+                    {proposalLifecycle?.title ?? "Proposal lifecycle in progress"}
+                  </h2>
+                  <div aria-live="polite" role="status">
+                    {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
+                    {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
+                    {proposalStatusMessage ? <p className="muted-copy">{proposalStatusMessage}</p> : null}
+                  </div>
+                  <dl className="workspace-meta">
+                    <div>
+                      <dt>Approval readiness</dt>
+                      <dd>
+                        {currentWorkspace.view_model?.policy_presentation.approval_status_label ??
+                          proposalLifecycle?.readinessLabel ??
+                          "Waiting for policy review"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Packet status</dt>
+                      <dd>{currentWorkspace.proposal_state.summary.submission_status ?? "unknown"}</dd>
+                    </div>
+                    <div>
+                      <dt>Next step</dt>
+                      <dd>
+                        {currentWorkspace.view_model?.policy_presentation.next_step_label ??
+                          formatFollowUpStatus(
+                            renderableProposalFollowUp?.status ??
+                              currentWorkspace.proposal_state.summary.follow_up_status
+                          )}
+                      </dd>
+                    </div>
+                  </dl>
+                  <p>{proposalLifecycle?.summary ?? "Submission stored for later review."}</p>
+                  {shouldShowProposalRefresh(
+                    currentWorkspace.proposal_state,
+                    renderableProposalFollowUp
+                  ) || proposalLifecycle?.state === "failed" ? (
+                    <button
+                      type="button"
+                      className="secondary-button"
+                      disabled={Boolean(proposalBusyLabel)}
+                      onClick={handleProposalRefresh}
+                    >
+                      {proposalLifecycle?.state === "failed"
+                        ? "Retry policy check"
+                        : "Refresh live status"}
+                    </button>
+                  ) : null}
+                </>
+              ) : null
+            }
             approvalDetailsContent={
               panelVisibility.showProposalPanel ? (
                 <>

--- a/frontend/src/routes/WorkspacePage.tsx
+++ b/frontend/src/routes/WorkspacePage.tsx
@@ -7,8 +7,10 @@ import {
   createNotebookItem,
   deleteNotebookItem,
   fetchPlannerSession,
+  prepareApprovalPacketFromPolicyTab,
   recordWorkspaceSpendEvent,
   refreshWorkspaceProposalStatus,
+  retryPolicyServiceCheck,
   saveWorkspaceBudget,
   setNotebookFocus,
   submitPlannerTurn,
@@ -42,7 +44,7 @@ import { PlannerSidePanelSurface } from "../components/planner/PlannerSidePanelS
 import { TripComparison } from "../components/trips/TripComparison";
 import { PlanningNotebookPanel } from "../components/workspace/PlanningNotebookPanel";
 import { PlannerPanel } from "../components/workspace/panels/PlannerPanel";
-import { PolicyPanel as WorkspacePolicyPanel } from "../components/workspace/panels/PolicyPanel";
+import { derivePolicyPanelView, PolicyPanel as WorkspacePolicyPanel } from "../components/workspace/panels/PolicyPanel";
 import { RouteTradeoffsPanel } from "../components/workspace/panels/RouteTradeoffsPanel";
 import { RouteOptionWorkbench } from "../components/workspace/RouteOptionWorkbench";
 import { ScenarioComparison } from "../components/workspace/ScenarioComparison";
@@ -1693,9 +1695,58 @@ function WorkspacePageContent({
   }
 
   function handlePrepareApprovalPacket() {
-    setActiveTab("plan");
-    workspaceTabRefs.current.plan?.focus();
+    prepareApprovalPacketFromPolicyTab(trip.trip_id, {
+      focusPlanTab: () => {
+        setActiveTab("plan");
+        workspaceTabRefs.current.plan?.focus();
+      },
+      preloadPlannerSession: fetchPlannerSession,
+    });
   }
+
+  async function handlePolicyServiceRetry() {
+    setProposalBusyLabel("Retrying policy service check…");
+    setProposalError(null);
+    setProposalStatusMessage(null);
+    const refreshVersion = ++proposalRefreshVersion.current;
+    try {
+      const nextProposalState = await retryPolicyServiceCheck(trip.trip_id);
+      if (refreshVersion !== proposalRefreshVersion.current) {
+        return;
+      }
+      setCurrentWorkspace((previous) =>
+        previous
+          ? {
+              ...previous,
+              proposal_state: nextProposalState,
+            }
+          : previous
+      );
+      setProposalStatusMessage(
+        nextProposalState == null
+          ? "Policy status refreshed: no approval packet is currently saved."
+          : "Policy service check completed."
+      );
+    } catch (error) {
+      if (refreshVersion === proposalRefreshVersion.current) {
+        setProposalError(error instanceof Error ? error.message : "Policy service retry failed.");
+      }
+    } finally {
+      if (refreshVersion === proposalRefreshVersion.current) {
+        setProposalBusyLabel(null);
+      }
+    }
+  }
+
+  const policyPanelView = useMemo(
+    () =>
+      derivePolicyPanelView(currentWorkspace, {
+        onPrepare: handlePrepareApprovalPacket,
+        onRetry: handlePolicyServiceRetry,
+        onSatisfyPrecondition: handlePrepareApprovalPacket,
+      }),
+    [currentWorkspace, trip.trip_id]
+  );
 
   if (
     typeof window !== "undefined" &&
@@ -2429,70 +2480,8 @@ function WorkspacePageContent({
         <PolicyTabPanel labelledBy={workspaceTabButtonId("policy")}>
           <WorkspacePolicyPanel
             grid
-            noPacketAction={
-              currentWorkspace.proposal_state == null
-                ? { onPrepare: handlePrepareApprovalPacket }
-                : null
-            }
-            approvalPacketContent={
-              panelVisibility.showApprovalReadinessPanel && currentWorkspace.proposal_state != null ? (
-                <>
-                <p className="status-label">Approval packet</p>
-                <h2 data-testid="proposal-lifecycle">
-                  {proposalLifecycle?.title ?? "Proposal lifecycle in progress"}
-                </h2>
-                <>
-                    <div aria-live="polite" role="status">
-                      {proposalBusyLabel ? <p className="muted-copy">{proposalBusyLabel}</p> : null}
-                      {proposalError ? <p className="planner-inline-error">{proposalError}</p> : null}
-                      {proposalStatusMessage ? <p className="muted-copy">{proposalStatusMessage}</p> : null}
-                    </div>
-                    <dl className="workspace-meta">
-                      <div>
-                        <dt>Approval readiness</dt>
-                        <dd>
-                          {currentWorkspace.view_model?.policy_presentation.approval_status_label ??
-                            proposalLifecycle?.readinessLabel ??
-                            "Waiting for policy review"}
-                        </dd>
-                      </div>
-                      <div>
-                        <dt>Packet status</dt>
-                        <dd>{currentWorkspace.proposal_state.summary.submission_status ?? "unknown"}</dd>
-                      </div>
-                      <div>
-                        <dt>Comparables</dt>
-                        <dd>{currentWorkspace.proposal_state.summary.comparable_count ?? 0}</dd>
-                      </div>
-                      <div>
-                        <dt>Next step</dt>
-                        <dd>
-                          {currentWorkspace.view_model?.policy_presentation.next_step_label ??
-                            formatFollowUpStatus(
-                              renderableProposalFollowUp?.status ??
-                                currentWorkspace.proposal_state.summary.follow_up_status
-                            )}
-                        </dd>
-                      </div>
-                    </dl>
-                    <p>{proposalLifecycle?.summary ?? "Submission stored for later review."}</p>
-                    {shouldShowProposalRefresh(
-                      currentWorkspace.proposal_state,
-                      renderableProposalFollowUp
-                    ) || proposalLifecycle?.state === "failed" ? (
-                      <button
-                        type="button"
-                        className="secondary-button"
-                        disabled={Boolean(proposalBusyLabel)}
-                        onClick={handleProposalRefresh}
-                      >
-                        {proposalLifecycle?.state === "failed" ? "Retry policy check" : "Refresh live status"}
-                      </button>
-                    ) : null}
-                </>
-                </>
-              ) : null
-            }
+            view={policyPanelView}
+            statusMessage={proposalStatusMessage ?? proposalBusyLabel ?? proposalError}
             approvalDetailsContent={
               panelVisibility.showProposalPanel ? (
                 <>


### PR DESCRIPTION
## Summary
- Follow-up for merged #1707 verifier CONCERNS and partial #1712 scope: `PolicyPanel` now renders four distinguishable states (not-evaluated, compliant, non-compliant, service-unavailable).
- Wired prepare/retry client entry points in `frontend/src/api/workspace.ts` and mapped workspace proposal state in `WorkspacePage`.
- Added the named PolicyPanel regression tests required by #1678 acceptance criteria.

## Context
Orphan/closer sweep identified no other in-scope open PRs fleet-wide. Issue #1678 remains open after merged #1707 reported a scope gap and #1712 only landed the empty-state action.

## Validation
- `npx vitest run frontend/src/components/workspace/panels/PolicyPanel.test.tsx -t "empty state offers an action"` PASS
- `npx vitest run frontend/src/components/workspace/panels/PolicyPanel.test.tsx -t "renders four distinct policy states"` PASS

## Test plan
- [ ] Gate + required checks on PR head
- [ ] Merge after post-push review window; apply `verify:compare`
- [ ] Close #1678 only on durable verifier PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear policy status views for unevaluated, compliant, non-compliant, and unavailable states.
  - Added actions to prepare approval packets, retry policy checks, and resolve required business-trip preconditions.
  - Added issue details, live status messaging, and approval information within the policy panel.

- **Bug Fixes**
  - Improved handling and display of policy-service failures and proposal status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->