### PR TITLE
ci: install uv for browser canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
         with:
           python-version: '3.14'
 
+      - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '22'


### PR DESCRIPTION
Closes #1694

## Summary
- install the `uv` tool before invoking the two-trip browser-canary script
- pin the setup action to an immutable commit SHA

## Validation
- `actionlint .github/workflows/ci.yml`
- `bash -n scripts/run_two_trip_ui_canary.sh`

## Follow-up
This repairs the merge-commit CI failure from #1722 (`uv: command not found`).